### PR TITLE
forbid mixing classes with primitives as arguments when type_help is …

### DIFF
--- a/compiler/const-manipulations.h
+++ b/compiler/const-manipulations.h
@@ -66,6 +66,7 @@ protected:
       case op_conv_object:
       case op_conv_bool:
       case op_conv_mixed:
+      case op_force_mixed:
       case op_conv_uint:
       case op_conv_long:
       case op_conv_ulong:

--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -166,7 +166,6 @@ std::string debugTokenName(TokenType t) {
     {tok_conv_array, "tok_conv_array"},
     {tok_conv_object, "tok_conv_object"},
     {tok_conv_bool, "tok_conv_bool"},
-    {tok_conv_var, "tok_conv_var"},
     {tok_false, "tok_false"},
     {tok_true, "tok_true"},
     {tok_define, "tok_define"},

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -924,7 +924,6 @@ VertexPtr GenTree::conv_to(VertexPtr x, PrimitiveType tp, bool ref_flag) {
         return conv_to_lval<tp_string>(x);
       case tp_mixed:
         return x;
-        break;
       default:
         kphp_error (0, "convert_to supports only var, array, string or int with ref_flag");
         return x;
@@ -949,6 +948,8 @@ VertexPtr GenTree::conv_to(VertexPtr x, PrimitiveType tp, bool ref_flag) {
       return conv_to<tp_ULong>(x);
     case tp_regexp:
       return conv_to<tp_regexp>(x);
+    case tp_mixed:
+      return conv_to<tp_mixed>(x);
     default:
       return x;
   }

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -232,6 +232,9 @@ VertexPtr GenTree::conv_to(VertexPtr x) {
     case tp_regexp:
       return VertexAdaptor<op_conv_regexp>::create(x).set_location(x);
 
+    case tp_mixed:
+      return VertexAdaptor<op_conv_mixed>::create(x).set_location(x);
+
     default:
       return x;
   }

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -579,6 +579,11 @@ void ExprNodeRecalc::recalc_expr(VertexPtr expr) {
       break;
 
     case op_conv_mixed:
+      // we don't want to spoil types and need this vertex just for further checks
+      recalc_expr(expr.as<op_conv_mixed>()->expr());
+      break;
+
+    case op_force_mixed:
       recalc_ptype<tp_mixed>();
       break;
 

--- a/compiler/inferring/type-data.cpp
+++ b/compiler/inferring/type-data.cpp
@@ -388,6 +388,13 @@ TypeData::lookup_iterator TypeData::lookup_end() const {
   return subkeys_values.end();
 }
 
+const TypeData *TypeData::get_deepest_type_of_array() const {
+  if (ptype() == tp_array) {
+    return lookup_at(Key::any_key())->get_deepest_type_of_array();
+  }
+  return this;
+}
+
 void TypeData::set_lca(const TypeData *rhs, bool save_or_false, bool save_or_null) {
   if (rhs == nullptr) {
     return;

--- a/compiler/inferring/type-data.h
+++ b/compiler/inferring/type-data.h
@@ -148,6 +148,8 @@ public:
   lookup_iterator lookup_begin() const;
   lookup_iterator lookup_end() const;
 
+  const TypeData *get_deepest_type_of_array() const;
+
   const TypeData *const_read_at(const Key &key) const;
   const TypeData *const_read_at(const MultiKey &multi_key) const;
   void set_lca(const TypeData *rhs, bool save_or_false = true, bool save_or_null = true);

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -140,8 +140,7 @@ void LexerData::hack_last_tokens() {
     {tok_string, tok_conv_string},
     {tok_array,  tok_conv_array},
     {tok_object, tok_conv_object},
-    {tok_bool,   tok_conv_bool},
-    {tok_var,    tok_conv_var},
+    {tok_bool,   tok_conv_bool}
   };
 
   auto remove_last_tokens = [this](size_t cnt) {

--- a/compiler/operation.cpp
+++ b/compiler/operation.cpp
@@ -132,7 +132,6 @@ void OpInfo::init_static() {
   add_unary_op(curP, tok_conv_array, op_conv_array);
   add_unary_op(curP, tok_conv_object, op_conv_object);
   add_unary_op(curP, tok_conv_bool, op_conv_bool);
-  add_unary_op(curP, tok_conv_var, op_conv_mixed);
   add_unary_op(curP, tok_at, op_noerr);
   ++curP;
 

--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -359,7 +359,12 @@ void CFG::create_condition_cfg(VertexPtr tree_node, Node *res_start, Node *res_t
       if (auto call = tree_node.try_as<op_func_call>()) {
         is_func_id_t type = get_ifi_id(tree_node);
         if (type != ifi_error) {
-          if (auto var = call->args()[0].try_as<op_var>()) {
+          auto var = call->args()[0].try_as<op_var>();
+          if (auto mixed_conv = call->args()[0].try_as<op_conv_mixed>()) {
+            // we're going to analyze internal var, instead of fake cast to mixed
+            var = mixed_conv->expr().try_as<op_var>();
+          }
+          if (var) {
             is_func_id_t true_type{};
             if (type == ifi_is_bool) {
               true_type = static_cast<is_func_id_t>(ifi_is_bool | ifi_is_false);
@@ -903,6 +908,7 @@ void CFG::create_cfg(VertexPtr tree_node, Node *res_start, Node *res_finish, boo
     case op_conv_array_l:
     case op_conv_object:
     case op_conv_mixed:
+    case op_force_mixed:
     case op_conv_uint:
     case op_conv_long:
     case op_conv_ulong:

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -209,14 +209,13 @@ VertexPtr OptimizationPass::remove_extra_conversions(VertexPtr root) {
         res = expr;
       } else if (root->type() == op_conv_ulong && tp->ptype() == tp_ULong) {
         res = expr;
-      } else if (root->type() == op_conv_mixed) {
-        if (tp->ptype() == tp_void) {
+      } else if (root->type() == op_force_mixed && tp->ptype() == tp_void) {
           expr->rl_type = val_none;
           res = VertexAdaptor<op_seq_rval>::create(expr, VertexAdaptor<op_null>::create());
-        } else if (type_lca(tp->ptype(), tp_mixed) == tp_mixed) {
-          res = expr;
-        }
       }
+    }
+    if (root->type() == op_conv_mixed) {
+      res = expr;
     }
     if (root->type() == op_conv_drop_null){
       if (!tp->can_store_null()) {

--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -94,7 +94,7 @@ public:
           current_function->type == FunctionData::func_switch ||
           current_function->disabled_warnings.count("return")) {
         if (return_op->has_expr()) {
-          return VertexAdaptor<op_return>::create(VertexAdaptor<op_conv_mixed>::create(return_op->expr()));
+          return VertexAdaptor<op_return>::create(VertexAdaptor<op_force_mixed>::create(return_op->expr()));
         } else {
           return VertexAdaptor<op_return>::create(VertexAdaptor<op_null>::create());
         }

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -156,7 +156,6 @@ enum TokenType {
   tok_conv_array,
   tok_conv_object,
   tok_conv_bool,
-  tok_conv_var,
 
   tok_false,
   tok_true,

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -1569,7 +1569,7 @@
     }
   },
   {
-    "comment": "(var)expr()",
+    "comment": "fake vertex we need it to forbid casts of classes to mixed in context of internal functions(from functions.txt)",
     "name": "op_conv_mixed",
     "base_name": "meta_op_unary",
     "props": {
@@ -1578,6 +1578,11 @@
       "type": "conv_op",
       "str": "mixed"
     }
+  },
+  {
+    "comment": "converts expression to mixed as (mixed) $x, used only for returns of global switches/main functions/disable return warning",
+    "name": "op_force_mixed",
+    "base_name": "op_conv_mixed"
   },
   {
     "comment": "artificial op that converts expr() to tp_UInt",

--- a/functions.txt
+++ b/functions.txt
@@ -21,16 +21,16 @@ class Exception {
 interface Memcache {
     public function get ($key) ::: mixed;
     public function delete ($key ::: string) ::: bool;
-    public function add ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function set ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function replace ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function decrement ($key ::: string, $v ::: any = 1) ::: mixed;
-    public function increment ($key ::: string, $v ::: any = 1) ::: mixed;
+    public function add ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function set ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function replace ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function decrement ($key ::: string, $v ::: mixed = 1) ::: mixed;
+    public function increment ($key ::: string, $v ::: mixed = 1) ::: mixed;
     public function getVersion () ::: mixed;
 
     // this two functions shouldn't be there, but we need it to rewrite code
     public function addServer ($host ::: string, $port ::: int = 11211, $persistent ::: bool = true, $weight ::: int = 1, $timeout ::: float = 1, $retry_interval ::: int = 15, $status ::: bool = true, $failure_callback ::: mixed = null, $timeoutms ::: int = 0) ::: bool;
-    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: any = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
+    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: mixed = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
 }
 
 
@@ -39,15 +39,15 @@ class McMemcache implements Memcache {
 
     public function get ($key) ::: mixed;
     public function delete ($key ::: string) ::: bool;
-    public function add ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function set ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function replace ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int  = 0) ::: bool;
-    public function decrement ($key ::: string, $v ::: any = 1) ::: mixed;
-    public function increment ($key ::: string, $v ::: any = 1) ::: mixed;
+    public function add ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function set ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function replace ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int  = 0) ::: bool;
+    public function decrement ($key ::: string, $v ::: mixed = 1) ::: mixed;
+    public function increment ($key ::: string, $v ::: mixed = 1) ::: mixed;
     public function getVersion () ::: mixed;
     public function addServer ($host ::: string, $port ::: int = 11211, $persistent ::: bool = true, $weight ::: int = 1, $timeout ::: float = 1, $retry_interval ::: int = 15, $status ::: bool = true, $failure_callback ::: mixed = null, $timeoutms ::: int = 0) ::: bool;
 
-    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: any = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
+    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: mixed = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
 }
 
 class RpcMemcache implements Memcache {
@@ -55,14 +55,14 @@ class RpcMemcache implements Memcache {
 
     public function get ($key) ::: mixed;
     public function delete ($key ::: string) ::: bool;
-    public function add ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function set ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
-    public function replace ($key ::: string, $value ::: any, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function add ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function set ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
+    public function replace ($key ::: string, $value ::: mixed, $flags ::: int = 0, $expire ::: int = 0) ::: bool;
     public function decrement ($key ::: string, $v ::: int = 1) ::: mixed;
     public function increment ($key ::: string, $v ::: int = 1) ::: mixed;
 
     public function getVersion () ::: mixed;
-    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: any = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
+    public function rpc_connect ($host ::: string, $port ::: int, $default_actor_id ::: mixed = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: bool;
 
     public function addServer ($host ::: string, $port ::: int = 11211, $persistent ::: bool = true, $weight ::: int = 1, $timeout ::: float = 1, $retry_interval ::: int = 15, $status ::: bool = true, $failure_callback ::: mixed = null, $timeoutms ::: int = 0) ::: bool;
 }
@@ -250,19 +250,19 @@ function count ($val ::: any) ::: int;
 function sizeof ($val ::: any) ::: int;
 function gettype ($v ::: any) ::: string;
 function is_scalar ($v ::: any) ::: bool;
-function is_numeric ($v ::: any) ::: bool;
+function is_numeric ($v ::: mixed) ::: bool;
 function is_null ($v ::: any) ::: bool;
-function is_bool ($v ::: any) ::: bool;
-function is_int ($v ::: any) ::: bool;
-function is_integer ($v ::: any) ::: bool;
-function is_long ($v ::: any) ::: bool;
+function is_bool ($v ::: mixed) ::: bool;
+function is_int ($v ::: mixed) ::: bool;
+function is_integer ($v ::: mixed) ::: bool;
+function is_long ($v ::: mixed) ::: bool;
 function is_finite ($v ::: float) ::: bool;
 function is_infinite ($v ::: float) ::: bool;
 function is_nan ($v ::: float) ::: bool;
-function is_float ($v ::: any) ::: bool;
-function is_double ($v ::: any) ::: bool;
-function is_real ($v ::: any) ::: bool;
-function is_string ($v ::: any) ::: bool;
+function is_float ($v ::: mixed) ::: bool;
+function is_double ($v ::: mixed) ::: bool;
+function is_real ($v ::: mixed) ::: bool;
+function is_string ($v ::: mixed) ::: bool;
 function is_array ($v ::: any) ::: bool;
 function is_object ($v ::: any) ::: bool;
 function get_class ($v ::: any) ::: string;
@@ -315,10 +315,10 @@ define('JSON_UNESCAPED_UNICODE', 1);
 define('JSON_FORCE_OBJECT', 16);
 define('JSON_PARTIAL_OUTPUT_ON_ERROR', 512);
 
-function serialize ($v ::: any) ::: string;
+function serialize($v ::: mixed) ::: string;
 /** @kphp-pure-function */
 function unserialize ($v ::: string) ::: mixed;
-function json_encode ($v ::: any, $options ::: int = 0) ::: string | false;
+function json_encode ($v ::: mixed, $options ::: int = 0) ::: string | false;
 function json_decode ($v ::: string, $assoc ::: bool = false) ::: mixed;
 
 function msgpack_serialize($v ::: mixed) ::: string | null;
@@ -469,7 +469,7 @@ function parse_url ($str ::: string, $component ::: int = -1) ::: mixed;
 define('M_PI', 3.1415926535897932384626433832795);
 
 /** @kphp-pure-function */
-function abs ($v ::: any) ::: ^1 | int;
+function abs ($v ::: mixed) ::: ^1 | int;
 /** @kphp-pure-function */
 function acos ($v ::: float) ::: float;
 /** @kphp-pure-function */
@@ -642,7 +642,7 @@ function mysqli_connect($host ::: string, $username ::: string, $password ::: st
 function mysqli_select_db($dn :<=: \mysqli, $name ::: string) ::: bool;
 
 
-function function_exists ($func_name ::: any) ::: bool;
+function function_exists ($func_name ::: mixed) ::: bool;
 
 define('FILE_APPEND', 1);
 
@@ -697,9 +697,9 @@ function new_RpcMemcache($fake ::: bool = false) ::: Memcache;
 function vk_utf8_to_win ($text ::: string, $max_len ::: int = 0, $exit_on_error ::: bool = false) ::: string;
 function vk_win_to_utf8 ($text ::: string, $escape ::: bool = true) ::: string;
 function vk_flex ($name ::: string, $case_name ::: string, $sex ::: int, $type ::: string, $lang_id ::: int = 0) ::: string;
-function vk_json_encode ($v ::: any) ::: string | false;
+function vk_json_encode ($v ::: mixed) ::: string | false;
 /** @kphp-extern-func-info can_throw */
-function vk_json_encode_safe ($v ::: any) ::: string;
+function vk_json_encode_safe ($v ::: mixed) ::: string;
 function vk_whitespace_pack ($str ::: string, $html_opt ::: bool = false) ::: string;
 function vk_sp_simplify ($str ::: string) ::: string;
 function vk_sp_full_simplify ($str ::: string) ::: string;
@@ -772,19 +772,19 @@ class RpcConnection {
 }
 
 /** rpc store **/
-function new_rpc_connection ($str ::: string, $port ::: int, $default_actor_id ::: any = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: \RpcConnection;
+function new_rpc_connection ($str ::: string, $port ::: int, $default_actor_id ::: mixed = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: \RpcConnection;
 function store_gzip_pack_threshold ($pack_threshold_bytes ::: int) ::: void;
 function store_start_gzip_pack() ::: void;
 function store_finish_gzip_pack ($pack_threshold_bytes ::: int) ::: void;
 function rpc_clean() ::: bool;
-function store_header ($actor_id ::: any, $flags ::: int = 0) ::: bool;
+function store_header ($actor_id ::: mixed, $flags ::: int = 0) ::: bool;
 function store_error ($error_code ::: int, $error_text ::: string) ::: bool;
 function store_raw ($v ::: string) ::: bool;
 function set_fail_rpc_on_int32_overflow ($fail_rpc ::: bool) ::: bool;
 function store_int ($v ::: int) ::: bool;
-function store_unsigned_int ($v ::: any) ::: bool;
+function store_unsigned_int ($v ::: mixed) ::: bool;
 function store_long ($v ::: int) ::: bool;
-function store_unsigned_long ($v ::: any) ::: bool;
+function store_unsigned_long ($v ::: mixed) ::: bool;
 function store_unsigned_int_hex ($v ::: string) ::: bool;
 function store_unsigned_long_hex ($v ::: string) ::: bool;
 function store_double ($v ::: float) ::: bool;
@@ -800,8 +800,8 @@ function rpc_get ($request_id ::: int) ::: string | false;
 function rpc_get_synchronously ($request_id ::: int) ::: string | false;
 /** @kphp-extern-func-info resumable */
 function rpc_get_and_parse ($request_id ::: int) ::: bool;
-function rpc_queue_create ($request_ids ::: any = TODO) ::: int;
-function rpc_queue_push ($queue_id ::: int, $request_ids ::: any) ::: int;
+function rpc_queue_create ($request_ids ::: mixed = TODO) ::: int;
+function rpc_queue_push ($queue_id ::: int, $request_ids ::: mixed) ::: int;
 function rpc_queue_empty ($queue_id ::: int) ::: bool;
 /** @kphp-extern-func-info resumable */
 function rpc_queue_next ($queue_id ::: int, $timeout ::: float = -1.0) ::: int | false;
@@ -814,7 +814,7 @@ function rpc_wait_concurrently ($request_id ::: int) ::: bool;
 /** @kphp-extern-func-info can_throw */
 function rpc_mc_parse_raw_wildcard_with_flags_to_array ($raw_result ::: string, &$result ::: array) ::: bool;
 
-function rpc_tl_query_one ($rpc_conn :<=: \RpcConnection, $arr ::: any, $timeout ::: float = -1.0) ::: int;
+function rpc_tl_query_one ($rpc_conn :<=: \RpcConnection, $arr ::: mixed, $timeout ::: float = -1.0) ::: int;
 function rpc_tl_query ($rpc_conn :<=: \RpcConnection, $arr ::: array, $timeout ::: float = -1.0, $ignore_answer ::: bool = false) ::: int[];
 /** @kphp-extern-func-info resumable */
 function rpc_tl_query_result_one ($query_id ::: int) ::: mixed[];
@@ -868,7 +868,7 @@ function wait_multi ($resumables :<=: future(any)[]) ::: (^1[*][*] | null)[];
 /** @kphp-extern-func-info can_throw cpp_template_call */
 function wait_synchronously ($id :<=: future(any) | false) ::: ^1[*] | null;
 /** @kphp-extern-func-info resumable */
-function wait_concurrently ($id ::: any) ::: bool;
+function wait_concurrently ($id ::: future<any>) ::: bool;
 function wait_queue_create ($request_ids :<=: array< future<any> | false > = []) ::: future_queue<^1[*][*]>;
 function wait_queue_push (&$queue_id :<=: future_queue<any>, $request_ids :<=: future<any> | false) ::: void;
 function wait_queue_empty ($queue_id :<=: future_queue<any>) ::: bool;
@@ -890,12 +890,12 @@ function query_x2 ($x ::: int) ::: int;
  * as function calls they are replaced by builtins anyway
  **/
 function boolval ($v ::: any) ::: bool;
-function intval ($v ::: any) ::: int;
-function floatval ($v ::: any) ::: float;
-function strval ($v ::: any) ::: string;
-function uintval ($v ::: any) ::: UInt;
-function longval ($v ::: any) ::: Long;
-function ulongval ($v ::: any) ::: ULong;
+function intval ($v ::: mixed) ::: int;
+function floatval ($v ::: mixed) ::: float;
+function strval ($v ::: mixed) ::: string;
+function uintval ($v ::: mixed) ::: UInt;
+function longval ($v ::: mixed) ::: Long;
+function ulongval ($v ::: mixed) ::: ULong;
 
 /** files **/
 define('STDIN', 'php://stdin');

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -66,9 +66,6 @@ TEST(lexer_test, test_php_tokens) {
     // strings: simple syntax doesn't support indexing of the accessed instance member
     {R"("$x->y[0]")", {"tok_str_begin(\")", "tok_expr_begin", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end", "tok_str([0])", "tok_str_end(\")"}},
 
-    // TODO: shouldn't it be (mixed)$x? It's converted to op_conv_mixed
-    {"(var)$x", {"tok_conv_var", "tok_var_name($x)"}},
-
     {"[1]", {"tok_opbrk([)", "tok_int_const(1)", "tok_clbrk(])"}},
     {"array(1)", {"tok_array(array)", "tok_oppar(()", "tok_int_const(1)", "tok_clpar())"}},
 

--- a/tests/phpt/cl/177_fail_mix_classes_with_mixed_check.php
+++ b/tests/phpt/cl/177_fail_mix_classes_with_mixed_check.php
@@ -1,0 +1,7 @@
+@kphp_should_fail
+/conversion from A to mixed is forbidden/
+<?php
+
+class A { public $x = 10; }
+$as = [new A()];
+json_encode($as);

--- a/tests/phpt/cl/178_fail_pass_class_to_hll_stats.php
+++ b/tests/phpt/cl/178_fail_pass_class_to_hll_stats.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/conversion from A to mixed is forbidden/
+<?php
+class A {}
+function demo() {
+  var_dump(vk_stats_hll_merge(new A));
+}
+demo();


### PR DESCRIPTION
detect the passing of instances and compound from them types to internal functions with `mixed` type-cast.