### PR TITLE
add `debug-prefix-map` option to enhance paths to source files

### DIFF
--- a/cmake/init-compilation-flags.cmake
+++ b/cmake/init-compilation-flags.cmake
@@ -86,3 +86,5 @@ endif()
 
 add_link_options(-rdynamic -L/usr/local/lib -ggdb)
 add_definitions(-D_GNU_SOURCE)
+# prevents the `build` directory to be appeared in symbols, it's necessary for remote debugging with path mappings
+add_compile_options(-fdebug-prefix-map="${CMAKE_BINARY_DIR}=${CMAKE_SOURCE_DIR}")


### PR DESCRIPTION
It fixes paths in the compiler binary. e.g. `addr2line` gives a correct path `kphp/compiler/kphp2cpp.cpp` to source files instead of `kphp/build/../compiler/kphp2cpp.cpp`