### PR TITLE
permit FQN forms for the global function names

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 
 #include "common/algorithms/find.h"
+#include "common/algorithms/contains.h"
 #include "common/type_traits/constexpr_if.h"
 
 #include "common/php-functions.h"
@@ -539,7 +540,17 @@ VertexPtr GenTree::get_expr_top(bool was_arrow) {
         break;
       }
       cur--;
-      res = get_func_call<op_func_call, op_none>();
+
+      // we don't support namespaces for functions yet, but we
+      // permit \func() syntax and interpret it as func();
+      // this logic is compatible with what we'll get after the
+      // function namespaces will be implemented
+      auto func_call = get_func_call<op_func_call, op_none>();
+      if (func_call->str_val[0] == '\\' && !vk::contains(func_call->str_val, "::")) {
+        func_call->str_val.erase(0, 1);
+      }
+
+      res = func_call;
       return_flag = was_arrow;
       break;
     }

--- a/tests/phpt/func_namespaces/fqn_simple.php
+++ b/tests/phpt/func_namespaces/fqn_simple.php
@@ -1,0 +1,10 @@
+@ok
+<?php
+
+function f() { return 500; }
+
+var_dump(\count([1]));
+var_dump(\f());
+
+var_dump(count([1]));
+var_dump(f());

--- a/tests/phpt/func_namespaces/fqn_static_method.php
+++ b/tests/phpt/func_namespaces/fqn_static_method.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+require __DIR__ . '/include/Utils/Foo.php';
+require __DIR__ . '/include/Foo.php';
+
+use VK\Utils;
+
+class Foo {
+  public static function f() { var_dump('f()'); }
+}
+
+\Foo::f();
+var_dump(\VK\Utils\Foo::f());
+var_dump(\Utils\Foo::f());
+var_dump(VK\Utils\Foo::f());
+var_dump(Utils\Foo::f());

--- a/tests/phpt/func_namespaces/fqn_undefined_error.php
+++ b/tests/phpt/func_namespaces/fqn_undefined_error.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/Unknown function g/
+/Unknown function f/
+/Unknown function A\\B\\f()/
+<?php
+
+var_dump(\g());
+var_dump(\f());
+var_dump(\A\B\f());

--- a/tests/phpt/func_namespaces/include/Foo.php
+++ b/tests/phpt/func_namespaces/include/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace VK\Utils;
+
+class Foo {
+  public static function f() { return 1; }
+}

--- a/tests/phpt/func_namespaces/include/Utils/Foo.php
+++ b/tests/phpt/func_namespaces/include/Utils/Foo.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Utils;
+
+class Foo {
+  public static function f() { return 2; }
+}


### PR DESCRIPTION
Since FQN names always resolve to the name without leading '\',
we can start with this and implement real function namespaces
support later (https://www.php.net/manual/en/language.namespaces.rules.php).

This change makes it possible to compile PHP projects that refer
to global functions using full qualified names.
Here is an example: https://github.com/symfony/polyfill-ctype/blob/main/Ctype.php#L36