### PR TITLE
switch tl2php to int64_t TL long 

### DIFF
--- a/common/tl2php/combinator-to-php.cpp
+++ b/common/tl2php/combinator-to-php.cpp
@@ -88,7 +88,7 @@ bool CombinatorToPhp::try_as_primitive_builtin_type(const vk::string_view &tl_ty
     {"String", PhpTypeName{"string", php_field_type::t_string}},
     {"Int",    PhpTypeName{"int", php_field_type::t_int}},
     {"#",      PhpTypeName{"int", php_field_type::t_int}},
-    {"Long",   PhpTypeName{"mixed", php_field_type::t_mixed}},
+    {"Long",   PhpTypeName{"int", php_field_type::t_int}},
     {"Double", PhpTypeName{"float", php_field_type::t_double}},
     {"Float",  PhpTypeName{"float", php_field_type::t_double}},
     {"Bool",   PhpTypeName{"boolean", php_field_type::t_bool}},

--- a/common/tl2php/gen-php-code.cpp
+++ b/common/tl2php/gen-php-code.cpp
@@ -595,6 +595,11 @@ struct ClassDefinition {
     }
     os << " {" << SkipLine{};
 
+
+    if (self.class_repr.php_class_name == "rpcResponseHeader") {
+      os << "  private static $_enable_new_tl_long = true; // toggle for switching to int64_t TL long, will be deleted" << SkipLine{};
+    }
+
     for (const auto &field : self.class_repr.class_fields) {    // биты филд масок
       if (!field.field_mask_name.empty()) {
         os << ClassFieldBitMask{field};


### PR DESCRIPTION
TL long representation in PHP becomes `int64_t` instead of `mixed`.
Transition to it must be performed with taking into account that existing PHP code relies on `mixed` type. PHP code fixes are required for that. 
Moreover, transition must look 'simultaneous' for KPHP and vkext. For this reason the temporary 'toggle' is implemented as a private constant in one PHP TL class. Internal behavior of KPHP and vkext depends on this toggle. When it's off, TL long is represented as `mixed`, when it's on - as `int64_t`. When transition is completed, the toggle will be deleted and behavior will correspond `int64_t` TL long representation.