### PR TITLE
Some fixes in RPC lib

### DIFF
--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -1188,7 +1188,7 @@ array<mixed> tl_fetch_error(const char *error, int error_code) {
   return tl_fetch_error(string(error), error_code);
 }
 
-static long long rpc_tl_results_last_query_num = -1;
+long long rpc_tl_results_last_query_num = -1;
 
 bool try_fetch_rpc_error(array<mixed> &out_if_error) {
   int x = rpc_lookup_int();
@@ -1401,7 +1401,7 @@ array<mixed> f$rpc_tl_query_result_one(int64_t query_id) {
 
   if (dl::query_num != rpc_tl_results_last_query_num) {
     resumable_finished = true;
-    return tl_fetch_error("There was no TL queries in current script run", TL_ERROR_INTERNAL);
+    return tl_fetch_error("There were no TL queries in current script run", TL_ERROR_INTERNAL);
   }
 
   class_instance<RpcTlQuery> rpc_query = RpcPendingQueries::get().withdraw(query_id);

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -1240,7 +1240,6 @@ class_instance<RpcTlQuery> store_function(const mixed &tl_object) {
 array<mixed> fetch_function(const class_instance<RpcTlQuery> &rpc_query) {
   array<mixed> new_tl_object;
   if (try_fetch_rpc_error(new_tl_object)) {
-
     return new_tl_object;       // this object carries an error (see tl_fetch_error())
   }
   php_assert(!rpc_query.is_null());
@@ -1394,22 +1393,30 @@ public:
 
 
 array<mixed> f$rpc_tl_query_result_one(int64_t query_id) {
+  auto resumable_finalizer = vk::finally([] { resumable_finished = true; });
+
   if (query_id <= 0) {
-    resumable_finished = true;
     return tl_fetch_error("Wrong query_id", TL_ERROR_WRONG_QUERY_ID);
   }
 
   if (dl::query_num != rpc_tl_results_last_query_num) {
-    resumable_finished = true;
     return tl_fetch_error("There were no TL queries in current script run", TL_ERROR_INTERNAL);
   }
 
   class_instance<RpcTlQuery> rpc_query = RpcPendingQueries::get().withdraw(query_id);
   if (rpc_query.is_null()) {
-    resumable_finished = true;
     return tl_fetch_error("Can't use rpc_tl_query_result for non-TL query", TL_ERROR_INTERNAL);
   }
 
+  if (!rpc_query.get()->result_fetcher || rpc_query.get()->result_fetcher->empty()) {
+    return tl_fetch_error("Rpc query has empty result fetcher", TL_ERROR_INTERNAL);
+  }
+
+  if (rpc_query.get()->result_fetcher->is_typed) {
+    return tl_fetch_error("Can't get untyped result from typed TL query. Use consistent API for that", TL_ERROR_INTERNAL);
+  }
+
+  resumable_finalizer.disable();
   return start_resumable<array<mixed>>(new rpc_tl_query_result_one_resumable(query_id, std::move(rpc_query)));
 }
 

--- a/runtime/rpc.h
+++ b/runtime/rpc.h
@@ -10,6 +10,8 @@
 #include "runtime/kphp_core.h"
 #include "runtime/resumable.h"
 
+extern long long rpc_tl_results_last_query_num;
+
 extern const string tl_str_;
 extern const string tl_str_underscore;
 extern const string tl_str_resultFalse;

--- a/runtime/typed_rpc.cpp
+++ b/runtime/typed_rpc.cpp
@@ -167,9 +167,11 @@ int64_t typed_rpc_tl_query_impl(const class_instance<C$RpcConnection> &connectio
   if (ignore_answer) {
     return -1;
   }
+
   if (dl::query_num != rpc_tl_results_last_query_num) {
     rpc_tl_results_last_query_num = dl::query_num;
   }
+
   class_instance<RpcTlQuery> query;
   query.alloc();
   query.get()->query_id = query_id;
@@ -199,6 +201,10 @@ class_instance<C$VK$TL$RpcResponse> typed_rpc_tl_query_result_one_impl(int64_t q
 
   if (!query.get()->result_fetcher || query.get()->result_fetcher->empty()) {
     return error_factory.make_error("Rpc query has empty result fetcher", TL_ERROR_INTERNAL);
+  }
+
+  if (!query.get()->result_fetcher->is_typed) {
+    return error_factory.make_error("Can't get typed result from untyped TL query. Use consistent API for that", TL_ERROR_INTERNAL);
   }
 
   resumable_finalizer.disable();

--- a/runtime/typed_rpc.cpp
+++ b/runtime/typed_rpc.cpp
@@ -167,7 +167,9 @@ int64_t typed_rpc_tl_query_impl(const class_instance<C$RpcConnection> &connectio
   if (ignore_answer) {
     return -1;
   }
-
+  if (dl::query_num != rpc_tl_results_last_query_num) {
+    rpc_tl_results_last_query_num = dl::query_num;
+  }
   class_instance<RpcTlQuery> query;
   query.alloc();
   query.get()->query_id = query_id;
@@ -184,6 +186,10 @@ class_instance<C$VK$TL$RpcResponse> typed_rpc_tl_query_result_one_impl(int64_t q
 
   if (query_id <= 0) {
     return error_factory.make_error("Rpc query has incorrect query id", TL_ERROR_WRONG_QUERY_ID);
+  }
+
+  if (dl::query_num != rpc_tl_results_last_query_num) {
+    return error_factory.make_error("There were no TL queries in current script run", TL_ERROR_INTERNAL);
   }
 
   auto query = RpcPendingQueries::get().withdraw(query_id);


### PR DESCRIPTION
Here are 2 fixes:
- Update script runs counter on getting typed RPC TL response. Without it `rpc_tl_pending_queries_count()` always returns 0 if only typed RPC requests are used.
- Fix fatal error on inconsistent RPC TL API usage. Without it typed sending followed by untyped getting result or vice versa raises fatal error.