### PR TITLE
[tests] Add github actions config.

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -1,0 +1,115 @@
+name: Build
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: buster
+            compiler: g++
+            cpp: 14
+            asan: off
+            ubsan: off
+          - os: focal
+            compiler: g++
+            cpp: 14
+            asan: off
+            ubsan: off
+          - os: focal
+            compiler: clang++
+            cpp: 17
+            asan: off
+            ubsan: on
+          - os: focal
+            compiler: g++-10
+            cpp: 20
+            asan: on
+            ubsan: off
+
+    name: "${{matrix.os}}/${{matrix.compiler}}/c++${{matrix.cpp}}/asan=${{matrix.asan}}/ubsan=${{matrix.ubsan}}"
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Cache docker image
+      uses: actions/cache@v2
+      id: docker-image-cache
+      with:
+        path: kphp-build-env-${{matrix.os}}.tar
+        key: docker-image-cache-${{matrix.os}}-${{ hashFiles('.github/workflows/Dockerfile.*') }}
+          
+    - name: Buld and save docker image
+      if: steps.docker-image-cache.outputs.cache-hit != 'true'
+      run: |
+        docker build -f $GITHUB_WORKSPACE/.github/workflows/Dockerfile.${{matrix.os}} $GITHUB_WORKSPACE -t kphp-build-img-${{matrix.os}}
+        docker save --output kphp-build-env-${{matrix.os}}.tar kphp-build-img-${{matrix.os}}
+        
+    - name: Load docker image from cache
+      if: steps.docker-image-cache.outputs.cache-hit == 'true'
+      run: docker load --input kphp-build-env-${{matrix.os}}.tar
+      
+    - name: Start docker container
+      run: docker run -dt --name kphp-build-container-${{matrix.os}} --volume $GITHUB_WORKSPACE:$GITHUB_WORKSPACE kphp-build-img-${{matrix.os}}
+      
+    - name: Build all
+      run: docker exec kphp-build-container-${{matrix.os}} bash -c 
+              "cmake -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_CXX_STANDARD=${{matrix.cpp}} -DADDRESS_SANITIZER=${{matrix.asan}} -DUNDEFINED_SANITIZER=${{matrix.ubsan}} -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build && make -C ${{runner.workspace}}/build -j$(nproc) all"
+
+    - name: Run unit tests
+      run: docker exec kphp-build-container-${{matrix.os}} bash -c 
+              "make -C ${{runner.workspace}}/build -j$(nproc) test"
+
+    - name: Compile dummy PHP script
+      run: docker exec kphp-build-container-${{matrix.os}} bash -c 
+              "cd ${{runner.workspace}}/build && echo 'hello world' > demo.php && $GITHUB_WORKSPACE/objs/bin/kphp2cpp --cxx ${{matrix.compiler}} demo.php && kphp_out/server -o"
+
+    - name: Remove docker container
+      run: docker rm -f kphp-build-container-${{matrix.os}}
+
+  build-macos:
+    runs-on: ${{matrix.os}}-latest
+    strategy:
+      matrix:
+        include:
+          - os: macos
+            compiler: clang++
+            cpp: 14
+
+    name: "${{matrix.os}}/${{matrix.compiler}}/c++${{matrix.cpp}}"
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    - name: Setup Environment
+      run: |
+        brew install cmake glib-openssl re2 ccache fmt googletest
+        pip3 install jsonschema
+        
+    # when we fix build for mac, don't forget to combine this step with "Build step"
+    - name: Run cmake
+      run: cmake -DCMAKE_CXX_COMPILER=${{matrix.compiler}} -DCMAKE_CXX_STANDARD=${{matrix.cpp}} -S $GITHUB_WORKSPACE -B ${{runner.workspace}}/build
+        
+    - name: Build all
+      continue-on-error: true
+      run: make -C ${{runner.workspace}}/build -j$(nproc) all
+      
+    - name: Run unit tests
+      continue-on-error: true
+      run: make -C ${{runner.workspace}}/build -j$(nproc) test
+
+    - name: Compile dummy PHP script
+      working-directory: ${{runner.workspace}}/build
+      continue-on-error: true
+      run: |
+        echo 'hello world' > demo.php 
+        $GITHUB_WORKSPACE/objs/bin/kphp2cpp --cxx ${{matrix.compiler}} demo.php
+        kphp_out/server -o

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -1,0 +1,18 @@
+FROM debian:buster
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget && \
+    echo "deb https://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \ 
+    wget -qO - https://repo.vkpartner.ru/GPG-KEY.pub | apt-key add - && \
+    echo "deb https://repo.vkpartner.ru/kphp-buster/ buster main" >> /etc/apt/sources.list && \
+    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \
+    echo "deb https://packages.sury.org/php/ buster main" >> /etc/apt/sources.list.d/php.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git cmake-data=3.16* cmake=3.16* make g++ gperf python3-minimal python3-jsonschema \
+      curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
+      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.focal
+++ b/.github/workflows/Dockerfile.focal
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget && \
+    wget -qO - https://repo.vkpartner.ru/GPG-KEY.pub | apt-key add - && \
+    echo "deb https://repo.vkpartner.ru/kphp-focal/ focal main" >> /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends \
+      git cmake make clang g++ g++-10 gperf python3-minimal python3-jsonschema \
+      curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
+      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -ms /bin/bash kitten
+
+ENV ASAN_OPTIONS=detect_leaks=0
+ENV UBSAN_OPTIONS=print_stacktrace=1:allow_addr2line=1


### PR DESCRIPTION
Hi.

There are 5 builds:
1) buster/g++/c++14
2) focal/g++/c++14
3) focal/clang++/c++17/ubsan
4) focal/g++-10/c++20/asan
5) macos/clang++/c++14

Details
1) All linux builds work via Dockerfile, because it allows to cache prepared env, and reuse it later;
2) Macos build isn't cached, because it fails faster :) May be later it make sense to think about it;
3) Stages: (cmake + make) + run unit tests + build dummy php file and run it;
4) For Macos only cmake works, other fail and they are ignored;
5) The builds are started on creating pull request and pushing something to master.

Examples in my fork:
actions: https://github.com/AlexK0/kphp/actions
pr: https://github.com/AlexK0/kphp/pull/2