### PR TITLE
Check return of forked function args.

### DIFF
--- a/compiler/pipes/fix-returns.cpp
+++ b/compiler/pipes/fix-returns.cpp
@@ -47,3 +47,13 @@ VertexPtr FixReturnsPass::on_enter_vertex(VertexPtr root) {
 
   return root;
 }
+
+bool FixReturnsPass::user_recursion(VertexPtr root) {
+  if (auto fork_vertex = root.try_as<op_fork>()) {
+    for (auto arg : fork_vertex->func_call()->args()) {
+      run_function_pass(arg, this);
+    }
+    return true;
+  }
+  return false;
+}

--- a/compiler/pipes/fix-returns.h
+++ b/compiler/pipes/fix-returns.h
@@ -12,9 +12,7 @@ public:
     return "Fix returns";
   }
 
-  VertexPtr on_enter_vertex(VertexPtr root) override;
+  VertexPtr on_enter_vertex(VertexPtr root) final;
 
-  bool user_recursion(VertexPtr root) override {
-    return root->type() == op_fork;
-  }
+  bool user_recursion(VertexPtr root) final;
 };

--- a/tests/phpt/fork/016_forked_function_arg_returns_void_error.php
+++ b/tests/phpt/fork/016_forked_function_arg_returns_void_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/Using result of void function g/
+<?php
+
+function g() { echo "hi"; }
+
+function f($x) { return $x; }
+
+function demo() {
+  $res = fork(f(g()));
+}
+
+demo();


### PR DESCRIPTION
Hi,

here is a fix of SIGABRT which is raised on the following code
```php
<?php

function g() { echo "hi";}

function f($x) { return $x; }

function demo() {
  $res = fork(f(g()));
}

demo();
```

So after this patch, KPHP checks the function calls which are passed to forked functions.