### PR TITLE
Always treat TL long as int64_t in KPHP

### DIFF
--- a/compiler/code-gen/files/tl2cpp/tl-combinator.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-combinator.cpp
@@ -169,7 +169,7 @@ std::string CombinatorStore::get_value_absence_check_for_optional_arg(const std:
   auto *type = tl2cpp::type_of(arg->type_expr);
   kphp_assert(type);
   std::string check_target = "tl_object->$" + arg->name;
-  if (tl2cpp::is_tl_type_wrapped_to_Optional(type) || (type->id == TL_LONG && !TlClasses::new_tl_long) || !tl2cpp::CUSTOM_IMPL_TYPES.count(type->name)) {
+  if (tl2cpp::is_tl_type_wrapped_to_Optional(type) || !tl2cpp::CUSTOM_IMPL_TYPES.count(type->name)) {
     // if it's Optional OR var OR class_instance<T>
     return check_target + ".is_null()";
   } else {

--- a/compiler/code-gen/files/tl2cpp/tl-module.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-module.cpp
@@ -19,19 +19,6 @@ void Module::compile_tl_h_file(CodeGenerator &W) const {
   W << ExternInclude("tl/tl_const_vars.h");
   W << h_includes;
   W << NL;
-  if (name == "common") {
-    std::string is_new_tl_long = TlClasses::new_tl_long ? "true" : "false";
-    W << "using t_Long = tl_Long_impl<" << is_new_tl_long << ">;\n"
-         "\n"
-         "template<typename T, unsigned int inner_magic>\n"
-         "using t_LongKeyDictionary = tl_Dictionary_impl<t_Long, T, inner_magic, " << is_new_tl_long << ">;\n"
-         "\n"
-         "template<typename T, unsigned int inner_magic>\n"
-         "using t_Dictionary = tl_Dictionary_impl<t_String, T, inner_magic, " << is_new_tl_long << ">;\n"
-         "\n"
-         "template<typename T, unsigned int inner_magic>\n"
-         "using t_IntKeyDictionary = tl_Dictionary_impl<t_Int, T, inner_magic, " << is_new_tl_long << ">;" << NL << NL;
-  }
   for (const auto &t : target_types) {
     for (const auto &constructor : t->constructors) {
       W << TlConstructorDecl(constructor.get());

--- a/compiler/code-gen/files/tl2cpp/tl2cpp-utils.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl2cpp-utils.cpp
@@ -244,7 +244,7 @@ bool is_tl_type_wrapped_to_Optional(const vk::tl::type *type) {
   // [fields_mask.n? | Maybe] [int|string|array|double|bool] -- with Optional
   // [fields_mask.n? | Maybe] [class_instance<T>|Optional<T>|var] -- without Optional
   return is_tl_type_a_php_array(type) || vk::any_of_equal(type->id, TL_INT, TL_DOUBLE, TL_FLOAT, TL_STRING) || type->name == "Bool" || type->is_integer_variable()
-                                      || (type->id == TL_LONG && TlClasses::new_tl_long);
+                                      || type->id == TL_LONG;
 }
 
 // classes VK\TL\*\Types\* are a non-interface types that correspond to the TL-constructors

--- a/compiler/pipes/check-tl-classes.cpp
+++ b/compiler/pipes/check-tl-classes.cpp
@@ -38,20 +38,8 @@ void verify_class_against_repr(ClassPtr class_id, const vk::tl::PhpClassRepresen
   }
 }
 
-static void read_toggle_constant_for_switching_to_new_tl_long(ClassPtr class_id) {
-  // this is a temporary toggle that will be removed when we'll finish the int64_t transition for TL long
-  if (class_id->name == R"(VK\TL\_common\Types\rpcResponseHeader)") {
-    if (const auto *toggle_constant = class_id->get_static_field("_enable_new_tl_long")) {
-      if (toggle_constant->var->init_val->type() == op_true) {
-        TlClasses::new_tl_long = true;
-      }
-    }
-  }
-}
-
 void check_class(ClassPtr class_id) {
   if (class_id->is_tl_class) {
-    read_toggle_constant_for_switching_to_new_tl_long(class_id);
     const size_t pos = class_id->name.find(vk::tl::PhpClasses::tl_namespace());
     kphp_error_return(pos != std::string::npos,
                       fmt_format("Bad tl-class '{}' namespace", class_id->name));

--- a/compiler/tl-classes.cpp
+++ b/compiler/tl-classes.cpp
@@ -11,8 +11,6 @@
 
 #include "compiler/stage.h"
 
-bool TlClasses::new_tl_long{false};
-
 void TlClasses::load_from(const std::string &tlo_schema, bool generate_tl_internals) {
   auto tl_expected_ptr = vk::tl::parse_tlo(tlo_schema.c_str(), true);
   kphp_error_return(tl_expected_ptr.has_value(),

--- a/compiler/tl-classes.h
+++ b/compiler/tl-classes.h
@@ -11,8 +11,6 @@
 
 class TlClasses {
 public:
-  static bool new_tl_long;
-
   void load_from(const std::string &tlo_schema, bool generate_tl_internals);
 
   const std::unique_ptr<const vk::tl::tl_scheme> &get_scheme() const { return scheme_; }

--- a/functions.txt
+++ b/functions.txt
@@ -58,8 +58,8 @@ class RpcMemcache implements Memcache {
     public function add ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
     public function set ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
     public function replace ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function decrement ($key ::: string, $v ::: any = 1) ::: mixed;
-    public function increment ($key ::: string, $v ::: any = 1) ::: mixed;
+    public function decrement ($key ::: string, $v ::: int = 1) ::: mixed;
+    public function increment ($key ::: string, $v ::: int = 1) ::: mixed;
 
     public function getVersion () ::: mixed;
     public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: any = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
@@ -783,7 +783,7 @@ function store_raw ($v ::: string) ::: bool;
 function set_fail_rpc_on_int32_overflow ($fail_rpc ::: bool) ::: bool;
 function store_int ($v ::: int) ::: bool;
 function store_unsigned_int ($v ::: any) ::: bool;
-function store_long ($v ::: any) ::: bool;
+function store_long ($v ::: int) ::: bool;
 function store_unsigned_long ($v ::: any) ::: bool;
 function store_unsigned_int_hex ($v ::: string) ::: bool;
 function store_unsigned_long_hex ($v ::: string) ::: bool;

--- a/runtime/memcache.cpp
+++ b/runtime/memcache.cpp
@@ -39,7 +39,7 @@ static int mc_last_key_len{0};
 static mixed mc_res;
 static bool mc_bool_res{false};
 
-mixed rpc_mc_run_increment(int op, const class_instance<C$RpcConnection> &conn, const string &key, const mixed &v, double timeout);
+mixed rpc_mc_run_increment(int op, const class_instance<C$RpcConnection> &conn, const string &key, int64_t v, double timeout);
 bool rpc_mc_run_set(int32_t op, const class_instance<C$RpcConnection> &conn, const string &key, const mixed &value, int64_t flags, int64_t expire, double timeout);
 bool f$rpc_mc_delete(const class_instance<C$RpcConnection> &conn, const string &key, double timeout = -1.0, bool fake = false);
 mixed f$rpc_mc_get(const class_instance<C$RpcConnection> &conn, const string &key, double timeout = -1.0, bool fake = false);
@@ -780,28 +780,28 @@ bool f$RpcMemcache$$delete(const class_instance<C$RpcMemcache> &mc, const string
   return catchException(f$rpc_mc_delete(cur_host.conn, real_key, -1.0, mc->fake), false);
 }
 
-mixed f$RpcMemcache$$decrement(const class_instance<C$RpcMemcache> &mc, const string &key, const mixed &count) {
-  if (mc->hosts.count() <= 0) {
+mixed f$RpcMemcache$$decrement(const class_instance<C$RpcMemcache> &v$this, const string &key, int64_t count) {
+  if (v$this->hosts.count() <= 0) {
     php_warning("There is no available server to run RpcMemcache::decrement with key \"%s\"", key.c_str());
     return false;
   }
 
   const string real_key = mc_prepare_key(key);
-  auto cur_host = get_host(mc->hosts);
+  auto cur_host = get_host(v$this->hosts);
   mc_method = "decrement";
-  return catchException(rpc_mc_run_increment(mc->fake ? TL_ENGINE_MC_DECR_QUERY : MEMCACHE_DECR, cur_host.conn, real_key, count, -1), false);
+  return catchException(rpc_mc_run_increment(v$this->fake ? TL_ENGINE_MC_DECR_QUERY : MEMCACHE_DECR, cur_host.conn, real_key, count, -1), false);
 }
 
-mixed f$RpcMemcache$$increment(const class_instance<C$RpcMemcache> &mc, const string &key, const mixed &count) {
-  if (mc->hosts.count() <= 0) {
+mixed f$RpcMemcache$$increment(const class_instance<C$RpcMemcache> &v$this, const string &key, int64_t count) {
+  if (v$this->hosts.count() <= 0) {
     php_warning("There is no available server to run RpcMemcache::increment with key \"%s\"", key.c_str());
     return false;
   }
 
   const string real_key = mc_prepare_key(key);
-  auto cur_host = get_host(mc->hosts);
+  auto cur_host = get_host(v$this->hosts);
   mc_method = "increment";
-  return catchException(rpc_mc_run_increment(mc->fake ? TL_ENGINE_MC_INCR_QUERY : MEMCACHE_INCR, cur_host.conn, real_key, count, -1.0), false);
+  return catchException(rpc_mc_run_increment(v$this->fake ? TL_ENGINE_MC_INCR_QUERY : MEMCACHE_INCR, cur_host.conn, real_key, count, -1.0), false);
 }
 
 mixed f$RpcMemcache$$getVersion(const class_instance<C$RpcMemcache>& mc) {
@@ -924,7 +924,7 @@ bool rpc_mc_run_set(int32_t op, const class_instance<C$RpcConnection> &conn, con
   return res == MEMCACHE_TRUE;
 }
 
-mixed rpc_mc_run_increment(int op, const class_instance<C$RpcConnection> &conn, const string &key, const mixed &v, double timeout) {
+mixed rpc_mc_run_increment(int op, const class_instance<C$RpcConnection> &conn, const string &key, int64_t v, double timeout) {
   const string real_key = mc_prepare_key(key);
   bool is_immediate = mc_is_immediate_query(real_key);
 

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -122,8 +122,8 @@ bool f$RpcMemcache$$set(const class_instance<C$RpcMemcache> &v$this,const string
 bool f$RpcMemcache$$replace(const class_instance<C$RpcMemcache> &v$this, const string &key, const mixed &value, int64_t flags = 0, int64_t expire = 0);
 mixed f$RpcMemcache$$get(const class_instance<C$RpcMemcache> &v$this, const mixed &key_var);
 bool f$RpcMemcache$$delete(const class_instance<C$RpcMemcache> &v$this, const string &key);
-mixed f$RpcMemcache$$decrement(const class_instance<C$RpcMemcache> &v$this, const string &key, const mixed &count = 1);
-mixed f$RpcMemcache$$increment(const class_instance<C$RpcMemcache> &v$this, const string &key, const mixed &count = 1);
+mixed f$RpcMemcache$$decrement(const class_instance<C$RpcMemcache> &v$this, const string &key, int64_t count = 1);
+mixed f$RpcMemcache$$increment(const class_instance<C$RpcMemcache> &v$this, const string &key, int64_t count = 1);
 mixed f$RpcMemcache$$getVersion(const class_instance<C$RpcMemcache>& v$this);
 
 /*

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -578,10 +578,6 @@ bool f$store_unsigned_int(const string &v) {
   return store_raw(store_parse_number_unsigned<unsigned int>(v));
 }
 
-bool f$store_long(const string &v) {
-  return store_raw(store_parse_number<long long>(v));
-}
-
 bool f$store_unsigned_long(const string &v) {
   return store_raw(store_parse_number_unsigned<unsigned long long>(v));
 }
@@ -649,7 +645,7 @@ bool f$store_many(const array<mixed> &a) {
         f$store_string(a.get_value(i).to_string());
         break;
       case 'l':
-        f$store_long(a.get_value(i));
+        f$store_long(a.get_value(i).to_int());
         break;
       case 'd':
       case 'i':
@@ -1125,7 +1121,7 @@ bool f$store_unsigned_int(const mixed &v) {
   return store_unsigned_int(store_parse_number_unsigned<unsigned int>(v));
 }
 
-bool f$store_long(const mixed &v) {
+bool store_long(const mixed &v) {
   return store_long(store_parse_number<long long>(v));
 }
 

--- a/runtime/rpc.h
+++ b/runtime/rpc.h
@@ -139,7 +139,7 @@ bool f$store_int(int64_t v);
 bool f$store_unsigned_int(const string &v);
 
 bool store_long(long long v);
-bool f$store_long(const string &v);
+bool store_long(const mixed &v);
 
 bool f$store_unsigned_long(const string &v);
 
@@ -194,8 +194,6 @@ bool f$store_unsigned_int(const mixed &v);
 bool f$rpc_wait(int64_t request_id);
 
 bool f$rpc_wait_concurrently(int64_t request_id);
-
-bool f$store_long(const mixed &v);
 
 bool f$store_long(int64_t v);
 

--- a/runtime/tl/tl_builtins.h
+++ b/runtime/tl/tl_builtins.h
@@ -177,7 +177,7 @@ struct t_Int {
 
 struct t_Long {
   void store(const mixed &tl_object) {
-    f$store_long(tl_object);
+    store_long(tl_object);
   }
 
   mixed fetch() {


### PR DESCRIPTION
Final step of new TL long transition described [here](https://github.com/VKCOM/kphp/pull/4).
TL long representation doesn't depend on the toggle anymore, it's always `int64_t`.
`store_long`, `RpcMemcache::increment` and `RpcMemcache::decrement` operate with `int64_t` instead of `mixed`.