### PR TITLE
support PHP8 union type hints and mixed typehint

### DIFF
--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -508,12 +508,10 @@ void init_assumptions_for_return(FunctionPtr f, VertexAdaptor<op_function> root)
       return;
     }
   }
-  if (!f->return_typehint.empty()) {
-    if (auto parsed = phpdoc_parse_type_and_var_name(f->return_typehint, f)) {
-      if (parsed.type_expr->type() != op_type_expr_callable) {
-        assumption_add_for_return(f, assumption_create_from_phpdoc(parsed.type_expr));
-        return;
-      }
+  if (f->return_typehint) {
+    if (f->return_typehint->type() != op_type_expr_callable) {
+      assumption_add_for_return(f, assumption_create_from_phpdoc(f->return_typehint));
+      return;
     }
   }
 

--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -415,9 +415,8 @@ void init_assumptions_for_arguments(FunctionPtr f, VertexAdaptor<op_function> ro
   VertexRange params = root->params()->args();
   for (auto i : params.get_reversed_range()) {
     VertexAdaptor<op_func_param> param = i.as<op_func_param>();
-    if (!param->type_declaration.empty()) {
-      auto result = phpdoc_parse_type_and_var_name(param->type_declaration, f);
-      auto a = assumption_create_from_phpdoc(result.type_expr);
+    if (param->type_declaration) {
+      auto a = assumption_create_from_phpdoc(param->type_declaration);
       if (!a->is_primitive()) {
         assumption_add_for_var(f, param->var()->get_string(), a);
       }

--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -415,8 +415,8 @@ void init_assumptions_for_arguments(FunctionPtr f, VertexAdaptor<op_function> ro
   VertexRange params = root->params()->args();
   for (auto i : params.get_reversed_range()) {
     VertexAdaptor<op_func_param> param = i.as<op_func_param>();
-    if (param->type_declaration) {
-      auto a = assumption_create_from_phpdoc(param->type_declaration);
+    if (param->type_hint) {
+      auto a = assumption_create_from_phpdoc(param->type_hint);
       if (!a->is_primitive()) {
         assumption_add_for_var(f, param->var()->get_string(), a);
       }

--- a/compiler/data/class-members.cpp
+++ b/compiler/data/class-members.cpp
@@ -161,7 +161,8 @@ void ClassMembersContainer::add_instance_method(FunctionPtr function) {
   function->class_id = klass;
   function->context_class = klass;
 
-  auto rule_this_var = GenTree::create_type_help_class_vertex(klass);
+  auto rule_this_var = GenTree::create_type_help_class_vertex(klass->name);
+  rule_this_var->class_ptr = klass;
   auto this_var = function->root->params()->args()[0].as<op_func_param>()->var();
   this_var->type_rule = VertexAdaptor<op_common_type_rule>::create(rule_this_var);
 

--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -284,7 +284,7 @@ void FunctionData::add_kphp_infer_hint(FunctionData::InferHint::InferType infer_
     return;
   }
   type_expr.set_location(root);
-  infer_hints.emplace_back(InferHint{infer_type, param_i, type_expr});
+  infer_hints.emplace_back(infer_type, param_i, type_expr);
 }
 
 bool FunctionData::is_lambda_with_uses() const {

--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -42,6 +42,7 @@ FunctionPtr FunctionData::clone_from(const std::string &new_name, FunctionPtr ot
   res->name = new_name;
   res->update_location_in_body();
   res->name_gen_map = {};
+  res->return_typehint = other->return_typehint.clone();
 
   res->assumptions_for_vars = {};
   res->assumption_args_status = AssumptionStatus::unknown;

--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -278,12 +278,12 @@ string FunctionData::get_human_readable_name(bool add_details) const {
   return result_name;
 }
 
-void FunctionData::add_kphp_infer_hint(FunctionData::InferHint::infer_mask infer_mask, int param_i, VertexPtr type_rule) {
-  if (!type_rule) {
+void FunctionData::add_kphp_infer_hint(FunctionData::InferHint::InferType infer_type, int param_i, VertexPtr type_expr) {
+  if (!type_expr) {
     return;
   }
-  type_rule.set_location(root);
-  infer_hints.emplace_back(InferHint{infer_mask, param_i, type_rule});
+  type_expr.set_location(root);
+  infer_hints.emplace_back(InferHint{infer_type, param_i, type_expr});
 }
 
 bool FunctionData::is_lambda_with_uses() const {

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -100,7 +100,7 @@ public:
   int tinf_state = 0;
   vector<tinf::VarNode> tinf_nodes;
   vector<InferHint> infer_hints;        // kphp-infer hint/check for param/return
-  std::string return_typehint;
+  VertexPtr return_typehint;
 
   bool has_variadic_param = false;
   bool should_be_sync = false;

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -33,23 +33,23 @@ private:
 
 public:
   struct InferHint {
-    enum infer_mask {
-      check         = 0b00001,
-      hint          = 0b00010,
-      hint_check    = 0b00100,
-      cast          = 0b01000,
+    enum class InferType {
+      check,
+      hint,
+      hint_check,
+      cast,
     };
 
-    InferHint(infer_mask infer_type, int param_i, VertexPtr type_rule) :
+    InferHint(InferType infer_type, int param_i, VertexPtr type_expr) :
       infer_type(infer_type),
       param_i(param_i),
-      type_rule(type_rule) {
+      type_expr(type_expr) {
     }
 
 
-    infer_mask infer_type;
+    InferType infer_type;
     int param_i;            // 0..N — arguments, -1 return (just like in tinf)
-    VertexPtr type_rule;    // op_lt_type_rule / op_common_type_rule / etc
+    VertexPtr type_expr;    // not op_lt_type_rule/etc, but what's inside (the type representation itself)
   };
 
   int id = -1;
@@ -153,7 +153,7 @@ public:
   std::string get_performance_inspections_warning_chain(PerformanceInspections::Inspections inspection, bool search_disabled_inspection = false) const noexcept;
   static string get_human_readable_name(const std::string &name, bool add_details = true);
   string get_human_readable_name(bool add_details = true) const;
-  void add_kphp_infer_hint(InferHint::infer_mask infer_mask, int param_i, VertexPtr type_rule);
+  void add_kphp_infer_hint(InferHint::InferType infer_type, int param_i, VertexPtr type_expr);
 
   bool has_implicit_this_arg() const {
     return modifiers.is_instance();

--- a/compiler/data/lambda-generator.cpp
+++ b/compiler/data/lambda-generator.cpp
@@ -184,11 +184,11 @@ VertexAdaptor<op_func_param_list> LambdaGenerator::create_invoke_params(VertexAd
   // every parameter (excluding $this) could be any class_instance
   for (size_t i = 1, id = 0; i < func_parameters.size(); ++i) {
     auto param = func_parameters[i].as<op_func_param>();
-    if (param->type_declaration == "callable") {
+    if (param->type_declaration && param->type_declaration->type() == op_type_expr_callable) {
       param->template_type_id = static_cast<int>(id);
       param->is_callable = true;
       id++;
-    } else if (param->type_declaration.empty()) {
+    } else if (!param->type_declaration) {
       param->template_type_id = static_cast<int>(id);
       id++;
     }

--- a/compiler/data/lambda-generator.cpp
+++ b/compiler/data/lambda-generator.cpp
@@ -184,11 +184,11 @@ VertexAdaptor<op_func_param_list> LambdaGenerator::create_invoke_params(VertexAd
   // every parameter (excluding $this) could be any class_instance
   for (size_t i = 1, id = 0; i < func_parameters.size(); ++i) {
     auto param = func_parameters[i].as<op_func_param>();
-    if (param->type_declaration && param->type_declaration->type() == op_type_expr_callable) {
+    if (param->type_hint && param->type_hint->type() == op_type_expr_callable) {
       param->template_type_id = static_cast<int>(id);
       param->is_callable = true;
       id++;
-    } else if (!param->type_declaration) {
+    } else if (!param->type_hint) {
       param->template_type_id = static_cast<int>(id);
       id++;
     }

--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -232,8 +232,8 @@ std::string debugVertexMore(VertexPtr v) {
     case op_int_const:
       return v->get_string();
     case op_type_expr_class:
-      return v.as<op_type_expr_class>()->class_ptr
-             ? v.as<op_type_expr_class>()->class_ptr->name : "class_ptr = null";
+      return v.as<op_type_expr_class>()->class_name + " = " +
+             (v.as<op_type_expr_class>()->class_ptr ? v.as<op_type_expr_class>()->class_ptr->name : "unresolved");
     case op_type_expr_type:
       return ptype_name(v->type_help);
     case op_seq:

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -643,7 +643,7 @@ VertexAdaptor<op_ternary> GenTree::create_ternary_op_vertex(VertexPtr condition,
 VertexAdaptor<op_type_expr_class> GenTree::create_type_help_class_vertex(const std::string &unresolved_class_name) {
   auto type_rule = VertexAdaptor<op_type_expr_class>::create();
   type_rule->type_help = tp_Class;
-  type_rule->class_ptr = ClassPtr{}; // this will be set later, see phpdoc_prepare_type_rule_resolving_classes()
+  type_rule->class_ptr = {}; // this will be set later, see phpdoc_prepare_type_rule_resolving_classes()
   type_rule->class_name = unresolved_class_name;
   return type_rule;
 }

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -786,7 +786,7 @@ VertexPtr GenTree::get_def_value() {
 VertexAdaptor<op_func_param> GenTree::get_func_param_without_callbacks(bool from_callback) {
   auto location = auto_location();
 
-  VertexPtr type_hint = get_typehint_as_type_expr();
+  VertexPtr type_hint = get_typehint();
   bool is_varg = false;
 
   // if the argument is vararg and has a type hint — e.g. int ...$a — then cur points to $a, as ... were consumed by the type lexer
@@ -1515,7 +1515,7 @@ VertexAdaptor<op_function> GenTree::get_function(TokenType tok, vk::string_view 
 
   if (test_expect(tok_colon)) {
     next_cur();
-    cur_function->return_typehint = get_typehint_as_type_expr();
+    cur_function->return_typehint = get_typehint();
     kphp_error(cur_function->return_typehint, "Expected return typehint after :");
   }
 
@@ -1898,26 +1898,7 @@ VertexAdaptor<op_empty> GenTree::get_static_field_list(vk::string_view phpdoc_st
   return VertexAdaptor<op_empty>::create();
 }
 
-std::string GenTree::get_typehint() {
-  std::string typehint;
-  bool is_nullable = false;
-
-  if (test_expect(tok_question)) {
-    is_nullable = true;
-    next_cur();
-  }
-
-  if (vk::any_of_equal(cur->type(), tok_func_name, tok_array, tok_string, tok_int, tok_float, tok_bool, tok_callable, tok_void)) {
-    typehint = std::string(cur->str_val) + (is_nullable ? "|null" : "");
-    next_cur();
-  } else {
-    kphp_error(!is_nullable, "Syntax error: question token without type specifier");
-  }
-
-  return typehint;
-}
-
-VertexPtr GenTree::get_typehint_as_type_expr() {
+VertexPtr GenTree::get_typehint() {
   // optimization: don't start the lexer if it's 100% not a type hint here (so it wouldn't be parsed, and it's okay)
   // without this, everything still works, just a bit slower
   if (vk::any_of_equal(cur->type(), TokenType::tok_var_name, TokenType::tok_clpar, TokenType::tok_and, TokenType::tok_varg)) {

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1905,12 +1905,13 @@ VertexPtr GenTree::get_typehint() {
     return {};
   }
 
-  auto start = cur;
-  PhpDocTypeRuleParser parser(cur_function);
-  VertexPtr type_expr = parser.parse_from_tokens_silent(cur);
-  CE(!kphp_error(cur == start || type_expr, "Cannot parse type hint"));
-
-  return type_expr;
+  try {
+    PhpDocTypeRuleParser parser(cur_function);
+    return parser.parse_from_tokens(cur);
+  } catch (std::runtime_error &) {
+    kphp_error(0, "Cannot parse type hint");
+    return {};
+  }
 }
 
 VertexPtr GenTree::get_statement(vk::string_view phpdoc_str) {

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1498,10 +1498,6 @@ VertexAdaptor<op_function> GenTree::get_function(TokenType tok, vk::string_view 
   StackPushPop<FunctionPtr> f_alive(functions_stack, cur_function, FunctionData::create_function(func_name, func_root, FunctionData::func_local));
   cur_function->phpdoc_str = phpdoc_str;
   cur_function->modifiers = modifiers;
-  if (!is_lambda) { // todo delete this after resolve_uses() is not needed in phpdoc
-    cur_function->class_id = cur_class;
-    cur_function->context_class = cur_class;
-  }
 
   // function params follow the function name, followed by the 'use' list for closures
   CE(cur_function->root->params_ref() = parse_cur_function_param_list());

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -829,7 +829,7 @@ VertexAdaptor<op_func_param> GenTree::get_func_param_without_callbacks(bool from
     if (def_val && def_val->type() == op_null) {
       type_hint = VertexAdaptor<op_type_expr_lca>::create(type_hint, GenTree::create_type_help_vertex(tp_Null));
     }
-    v->type_declaration = type_hint;
+    v->type_hint = type_hint;
   }
 
   if (type_rule) {

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -159,8 +159,7 @@ public:
   static VertexAdaptor<op_func_call> generate_critical_error(std::string msg);
 
 private:
-  std::string get_typehint();
-  VertexPtr get_typehint_as_type_expr();
+  VertexPtr get_typehint();
 
   VertexAdaptor<op_func_param_list> parse_cur_function_param_list();
 

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -70,8 +70,7 @@ public:
 
   static void func_force_return(VertexAdaptor<op_function> func, VertexPtr val = {});
   VertexAdaptor<op_ternary> create_ternary_op_vertex(VertexPtr condition, VertexPtr true_expr, VertexPtr false_expr);
-  VertexAdaptor<op_type_expr_class> create_type_help_class_vertex(vk::string_view klass_name);
-  static VertexAdaptor<op_type_expr_class> create_type_help_class_vertex(ClassPtr klass);
+  static VertexAdaptor<op_type_expr_class> create_type_help_class_vertex(const std::string &unresolved_class_name);
   template<Operation op = meta_op_base>
   static VertexAdaptor<op_type_expr_type> create_type_help_vertex(PrimitiveType type, const std::vector<VertexAdaptor<op>> &children = {}) {
     auto type_rule = VertexAdaptor<op_type_expr_type>::create(children);
@@ -161,6 +160,7 @@ public:
 
 private:
   std::string get_typehint();
+  VertexPtr get_typehint_as_type_expr();
 
   VertexAdaptor<op_func_param_list> parse_cur_function_param_list();
 

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -297,10 +297,6 @@ VertexPtr PhpDocTypeRuleParser::parse_type_array() {
     res = GenTree::create_type_help_vertex(tp_array, {res});
     cur_tok += 2;
   }
-  if (cur_tok->type() == tok_varg) {      // "int ...$args" is identical to "int [] $args"; can also handle "(int|false) ..."
-    cur_tok++;
-    res = GenTree::create_type_help_vertex(tp_array, {res});
-  }
 
   return res;
 }
@@ -485,6 +481,13 @@ VertexPtr PhpDocTypeRuleParser::parse_type_expression() {
 VertexPtr PhpDocTypeRuleParser::parse_from_tokens(std::vector<Token>::const_iterator &tok_iter) {
   cur_tok = tok_iter;
   VertexPtr v = parse_type_expression();      // could throw an exception
+
+  // "?int ...$args" == "(?int)[] $args", "int|false ...$a" == "(int|false)[] $a"; handle "..." after all has been parsed
+  if (cur_tok->type() == tok_varg) {
+    cur_tok++;
+    v = GenTree::create_type_help_vertex(tp_array, {v});
+  }
+
   tok_iter = cur_tok;
   return v;                                   // not null if an exception was not thrown
 }

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -121,12 +121,6 @@ vector<php_doc_tag> parse_php_doc(vk::string_view phpdoc) {
 }
 
 VertexPtr PhpDocTypeRuleParser::parse_classname(const std::string &phpdoc_class_name) {
-  const std::string &class_name = resolve_uses(current_function, phpdoc_class_name, '\\');
-  ClassPtr klass = G->get_class(class_name);
-  if (!klass) {
-    unknown_classes_list.push_back(class_name);
-  }
-
   cur_tok++;
   // we return an op_type_expr_class with a _relative_ class_name inside (it may also be "self" or similar)
   // later on, this string class_name will be resolved to a class_ptr (see phpdoc_prepare_type_rule_resolving_classes)

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -635,7 +635,7 @@ bool phpdoc_prepare_type_expr_resolving_classes(FunctionPtr cur_function, Vertex
   }
 
   for (auto i : *type_expr) {
-    all_resolved &= phpdoc_prepare_type_expr_resolving_classes(cur_function, i);
+    all_resolved = all_resolved && phpdoc_prepare_type_expr_resolving_classes(cur_function, i);
   }
 
   return all_resolved;

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -108,3 +108,5 @@ std::vector<PhpDocTagParseResult> phpdoc_find_tag_multi(vk::string_view phpdoc, 
 std::vector<std::string> phpdoc_find_tag_as_string_multi(vk::string_view phpdoc, php_doc_tag::doc_type tag_type);
 
 bool phpdoc_tag_exists(vk::string_view phpdoc, php_doc_tag::doc_type tag_type);
+
+bool phpdoc_prepare_type_expr_resolving_classes(FunctionPtr cur_function, VertexPtr type_expr);

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -80,12 +80,9 @@ public:
   VertexPtr parse_from_tokens(std::vector<Token>::const_iterator &tok_iter);
   VertexPtr parse_from_tokens_silent(std::vector<Token>::const_iterator &tok_iter) noexcept;
 
-  const std::vector<std::string> &get_unknown_classes() const { return unknown_classes_list; }
-
 private:
   FunctionPtr current_function;
   std::vector<Token>::const_iterator cur_tok;
-  std::vector<std::string> unknown_classes_list;
 
   VertexPtr parse_classname(const std::string &phpdoc_class_name);
   VertexPtr parse_simple_type();

--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -445,21 +445,21 @@ void CollectMainEdgesPass::on_function(FunctionPtr function) {
       create_set(function->param_ids[i], as_rvalue(function, i));
     }
 
-    using infer_mask = FunctionData::InferHint::infer_mask;
+    using InferType = FunctionData::InferHint::InferType;
     // @kphp-infer hint/check for @param/@return — is less/set on the associated tinf_node(s) function.
     for (const FunctionData::InferHint &hint : function->infer_hints) {
       switch (hint.infer_type) {
-        case infer_mask::hint_check:
-          create_set(as_lvalue(function, hint.param_i), VertexAdaptor<op_common_type_rule>::create(hint.type_rule));
-          create_less(as_rvalue(function, hint.param_i), VertexAdaptor<op_lt_type_rule>::create(hint.type_rule));
+        case InferType::hint_check:
+          create_set(as_lvalue(function, hint.param_i), VertexAdaptor<op_common_type_rule>::create(hint.type_expr));
+          create_less(as_rvalue(function, hint.param_i), VertexAdaptor<op_lt_type_rule>::create(hint.type_expr));
           break;
-        case infer_mask::check:
-          create_less(as_rvalue(function, hint.param_i), VertexAdaptor<op_lt_type_rule>::create(hint.type_rule));
+        case InferType::check:
+          create_less(as_rvalue(function, hint.param_i), VertexAdaptor<op_lt_type_rule>::create(hint.type_expr));
           break;
-        case infer_mask::hint:
-          create_set(as_lvalue(function, hint.param_i), VertexAdaptor<op_common_type_rule>::create(hint.type_rule));
+        case InferType::hint:
+          create_set(as_lvalue(function, hint.param_i), VertexAdaptor<op_common_type_rule>::create(hint.type_expr));
           break;
-        case infer_mask::cast:
+        case InferType::cast:
           // do nothing: cast is a type_help attached in parse_and_apply_function_kphp_phpdoc()
           break;
       }

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -106,20 +106,16 @@ private:
 
   // Searching for classes inside @var/@param phpdoc as well as inside type hints
   inline void require_all_classes_in_phpdoc_type(VertexPtr type_expr) {
-    std::function<void(VertexPtr)> find_unknown_and_require = [this, &find_unknown_and_require](VertexPtr type_expr) {
-      if (auto as_op_class = type_expr.try_as<op_type_expr_class>()) {
-        const std::string &class_name = resolve_uses(current_function, as_op_class->class_name, '\\');
-        if (!G->get_class(class_name)) {
-          require_class(replace_characters(class_name, '\\', '/'));
-        }
+    if (auto as_op_class = type_expr.try_as<op_type_expr_class>()) {
+      const std::string &class_name = resolve_uses(current_function, as_op_class->class_name, '\\');
+      if (!G->get_class(class_name)) {
+        require_class(replace_characters(class_name, '\\', '/'));
       }
+    }
 
-      for (auto i : *type_expr) {
-        find_unknown_and_require(i);
-      }
-    };
-
-    find_unknown_and_require(type_expr);
+    for (auto i : *type_expr) {
+      require_all_classes_in_phpdoc_type(i);
+    }
   }
 
   // Collect classes to require from the function prototype.

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -128,8 +128,8 @@ private:
   //          TODO: fix this when we'll parse the phpdoc once.
   inline void require_all_classes_from_func_declaration(FunctionPtr f) {
     for (const auto &p: f->get_params()) {
-      if (p.as<op_func_param>()->type_declaration) {
-        require_all_classes_in_phpdoc_type(p.as<op_func_param>()->type_declaration);
+      if (p.as<op_func_param>()->type_hint) {
+        require_all_classes_in_phpdoc_type(p.as<op_func_param>()->type_hint);
       }
     }
     // f->return_typehint is ignored;

--- a/compiler/pipes/prepare-function.cpp
+++ b/compiler/pipes/prepare-function.cpp
@@ -23,7 +23,7 @@
 // Note that @kphp-required is analyzed inside gentree.
 class ParseAndApplyPHPDoc {
 private:
-  using infer_mask = FunctionData::InferHint::infer_mask;
+  using InferType = FunctionData::InferHint::InferType;
 
 public:
   ParseAndApplyPHPDoc(FunctionPtr f) :
@@ -128,7 +128,7 @@ private:
         f_->is_template = true;
       } else if (!op_func_param->type_declaration.empty()) {
         auto parsed = phpdoc_parse_type_and_var_name(op_func_param->type_declaration, f_);
-        f_->add_kphp_infer_hint(infer_mask::hint_check, param_i, parsed.type_expr);
+        f_->add_kphp_infer_hint(InferType::hint_check, param_i, parsed.type_expr);
       }
     }
   }
@@ -136,7 +136,7 @@ private:
   void apply_return_type_hint() {
     if (!f_->return_typehint.empty()) {
       auto parsed = phpdoc_parse_type_and_var_name(f_->return_typehint, f_);
-      f_->add_kphp_infer_hint(infer_mask::hint_check, -1, parsed.type_expr);
+      f_->add_kphp_infer_hint(InferType::hint_check, -1, parsed.type_expr);
     }
   }
 
@@ -305,7 +305,7 @@ private:
     }
 
     // todo better to add hint_check here, but vk.com has lots of errors, maybe will be fixed later
-    f_->add_kphp_infer_hint(infer_mask::check, -1, doc_parsed.type_expr);
+    f_->add_kphp_infer_hint(InferType::check, -1, doc_parsed.type_expr);
     has_return_php_doc_ = true;
   }
 
@@ -336,7 +336,7 @@ private:
       }
     }
 
-    f_->add_kphp_infer_hint(infer_mask::hint_check, param_i, doc_parsed.type_expr);
+    f_->add_kphp_infer_hint(InferType::hint_check, param_i, doc_parsed.type_expr);
 
     if (infer_cast_) {
       auto expr_type_v = doc_parsed.type_expr.try_as<op_type_expr_type>();
@@ -367,7 +367,7 @@ private:
       bool assume_return_void = !f_->is_constructor() && !f_->assumption_for_return;
 
       if (assume_return_void) {
-        f_->add_kphp_infer_hint(infer_mask::check, -1, GenTree::create_type_help_vertex(tp_void));
+        f_->add_kphp_infer_hint(InferType::check, -1, GenTree::create_type_help_vertex(tp_void));
       }
     }
   }

--- a/compiler/pipes/prepare-function.cpp
+++ b/compiler/pipes/prepare-function.cpp
@@ -121,14 +121,13 @@ private:
     for (int param_i = 0; param_i < func_params_.size(); ++param_i) {
       auto op_func_param = func_params_[param_i].as<meta_op_func_param>();
 
-      if (op_func_param->type_declaration == "callable") {
+      if (op_func_param->type_declaration && op_func_param->type_declaration->type() == op_type_expr_callable) {
         op_func_param->is_callable = true;
         op_func_param->template_type_id = id_of_kphp_template_++;
-        op_func_param->type_declaration.clear();
+        op_func_param->type_declaration = {};
         f_->is_template = true;
-      } else if (!op_func_param->type_declaration.empty()) {
-        auto parsed = phpdoc_parse_type_and_var_name(op_func_param->type_declaration, f_);
-        f_->add_kphp_infer_hint(InferType::hint_check, param_i, parsed.type_expr);
+      } else if (op_func_param->type_declaration) {
+        f_->add_kphp_infer_hint(InferType::hint_check, param_i, op_func_param->type_declaration);
       }
     }
   }
@@ -353,7 +352,7 @@ private:
     for (auto name_and_param_id : name_to_function_param_) {
       auto op_func_param = func_params_[name_and_param_id.second].as<meta_op_func_param>();
 
-      if (op_func_param->type_declaration.empty()) {
+      if (!op_func_param->type_declaration) {
         kphp_error(false, fmt_format("Specify @param or type hint for ${}", name_and_param_id.first));
       }
     }

--- a/compiler/pipes/prepare-function.cpp
+++ b/compiler/pipes/prepare-function.cpp
@@ -121,13 +121,13 @@ private:
     for (int param_i = 0; param_i < func_params_.size(); ++param_i) {
       auto op_func_param = func_params_[param_i].as<meta_op_func_param>();
 
-      if (op_func_param->type_declaration && op_func_param->type_declaration->type() == op_type_expr_callable) {
+      if (op_func_param->type_hint && op_func_param->type_hint->type() == op_type_expr_callable) {
         op_func_param->is_callable = true;
         op_func_param->template_type_id = id_of_kphp_template_++;
-        op_func_param->type_declaration = {};
+        op_func_param->type_hint = {};
         f_->is_template = true;
-      } else if (op_func_param->type_declaration) {
-        f_->add_kphp_infer_hint(InferType::hint_check, param_i, op_func_param->type_declaration);
+      } else if (op_func_param->type_hint) {
+        f_->add_kphp_infer_hint(InferType::hint_check, param_i, op_func_param->type_hint);
       }
     }
   }
@@ -352,7 +352,7 @@ private:
     for (auto name_and_param_id : name_to_function_param_) {
       auto op_func_param = func_params_[name_and_param_id.second].as<meta_op_func_param>();
 
-      if (!op_func_param->type_declaration) {
+      if (!op_func_param->type_hint) {
         kphp_error(false, fmt_format("Specify @param or type hint for ${}", name_and_param_id.first));
       }
     }

--- a/compiler/pipes/prepare-function.cpp
+++ b/compiler/pipes/prepare-function.cpp
@@ -134,9 +134,8 @@ private:
   }
 
   void apply_return_type_hint() {
-    if (!f_->return_typehint.empty()) {
-      auto parsed = phpdoc_parse_type_and_var_name(f_->return_typehint, f_);
-      f_->add_kphp_infer_hint(InferType::hint_check, -1, parsed.type_expr);
+    if (f_->return_typehint) {
+      f_->add_kphp_infer_hint(InferType::hint_check, -1, f_->return_typehint);
     }
   }
 
@@ -363,7 +362,7 @@ private:
   void check_function_has_return_or_type_hint() {
     // at this point, all phpdocs have been parsed, and has_return_php_doc_ is true if @return found
     // if we have no @return and no return hint, assume @return void
-    if (f_->return_typehint.empty() && !has_return_php_doc_) {
+    if (!f_->return_typehint && !has_return_php_doc_) {
       bool assume_return_void = !f_->is_constructor() && !f_->assumption_for_return;
 
       if (assume_return_void) {

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -37,8 +37,8 @@ void ResolveSelfStaticParentPass::on_start() {
     phpdoc_prepare_type_expr_resolving_classes(current_function, current_function->return_typehint);
   }
   for (auto param : current_function->get_params()) {
-    if (param->type() == op_func_param && param.as<op_func_param>()->type_declaration) {
-      phpdoc_prepare_type_expr_resolving_classes(current_function, param.as<op_func_param>()->type_declaration);
+    if (param->type() == op_func_param && param.as<op_func_param>()->type_hint) {
+      phpdoc_prepare_type_expr_resolving_classes(current_function, param.as<op_func_param>()->type_hint);
     }
   }
 }

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -12,6 +12,8 @@
 #include "compiler/data/src-file.h"
 #include "compiler/gentree.h"
 #include "compiler/name-gen.h"
+#include "compiler/phpdoc.h"
+
 
 void ResolveSelfStaticParentPass::on_start() {
   // replace self::, parent:: and accesses to other classes like Classes\A::CONST
@@ -29,6 +31,10 @@ void ResolveSelfStaticParentPass::on_start() {
         run_function_pass(f.var->init_val, this);
       }
     });
+  }
+
+  if (current_function->return_typehint) {
+    phpdoc_prepare_type_expr_resolving_classes(current_function, current_function->return_typehint);
   }
 }
 
@@ -99,6 +105,10 @@ VertexPtr ResolveSelfStaticParentPass::on_enter_vertex(VertexPtr v) {
                      fmt_format("Cannot instantiate abstract class {}", alloc->allocated_class_name), return v);
       check_access_to_class_from_this_file(alloc->allocated_class);
     }
+  }
+
+  if (v->type_rule) {
+    phpdoc_prepare_type_expr_resolving_classes(current_function, v->type_rule->rule());
   }
 
   return v;

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -36,6 +36,11 @@ void ResolveSelfStaticParentPass::on_start() {
   if (current_function->return_typehint) {
     phpdoc_prepare_type_expr_resolving_classes(current_function, current_function->return_typehint);
   }
+  for (auto param : current_function->get_params()) {
+    if (param->type() == op_func_param && param.as<op_func_param>()->type_declaration) {
+      phpdoc_prepare_type_expr_resolving_classes(current_function, param.as<op_func_param>()->type_declaration);
+    }
+  }
 }
 
 VertexPtr ResolveSelfStaticParentPass::on_enter_vertex(VertexPtr v) {

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -239,6 +239,9 @@
     "extra_fields": {
       "class_ptr": {
         "type": "ClassPtr"
+      },
+      "class_name": {
+        "type": "std::string"
       }
     }
   },

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -167,7 +167,7 @@
         "default": -1
       },
       "type_declaration": {
-        "type": "std::string"
+        "type": "VertexPtr"
       },
       "is_callable": {
         "type": "bool",

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -166,7 +166,7 @@
         "type": "int",
         "default": -1
       },
-      "type_declaration": {
+      "type_hint": {
         "type": "VertexPtr"
       },
       "is_callable": {
@@ -493,7 +493,7 @@
     }
   },
   {
-    "comment": "var(); or var() = default_value(); type hints are stored in type_declaration",
+    "comment": "var(); or var() = default_value(); type hints are stored in type_hint",
     "name": "op_func_param",
     "base_name": "meta_op_func_param"
   },

--- a/tests/phpt/typehints/params/02_question_tok_instead_of_params.php
+++ b/tests/phpt/typehints/params/02_question_tok_instead_of_params.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Syntax error: question token without type specifier/
+/Cannot parse type hint/
 <?php
 function foo(?) {
 }

--- a/tests/phpt/typehints/params/04_question_with_var.php
+++ b/tests/phpt/typehints/params/04_question_with_var.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Syntax error: question token without type specifier/
+/Cannot parse type hint/
 <?php
 function foo(? $var) {
 }

--- a/tests/phpt/typehints/return_types/13_static_is_not_allowed.php
+++ b/tests/phpt/typehints/return_types/13_static_is_not_allowed.php
@@ -1,9 +1,0 @@
-@kphp_should_fail
-/Expected return typehint after/
-<?php
-class A {
-  public static function foo():static {
-    return new self();
-  }
-}
-

--- a/tests/phpt/typehints/return_types/13_static_return_type.php
+++ b/tests/phpt/typehints/return_types/13_static_return_type.php
@@ -1,0 +1,29 @@
+@ok
+<?php
+class Base {
+  // :static is unsupported in PHP till 8.0, but supported in KPHP
+  // test it, making two declarations — for PHP and for KPHP
+  public static function foo()
+#ifndef KPHP
+/*
+#endif
+: static
+#ifndef KPHP
+ */
+#endif
+    {
+    return new static();
+  }
+}
+
+class D1 extends Base {
+    var $d1 = 0;
+}
+
+class D2 extends Base {
+    var $d2 = 0;
+}
+
+Base::foo();
+D1::foo()->d1;
+D2::foo()->d2;


### PR DESCRIPTION
Previously, type hints (params of functions and return typehints) were parsed separately and stored as strings.

Now, KPHP parses type hints just the same as PHPDoc. This leads to support union type hints, like
function f(int|false $a): string|int
Also, 'mixed' is parsed correctly as a consequence:
function f(mixed $a): mixed

Moreover, a correct syntax is ANY type that can appear in PHPDoc. For instance, these examples are correct for KPHP, though they fail on PHP:
function f(int[] $arr): mixed[]
function f(tuple<int, string> $t): (int|false)[]

Multiple commits are squashed into a single, you can see development history in the PR.