### PR TITLE
Change the disabled profiler behavior

### DIFF
--- a/runtime/profiler.cpp
+++ b/runtime/profiler.cpp
@@ -617,7 +617,3 @@ void f$profiler_set_function_label(const string &label) noexcept {
     top->use_function_label(label_view);
   }
 }
-
-bool f$profiler_is_enabled() noexcept {
-  return ProfilerContext::get().call_stack.get_top();
-}

--- a/runtime/profiler.h
+++ b/runtime/profiler.h
@@ -267,4 +267,3 @@ void global_init_profiler() noexcept;
 
 void f$profiler_set_log_suffix(const string &suffix) noexcept;
 void f$profiler_set_function_label(const string &label) noexcept;
-bool f$profiler_is_enabled() noexcept;


### PR DESCRIPTION
Hi,

1) Replace `profiler_is_enabled()` call with `true` if profiler is enabled and with `false` if it is disabled;
2) Move `profiler_set_log_suffix()` and `profiler_set_function_label()` under `if(false)` for the disabled profiler.

I leave code under 'false' on purpose, so it is reachable and we can avoid compilation errors after profiler enabling.