### PR TITLE
improve kphp2cpp error message for non-existing files

### DIFF
--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -285,7 +285,12 @@ void CompilerSettings::init() {
   ld_flags.value_ += " -rdynamic";
 
   for (auto &main_file : main_files.value_) {
-    main_file = get_full_path(main_file);
+    auto full_path = get_full_path(main_file);
+    if (full_path.empty()) {
+      // get_full_path() calls realpath() which will set the errno in case of failure
+      throw std::runtime_error{fmt_format("Failed to open file [{}] : {}", main_file, strerror(errno))};
+    }
+    main_file = full_path;
   }
 
   const auto &first_main_file = main_files.get().front();


### PR DESCRIPTION
Instead of doing an assert, do something with a more user-friendly
output for a somewhat common case where the user typed the filename incorrectly.

Imagine that you're doing this:

	$ kphp2cpp foobar.php

Where `foobar.php` doesn't exist.

kphp2cpp message before:
```
Fatal error [gen by $KPHP/compiler/compiler-settings.cpp at 293]
In stage = []:
  [file = unknown]
  [function = unknown function:-1]
  Assertion dir_pos != std::string::npos failed

Compilation failed.
It is probably happened due to incorrect or unsupported PHP input.
But it is still bug in compiler.
[pid 12570] [time 1605115955] SIGABRT caught, terminating program
[pid 12570] [time 1605115955] errno = No such file or directory
[pid 12570] [time 1605115955]
------- Register Values -------
[pid 12570] [time 1605115955] RIP=0x00007F063442DE97 RSP=0x00007FFF4A53EB60 RBP=0x00007FFF4A53EE70 RDI=0x0000000000000002 RSI=0x00007FFF4A53EB60 RDX=0x0000000000000000 RCX=0x00007F063442DE97 R8=0x0000000000000000 R9=0x00007FFF4A53EB60 R10=0x0000000000000008 RBX=0x0000000000000001 RAX=0x0000000000000000 CR2=0x0000000000000000 R11=0x0000000000000246 R12=0x00007FFF4A53FF80 R13=0x0000000000000003 R14=0x00007FFF4A53FC20 R15=0x0000000000000003
[pid 12570] [time 1605115955]
------- Stack Backtrace -------
./kphp(_Z15print_backtracev+0x53)[0xc5b6cc]
./kphp[0xc5bcec]
/lib/x86_64-linux-gnu/libpthread.so.0(+0x12890)[0x7f0635131890]
/lib/x86_64-linux-gnu/libc.so.6(gsignal+0xc7)[0x7f063442de97]
/lib/x86_64-linux-gnu/libc.so.6(abort+0x141)[0x7f063442f801]
./kphp(_Z20on_compilation_errorPKcS0_iS0_12AssertLevelT+0x1bd)[0xbfbef5]
./kphp(_ZN16CompilerSettings4initEv+0xf78)[0xb95310]
./kphp(main+0x2392)[0x9110ba]
/lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0xe7)[0x7f0634410b97]
./kphp(_start+0x2a)[0x90dc2a]
[pid 12570] [time 1605115955] -------------------------------
[pid 12570] [time 1605115955] kphp2cpp compiled at Nov 11 2020 17:35:15 MSK by gcc 8.4.0 64-bit after commit a8ef101452ec673cbd39776f32ae4701f716b371 branch null_coalesce_assign[pid 12570] [time 1605115955]
```

kphp2cpp message after:
```
Failed to open file [foobar.php] : No such file or directory
```

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>