### PR TITLE
Allow to change unix_socket_directory in runtime

### DIFF
--- a/vkext/vkext-rpc.cpp
+++ b/vkext/vkext-rpc.cpp
@@ -69,7 +69,6 @@ struct stats stats;
 double ping_timeout = PING_TIMEOUT;
 
 static int use_unix;
-static const char *unix_socket_directory;
 
 #define IP_PRINT_STR "%u.%u.%u.%u"
 #define IP_TO_PRINT(a) ((unsigned)(a)) >> 24, (((unsigned)(a)) >> 16) & 0xff, (((unsigned)(a)) >> 8) & 0xff, (((unsigned)(a))) & 0xff
@@ -157,7 +156,9 @@ rpc_connection *rpc_connection_get(int fd) {
 }
 
 static int rpc_sock_connect_unix(int port) {
-  assert(use_unix && unix_socket_directory);
+  assert(use_unix);
+  const char* unix_socket_directory = VK_INI_STR("vkext.unix_socket_directory");
+  assert(unix_socket_directory && unix_socket_directory[0] && "Incorrect unix_socket_directory is set");
 
   const int fd = socket(AF_FILE, SOCK_STREAM, 0);
   if (fd != -1) {
@@ -3406,9 +3407,6 @@ void rpc_on_minit(int module_number) { /* {{{ */
   if (VK_INI_STR("vkext.use_unix")) {
     use_unix = atoi(VK_INI_STR("vkext.use_unix"));
   }
-
-  unix_socket_directory = VK_INI_STR("vkext.unix_socket_directory");
-  assert(unix_socket_directory && unix_socket_directory[0]);
 
   END_TIMER (minit);
 }


### PR DESCRIPTION
__Proof__: https://www.php.net/manual/en/internals2.ze1.zendapi.php

__TL;DR__
`INI_STR(name)` - Returns the current value of entry name as string. Note: This string is not duplicated, but instead points to internal data. Further access requires duplication to local memory.

__Description__:
This commit allows users in php code change unix_socket_directory through `ini_set("vkext.unix_socket_directory", your_new_path")`. Also it fixes possible `SIGSEGV` if someone used mentioned operation before.
