### PR TITLE
add support for simple ${var} string interpolation expressions

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -303,9 +303,12 @@ bool TokenLexerName::parse(LexerData *lexer_data) const {
   }
 
   const char *t = s;
+  bool closing_curly = false; // whether it's a ${varname} and we need to find matching '}'
   if (type == tok_var_name) {
     if (t[0] == '{') {
-      return TokenLexerError("${ is not supported by kPHP").parse(lexer_data);
+      s++; // string value should start after the '{'
+      t++; // consume '{'
+      closing_curly = true;
     }
     if (is_alpha(t[0])) {
       t++;
@@ -342,6 +345,13 @@ bool TokenLexerName::parse(LexerData *lexer_data) const {
   }
 
   vk::string_view name(s, t);
+
+  if (closing_curly) {
+    if (t[0] != '}') {
+      return TokenLexerError("Expected '}' after " + string(s, t)).parse(lexer_data);
+    }
+    t++; // consume '}'
+  }
 
   if (type == tok_func_name) {
     const KeywordType *tp = KeywordsSet::get_type(name.begin(), name.size());

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -38,6 +38,11 @@ TEST(lexer_test, test_php_tokens) {
     {R"("$x->y")", {"tok_str_begin(\")", "tok_expr_begin", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end", "tok_str_end(\")"}},
     {R"("{$x->y}")", {"tok_str_begin(\")", "tok_expr_begin({)", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end(})", "tok_str_end(\")"}},
 
+    // strings: ${var} syntax
+    // note that debug_str for vars is "${x}", but str_val is just "x"
+    {R"("${x}")", {"tok_str_begin(\")", "tok_expr_begin", "tok_var_name(${x})", "tok_expr_end", "tok_str_end(\")"}},
+    {R"("a${foo}b")", {"tok_str_begin(\")", "tok_str(a)", "tok_expr_begin", "tok_var_name(${foo})", "tok_expr_end", "tok_str(b)", "tok_str_end(\")"}},
+
     // strings: $x[int] syntax
     {R"("$x[0]")", {"tok_str_begin(\")", "tok_expr_begin", "tok_var_name($x)", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])", "tok_expr_end", "tok_str_end(\")"}},
     {R"("{$x[0]}")", {"tok_str_begin(\")", "tok_expr_begin({)", "tok_var_name($x)", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])", "tok_expr_end(})", "tok_str_end(\")"}},

--- a/tests/phpt/phc/parsing/instring.php
+++ b/tests/phpt/phc/parsing/instring.php
@@ -36,7 +36,7 @@
 
   unset ($bc);
 	echo "a $bc\n";
-#	echo "a ${b}c\n";
+  echo "a ${b}c\n";
   echo "a $arr[0] c\n";
   echo "a $arr[-1] c\n";
   echo "a $arr[$b] c\n";
@@ -48,9 +48,9 @@
 	echo <<<END
 a $bc d
 END;
-#  echo <<<END
-#a ${b}c d
-#END;
+  echo <<<END
+a ${b}c d
+END;
 	 echo <<<END
 a $arr[0] d
 END;

--- a/tests/phpt/phc/parsing/instring_complex.php
+++ b/tests/phpt/phc/parsing/instring_complex.php
@@ -12,4 +12,8 @@
 	echo "g {$y[$z]} h\n";
 	echo "i {$y[1][2]} j\n";
 	echo "{$y[1][2]} k\n";
+
+	echo "a ${x} b\n";
+	echo "a${x}b\n";
+	echo "${x}${z}\n";
 ?>

--- a/tests/phpt/phc/parsing/instring_complex_badsyntax_error.php
+++ b/tests/phpt/phc/parsing/instring_complex_badsyntax_error.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/Expected '}' after x/
+/Variable name expected/
+<?php
+
+// Tests with incomplete ${...} expression in strings.
+
+var_dump("${x"); // missing closing '}'
+var_dump("${"); // missing var name

--- a/tests/phpt/phc/parsing/instring_complex_error.php
+++ b/tests/phpt/phc/parsing/instring_complex_error.php
@@ -1,0 +1,12 @@
+@kphp_should_fail
+/Expected '}' after arr/
+/Expected '}' after xs/
+<?php
+
+// These two work in PHP, but are currently rejected by the KPHP
+
+$arr = ['key' => 'val'];
+$xs = [1, 2];
+
+var_dump("${arr['key']}");
+var_dump("-${xs[0]}-");

--- a/tests/phpt/phc/parsing/instring_complex_error2.php
+++ b/tests/phpt/phc/parsing/instring_complex_error2.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/Expected '}' after obj/
+<?php
+
+// This is invalid in both PHP and KPHP
+
+class Example {
+  public $prop = 10;
+}
+
+$obj = new Example();
+
+var_dump("-${obj->prop}-");

--- a/tests/phpt/phc/parsing/instring_complex_error3.php
+++ b/tests/phpt/phc/parsing/instring_complex_error3.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/Variable name expected/
+<?php
+
+// Works in PHP, not supported in KPHP
+
+$foo = 15;
+var_dump("${'foo'}");

--- a/tests/phpt/phc/parsing/instring_complex_error4.php
+++ b/tests/phpt/phc/parsing/instring_complex_error4.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Expected '}' after get_varname/
+<?php
+
+// Works in PHP, not supported in KPHP
+
+function get_varname() { return 'foo'; }
+
+$foo = 15;
+var_dump("${get_varname()}");


### PR DESCRIPTION
This syntax is preferred by some programmers over {$...}.

The main reasoning behind this change is to make more PHP
programs compile as KPHP programs.

A more compilcated ${<expr>} form is not implemented, so
this will result in a compile error: "${a[0]}".
We may add more complete support for this syntax later.

Note: <expr> inside ${<expr>} is subtle and should
be handled separately, if ever attempted to be implemented.
For example, "${'foo'}" is identical to "$foo".
We don't support ${'foo'} variable syntax yet (which is a
valid freestanding PHP variable syntax btw).

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>