### PR TITLE
add ??= operator support

### DIFF
--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -142,6 +142,7 @@ std::string debugTokenName(TokenType t) {
     {tok_set_shr, "tok_set_shr"},
     {tok_set_shl, "tok_set_shl"},
     {tok_set_dot, "tok_set_dot"},
+    {tok_set_null_coalesce, "tok_set_null_coalesce"},
     {tok_double_arrow, "tok_double_arrow"},
     {tok_double_colon, "tok_double_colon"},
     {tok_arrow, "tok_arrow"},

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -1023,6 +1023,7 @@ void TokenLexerCommon::init() {
   add_rule(h, ".=", tok_set_dot);
   add_rule(h, ">>=", tok_set_shr);
   add_rule(h, "<<=", tok_set_shl);
+  add_rule(h, "\?\?=", tok_set_null_coalesce); // escaping ? to avoid trigraphs
 
   add_rule(h, "=>", tok_double_arrow);
   add_rule(h, "::", tok_double_colon);

--- a/compiler/operation.cpp
+++ b/compiler/operation.cpp
@@ -64,6 +64,7 @@ void OpInfo::init_static() {
   add_binary_op(curP, tok_set_dot, op_set_dot);
   add_binary_op(curP, tok_set_shr, op_set_shr);
   add_binary_op(curP, tok_set_shl, op_set_shl);
+  add_binary_op(curP, tok_set_null_coalesce, op_set_null_coalesce);
   curP++;
 
   add_binary_op(curP, tok_question, op_ternary);

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -129,6 +129,7 @@ enum TokenType {
   tok_set_shr,
   tok_set_shl,
   tok_set_dot,
+  tok_set_null_coalesce,
   tok_double_arrow,
   tok_double_colon,
   tok_arrow,

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -1384,6 +1384,19 @@
     }
   },
   {
+    "comment": "lhs() ??= rhs(); where lhs() does not contain op_func_call",
+    "name": "op_set_null_coalesce",
+    "base_name": "op_set_modify",
+    "props": {
+      "base_op": "op_null_coalesce",
+      "cnst": "cnst_nonconst_func",
+      "fixity": "right_opp",
+      "rl": "rl_set",
+      "type": "binary_op",
+      "str": "\\?\\?="
+    }
+  },
+  {
     "comment": "cond() ? true_expr() : false_expr()",
     "sons": {
       "true_expr": 1,

--- a/tests/phpt/null_coalescing/12_assignment.php
+++ b/tests/phpt/null_coalescing/12_assignment.php
@@ -1,0 +1,101 @@
+@ok php7_4
+<?php
+
+/**
+ * @return string[]
+ */
+function foobar() {
+  echo "foobar called\n";
+  return ['a'];
+}
+
+function get_null() {
+  echo "get_null()\n";
+  return null;
+}
+
+function test_variable() {
+  /** @var int */
+  $v0 = 7;
+  /** @var null|int */
+  $v1 = 1 ? null : $v0;
+  /** @var mixed */
+  $v3 = 0 ? $v1 : "xxxx";
+  /** @var string|int */
+  $v4 = "";
+
+  $v0 ??= 2;
+  var_dump($v0);
+  $v1 ??= 3;
+  var_dump($v1);
+  $v1 ??= $v0;
+  var_dump($v1);
+  $v3 ??= $v1;
+  var_dump($v3);
+  $v4 ??= $v1;
+  var_dump($v4);
+  $v3 ??= foobar();
+  var_dump($v3);
+}
+
+function test_int() : int {
+  $x = 0;
+  $x ??= 15;
+  var_dump($x);
+  return $x;
+}
+
+function test_null() : int {
+  $x = null;
+  $x ??= 15; // $x is never null now, var split should make it int-typed
+  var_dump($x);
+  return $x;
+}
+
+class Row {
+  /** @var null|int[] */
+  public $values = null;
+
+  /** @var ?int */
+  public static $static_int = 0;
+  /** @var ?string */
+  public static $static_string = null;
+}
+
+function test_objects_with_arrays() {
+  $row = new Row();
+
+  var_dump($row->values === null);
+
+  $row->values ??= [];
+  var_dump($row->values === []);
+
+  $row->values ??= [1, 2];
+  var_dump($row->values === []);
+
+  $row->values['foo'] ??= 9000;
+  var_dump($row->values['foo'] == 9000);
+
+  $row->values['foo'] ??= 0;
+  var_dump($row->values['foo'] != 0);
+}
+
+function test_static() {
+  Row::$static_int ??= 123;
+  var_dump(Row::$static_int);
+  Row::$static_int = null;
+  Row::$static_int ??= 123;
+  var_dump(Row::$static_int);
+
+  Row::$static_string ??= get_null();
+  Row::$static_string ??= get_null();
+  Row::$static_string ??= "foo";
+  Row::$static_string ??= get_null();
+  var_dump(Row::$static_string);
+}
+
+test_int();
+test_null();
+test_variable();
+test_objects_with_arrays();
+test_static();

--- a/tests/phpt/null_coalescing/13_assignment_call_rhs.php
+++ b/tests/phpt/null_coalescing/13_assignment_call_rhs.php
@@ -1,0 +1,25 @@
+@ok php7_4
+<?php
+
+function get_arg(): string {
+  var_dump("get_arg");
+  return "foo";
+}
+
+function get_string(string $x): string {
+   var_dump("get_string");
+   return $x;
+}
+
+function test_call_rhs() {
+  /** @var ?string */
+  $x = null;
+
+  $x ??= get_string(get_arg()); // get_string(get_arg()) is evaluated
+  var_dump($x);
+
+  $x ??= get_string(get_arg()); // get_string(get_arg()) is not evaluated
+  var_dump($x);
+}
+
+test_call_rhs();

--- a/tests/phpt/null_coalescing/14_assignment_throw_exceptions.php
+++ b/tests/phpt/null_coalescing/14_assignment_throw_exceptions.php
@@ -1,0 +1,57 @@
+@ok php7_4
+<?php
+
+/**
+ * @param int|null $v
+ * @param bool $throw
+ * @return int|null
+ */
+function foo($v, $throw) {
+  echo "call foo($v, $throw)\n";
+  if ($throw) {
+    throw new Exception("foo exception $v");
+  }
+  return $v;
+}
+
+function test_exception_rhs_try_catch_wrap() {
+  /** @var ?int */
+  $x = null;
+  try {
+    $x ??= foo(1, true);
+    echo "unreachable\n";
+  } catch (Exception $e) {
+    echo __LINE__ . " Exception: " . $e->getMessage() . "\n";
+  }
+  var_dump($x);
+
+  try {
+    $x ??= foo(1, false);
+    $x ??= foo(null, true); // not evaluated: shouldn't throw
+    var_dump($x);
+  } catch (Exception $e) {
+    echo __LINE__ . " Exception: " . $e->getMessage() . "\n";
+  }
+}
+
+function test_exception_rhs_no_wrap() {
+  /**
+   * @return string
+   */
+  function test_1() {
+    $x = null;
+    $x ??= foo(1, true);
+    var_dump($x);
+    return "ok";
+  }
+
+  try {
+    $r = test_1();
+    var_dump($r);
+  } catch (Exception $e) {
+    echo __LINE__ . " Exception: " . $e->getMessage() . "\n";
+  }
+}
+
+test_exception_rhs_try_catch_wrap();
+test_exception_rhs_no_wrap();

--- a/tests/phpt/null_coalescing/15_assignment_lhs_fncall_error.php
+++ b/tests/phpt/null_coalescing/15_assignment_lhs_fncall_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+}
+
+function get_a(): A {
+   return new A();
+}
+
+get_a()->x ??= 99;

--- a/tests/phpt/null_coalescing/16_assignment_lhs_fncall_error2.php
+++ b/tests/phpt/null_coalescing/16_assignment_lhs_fncall_error2.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+    /** @var A */
+    public $next = null;
+}
+
+$a = new A();
+
+function get_a(): A {
+   global $a;
+   return $a;
+}
+
+get_a()->next->next->x ??= 99;

--- a/tests/phpt/null_coalescing/17_assignment_lhs_fncall_error3.php
+++ b/tests/phpt/null_coalescing/17_assignment_lhs_fncall_error3.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+}
+
+function f() : int { return 0; }
+
+$a = [new A()];
+
+$a[f()]->x ??= 99;

--- a/tests/phpt/null_coalescing/18_assignment_lhs_fncall_error4.php
+++ b/tests/phpt/null_coalescing/18_assignment_lhs_fncall_error4.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+}
+
+(new A())->x ??= 99;

--- a/tests/phpt/null_coalescing/19_assignment_lhs_methodcall_error.php
+++ b/tests/phpt/null_coalescing/19_assignment_lhs_methodcall_error.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+
+    /** @var A */
+    public $y = null;
+
+    public function next() : A {
+      return null;
+    }
+}
+
+$a = new A();
+
+$a->y->next()->y->x ??= 99;

--- a/tests/phpt/null_coalescing/20_assignment_lhs_methodcall_error2.php
+++ b/tests/phpt/null_coalescing/20_assignment_lhs_methodcall_error2.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+
+    public static function make() : A {
+      return new A();
+    }
+}
+
+A::make()->x ??= 99;

--- a/tests/phpt/null_coalescing/21_assignment_lhs_methodcall_error3.php
+++ b/tests/phpt/null_coalescing/21_assignment_lhs_methodcall_error3.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+class A {
+    /** @var ?int */
+    public $x = null;
+
+    public function next() : A {
+      return null;
+    }
+}
+
+$a = [new A(), new A()];
+
+$a[0]->next()->x ??= 99;

--- a/tests/phpt/null_coalescing/22_assignment_this_reassign_error.php
+++ b/tests/phpt/null_coalescing/22_assignment_this_reassign_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/Modification of const variable: this/
+<?php
+
+class Test {
+    public function foobar() {
+        $this = new Test();
+    }
+}
+
+// make sure that Test and foobar are not eliminated as a dead code
+$x = new Test();
+$x->foobar();

--- a/tests/phpt/null_coalescing/23_assignment_error.php
+++ b/tests/phpt/null_coalescing/23_assignment_error.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/Function calls on the left-hand side of \?\?= are not supported/
+<?php
+
+function get_array(array $arr) : array {
+  echo "get array\n";
+  return $arr;
+}
+
+function test_fncall() {
+  get_array([])[10] ??= 50;
+  var_dump($a);
+}
+
+test_fncall();


### PR DESCRIPTION
Implemented as a pseudo op op_set_null_coalesce that is being
re-written as op_set+op_null_coalesce in GenTreePostprocessPass.

	`$x ??= $y` => `$x = $x ?? $y`

We don't allow $x to be a function call to avoid issues with
evaluation order and the number of times $x being evaluated.

An example where the results are especially exciting in PHP `7.4.11`:

```php
	<?php
	class A {
	/** @var ?int */
	  public $value = null;
	}
	function id($x) { echo "id()\n"; return $x; }
	$a = new A();
	id($a)->value ??= 10; // id() is called twice (!)
	id($a)->value ??= 20; // id() is called only once
```

In KPHP such code would give a compile-time error right now.

It's more convenient to replace the pseudo op node than try to
parse tok_set_null_coalesce into op_set from the beginning.

We could have op_set_null_coalesce as a real op that would live
up to the code generation, but it requires special efforts
to preserve the ability to split lhs variables.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>