### PR TITLE
fix race in resolving defines and checking defaults

### DIFF
--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -102,6 +102,7 @@ prepend(KPHP_COMPILER_PIPES_SOURCES pipes/
         calc-val-ref.cpp
         cfg-end.cpp
         cfg.cpp
+        check-abstract-function-defaults.cpp
         check-access-modifiers.cpp
         check-classes.cpp
         check-conversions.cpp

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -37,6 +37,7 @@
 #include "compiler/pipes/calc-val-ref.h"
 #include "compiler/pipes/cfg-end.h"
 #include "compiler/pipes/cfg.h"
+#include "compiler/pipes/check-abstract-function-defaults.h"
 #include "compiler/pipes/check-access-modifiers.h"
 #include "compiler/pipes/check-classes.h"
 #include "compiler/pipes/check-conversions.h"
@@ -237,6 +238,7 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PassC<InlineDefinesUsagesPass>{}
     >> PassC<PreprocessEq3Pass>{}
     >> SyncC<GenerateVirtualMethods>{}
+    >> PipeC<CheckAbstractFunctionDefaults>{}
     >> PassC<TransformToSmartInstanceof>{}
     // functions which were generated from templates
     // need to be preprocessed therefore we tie second output and input of Pipe

--- a/compiler/data/virtual-method-generator.cpp
+++ b/compiler/data/virtual-method-generator.cpp
@@ -79,26 +79,6 @@ bool check_that_signatures_are_same(FunctionPtr interface_function, ClassPtr con
     return false;
   }
 
-  auto get_string_repr = [] (VertexPtr v) {
-    auto param = v.try_as<op_func_param>();
-    kphp_assert(param);
-    if (!param->has_default_value()) {
-      return std::string{"NoDefault"};
-    }
-    return VertexPtrFormatter::to_string(param->default_value());
-  };
-
-  for (auto arg_id = interface_function->get_min_argn(); arg_id < i_argn; ++arg_id) {
-    auto interface_repr = get_string_repr(interface_params[arg_id]);
-    auto derived_repr = get_string_repr(derived_params[arg_id]);
-
-    kphp_error(interface_repr == derived_repr,
-      fmt_format("default value of interface parameter:`{}` may not differ from value of derived parameter: `{}`, in function: {}",
-                 TermStringFormat::paint(interface_repr, TermStringFormat::green),
-                 TermStringFormat::paint(derived_repr, TermStringFormat::green),
-                 TermStringFormat::paint(derived_method->get_human_readable_name(), TermStringFormat::red)));
-  }
-
   return true;
 }
 

--- a/compiler/pipes/check-abstract-function-defaults.cpp
+++ b/compiler/pipes/check-abstract-function-defaults.cpp
@@ -1,0 +1,49 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/pipes/check-abstract-function-defaults.h"
+
+#include "common/containers/final_action.h"
+#include "common/termformat/termformat.h"
+
+#include "compiler/data/class-data.h"
+#include "compiler/data/function-data.h"
+#include "compiler/pipes/calc-real-defines-values.h"
+
+void CheckAbstractFunctionDefaults::execute(FunctionPtr interface_function, DataStream<FunctionPtr> &os) {
+  stage::set_function(interface_function);
+  auto forward_function_next = vk::finally([&] { os << interface_function; });
+
+  if (!interface_function->modifiers.is_abstract()) {
+    return;
+  }
+
+  auto get_default = [](VertexPtr v) {
+    auto param = v.try_as<op_func_param>();
+    kphp_assert(param);
+    if (param->has_default_value()) {
+      return param->default_value();
+    }
+    return VertexPtr{};
+  };
+
+  auto interface_params = interface_function->get_params();
+  for (auto derived_class : interface_function->class_id->get_all_inheritors()) {
+    auto *derived_method = derived_class->members.get_instance_method(interface_function->local_name());
+    if (!derived_method || derived_method->function == interface_function) {
+      continue;
+    }
+    auto derived_params = derived_method->function->get_params();
+
+    for (auto arg_id = interface_function->get_min_argn(); arg_id < interface_params.size(); ++arg_id) {
+      auto derived_default = get_default(derived_params[arg_id]);
+      auto interface_default = get_default(interface_params[arg_id]);
+      kphp_error(Vertex::deep_equal(derived_default, interface_default),
+                 fmt_format("default value of interface parameter:`{}` may not differ from value of derived parameter: `{}`, in function: {}",
+                            TermStringFormat::paint(VertexPtrFormatter::to_string(interface_default), TermStringFormat::green),
+                            TermStringFormat::paint(VertexPtrFormatter::to_string(derived_default), TermStringFormat::green),
+                            TermStringFormat::paint(derived_method->function->get_human_readable_name(), TermStringFormat::red)));
+    }
+  }
+}

--- a/compiler/pipes/check-abstract-function-defaults.h
+++ b/compiler/pipes/check-abstract-function-defaults.h
@@ -1,0 +1,13 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "compiler/data/data_ptr.h"
+#include "compiler/threading/data-stream.h"
+
+class CheckAbstractFunctionDefaults {
+public:
+    void execute(FunctionPtr interface_function, DataStream<FunctionPtr> &os);
+};

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -208,6 +208,22 @@ public:
     return v;
   }
 
+    static bool deep_equal(VertexPtr lhs, VertexPtr rhs) {
+      if (lhs == rhs) {
+        return true;
+      }
+      if (!lhs || !rhs) {
+        return false;
+      }
+
+      auto get_string_def = [](VertexPtr v) {
+        return v->has_get_string() ? v->get_string() : "";
+      };
+
+      return lhs->type() == rhs->type() &&
+             get_string_def(lhs) == get_string_def(rhs) &&
+             std::equal(lhs->begin(), lhs->end(), rhs->begin(), rhs->end(), deep_equal);
+    }
 };
 
 using Vertex = vertex_inner<meta_op_base>;

--- a/tests/phpt/interfaces/015_default_in_derived_classes.php
+++ b/tests/phpt/interfaces/015_default_in_derived_classes.php
@@ -8,7 +8,42 @@ interface WithDefault2 {
      * @param int $x
      * @param int $y
      */
-    public function foo($x, $y = 10 + 10 * AB);
+    public function foo($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo2($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo12($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo22($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo3($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo32($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo312($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo322($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB);
 }
 
 class B implements WithDefault2 {
@@ -16,7 +51,42 @@ class B implements WithDefault2 {
      * @param int $x
      * @param int $y
      */
-    public function foo($x = 20, $y = 10 + 10 * AB) { var_dump($x, $y); }
+    public function foo($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo2($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo12($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo22($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo3($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo32($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo312($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
+    /**
+     * @param int $x
+     * @param int $y
+     */
+    public function foo322($x = 20, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) { var_dump($x, $y); }
 }
 
 class A implements WithDefault2 {
@@ -25,7 +95,63 @@ class A implements WithDefault2 {
      * @param int $y
      * @param int $z
      */
-    public function foo($x, $y = 10 + 10 * AB, $z = 10) {
+    public function foo($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo2($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo12($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo22($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo3($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo32($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo312($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
+        var_dump($x, $y, $z);
+    }
+    /**
+     * @param int $x
+     * @param int $y
+     * @param int $z
+     */
+    public function foo322($x, $y = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB, $z = AB + AB + AB * AB + AB + AB + AB + AB * AB + AB + AB + AB + AB * AB + AB * AB + AB + AB * AB + AB + AB + AB + AB * AB + AB) {
         var_dump($x, $y, $z);
     }
 }
@@ -36,6 +162,13 @@ $b->foo();
 /** @var WithDefault2 $a */
 $a = $b;
 $a->foo(1, 2);
+$a->foo2(1, 2);
+$a->foo12(1, 2);
+$a->foo22(1, 2);
+$a->foo3(1, 2);
+$a->foo32(1, 2);
+$a->foo312(1, 2);
+$a->foo322(1, 2);
 
 $a = new A();
 $a->foo(1, 2);

--- a/tests/phpt/interfaces/133_different_defaults_in_derived.php
+++ b/tests/phpt/interfaces/133_different_defaults_in_derived.php
@@ -1,0 +1,24 @@
+@kphp_should_fail
+/default value of interface parameter:`1234:const int` may not differ from value of derived parameter: `56789:const int`, in function: AA::foo/
+<?php
+
+interface II {
+    function foo($x = 1234);
+}
+
+class AA implements II {
+    function foo($x = 56789) { var_dump($x); }
+}
+
+class BB implements II {
+    function foo($x = 0) { var_dump($x); }
+}
+
+function foo(II $ii) { $ii->foo(); }
+
+function demo() {
+    foo(new AA);
+    foo(new BB);
+}
+
+demo();


### PR DESCRIPTION
When we check that the default argument of interface or abstract method has the same value as every overloaded method from derived classes we have a data race. `InlineDefinesUsagesPass` tries can inline defines used as default value at the same time when we investigate such a situation.

Now we separate that check and do it after the synchronization pipe `GenerateVirtualMethods`.