### PR TITLE
add `final` specifier to vertex classes if there are no derived

### DIFF
--- a/compiler/vertex-gen.py
+++ b/compiler/vertex-gen.py
@@ -54,11 +54,11 @@ def output_include_directive(f, name):
         f.write('#include "%s/vertex-%s.h"\n' % (REL_DIR, name))
 
 
-def output_class_header(f, base_name, name):
+def output_class_header(f, base_name, name, final_specifier=""):
     f.write("""
 template<>
-class vertex_inner<{name}> : public vertex_inner<{base_name}> {{
-public:""".format(name=name, base_name=base_name))
+class vertex_inner<{name}> {final_specifier}: public vertex_inner<{base_name}> {{
+public:""".format(name=name, base_name=base_name, final_specifier=final_specifier))
 
 
 def get_string_extra():
@@ -282,7 +282,12 @@ def output_vertex_type(type_data, data, schema):
                 if type_prop:
                     output_include_directive(f, type_prop)
 
-        output_class_header(f, base_name, name)
+        final_specifier = "final"
+        for v in data:
+            if "base_name" in v and type_data["name"] == v["base_name"]:
+                final_specifier = ""
+                break
+        output_class_header(f, base_name, name, final_specifier)
 
         output_extras(f, type_data)
         output_extra_fields(f, type_data)
@@ -322,7 +327,6 @@ def check_is_base(base, derived, data):
             if i["name"] == derived["base_name"]:
                 derived = i
                 break
-
 
 def output_vertex_is_base_of(data):
     with open_file("is-base-of.h") as f:


### PR DESCRIPTION
add final specifier to almost all vertices to avoid virtual call for `get_string` and similar methods