### PR TITLE
Write JSON logs from signal handlers & after exceptions

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -72,6 +72,10 @@ jobs:
       run: docker exec kphp-build-container-${{matrix.os}} bash -c 
               "cd ${{runner.workspace}}/build && echo 'hello world' > demo.php && $GITHUB_WORKSPACE/objs/bin/kphp2cpp --cxx ${{matrix.compiler}} demo.php && kphp_out/server -o"
 
+    - name: Run python tests
+      run: docker exec kphp-build-container-${{matrix.os}} bash -c
+              "KPHP_CXX=${{matrix.compiler}} python3 -m pytest --tb=native -n$(nproc) $GITHUB_WORKSPACE/tests/python/"
+
     - name: Remove docker container
       run: docker rm -f kphp-build-container-${{matrix.os}}
 

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -10,9 +10,11 @@ RUN apt-get update && \
     echo "deb https://packages.sury.org/php/ buster main" >> /etc/apt/sources.list.d/php.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      git cmake-data=3.16* cmake=3.16* make g++ gperf python3-minimal python3-jsonschema \
+      git cmake-data=3.16* cmake=3.16* make g++ gperf netcat \
+      python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
       libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
+    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.focal
+++ b/.github/workflows/Dockerfile.focal
@@ -7,9 +7,11 @@ RUN apt-get update && \
     echo "deb https://repo.vkpartner.ru/kphp-focal/ focal main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      git cmake make clang g++ g++-10 gperf python3-minimal python3-jsonschema \
+      git cmake make clang g++ g++-10 gperf netcat \
+      python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
       libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
+    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash kitten

--- a/common/dl-utils-lite.cpp
+++ b/common/dl-utils-lite.cpp
@@ -61,15 +61,19 @@ double dl_time () {
   return dl_get_utime (CLOCK_MONOTONIC);
 }
 
-void dl_print_backtrace () {
-  void *buffer[64];
-  int nptrs = backtrace (buffer, 64);
+void dl_print_backtrace(void **trace, int trace_size) {
   write (2, "\n------- Stack Backtrace -------\n", 33);
-  backtrace_symbols_fd (buffer, nptrs, 2);
+  backtrace_symbols_fd (trace, trace_size, 2);
   write (2, "-------------------------------\n", 32);
 }
 
-void dl_print_backtrace_gdb () {
+void dl_print_backtrace() {
+  void *buffer[64];
+  int nptrs = backtrace (buffer, 64);
+  dl_print_backtrace(buffer, nptrs);
+}
+
+void dl_print_backtrace_gdb() {
   char * const envp[] = {NULL};
   char pid_buf[30];
   sprintf (pid_buf, "%d", getpid());

--- a/common/dl-utils-lite.h
+++ b/common/dl-utils-lite.h
@@ -21,8 +21,9 @@ void dl_restore_signal_mask ();
 void dl_block_all_signals ();
 void dl_allow_all_signals ();
 
-void dl_print_backtrace ();
-void dl_print_backtrace_gdb ();
+void dl_print_backtrace(void **trace, int trace_size);
+void dl_print_backtrace();
+void dl_print_backtrace_gdb();
 
 void dl_set_default_handlers ();
 

--- a/common/wrappers/string_view.h
+++ b/common/wrappers/string_view.h
@@ -69,6 +69,10 @@ public:
     return *begin();
   }
 
+  char back() const noexcept {
+    return *rbegin();
+  }
+
   size_t size() const noexcept {
     return _count;
   }

--- a/runtime/exception.h
+++ b/runtime/exception.h
@@ -16,11 +16,13 @@ struct C$Exception : refcountable_php_classes<C$Exception> {
   int64_t code = 0;
   string file;
   int64_t line = 0;
+  array<void *> raw_trace;
   array<array<string>> trace;
 
   void accept(InstanceMemoryEstimateVisitor &visitor) {
     visitor("", message);
     visitor("", file);
+    visitor("", raw_trace);
     visitor("", trace);
   }
 };

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -42,6 +42,7 @@
 #include "runtime/udp.h"
 #include "runtime/url.h"
 #include "runtime/zlib.h"
+#include "server/json-logger.h"
 #include "server/php-engine-vars.h"
 #include "server/php-queries.h"
 #include "server/php-query-data.h"
@@ -2106,7 +2107,7 @@ static void free_runtime_libs() {
   free_streams_lib();
   free_udp_lib();
   OnKphpWarningCallback::get().reset();
-  KphpErrorContext::get().reset();
+  JsonLogger::get().reset();
 
   free_confdata_functions_lib();
   free_instance_cache_lib();

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2107,7 +2107,7 @@ static void free_runtime_libs() {
   free_streams_lib();
   free_udp_lib();
   OnKphpWarningCallback::get().reset();
-  JsonLogger::get().reset();
+  JsonLogger::get().reset_buffers();
 
   free_confdata_functions_lib();
   free_instance_cache_lib();

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2207,7 +2207,7 @@ void read_engine_tag(const char *file_name) {
   buf[j] = 0;
 
   engine_tag = strdup(buf);
-  release_version = static_cast<int32_t>(string::to_int(engine_tag, static_cast<string::size_type>(strlen(engine_tag))));
+  JsonLogger::get().init(string::to_int(engine_tag, static_cast<string::size_type>(strlen(engine_tag))));
 }
 
 void f$raise_sigsegv() {

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2107,7 +2107,7 @@ static void free_runtime_libs() {
   free_streams_lib();
   free_udp_lib();
   OnKphpWarningCallback::get().reset();
-  JsonLogger::get().reset_buffers();
+  vk::singleton<JsonLogger>::get().reset_buffers();
 
   free_confdata_functions_lib();
   free_instance_cache_lib();
@@ -2207,7 +2207,7 @@ void read_engine_tag(const char *file_name) {
   buf[j] = 0;
 
   engine_tag = strdup(buf);
-  JsonLogger::get().init(string::to_int(engine_tag, static_cast<string::size_type>(strlen(engine_tag))));
+  vk::singleton<JsonLogger>::get().init(string::to_int(engine_tag, static_cast<string::size_type>(strlen(engine_tag))));
 }
 
 void f$raise_sigsegv() {

--- a/runtime/memory_usage.h
+++ b/runtime/memory_usage.h
@@ -13,7 +13,7 @@ int64_t f$estimate_memory_usage(const string &value);
 int64_t f$estimate_memory_usage(const mixed &value);
 
 template<typename T,
-  typename = vk::enable_if_in_list<T, vk::list_of_types<bool, int64_t, double, Unknown>>>
+  typename = vk::enable_if_in_list<T, vk::list_of_types<bool, int64_t, double, Unknown, void *>>>
 int64_t f$estimate_memory_usage(const T &);
 
 template<typename T>

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -1545,18 +1545,21 @@ int64_t f$system(const string &query) {
 }
 
 void f$kphp_set_context_on_error(const array<mixed> &tags, const array<mixed> &extra_info, const string& env) {
-  auto &context = JsonLogger::get();
+  auto &json_logger = JsonLogger::get();
   static_SB.clean();
 
   if (do_json_encode(tags, 0, false)) {
-    context.set_tags({static_SB.c_str(), static_SB.size()});
+    dl::CriticalSectionGuard critical_section;
+    json_logger.set_tags({static_SB.c_str(), static_SB.size()});
   }
   static_SB.clean();
 
   if (do_json_encode(extra_info, 0, false)) {
-    context.set_extra_info({static_SB.c_str(), static_SB.size()});
+    dl::CriticalSectionGuard critical_section;
+    json_logger.set_extra_info({static_SB.c_str(), static_SB.size()});
   }
   static_SB.clean();
 
-  context.set_env({env.c_str(), env.size()});
+  dl::CriticalSectionGuard critical_section;
+  json_logger.set_env({env.c_str(), env.size()});
 }

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -19,6 +19,7 @@
 #include "runtime/math_functions.h"
 #include "runtime/string_functions.h"
 #include "runtime/vkext.h"
+#include "server/json-logger.h"
 #include "server/php-engine-vars.h"
 
 string f$uniqid(const string &prefix, bool more_entropy) {
@@ -1544,7 +1545,7 @@ int64_t f$system(const string &query) {
 }
 
 void f$kphp_set_context_on_error(const array<mixed> &tags, const array<mixed> &extra_info, const string& env) {
-  auto &context = KphpErrorContext::get();
+  auto &context = JsonLogger::get();
   static_SB.clean();
 
   if (do_json_encode(tags, 0, false)) {

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -1548,15 +1548,25 @@ void f$kphp_set_context_on_error(const array<mixed> &tags, const array<mixed> &e
   auto &json_logger = JsonLogger::get();
   static_SB.clean();
 
-  if (do_json_encode(tags, 0, false)) {
+  const auto get_json_string_from_SB_without_brackets = [] {
+    vk::string_view json_str{static_SB.c_str(), static_SB.size()};
+    php_assert(json_str.size() >= 2 && json_str.front() == '{' && json_str.back() == '}');
+    json_str.remove_prefix(1);
+    json_str.remove_suffix(1);
+    return json_str;
+  };
+
+  if (do_json_encode(tags, JSON_FORCE_OBJECT, false)) {
+    auto tags_json = get_json_string_from_SB_without_brackets();
     dl::CriticalSectionGuard critical_section;
-    json_logger.set_tags({static_SB.c_str(), static_SB.size()});
+    json_logger.set_tags(tags_json);
   }
   static_SB.clean();
 
-  if (do_json_encode(extra_info, 0, false)) {
+  if (do_json_encode(extra_info, JSON_FORCE_OBJECT, false)) {
+    auto extra_info_json = get_json_string_from_SB_without_brackets();
     dl::CriticalSectionGuard critical_section;
-    json_logger.set_extra_info({static_SB.c_str(), static_SB.size()});
+    json_logger.set_extra_info(extra_info_json);
   }
   static_SB.clean();
 

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -1549,14 +1549,14 @@ void f$kphp_set_context_on_error(const array<mixed> &tags, const array<mixed> &e
   static_SB.clean();
 
   if (do_json_encode(tags, 0, false)) {
-    context.set_tags(static_SB.c_str(), static_SB.size());
+    context.set_tags({static_SB.c_str(), static_SB.size()});
   }
   static_SB.clean();
 
   if (do_json_encode(extra_info, 0, false)) {
-    context.set_extra_info(static_SB.c_str(), static_SB.size());
+    context.set_extra_info({static_SB.c_str(), static_SB.size()});
   }
   static_SB.clean();
 
-  context.set_env(env.c_str(), env.size());
+  context.set_env({env.c_str(), env.size()});
 }

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -1545,7 +1545,7 @@ int64_t f$system(const string &query) {
 }
 
 void f$kphp_set_context_on_error(const array<mixed> &tags, const array<mixed> &extra_info, const string& env) {
-  auto &json_logger = JsonLogger::get();
+  auto &json_logger = vk::singleton<JsonLogger>::get();
   static_SB.clean();
 
   const auto get_json_string_from_SB_without_brackets = [] {

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -225,7 +225,7 @@ void write_json_error_to_log(int version, char *msg, int type, int nptrs, void**
   const auto &json_logger = JsonLogger::get();
 
   const auto format = R"({"version":%d,"type":%d,"created_at":%ld,"msg":"%s","env":"%s")";
-  fprintf(json_log_file_ptr, format, version, type, time(nullptr), msg, json_logger.env_c_str());
+  fprintf(json_log_file_ptr, format, version, type, time(nullptr), msg, json_logger.get_env().data()); // TODO FIX THIS BUG
 
   fprintf(json_log_file_ptr, R"(,"trace":[)");
   for (int i = 0; i < nptrs; i++) {
@@ -237,11 +237,11 @@ void write_json_error_to_log(int version, char *msg, int type, int nptrs, void**
   fprintf(json_log_file_ptr, "]");
 
   if (json_logger.tags_are_set()) {
-    fprintf(json_log_file_ptr, R"(,"tags":%s)", json_logger.tags_c_str());
+    fprintf(json_log_file_ptr, R"(,"tags":%s)", json_logger.get_tags().data()); // TODO FIX THIS BUG
   }
 
   if (json_logger.extra_info_is_set()) {
-    fprintf(json_log_file_ptr, R"(,"extra_info":%s)", json_logger.extra_info_c_str());
+    fprintf(json_log_file_ptr, R"(,"extra_info":%s)", json_logger.get_extra_info().data()); // TODO FIX THIS BUG
   }
 
   fprintf(json_log_file_ptr, "}\n");

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -151,7 +151,7 @@ static void php_warning_impl(bool out_of_memory, int error_type, char const *mes
     OnKphpWarningCallback::get().invoke_callback(string(buf));
   }
 
-  JsonLogger::get().write_log(buf, error_type, cur_time, buffer, nptrs);
+  JsonLogger::get().write_log(buf, error_type, cur_time, buffer, nptrs, out_of_memory || die_on_fail || error_type == E_ERROR);
 
   if (die_on_fail) {
     raise_php_assert_signal__();

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -27,7 +27,6 @@
 
 const char *engine_tag = "[";
 const char *engine_pid = "] ";
-int release_version = 0;
 
 int php_disable_warnings = 0;
 int php_warning_level = 2;
@@ -152,7 +151,7 @@ static void php_warning_impl(bool out_of_memory, int error_type, char const *mes
     OnKphpWarningCallback::get().invoke_callback(string(buf));
   }
 
-  JsonLogger::get().write_log(buf, release_version, error_type, buffer, nptrs);
+  JsonLogger::get().write_log(buf, error_type, cur_time, buffer, nptrs);
 
   if (die_on_fail) {
     raise_php_assert_signal__();

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -151,7 +151,7 @@ static void php_warning_impl(bool out_of_memory, int error_type, char const *mes
     OnKphpWarningCallback::get().invoke_callback(string(buf));
   }
 
-  JsonLogger::get().write_log(buf, error_type, cur_time, buffer, nptrs, out_of_memory || die_on_fail || error_type == E_ERROR);
+  vk::singleton<JsonLogger>::get().write_log(buf, error_type, cur_time, buffer, nptrs, out_of_memory || die_on_fail || error_type == E_ERROR);
 
   if (die_on_fail) {
     raise_php_assert_signal__();
@@ -197,5 +197,5 @@ void php_assert__(const char *msg, const char *file, int line) {
 
 void raise_php_assert_signal__() {
   raise(SIGPHPASSERT);
-  JsonLogger::get().fsync_log_file();
+  vk::singleton<JsonLogger>::get().fsync_log_file();
 }

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -14,7 +14,6 @@ extern int die_on_fail;
 
 extern const char *engine_tag;
 extern const char *engine_pid;
-extern int release_version;
 
 extern int php_disable_warnings;
 extern int php_warning_level;

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -35,7 +35,7 @@ void raise_php_assert_signal__();
 } while(0)
 
 #define php_critical_error(format, ...) do {                                                              \
-  php_error ("Critical error \"" format "\" in file %s on line %d", ##__VA_ARGS__, __FILE__, __LINE__); \
+  php_error ("Critical error \"" format "\" in file %s on line %d", ##__VA_ARGS__, __FILE__, __LINE__);   \
   raise_php_assert_signal__();                                                                            \
   fprintf (stderr, "_exiting in php_critical_error\n");                                                   \
   _exit (1);                                                                                              \

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -40,38 +40,3 @@ void raise_php_assert_signal__();
   fprintf (stderr, "_exiting in php_critical_error\n");                                                   \
   _exit (1);                                                                                              \
 } while(0)
-
-class KphpErrorContext: vk::not_copyable {
-public:
-  static KphpErrorContext& get();
-
-  bool tags_are_set() const {
-    return tags_buffer[0] != '\0';
-  }
-
-  bool extra_info_is_set() const {
-    return extra_info_buffer[0] != '\0';
-  }
-
-  void set_extra_info(const char *ptr, size_t size);
-  void set_tags(const char *ptr, size_t size);
-  void set_env(const char *ptr, size_t size);
-  void reset();
-
-  const char *tags_c_str() const {
-    return tags_buffer;
-  }
-
-  const char *extra_info_c_str() const {
-    return extra_info_buffer;
-  }
-
-  const char *env_c_str() const {
-    return env_buffer;
-  }
-private:
-  KphpErrorContext() = default;
-  char tags_buffer[10 * 1024]{0};
-  char extra_info_buffer[10 * 1024]{0};
-  char env_buffer[128]{0};
-};

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -2,7 +2,10 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 #include <cstring>
+#include <unistd.h>
 
+#include "common/algorithms/find.h"
+#include "common/wrappers/likely.h"
 #include "server/json-logger.h"
 
 namespace {
@@ -15,7 +18,122 @@ void copy_if_enough_size(vk::string_view src, vk::string_view &dest, std::array<
   }
 }
 
+template<uint8_t BASE>
+char *append_raw_integer(char *buffer, int64_t value) noexcept {
+  static_assert(vk::any_of_equal(BASE, 10, 16), "Expected 10 or 16");
+  char *first = buffer;
+  auto unsigned_integer = static_cast<uint64_t>(value);
+  if (BASE == 16) {
+    *first++ = '0';
+    *first++ = 'x';
+  } else if (value < 0) {
+    *first++ = '-';
+    unsigned_integer = ~unsigned_integer + 1;
+  }
+  char *last = first;
+  do {
+    const uint64_t c = unsigned_integer % BASE;
+    unsigned_integer /= BASE;
+    *last++ = (BASE == 16 && c >= 10) ? static_cast<char>('a' + c - 10) : static_cast<char>('0' + c);
+  } while (unsigned_integer);
+  std::reverse(first, last);
+  return last;
+}
+
 } // namespace
+
+bool JsonLogger::JsonBuffer::try_start_json() noexcept {
+  const bool acquired = !busy_.exchange(true);
+  if (acquired) {
+    last_ = buffer_.begin();
+    *last_++ = '{';
+  }
+  return acquired;
+}
+
+void JsonLogger::JsonBuffer::finish_json_and_flush(FILE *out) noexcept {
+  assert(*(last_ - 1) == ',');
+  *(last_ - 1) = '}';
+  *last_++ = '\n';
+  fwrite(buffer_.data(), 1, static_cast<size_t>(last_ - buffer_.data()), out);
+  fflush(out);
+  last_ = nullptr;
+  busy_ = false;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_key(vk::string_view key) noexcept {
+  *last_++ = '"';
+  std::copy(key.begin(), key.end(), last_);
+  last_ += key.size();
+  *last_++ = '"';
+  *last_++ = ':';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::start_array() noexcept {
+  *last_++ = '[';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::finish_array() noexcept {
+  if (*(last_ - 1) == ',') {
+    *(last_ - 1) = ']';
+  } else {
+    *last_++ = ']';
+  }
+  *last_++ = ',';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_string(vk::string_view value) noexcept {
+  *last_++ = '"';
+  std::copy(value.begin(), value.end(), last_);
+  last_ += value.size();
+  *last_++ = '"';
+  *last_++ = ',';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_raw(vk::string_view raw_element) noexcept {
+  std::copy(raw_element.begin(), raw_element.end(), last_);
+  last_ += raw_element.size();
+  *last_++ = ',';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_integer(int64_t value) noexcept {
+  last_ = append_raw_integer<10>(last_, value);
+  *last_++ = ',';
+  return *this;
+}
+
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_hex_as_string(int64_t value) noexcept {
+  *last_++ = '"';
+  last_ = append_raw_integer<16>(last_, value);
+  *last_++ = '"';
+  *last_++ = ',';
+  return *this;
+}
+
+template<class Mapper>
+JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_string_safe(vk::string_view value, Mapper value_mapper) noexcept {
+  *last_++ = '"';
+  constexpr size_t reserved_bytes = 16;
+  size_t left_bytes = buffer_.size() - static_cast<size_t>(last_ - buffer_.data());
+  assert(left_bytes >= reserved_bytes);
+  left_bytes -= reserved_bytes;
+  const size_t write_bytes = std::min(left_bytes, value.size());
+  std::transform(value.begin(), value.begin() + write_bytes, last_, value_mapper);
+  last_ += write_bytes;
+  if (unlikely(write_bytes != value.size())) {
+    const vk::string_view truncated_dots{"..."};
+    std::copy(truncated_dots.begin(), truncated_dots.end(), last_);
+    last_ += truncated_dots.size();
+  }
+  *last_++ = '"';
+  *last_++ = ',';
+  return *this;
+}
 
 JsonLogger &JsonLogger::get() noexcept {
   static JsonLogger logger;
@@ -32,6 +150,35 @@ void JsonLogger::set_extra_info(vk::string_view extra_info) noexcept {
 
 void JsonLogger::set_env(vk::string_view env) noexcept {
   copy_if_enough_size(env, env_, env_buffer_);
+}
+
+void JsonLogger::write_to(FILE *out, vk::string_view message, int version, int type, void **trace, int trace_size) noexcept {
+  auto json_out_it = buffers_.begin();
+  for (; json_out_it != buffers_.end() && !json_out_it->try_start_json(); ++json_out_it) {
+  }
+  assert(json_out_it != buffers_.end());
+
+  json_out_it->append_key("version").append_integer(version);
+  json_out_it->append_key("type").append_integer(type);
+  json_out_it->append_key("created_at").append_integer(time(nullptr));
+  json_out_it->append_key("env").append_string(env_);
+  if (!tags_.empty()) {
+    json_out_it->append_key("tags").append_raw(tags_);
+  }
+  if (!extra_info_.empty()) {
+    json_out_it->append_key("extra_info").append_raw(extra_info_);
+  }
+
+  json_out_it->append_key("trace").start_array();
+  for (int i = 0; i < trace_size; i++) {
+    json_out_it->append_hex_as_string(reinterpret_cast<int64_t>(trace[i]));
+  }
+  json_out_it->finish_array();
+
+  json_out_it->append_key("msg").append_string_safe(message, [](char c) {
+    return c == '"' ? '\'' : (c == '\n' ? ' ' : c);
+  });
+  json_out_it->finish_json_and_flush(out);
 }
 
 void JsonLogger::reset() noexcept {

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -5,41 +5,37 @@
 
 #include "server/json-logger.h"
 
+namespace {
 
-JsonLogger &JsonLogger::get() {
+template<size_t N>
+void copy_if_enough_size(vk::string_view src, vk::string_view &dest, std::array<char, N> &buffer) noexcept {
+  if (src.size() <= buffer.size()) {
+    std::copy(src.begin(), src.end(), buffer.begin());
+    dest = {buffer.data(), src.size()};
+  }
+}
+
+} // namespace
+
+JsonLogger &JsonLogger::get() noexcept {
   static JsonLogger logger;
   return logger;
 }
 
-void JsonLogger::set_tags(const char *ptr, size_t size) {
-  if ((size + 1) > sizeof(tags_buffer)) {
-    return;
-  }
-
-  memcpy(tags_buffer, ptr, size);
-  tags_buffer[size] = '\0';
+void JsonLogger::set_tags(vk::string_view tags) noexcept {
+  copy_if_enough_size(tags, tags_, tags_buffer_);
 }
 
-void JsonLogger::set_extra_info(const char *ptr, size_t size) {
-  if ((size + 1) > sizeof(extra_info_buffer)) {
-    return;
-  }
-
-  memcpy(extra_info_buffer, ptr, size);
-  extra_info_buffer[size] = '\0';
+void JsonLogger::set_extra_info(vk::string_view extra_info) noexcept {
+  copy_if_enough_size(extra_info, extra_info_, extra_info_buffer_);
 }
 
-void JsonLogger::set_env(const char *ptr, size_t size) {
-  if ((size + 1) > sizeof(env_buffer)) {
-    return;
-  }
-
-  memcpy(env_buffer, ptr, size);
-  env_buffer[size] = '\0';
+void JsonLogger::set_env(vk::string_view env) noexcept {
+  copy_if_enough_size(env, env_, env_buffer_);
 }
 
-void JsonLogger::reset() {
-  extra_info_buffer[0] = '\0';
-  tags_buffer[0] = '\0';
-  env_buffer[0] = '\0';
+void JsonLogger::reset() noexcept {
+  tags_ = {};
+  extra_info_ = {};
+  env_ = {};
 }

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -1,0 +1,45 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+#include <cstring>
+
+#include "server/json-logger.h"
+
+
+JsonLogger &JsonLogger::get() {
+  static JsonLogger logger;
+  return logger;
+}
+
+void JsonLogger::set_tags(const char *ptr, size_t size) {
+  if ((size + 1) > sizeof(tags_buffer)) {
+    return;
+  }
+
+  memcpy(tags_buffer, ptr, size);
+  tags_buffer[size] = '\0';
+}
+
+void JsonLogger::set_extra_info(const char *ptr, size_t size) {
+  if ((size + 1) > sizeof(extra_info_buffer)) {
+    return;
+  }
+
+  memcpy(extra_info_buffer, ptr, size);
+  extra_info_buffer[size] = '\0';
+}
+
+void JsonLogger::set_env(const char *ptr, size_t size) {
+  if ((size + 1) > sizeof(env_buffer)) {
+    return;
+  }
+
+  memcpy(env_buffer, ptr, size);
+  env_buffer[size] = '\0';
+}
+
+void JsonLogger::reset() {
+  extra_info_buffer[0] = '\0';
+  tags_buffer[0] = '\0';
+  env_buffer[0] = '\0';
+}

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -146,11 +146,6 @@ JsonLogger::JsonBuffer &JsonLogger::JsonBuffer::append_string_safe(vk::string_vi
   return *this;
 }
 
-JsonLogger &JsonLogger::get() noexcept {
-  static JsonLogger logger;
-  return logger;
-}
-
 void JsonLogger::init(int64_t release_version) noexcept {
   release_version_ = release_version;
 }

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -1,0 +1,43 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+#include <array>
+
+#include "common/mixin/not_copyable.h"
+
+class JsonLogger: vk::not_copyable {
+public:
+  static JsonLogger& get();
+
+  bool tags_are_set() const {
+    return tags_buffer[0] != '\0';
+  }
+
+  bool extra_info_is_set() const {
+    return extra_info_buffer[0] != '\0';
+  }
+
+  void set_extra_info(const char *ptr, size_t size);
+  void set_tags(const char *ptr, size_t size);
+  void set_env(const char *ptr, size_t size);
+  void reset();
+
+  const char *tags_c_str() const {
+    return tags_buffer;
+  }
+
+  const char *extra_info_c_str() const {
+    return extra_info_buffer;
+  }
+
+  const char *env_c_str() const {
+    return env_buffer;
+  }
+private:
+  JsonLogger() = default;
+  char tags_buffer[10 * 1024]{0};
+  char extra_info_buffer[10 * 1024]{0};
+  char env_buffer[128]{0};
+};

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -27,7 +27,7 @@ public:
 
   // ATTENTION: this function is used in signal handlers, therefore it is expected to be safe for them
   // Details: https://man7.org/linux/man-pages/man7/signal-safety.7.html
-  void write_log(vk::string_view message, int type, int64_t created_at, void *const *trace, int64_t trace_size, bool uncaught_exception = false) noexcept;
+  void write_log(vk::string_view message, int type, int64_t created_at, void *const *trace, int64_t trace_size, bool uncaught) noexcept;
 
   void reset_buffers() noexcept;
 

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -4,38 +4,23 @@
 
 #pragma once
 #include <array>
+#include <atomic>
 
+#include "common/functional/identity.h"
 #include "common/mixin/not_copyable.h"
 #include "common/wrappers/string_view.h"
+
 
 class JsonLogger : vk::not_copyable {
 public:
   static JsonLogger &get() noexcept;
 
-  bool tags_are_set() const noexcept {
-    return !tags_.empty();
-  }
-
-  bool extra_info_is_set() const noexcept {
-    return !extra_info_.empty();
-  }
-
   void set_tags(vk::string_view tags) noexcept;
   void set_extra_info(vk::string_view extra_info) noexcept;
   void set_env(vk::string_view env) noexcept;
+
+  void write_to(FILE *out, vk::string_view message, int version, int type, void **trace, int trace_size) noexcept;
   void reset() noexcept;
-
-  vk::string_view get_tags() const noexcept {
-    return tags_;
-  }
-
-  vk::string_view get_extra_info() const noexcept {
-    return extra_info_;
-  }
-
-  vk::string_view get_env() const noexcept {
-    return env_;
-  }
 
 private:
   JsonLogger() = default;
@@ -47,4 +32,29 @@ private:
   std::array<char, 10 * 1024> tags_buffer_{0};
   std::array<char, 10 * 1024> extra_info_buffer_{0};
   std::array<char, 128> env_buffer_{0};
+
+  class JsonBuffer : vk::not_copyable {
+  public:
+    bool try_start_json() noexcept;
+    void finish_json_and_flush(FILE *out) noexcept;
+    JsonBuffer &append_key(vk::string_view key) noexcept;
+    JsonBuffer &start_array() noexcept;
+    JsonBuffer &finish_array() noexcept;
+    JsonBuffer &append_string(vk::string_view value) noexcept;
+    JsonBuffer &append_raw(vk::string_view raw_element) noexcept;
+    JsonBuffer &append_integer(int64_t value) noexcept;
+    JsonBuffer &append_hex_as_string(int64_t value) noexcept;
+    template<class Mapper = vk::identity>
+    JsonBuffer &append_string_safe(vk::string_view value, Mapper value_mapper = {}) noexcept;
+
+  private:
+#if __cplusplus >= 201703
+  static_assert(std::atomic<bool>::is_always_lock_free);
+#endif
+    volatile std::atomic<bool> busy_{false};
+    char *last_{nullptr};
+    std::array<char, 32 * 1024> buffer_{0};
+  };
+  std::array<JsonBuffer, 8> buffers_;
 };
+

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -6,38 +6,45 @@
 #include <array>
 
 #include "common/mixin/not_copyable.h"
+#include "common/wrappers/string_view.h"
 
-class JsonLogger: vk::not_copyable {
+class JsonLogger : vk::not_copyable {
 public:
-  static JsonLogger& get();
+  static JsonLogger &get() noexcept;
 
-  bool tags_are_set() const {
-    return tags_buffer[0] != '\0';
+  bool tags_are_set() const noexcept {
+    return !tags_.empty();
   }
 
-  bool extra_info_is_set() const {
-    return extra_info_buffer[0] != '\0';
+  bool extra_info_is_set() const noexcept {
+    return !extra_info_.empty();
   }
 
-  void set_extra_info(const char *ptr, size_t size);
-  void set_tags(const char *ptr, size_t size);
-  void set_env(const char *ptr, size_t size);
-  void reset();
+  void set_tags(vk::string_view tags) noexcept;
+  void set_extra_info(vk::string_view extra_info) noexcept;
+  void set_env(vk::string_view env) noexcept;
+  void reset() noexcept;
 
-  const char *tags_c_str() const {
-    return tags_buffer;
+  vk::string_view get_tags() const noexcept {
+    return tags_;
   }
 
-  const char *extra_info_c_str() const {
-    return extra_info_buffer;
+  vk::string_view get_extra_info() const noexcept {
+    return extra_info_;
   }
 
-  const char *env_c_str() const {
-    return env_buffer;
+  vk::string_view get_env() const noexcept {
+    return env_;
   }
+
 private:
   JsonLogger() = default;
-  char tags_buffer[10 * 1024]{0};
-  char extra_info_buffer[10 * 1024]{0};
-  char env_buffer[128]{0};
+
+  vk::string_view tags_;
+  vk::string_view extra_info_;
+  vk::string_view env_;
+
+  std::array<char, 10 * 1024> tags_buffer_{0};
+  std::array<char, 10 * 1024> extra_info_buffer_{0};
+  std::array<char, 128> env_buffer_{0};
 };

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -8,12 +8,13 @@
 
 #include "common/functional/identity.h"
 #include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
 #include "common/wrappers/string_view.h"
 
 
 class JsonLogger : vk::not_copyable {
 public:
-  static JsonLogger &get() noexcept;
+  friend class vk::singleton<JsonLogger>;
 
   void init(int64_t release_version) noexcept;
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2076,7 +2076,7 @@ void reopen_json_log() {
   if (logname) {
     char worker_json_log_file_name[PATH_MAX];
     sprintf(worker_json_log_file_name, "%s.json", logname);
-    if (!JsonLogger::get().reopen_log_file(worker_json_log_file_name)) {
+    if (!vk::singleton<JsonLogger>::get().reopen_log_file(worker_json_log_file_name)) {
       vkprintf(-1, "failed to open log '%s': error=%s", worker_json_log_file_name, strerror(errno));
     }
   }

--- a/server/php-query-data.cpp
+++ b/server/php-query-data.cpp
@@ -13,8 +13,12 @@
 #include "common/dl-utils-lite.h"
 
 static void *memdup(const void *src, size_t x) {
+  if (!src) {
+    assert(!x);
+    return nullptr;
+  }
   void *res = malloc(x);
-  assert (res != NULL);
+  assert(res);
   memcpy(res, src, x);
   return res;
 }
@@ -31,11 +35,7 @@ http_query_data *http_query_data_create(
   d->uri = (char *)memdup(qUri, qUriLen);
   d->get = (char *)memdup(qGet, qGetLen);
   d->headers = (char *)memdup(qHeaders, qHeadersLen);
-  if (qPost != nullptr) {
-    d->post = (char *)memdup(qPost, qPostLen);
-  } else {
-    d->post = nullptr;
-  }
+  d->post = (char *)memdup(qPost, qPostLen);
 
   d->uri_len = qUriLen;
   d->get_len = qGetLen;

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -520,7 +520,7 @@ void sigsegv_handler(int signum, siginfo_t *info, void *ucontext) {
 
   void *addr = info->si_addr;
   if (PHPScriptBase::is_running && PHPScriptBase::current_script->is_protected(static_cast<char *>(addr))) {
-    JsonLogger::get().write_log("Stack overflow", E_ERROR, cur_time, trace, trace_size);
+    JsonLogger::get().write_log("Stack overflow", E_ERROR, cur_time, trace, trace_size, true);
     write_str(2, "Error -1: Callstack overflow");
     print_http_data();
     dl_print_backtrace(trace, trace_size);
@@ -534,7 +534,7 @@ void sigsegv_handler(int signum, siginfo_t *info, void *ucontext) {
   } else {
     char message[32];
     strcpy(message, signum == SIGBUS ? "SIGBUS" : "SIGSEGV");
-    JsonLogger::get().write_log(strcat(message, " terminating program"), -1, cur_time, trace, trace_size);
+    JsonLogger::get().write_log(strcat(message, " terminating program"), -1, cur_time, trace, trace_size, true);
     JsonLogger::get().fsync_log_file();
     write_str(2, "Error -2: Segmentation fault");
     print_http_data();
@@ -548,7 +548,7 @@ void sigabrt_handler(int) {
   const int64_t cur_time = time(nullptr);
   void *trace[64];
   const int trace_size = backtrace(trace, 64);
-  JsonLogger::get().write_log("SIGABRT terminating program", -1, cur_time, trace, trace_size);
+  JsonLogger::get().write_log("SIGABRT terminating program", -1, cur_time, trace, trace_size, true);
   JsonLogger::get().fsync_log_file();
 
   print_prologue(cur_time);

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -367,10 +367,16 @@ void PHPScriptBase::run() {
     set_script_result(nullptr);
   } else {
     const Exception &e = CurException;
+    const int64_t current_time = time(nullptr);
+    const char *message = e->message.empty() ? "(empty)" : e->message.c_str();
+    JsonLogger::get().write_log(
+      dl_pstr("Unhandled exception from %s:%ld; Error %ld; Message: %s", e->file.c_str(), e->line, e->code, message),
+      E_ERROR, current_time, e->raw_trace.get_const_vector_pointer(), e->raw_trace.count(), true);
+
     const char *msg = dl_pstr("%s%ld%sError %ld: %s.\nUnhandled Exception caught in file %s at line %ld.\n"
                               "Backtrace:\n%s",
-                              engine_tag, time(nullptr), engine_pid,
-                              e->code, e->message.c_str(), e->file.c_str(), e->line,
+                              engine_tag, current_time, engine_pid,
+                              e->code, message, e->file.c_str(), e->line,
                               f$Exception$$getTraceAsString(e).c_str());
     fprintf(stderr, "%s", msg);
     fprintf(stderr, "-------------------------------\n\n");

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -475,6 +475,9 @@ static void stack_overflow_handler(int signum) {
 }
 
 void print_http_data() {
+  if (!PHPScriptBase::is_running) {
+    return;
+  }
   if (!PHPScriptBase::current_script) {
     write_str(2, "\nPHPScriptBase::current_script is nullptr\n");
   } else if (PHPScriptBase::current_script->data) {

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -369,7 +369,7 @@ void PHPScriptBase::run() {
     const Exception &e = CurException;
     const int64_t current_time = time(nullptr);
     const char *message = e->message.empty() ? "(empty)" : e->message.c_str();
-    JsonLogger::get().write_log(
+    vk::singleton<JsonLogger>::get().write_log(
       dl_pstr("Unhandled exception from %s:%ld; Error %ld; Message: %s", e->file.c_str(), e->line, e->code, message),
       E_ERROR, current_time, e->raw_trace.get_const_vector_pointer(), e->raw_trace.count(), true);
 
@@ -520,12 +520,12 @@ void sigsegv_handler(int signum, siginfo_t *info, void *ucontext) {
 
   void *addr = info->si_addr;
   if (PHPScriptBase::is_running && PHPScriptBase::current_script->is_protected(static_cast<char *>(addr))) {
-    JsonLogger::get().write_log("Stack overflow", E_ERROR, cur_time, trace, trace_size, true);
+    vk::singleton<JsonLogger>::get().write_log("Stack overflow", E_ERROR, cur_time, trace, trace_size, true);
     write_str(2, "Error -1: Callstack overflow");
     print_http_data();
     dl_print_backtrace(trace, trace_size);
     if (dl::in_critical_section) {
-      JsonLogger::get().fsync_log_file();
+      vk::singleton<JsonLogger>::get().fsync_log_file();
       kwrite_str(2, "In critical section: calling _exit (124)\n");
       _exit(124);
     } else {
@@ -534,8 +534,8 @@ void sigsegv_handler(int signum, siginfo_t *info, void *ucontext) {
   } else {
     char message[32];
     strcpy(message, signum == SIGBUS ? "SIGBUS" : "SIGSEGV");
-    JsonLogger::get().write_log(strcat(message, " terminating program"), -1, cur_time, trace, trace_size, true);
-    JsonLogger::get().fsync_log_file();
+    vk::singleton<JsonLogger>::get().write_log(strcat(message, " terminating program"), -1, cur_time, trace, trace_size, true);
+    vk::singleton<JsonLogger>::get().fsync_log_file();
     write_str(2, "Error -2: Segmentation fault");
     print_http_data();
     dl_print_backtrace(trace, trace_size);
@@ -548,8 +548,8 @@ void sigabrt_handler(int) {
   const int64_t cur_time = time(nullptr);
   void *trace[64];
   const int trace_size = backtrace(trace, 64);
-  JsonLogger::get().write_log("SIGABRT terminating program", -1, cur_time, trace, trace_size, true);
-  JsonLogger::get().fsync_log_file();
+  vk::singleton<JsonLogger>::get().write_log("SIGABRT terminating program", -1, cur_time, trace, trace_size, true);
+  vk::singleton<JsonLogger>::get().fsync_log_file();
 
   print_prologue(cur_time);
   write_str(2, "SIGABRT terminating program\n");

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -1,6 +1,7 @@
 prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         confdata-binlog-replay.cpp
         confdata-stats.cpp
+        json-logger.cpp
         lease-config-parser.cpp
         lease-rpc-client.cpp
         php-engine-vars.cpp

--- a/tests/python/lib/kphp_server.py
+++ b/tests/python/lib/kphp_server.py
@@ -1,3 +1,8 @@
+import json
+import time
+import re
+import os
+
 from .engine import Engine
 from .port_generator import get_port
 from .http_client import send_http_request, send_http_request_raw
@@ -23,10 +28,30 @@ class KphpServer(Engine):
             "kphp_server_{}".format("".join(chr(ord('A') + int(c)) for c in str(self._http_port)))
         self._options["--disable-sql"] = True
         self._options["--workers-num"] = 2
+        self._json_log_file_read_fd = None
+        self._json_logs = []
         if options:
             self.update_options(options)
         if auto_start:
             self.start()
+
+    def start(self, start_msgs=None):
+        super(KphpServer, self).start(start_msgs)
+        self._json_logs = []
+        self._json_log_file_read_fd = open(self._log_file + ".json", 'r')
+
+    def stop(self):
+        super(KphpServer, self).stop()
+        if self._json_log_file_read_fd:
+            self._json_log_file_read_fd.close()
+
+    def set_error_tag(self, tag):
+        error_tag_file = None
+        if tag is not None:
+            error_tag_file = os.path.join(self._working_dir, "error_tag_file")
+            with open(error_tag_file, 'w') as f:
+                f.write(str(tag))
+        self.update_options({"--error-tag": error_tag_file})
 
     @property
     def master_port(self):
@@ -70,3 +95,60 @@ class KphpServer(Engine):
         :return: ответ на запрос
         """
         return send_http_request_raw(self._http_port, request)
+
+    def _read_new_json_logs(self):
+        new_json_logs = list(filter(None, self._json_log_file_read_fd.readlines()))
+        if new_json_logs:
+            print("\n=========== Got new json logs ============")
+            print("".join(new_json_logs).strip())
+            print("============================================")
+            for log_record in map(json.loads, new_json_logs):
+                trace = log_record.get("trace", [])
+                if not trace:
+                    raise RuntimeError("Got an empty trace in json log")
+                bad_addresses = list(filter(lambda address: not address.startswith("0x"), trace))
+                if bad_addresses:
+                    raise RuntimeError("Got bad addresses in json log trace: " + ", ".join(bad_addresses))
+                del log_record["trace"]
+                created_at = log_record.get("created_at", 0)
+                if abs(created_at - time.time()) > 60:
+                    raise RuntimeError("Got bad timestamp in json log created_at: {}".format(created_at))
+                del log_record["created_at"]
+                self._json_logs.append(log_record)
+
+    def assert_json_log(self, expect, message="Can't wait expected json log", timeout=60):
+        """
+        Check kphp server json log
+        :param expect: Expected json record list
+        :param message: Error message in case of failure
+        :param timeout: Json records waiting time
+        """
+        start = time.time()
+        expected_records = expect[:]
+
+        while expected_records:
+            self._assert_availability()
+            self._read_new_json_logs()
+            self._json_logs = list(filter(None, self._json_logs))
+            for index, json_log_record in enumerate(self._json_logs):
+                if not expected_records:
+                    return
+                expected_record = expected_records[0]
+                expected_msg = expected_record["msg"]
+                got_msg = json_log_record["msg"]
+                if re.search(expected_msg, got_msg):
+                    expected_record_copy = expected_record.copy()
+                    expected_record_copy["msg"] = ""
+                    json_log_record_copy = json_log_record.copy()
+                    json_log_record_copy["msg"] = ""
+                    if expected_record_copy == json_log_record_copy:
+                        expected_records.pop(0)
+                        self._json_logs[index] = None
+
+            time.sleep(0.05)
+            if time.time() - start > timeout:
+                expected_str = json.dumps(obj=expected_records, indent=2)
+                raise RuntimeError("{}; Missed messages: {}".format(message, expected_str))
+
+    def get_workers(self):
+        return self._engine_process.children()

--- a/tests/python/tests/json_logs/php/index.php
+++ b/tests/python/tests/json_logs/php/index.php
@@ -1,0 +1,55 @@
+<?php
+
+function do_sigsegv() {
+  raise_sigsegv();
+}
+
+function do_exception(string $message, int $code) {
+  throw new Exception($message, $code);
+}
+
+function do_warning(string $message) {
+  warning($message);
+}
+
+function do_set_context(array $tags, array $extra_info, string $env) {
+  kphp_set_context_on_error($tags, $extra_info, $env);
+}
+
+function do_stack_overflow(int $x): int {
+  $z = 10;
+  if ($x) {
+    $y = do_stack_overflow($x + 1);
+    $z = $y + 1;
+  }
+  $z += do_stack_overflow($x + $z);
+  return $z;
+}
+
+function main() {
+  foreach (json_decode(file_get_contents('php://input')) as $action) {
+    switch ($action["op"]) {
+      case "sigsegv":
+        do_sigsegv();
+        break;
+      case "exception":
+        do_exception((string)$action["msg"], (int)$action["code"]);
+        break;
+      case "warning":
+        do_warning((string)$action["msg"]);
+        break;
+      case "set_context":
+        do_set_context((array)$action["tags"], (array)$action["extra_info"], (string)$action["env"]);
+        break;
+      case "stack_overflow":
+        do_stack_overflow(1);
+        break;
+      default:
+        echo "unknown operation";
+        return;
+    }
+  }
+  echo "ok";
+}
+
+main();

--- a/tests/python/tests/json_logs/test_exceptions.py
+++ b/tests/python/tests/json_logs/test_exceptions.py
@@ -1,0 +1,31 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJsonLogsExceptions(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+
+    def test_exception_no_context(self):
+        resp = self.kphp_server.http_post(json=[{"op": "exception", "msg": "hello", "code": 123}])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
+                "msg": "Unhandled exception from .+index.php:\\d+; Error 123; Message: hello",
+            }])
+
+    def test_exception_with_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"op": "exception", "msg": "world", "code": 3456}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "efg",  "tags": {"a": "b", "uncaught": True}, "extra_info": {"c": "d"},
+                "msg": "Unhandled exception from .+index.php:\\d+; Error 3456; Message: world",
+            }])

--- a/tests/python/tests/json_logs/test_signals.py
+++ b/tests/python/tests/json_logs/test_signals.py
@@ -1,0 +1,92 @@
+import signal
+import resource
+
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJsonLogsSignals(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+        cls.kphp_server.update_options({
+            "--workers-num": 5
+        })
+        resource.setrlimit(resource.RLIMIT_CORE, (0, 0))
+
+    def test_sigsegv_from_code(self):
+        with self.assertRaises(Exception):
+            self.kphp_server.http_post(
+                json=[
+                    {"op": "set_context", "env": "e1", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                    {"op": "sigsegv"}
+                ])
+
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "e1", "msg": "SIGSEGV terminating program",
+                "tags": {"a": "b"}, "extra_info": {"c": "d"}
+            }])
+
+    def test_worker_sigsegv(self):
+        self.kphp_server.get_workers()[0].send_signal(signal.SIGSEGV)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program"
+            }])
+
+    def test_worker_sigbus(self):
+        self.kphp_server.get_workers()[1].send_signal(signal.SIGBUS)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program"
+            }])
+
+    def test_worker_sigabrt(self):
+        self.kphp_server.get_workers()[2].send_signal(signal.SIGABRT)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program"
+            }])
+
+    def test_stack_overflow(self):
+        res = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "e1", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"op": "stack_overflow"}
+            ])
+        self.assertEqual(res.status_code, 500)
+        self.assertEqual(res.text, "ERROR")
+
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "e1", "msg": "Stack overflow",
+                "tags": {"a": "b"}, "extra_info": {"c": "d"}
+            }])
+
+    def test_master_sigsegv(self):
+        self.kphp_server.send_signal(signal.SIGSEGV)
+        with self.assertRaises(RuntimeError):
+            self.kphp_server.stop()
+        self.kphp_server.start()
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program"
+            }])
+
+    def test_master_sigbus(self):
+        self.kphp_server.send_signal(signal.SIGBUS)
+        with self.assertRaises(RuntimeError):
+            self.kphp_server.stop()
+        self.kphp_server.start()
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program"
+            }])
+
+    def test_master_sigabrt(self):
+        self.kphp_server.send_signal(signal.SIGABRT)
+        self.kphp_server.restart()
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program"
+            }])

--- a/tests/python/tests/json_logs/test_signals.py
+++ b/tests/python/tests/json_logs/test_signals.py
@@ -24,28 +24,31 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": -1, "env": "e1", "msg": "SIGSEGV terminating program",
-                "tags": {"a": "b"}, "extra_info": {"c": "d"}
+                "tags": {"a": "b", "uncaught": True}, "extra_info": {"c": "d"}
             }])
 
     def test_worker_sigsegv(self):
         self.kphp_server.get_workers()[0].send_signal(signal.SIGSEGV)
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program",
+                "tags": {"uncaught": True}
             }])
 
     def test_worker_sigbus(self):
         self.kphp_server.get_workers()[1].send_signal(signal.SIGBUS)
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program",
+                "tags": {"uncaught": True}
             }])
 
     def test_worker_sigabrt(self):
         self.kphp_server.get_workers()[2].send_signal(signal.SIGABRT)
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program",
+                "tags": {"uncaught": True}
             }])
 
     def test_stack_overflow(self):
@@ -60,7 +63,7 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": 1, "env": "e1", "msg": "Stack overflow",
-                "tags": {"a": "b"}, "extra_info": {"c": "d"}
+                "tags": {"a": "b", "uncaught": True}, "extra_info": {"c": "d"}
             }])
 
     def test_master_sigsegv(self):
@@ -70,7 +73,8 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
         self.kphp_server.start()
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGSEGV terminating program",
+                "tags": {"uncaught": True}
             }])
 
     def test_master_sigbus(self):
@@ -80,7 +84,8 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
         self.kphp_server.start()
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGBUS terminating program",
+                "tags": {"uncaught": True}
             }])
 
     def test_master_sigabrt(self):
@@ -88,5 +93,6 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
         self.kphp_server.restart()
         self.kphp_server.assert_json_log(
             expect=[{
-                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program"
+                "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program",
+                "tags": {"uncaught": True}
             }])

--- a/tests/python/tests/json_logs/test_warnings.py
+++ b/tests/python/tests/json_logs/test_warnings.py
@@ -1,0 +1,116 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJsonLogsWarnings(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+
+    def test_warning_no_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "warning", "msg": "hello"},
+                {"op": "warning", "msg": "world"}
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "env": "", "msg": "hello"},
+                {"version": 0, "type": 2, "env": "", "msg": "world"}
+            ])
+
+    def test_warning_with_special_chars(self):
+        resp = self.kphp_server.http_post(json=[{"op": "warning", "msg": 'aaa"bbb"\nccc'}])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "env": "", "msg": "aaa'bbb' ccc"}
+            ])
+
+    def test_warning_with_tags(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "", "tags": {"a": "b"}, "extra_info": {}},
+                {"op": "warning", "msg": "aaa"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "", "tags": {"a": "b"}}])
+
+    def test_warning_with_extra_info(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "", "tags": {}, "extra_info": {"a": "b"}},
+                {"op": "warning", "msg": "aaa"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "", "extra_info": {"a": "b"}}])
+
+    def test_warning_with_env(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "abc", "tags": {}, "extra_info": {}},
+                {"op": "warning", "msg": "aaa"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "abc"}])
+
+    def test_warning_with_full_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"op": "warning", "msg": "aaa"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "msg": "aaa", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}}
+            ])
+
+    def test_warning_override_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"op": "warning", "msg": "aaa"},
+                {"op": "set_context", "env": "", "tags": {}, "extra_info": {}},
+                {"op": "warning", "msg": "bbb"},
+                {"op": "set_context", "env": "xxx", "tags": {}, "extra_info": {}},
+                {"op": "warning", "msg": "ccc"},
+                {"op": "set_context", "env": "", "tags": {"aa": "bb"}, "extra_info": {}},
+                {"op": "warning", "msg": "ddd"},
+                {"op": "set_context", "env": "", "tags": {}, "extra_info": {"cc": "dd"}},
+                {"op": "warning", "msg": "eee"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "msg": "aaa", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"version": 0, "type": 2, "msg": "bbb", "env": ""},
+                {"version": 0, "type": 2, "msg": "ccc", "env": "xxx"},
+                {"version": 0, "type": 2, "msg": "ddd", "env": "", "tags": {"aa": "bb"}},
+                {"version": 0, "type": 2, "msg": "eee", "env": "", "extra_info": {"cc": "dd"}}
+            ])
+
+    def test_warning_vector_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "efg", "tags": ["a", "b"], "extra_info": ["c", "d"]},
+                {"op": "warning", "msg": "aaa"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 2, "msg": "aaa", "env": "efg",
+                "tags": {"0": "a", "1": "b"}, "extra_info": {"0": "c", "1": "d"}
+            }], timeout=1)
+
+    def test_error_tag_context(self):
+        self.kphp_server.set_error_tag(100500)
+        self.kphp_server.restart()
+        resp = self.kphp_server.http_post(json=[{"op": "warning", "msg": "hello"}])
+        self.assertEqual(resp.text, "ok")
+        self.kphp_server.assert_json_log(expect=[{"version": 100500, "type": 2, "env": "", "msg": "hello"}])
+        self.kphp_server.set_error_tag(None)
+        self.kphp_server.restart()

--- a/tests/python/tests/json_logs/test_warnings.py
+++ b/tests/python/tests/json_logs/test_warnings.py
@@ -15,17 +15,18 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
             expect=[
-                {"version": 0, "type": 2, "env": "", "msg": "hello"},
-                {"version": 0, "type": 2, "env": "", "msg": "world"}
+                {"version": 0, "type": 2, "env": "", "msg": "hello", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "env": "", "msg": "world", "tags": {"uncaught": False}}
             ])
 
     def test_warning_with_special_chars(self):
         resp = self.kphp_server.http_post(json=[{"op": "warning", "msg": 'aaa"bbb"\nccc'}])
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
-            expect=[
-                {"version": 0, "type": 2, "env": "", "msg": "aaa'bbb' ccc"}
-            ])
+            expect=[{
+                "version": 0, "type": 2, "env": "", "msg": "aaa'bbb' ccc",
+                "tags": {"uncaught": False}
+            }])
 
     def test_warning_with_tags(self):
         resp = self.kphp_server.http_post(
@@ -35,7 +36,10 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
-            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "", "tags": {"a": "b"}}])
+            expect=[{
+                "version": 0, "type": 2, "msg": "aaa", "env": "",
+                "tags": {"uncaught": False, "a": "b"}
+            }])
 
     def test_warning_with_extra_info(self):
         resp = self.kphp_server.http_post(
@@ -45,7 +49,10 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
-            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "", "extra_info": {"a": "b"}}])
+            expect=[{
+                "version": 0, "type": 2, "msg": "aaa", "env": "",
+                "tags": {"uncaught": False}, "extra_info": {"a": "b"}
+            }])
 
     def test_warning_with_env(self):
         resp = self.kphp_server.http_post(
@@ -55,7 +62,7 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
-            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "abc"}])
+            expect=[{"version": 0, "type": 2, "msg": "aaa", "env": "abc", "tags": {"uncaught": False}}])
 
     def test_warning_with_full_context(self):
         resp = self.kphp_server.http_post(
@@ -65,9 +72,10 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
-            expect=[
-                {"version": 0, "type": 2, "msg": "aaa", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}}
-            ])
+            expect=[{
+                "version": 0, "type": 2, "msg": "aaa", "env": "efg",
+                "tags": {"uncaught": False, "a": "b"}, "extra_info": {"c": "d"}
+            }])
 
     def test_warning_override_context(self):
         resp = self.kphp_server.http_post(
@@ -86,11 +94,17 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
         self.assertEqual(resp.text, "ok")
         self.kphp_server.assert_json_log(
             expect=[
-                {"version": 0, "type": 2, "msg": "aaa", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
-                {"version": 0, "type": 2, "msg": "bbb", "env": ""},
-                {"version": 0, "type": 2, "msg": "ccc", "env": "xxx"},
-                {"version": 0, "type": 2, "msg": "ddd", "env": "", "tags": {"aa": "bb"}},
-                {"version": 0, "type": 2, "msg": "eee", "env": "", "extra_info": {"cc": "dd"}}
+                {
+                    "version": 0, "type": 2, "msg": "aaa", "env": "efg",
+                    "tags": {"uncaught": False, "a": "b"}, "extra_info": {"c": "d"}
+                },
+                {"version": 0, "type": 2, "msg": "bbb", "env": "", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "msg": "ccc", "env": "xxx", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "msg": "ddd", "env": "", "tags": {"uncaught": False, "aa": "bb"}},
+                {
+                    "version": 0, "type": 2, "msg": "eee", "env": "",
+                    "tags": {"uncaught": False}, "extra_info": {"cc": "dd"}
+                }
             ])
 
     def test_warning_vector_context(self):
@@ -103,7 +117,7 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": 2, "msg": "aaa", "env": "efg",
-                "tags": {"0": "a", "1": "b"}, "extra_info": {"0": "c", "1": "d"}
+                "tags": {"uncaught": False, "0": "a", "1": "b"}, "extra_info": {"0": "c", "1": "d"}
             }], timeout=1)
 
     def test_error_tag_context(self):
@@ -111,6 +125,9 @@ class TestJsonLogsWarnings(KphpServerAutoTestCase):
         self.kphp_server.restart()
         resp = self.kphp_server.http_post(json=[{"op": "warning", "msg": "hello"}])
         self.assertEqual(resp.text, "ok")
-        self.kphp_server.assert_json_log(expect=[{"version": 100500, "type": 2, "env": "", "msg": "hello"}])
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 100500, "type": 2, "env": "", "msg": "hello", "tags": {"uncaught": False}
+            }])
         self.kphp_server.set_error_tag(None)
         self.kphp_server.restart()


### PR DESCRIPTION
Hi,

In order to write JSON logs from signal handlers, JSON logger must be **_async-signal-safe_**.
https://man7.org/linux/man-pages/man7/signal-safety.7.html

So,
1) JSON logger has been refactored to become signal safe:
    - no FILE stream API
    - handmade buffered out
    - raw file descriptor

2) Write JSON logs from SIGSEGV and SIGABRT handlers (for mater and workers) with error type -1 (except stack overflow, for it error type is 1)
3) Write JSON logs after uncaught exceptions, with additional tag `"uncaught": true` and error type 1
4) Add some python tests and integrate python tests into github workflow

Update:
5) Write `uncaught`  for each log record - set `true` if request has been unexpectedly terminated, false otherwise