### PR TITLE
handle exit and die calls without () in parser

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -225,7 +225,6 @@ VertexAdaptor<op_require> GenTree::get_require(bool once) {
   return require.set_location(location);
 }
 
-
 template<Operation Op, Operation EmptyOp>
 VertexAdaptor<Op> GenTree::get_func_call() {
   auto location = auto_location();
@@ -540,7 +539,11 @@ VertexPtr GenTree::get_expr_top(bool was_arrow) {
     case tok_func_name: {
       cur++;
       if (!test_expect(tok_oppar)) {
-        res = get_vertex_with_str_val(VertexAdaptor<op_func_name>{}, static_cast<string>(op->str_val));
+        if (vk::any_of_equal(op->str_val, "die", "exit")) { // can be called without "()"
+          res = get_vertex_with_str_val(VertexAdaptor<op_func_call>{}, static_cast<string>(op->str_val));
+        } else {
+          res = get_vertex_with_str_val(VertexAdaptor<op_func_name>{}, static_cast<string>(op->str_val));
+        }
         return_flag = was_arrow;
         break;
       }

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -203,18 +203,6 @@ void LexerData::hack_last_tokens() {
     tokens.back().type_ = tok_func_name;
   }
 
-  if (are_last_tokens(tok_func_name, except_token_tag<tok_oppar>{})) {
-    if (vk::any_of_equal(tokens[tokens.size() - 2].str_val, "exit", "die")) {
-      Token t = tokens.back();
-      tokens.pop_back();
-      tokens.emplace_back(tok_oppar);
-      tokens.emplace_back(tok_clpar);
-      tokens.push_back(t);
-      return;
-    }
-  }
-
-
   if (are_last_tokens(except_token_tag<tok_function>{}, tok_func_name, tok_oppar, any_token_tag{})) {
     if (tokens[tokens.size() - 3].str_val == "err") {
       Token t = tokens.back();

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -9,6 +9,11 @@ TEST(lexer_test, test_php_tokens) {
     std::vector<std::string> expected;
   };
   std::vector<testCase> tests = {
+    {"exit", {"tok_func_name(exit)"}},
+    {"exit()", {"tok_func_name(exit)", "tok_oppar(()", "tok_clpar())"}},
+    {"die", {"tok_func_name(die)"}},
+    {"die()", {"tok_func_name(die)", "tok_oppar(()", "tok_clpar())"}},
+
     {";", {"tok_semicolon(;)"}},
 
     {"'abc'", {"tok_str(abc)"}},
@@ -86,6 +91,6 @@ TEST(lexer_test, test_php_tokens) {
         return tok_str;
       });
 
-    ASSERT_EQ(expected, actual);
+    ASSERT_EQ(expected, actual) << "input was: " << test.input;
   }
 }

--- a/tests/phpt/phc/parsing/brackets.php
+++ b/tests/phpt/phc/parsing/brackets.php
@@ -32,6 +32,9 @@
 		exit();
 		#exit(1);
 
+		die;
+		die();
+
 		#$x = new C;
 		#$x = new C();
 		#$x = new C(0);

--- a/tests/phpt/phc/parsing/die.php
+++ b/tests/phpt/phc/parsing/die.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+die;
+die();
+die(0);


### PR DESCRIPTION
Instead of adding "(" and ")" to the tokens stream,
handle exit and die calls without "()" in GenTree.

The main benefit is that it'll be easier to implement
https://wiki.php.net/rfc/context_sensitive_lexer

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>