### PR TITLE
use std::stack for CFG::cacl_used to avoid stack overflow

### DIFF
--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -4,6 +4,8 @@
 
 #include "compiler/pipes/cfg.h"
 
+#include <stack>
+
 #include "compiler/data/function-data.h"
 #include "compiler/function-pass.h"
 #include "compiler/gentree.h"
@@ -1176,15 +1178,23 @@ void CFG::confirm_usage(VertexPtr v, bool recursive_flag) {
 }
 
 void CFG::calc_used(Node v) {
-  node_was[v] = cur_dfs_mark;
-  //fprintf (stdout, "calc_used %d\n", get_index (v));
+  std::stack<Node> node_stack;
+  node_stack.push(v);
 
-  for (const auto &node_subtree : node_subtrees[v]) {
-    confirm_usage(node_subtree.v, node_subtree.recursive_flag);
-  }
-  for (Node i : node_next[v]) {
-    if (node_was[i] != cur_dfs_mark) {
-      calc_used(i);
+  while (!node_stack.empty()) {
+    v = node_stack.top();
+    node_stack.pop();
+
+    node_was[v] = cur_dfs_mark;
+    //fprintf (stdout, "calc_used %d\n", get_index (v));
+
+    for (const auto &node_subtree : node_subtrees[v]) {
+      confirm_usage(node_subtree.v, node_subtree.recursive_flag);
+    }
+    for (Node i : node_next[v]) {
+      if (node_was[i] != cur_dfs_mark) {
+        node_stack.push(i);
+      }
     }
   }
 }

--- a/compiler/utils/idgen.h
+++ b/compiler/utils/idgen.h
@@ -12,9 +12,8 @@ struct IdGen {
 
   vector<IdMapBase *> id_maps;
   IdMap<IdType> ids;
-  int n;
+  int n{0};
 
-  IdGen();
   void add_id_map(IdMapBase *to_add);
 
   int init_id(IdType *to_add);
@@ -23,11 +22,6 @@ struct IdGen {
   iterator end();
   void clear();
 };
-
-template<class IdType>
-IdGen<IdType>::IdGen() :
-  n(0) {
-}
 
 template<class IdType>
 void IdGen<IdType>::add_id_map(IdMapBase *to_add) {

--- a/compiler/utils/idmap.h
+++ b/compiler/utils/idmap.h
@@ -42,7 +42,7 @@ template<class DataType>
 template<class IndexType>
 DataType &IdMap<DataType>::operator[](const IndexType &i) {
   int index = get_index(i);
-  kphp_assert(index >= 0 && "maybe you've forgotten pass function to stream");
+  kphp_assert_msg(index >= 0, "maybe you've forgotten pass function to stream");
   kphp_assert_msg(index < (int)data.size(), fmt_format("{} of {}\n", index, (int)data.size()));
   return data[index];
 }


### PR DESCRIPTION
For huge functions recursion could cause a SIGSEGV with the corrupted stack, it's better to be on the safe side.