### PR TITLE
remove support for multiple main files

### DIFF
--- a/compiler/code-gen/files/global_vars_memory_stats.cpp
+++ b/compiler/code-gen/files/global_vars_memory_stats.cpp
@@ -13,8 +13,8 @@
 #include "compiler/data/vars-collector.h"
 #include "compiler/inferring/public.h"
 
-GlobalVarsMemoryStats::GlobalVarsMemoryStats(const std::vector<SrcFilePtr> &main_files) :
-  main_files_(main_files) {
+GlobalVarsMemoryStats::GlobalVarsMemoryStats(SrcFilePtr main_file) :
+  main_file_{main_file} {
 }
 
 void GlobalVarsMemoryStats::compile(CodeGenerator &W) const {
@@ -22,9 +22,7 @@ void GlobalVarsMemoryStats::compile(CodeGenerator &W) const {
     return vk::none_of_equal(tinf::get_type(global_var)->get_real_ptype(), tp_bool, tp_int, tp_float, tp_Unknown);
   }};
 
-  for (auto main_file: main_files_) {
-    vars_collector.collect_global_and_static_vars_from(main_file->main_function);
-  }
+  vars_collector.collect_global_and_static_vars_from(main_file_->main_function);
 
   auto global_var_parts = vars_collector.flush();
   size_t global_vars_count = 0;

--- a/compiler/code-gen/files/global_vars_memory_stats.h
+++ b/compiler/code-gen/files/global_vars_memory_stats.h
@@ -8,7 +8,7 @@
 #include "compiler/data/data_ptr.h"
 
 struct GlobalVarsMemoryStats {
-  explicit GlobalVarsMemoryStats(const std::vector<SrcFilePtr> &main_files);
+  explicit GlobalVarsMemoryStats(SrcFilePtr main_file);
 
   void compile(CodeGenerator &W) const;
 
@@ -16,5 +16,5 @@ private:
   void compile_getter_part(CodeGenerator &W, const std::set<VarPtr> &global_vars, size_t part_id) const;
 
   const std::string getter_name_{"get_global_vars_memory_stats_impl"};
-  std::vector<SrcFilePtr> main_files_;
+  SrcFilePtr main_file_;
 };

--- a/compiler/code-gen/files/init-scripts.h
+++ b/compiler/code-gen/files/init-scripts.h
@@ -10,8 +10,8 @@
 #include "compiler/data/data_ptr.h"
 
 struct InitScriptsCpp {
-  std::vector<SrcFilePtr> main_file_ids;
+  SrcFilePtr main_file_id;
   std::vector<FunctionPtr> all_functions;
-  InitScriptsCpp(std::vector<SrcFilePtr> &&main_file_ids, std::vector<FunctionPtr> &&all_functions);
+  InitScriptsCpp(SrcFilePtr main_file_id, std::vector<FunctionPtr> &&all_functions);
   void compile(CodeGenerator &W) const;
 };

--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -300,11 +300,13 @@ LibPtr CompilerCore::register_lib(LibPtr lib) {
 }
 
 void CompilerCore::register_main_file(const string &file_name, DataStream<SrcFilePtr> &os) {
+  kphp_assert(!main_file);
+
   SrcFilePtr res = register_file(file_name, LibPtr{});
   kphp_error (file_name.empty() || res, fmt_format("Cannot load main file [{}]", file_name));
 
   if (res && try_require_file(res)) {
-    main_files.push_back(res);
+    main_file = res;
     os << res;
   }
 }
@@ -443,8 +445,8 @@ VarPtr CompilerCore::create_local_var(FunctionPtr function, const string &name, 
   return var;
 }
 
-const vector<SrcFilePtr> &CompilerCore::get_main_files() {
-  return main_files;
+SrcFilePtr CompilerCore::get_main_file() {
+  return main_file;
 }
 
 vector<VarPtr> CompilerCore::get_global_vars() {

--- a/compiler/compiler-core.h
+++ b/compiler/compiler-core.h
@@ -28,7 +28,7 @@ private:
   TSHashTable<DefinePtr> defines_ht;
   TSHashTable<VarPtr> global_vars_ht;
   TSHashTable<LibPtr> libs_ht;
-  vector<SrcFilePtr> main_files;
+  SrcFilePtr main_file;
   CompilerSettings *settings_;
   ComposerClassLoader composer_class_loader;
   TSHashTable<ClassPtr> classes_ht;
@@ -85,7 +85,7 @@ public:
   VarPtr get_global_var(const string &name, VarData::Type type, VertexPtr init_val, bool *is_new_inserted = nullptr);
   VarPtr create_local_var(FunctionPtr function, const string &name, VarData::Type type);
 
-  const vector<SrcFilePtr> &get_main_files();
+  SrcFilePtr get_main_file();
   vector<VarPtr> get_global_vars();
   vector<ClassPtr> get_classes();
   vector<DefinePtr> get_defines();

--- a/compiler/compiler-settings.h
+++ b/compiler/compiler-settings.h
@@ -91,7 +91,7 @@ public:
     colored
   };
 
-  KphpOption<std::vector<std::string>> main_files;
+  KphpOption<std::string> main_file;
 
   KphpOption<uint64_t> verbosity;
 

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -194,9 +194,8 @@ bool compiler_execute(CompilerSettings *settings) {
 
   DataStream<SrcFilePtr> src_file_stream;
 
-  for (const auto &main_file : settings->main_files.get()) {
-    G->register_main_file(main_file, src_file_stream);
-  }
+  G->register_main_file(settings->main_file.get(), src_file_stream);
+
   if (!G->settings().functions_file.get().empty()) {
     G->require_file(G->settings().functions_file.get(), LibPtr{}, src_file_stream);
   }

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -98,9 +98,12 @@ public:
       usage_and_exit();
     }
 
-    for (; optind < argc; ++optind) {
-      other_options_->set_option_arg_value(argv[optind]);
+    int num_optargs = argc - optind;
+    if (num_optargs != 1) {
+      printf("error: expected exactly 1 positional argument: main PHP file\n");
+      usage_and_exit();
     }
+    other_options_->set_option_arg_value(argv[optind]);
 
     finalize();
   }
@@ -204,7 +207,7 @@ int main(int argc, char *argv[]) {
 
   OptionParser::add_default_options();
   auto &parser = OptionParser::get_instance();
-  parser.add_other_args("<main-files-list>", settings->main_files);
+  parser.add_other_args("<main-file>", settings->main_file);
   parser.add("Verbosity", settings->verbosity,
              'v', "verbosity", "KPHP_VERBOSITY", "0", {"0", "1", "2", "3"});
   parser.add("Path to kphp source", settings->kphp_src_path,

--- a/compiler/pipes/calc-bad-vars.cpp
+++ b/compiler/pipes/calc-bad-vars.cpp
@@ -243,9 +243,7 @@ private:
       return;
     }
 
-    auto &main_files = G->get_main_files();
-    kphp_assert(main_files.size() == 1u);
-    auto &main_dep = main_files.back()->main_function->dep;
+    auto &main_dep = G->get_main_file()->main_function->dep;
     for (int i = 0; i < call_graph.n; i++) {
       FunctionPtr fun = call_graph.functions[i];
       if (fun->kphp_lib_export) {

--- a/compiler/pipes/filter-only-actually-used.cpp
+++ b/compiler/pipes/filter-only-actually-used.cpp
@@ -147,9 +147,8 @@ void remove_unused_class_methods(const std::vector<FunctionAndEdges> &all, const
 
 void FilterOnlyActuallyUsedFunctionsF::on_finish(DataStream<FunctionPtr> &os) {
   if (G->settings().profiler_level.get() == 2) {
-    for (const auto &main_file : G->get_main_files()) {
-      main_file->main_function->profiler_state = FunctionData::profiler_status::enable_as_root;
-    }
+    auto main_file = G->get_main_file();
+    main_file->main_function->profiler_state = FunctionData::profiler_status::enable_as_root;
   }
 
   auto all = tmp_stream.flush_as_vector();

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -92,9 +92,7 @@ void mark_global_vars_for_memory_stats() {
     tinf::get_type(variable)->get_all_class_types_inside(classes_inside);
     return false;
   }};
-  for (const auto &main_file : G->get_main_files()) {
-    vars_collector.collect_global_and_static_vars_from(main_file->main_function);
-  }
+  vars_collector.collect_global_and_static_vars_from(G->get_main_file()->main_function);
   for (auto klass: classes_inside) {
     klass->deeply_require_instance_memory_estimate_visitor();
   }

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -400,7 +400,7 @@ void php_worker_init_script(php_worker *worker) {
   //init memory allocator for queries
   php_queries_start();
 
-  script_t *script = get_script("#0");
+  script_t *script = get_script();
   dl_assert (script != nullptr, "failed to get script");
   if (php_script == nullptr) {
     php_script = php_script_create((size_t)max_memory, (size_t)(8 << 20));

--- a/server/php-script.cpp
+++ b/server/php-script.cpp
@@ -4,32 +4,12 @@
 
 #include "server/php-script.h"
 
-#include <cassert>
-#include <cstring>
-#include <map>
-#include <string>
+static script_t* main_script;
 
-#include "common/dl-utils-lite.h"
-
-static std::map<std::string, script_t *> scripts;
-
-script_t *get_script(const char *name) {
-  auto i = scripts.find(name);
-
-  if (i != scripts.end()) {
-    return i->second;
-  }
-
-  return nullptr;
+script_t *get_script() {
+  return main_script;
 }
 
-void set_script(const char *name, void (*run)(), void (*clear)()) {
-  static int cnt = 0;
-
-  auto script = new script_t{run, clear};
-  bool inserted __attribute__((unused)) = scripts.insert({name, script}).second;
-  assert(inserted);
-
-  inserted = scripts.insert({"#" + std::to_string(cnt++), script}).second;
-  assert(inserted);
+void set_script(void (*run)(), void (*clear)()) {
+  main_script = new script_t{run, clear};
 }

--- a/server/php-script.h
+++ b/server/php-script.h
@@ -12,8 +12,8 @@ struct script_t {
   void (*clear)();
 };
 
-script_t *get_script(const char *name);
-void set_script(const char *name, void (*run)(), void (*clear)());
+script_t *get_script();
+void set_script(void (*run)(), void (*clear)());
 
 /** script result **/
 


### PR DESCRIPTION
	usage: kphp <main-files>
	=>
	usage: kphp <main-file>

Supporting multiple main files doesn't seem to be useful
and it complicates code in some places where we need to
keep in mind that there could be several main files
although only the first one has real meaning.

Giving multiple positional arg to kphp command will result in an error:

	Expected exactly 1 positional argument: main PHP file

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>