### PR TITLE
fix 'too much'/'not enough' argument number errors messages for methods

### DIFF
--- a/compiler/pipes/check-function-calls.cpp
+++ b/compiler/pipes/check-function-calls.cpp
@@ -28,12 +28,16 @@ void CheckFunctionCallsPass::check_func_call(VertexPtr call) {
   VertexRange func_params = f->get_params();
   VertexRange call_params = call.as<op_func_call>()->args();
 
+  auto actual_params_n = [f](int n) {
+    // instance methods always have implicit $this param which we don't want to mention
+    return f->modifiers.is_instance() ? n - 1 : n;
+  };
+
   int func_params_n = static_cast<int>(func_params.size());
   int call_params_n = static_cast<int>(call_params.size());
-
   kphp_error_return(call_params_n >= f->get_min_argn(),
                     fmt_format("Not enough arguments in function call [{} : {}] [found {}] [expected at least {}]",
-                            f->file_id->file_name, f->get_human_readable_name(), call_params_n, f->get_min_argn())
+                            f->file_id->file_name, f->get_human_readable_name(), actual_params_n(call_params_n), actual_params_n(f->get_min_argn()))
   );
 
   kphp_error(call_params.begin() == call_params.end() || call_params[0]->type() != op_varg,
@@ -42,7 +46,7 @@ void CheckFunctionCallsPass::check_func_call(VertexPtr call) {
 
   kphp_error_return(func_params_n >= call_params_n,
                     fmt_format("Too much arguments in function call [{} : {}] [found {}] [expected {}]",
-                               f->file_id->file_name, f->get_human_readable_name(), call_params_n, func_params_n)
+                               f->file_id->file_name, f->get_human_readable_name(), actual_params_n(call_params_n), actual_params_n(func_params_n))
   );
 
   for (int i = 0; i < call_params.size(); i++) {

--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -247,11 +247,20 @@ private:
     const std::vector<VertexPtr> &cur_call_args = call->get_next();
     auto positional_args_start = cur_call_args.begin();
 
+    int min_args = func_args_n - 1; // variadic param may accept 0 args, so subtract 1
+    int explicit_args = call_args_n;
+    if (func->modifiers.is_instance()) {
+      // subtract the implicit $this argument
+      --min_args;
+      --explicit_args;
+    }
+
     auto variadic_args_start = positional_args_start;
     kphp_assert(func_args_n > 0);
 
     kphp_error_act(func_args_n - 1 <= call_args_n,
-                   fmt_format("function takes: {} arguments; passed only {}", func_args_n, call_args_n),
+                   fmt_format("Not enough arguments in function call [{} : {}] [found {}] [expected at least {}]",
+                              func->file_id->file_name, func->get_human_readable_name(), explicit_args, min_args),
                    return {});
     std::advance(variadic_args_start, func_args_n - 1);
 

--- a/tests/phpt/errors/006_method_params_n.php
+++ b/tests/phpt/errors/006_method_params_n.php
@@ -1,0 +1,33 @@
+@kphp_should_fail
+/Not enough arguments.*?Test::f_min1_max1\] \[found 0\] \[expected at least 1\]/
+/Not enough arguments.*?Test::f_min3_max4\] \[found 1\] \[expected at least 3\]/
+/Not enough arguments.*?Test::sf_min1_max1\] \[found 0\] \[expected at least 1\]/
+/Too much arguments.*?Test::f_min0_max0\] \[found 3\] \[expected 0\]/
+/Too much arguments.*?Test::f_min1_max1\] \[found 2\] \[expected 1\]/
+/Too much arguments.*?Test::f_min3_max4\] \[found 5\] \[expected 4\]/
+/Too much arguments.*?Test::sf_min0_max0\] \[found 2\] \[expected 0\]/
+<?php
+
+class Test {
+  public function f_min0_max0() { var_dump(__METHOD__); }
+  public function f_min1_max1($x) { var_dump(__METHOD__); }
+  public function f_min3_max4($x, $y, $z, $optional = 10) { var_dump(__METHOD__); }
+
+  public static function sf_min0_max0() { var_dump(__METHOD__); }
+  public static function sf_min1_max1($x) { var_dump(__METHOD__); }
+}
+
+$test = new Test();
+
+// less args than required
+
+$test->f_min1_max1();
+$test->f_min3_max4(1);
+Test::sf_min1_max1();
+
+// more args than allowed
+
+$test->f_min0_max0(1, 2, 3);
+$test->f_min1_max1(1, 2);
+$test->f_min3_max4(1, 2, 3, 4, 5);
+Test::sf_min0_max0(1, 2);

--- a/tests/phpt/errors/007_method_params_n_variadic.php
+++ b/tests/phpt/errors/007_method_params_n_variadic.php
@@ -1,0 +1,26 @@
+@kphp_should_fail
+/Not enough arguments.*?Test::f_min1_maxn\] \[found 0\] \[expected at least 1\]/
+/Not enough arguments.*?Test::f_min3_maxn\] \[found 2\] \[expected at least 3\]/
+/Not enough arguments.*?Test::sf_min1_maxn\] \[found 0\] \[expected at least 1\]/
+/Not enough arguments.*?Test::sf_min4_maxn\] \[found 1\] \[expected at least 4\]/
+<?php
+
+// as variadic functions are preprocessed, error is given
+// during the different stage; hence the separate test file for them
+
+class Test {
+  public function f_min1_maxn($x, ...$rest) { var_dump(__METHOD__); }
+  public function f_min3_maxn($x, $y, $z, ...$rest) { var_dump(__METHOD__); }
+
+  public static function sf_min1_maxn($x, ...$rest) { var_dump(__METHOD__); }
+  public static function sf_min4_maxn($x, $y, $z, $_, ...$rest) { var_dump(__METHOD__); }
+}
+
+$test = new Test();
+
+// less args than required
+
+$test->f_min1_maxn();
+$test->f_min3_maxn(1, 2);
+Test::sf_min1_maxn();
+Test::sf_min4_maxn(1);


### PR DESCRIPTION
For instance methods we were reporting methods as receiving and expecting
as N+1 due to the implicit $this argument.

This example demonstrates the problem:

```php
	class Foo { public function f($x) {} }
	$foo = new Foo();
	$foo->f(); // error: not enough arguments [found 1] [expected at least 2]
```

Variadic arguments make it even more exciting:

```php
	class Bar { public function g($x, ...$y) {} }
	$bar = new Bar();
	$bar->g(); // error: function takes: 3 arguments; passed only 1
```

With this change, we report saner errors:

```php
	$foo->f(); // error: not enought arguments [found 0] [expected at least 1]
	$bar->g(); // error: not enought arguments [found 0] [expected at least 1]
```