### PR TITLE
fix superfluous "No such file or directory" in composer mode

### DIFF
--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -532,8 +532,11 @@ void CompilerCore::init_composer_class_loader() {
   // folder in order to collect all dependencies (both direct and indirect).
 
   std::string vendor = settings().composer_root.get() + "/vendor";
-  for (const auto &composer_root : find_composer_folders(vendor)) {
-    composer_class_loader.load_file(composer_root);
+  bool vendor_folder_exists = access(vendor.c_str(), F_OK) == 0;
+  if (vendor_folder_exists) {
+    for (const auto &composer_root : find_composer_folders(vendor)) {
+      composer_class_loader.load_file(composer_root);
+    }
   }
 }
 


### PR DESCRIPTION
When --composer-root is specified, kphp2cpp will try to locate
$composer-root/vendor folder. If it's a newly created composer project
without dependencies (or "composer install" was never executed)
there will be no vendor folder at all.

This change makes sure that we don't try to traverse the non-existing folder.