### PR TITLE
Json logger improvements.

### DIFF
--- a/common/dl-utils-lite.h
+++ b/common/dl-utils-lite.h
@@ -28,6 +28,8 @@ void dl_set_default_handlers ();
 
 char* dl_pstr (char const *message, ...) __attribute__ ((format (printf, 1, 2)));
 
+const char *dl_get_assert_message() noexcept;
+
 void dl_assert__ (const char *expr, const char *file_name, const char *func_name,
                   int line, const char *desc, int use_perror);
 
@@ -39,8 +41,6 @@ void dl_assert__ (const char *expr, const char *file_name, const char *func_name
 #define dl_assert(f, str) dl_assert_impl (f, str, 0)
 #define dl_passert(f, str) dl_assert_impl (f, str, 1)
 #define dl_unreachable(str) dl_assert (0, str)
-#define dl_fail(str) dl_assert (0, str); exit(1);
-#define dl_pcheck(cmd) dl_passert (cmd >= 0, "call failed : "  #cmd)
 
 typedef struct {
   unsigned long long utime;

--- a/common/fast-backtrace.h
+++ b/common/fast-backtrace.h
@@ -14,5 +14,6 @@ extern char *stack_end;
 }
 
 int fast_backtrace (void **buffer, int size) __attribute__ ((noinline));
+int fast_backtrace_without_recursions(void **buffer, int size) noexcept;
 
 #endif

--- a/common/kprintf.cpp
+++ b/common/kprintf.cpp
@@ -24,6 +24,7 @@
 #include "common/options.h"
 #include "common/precise-time.h"
 #include "common/stats/provider.h"
+#include "common/wrappers/pathname.h"
 
 typedef struct {
   const char *name;
@@ -180,11 +181,7 @@ void kprintf_ (const char *file, int line, const char *format, ...) {
   struct tm t;
   struct timeval tv;
 
-  if (const char *file_short = strrchr(file, '/')) {
-    if (file_short[1]) {
-      file = file_short + 1;
-    }
-  }
+  file = kbasename(file);
   if (gettimeofday (&tv, NULL) || !localtime_r (&tv.tv_sec, &t)) {
     memset (&t, 0, sizeof (t));
   }

--- a/common/wrappers/pathname.h
+++ b/common/wrappers/pathname.h
@@ -2,14 +2,15 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-#ifndef KDB_COMMON_PATHNAME_H
-#define KDB_COMMON_PATHNAME_H
+#pragma once
 
-#include <string.h>
+#include <cstring>
 
-static inline const char *kbasename(const char *path) {
-  const char *p = strrchr(path, '/');
-  return p ? p + 1 : path;
+inline const char *kbasename(const char *path) noexcept {
+  if (const char *file_short = strrchr(path, '/')) {
+    if (file_short[1]) {
+      path = file_short + 1;
+    }
+  }
+  return path;
 }
-
-#endif // KDB_COMMON_PATHNAME_H

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2250,7 +2250,6 @@ void read_engine_tag(const char *file_name) {
   buf[j] = 0;
 
   engine_tag = strdup(buf);
-  vk::singleton<JsonLogger>::get().init(string::to_int(engine_tag, static_cast<string::size_type>(strlen(engine_tag))));
 }
 
 void f$raise_sigsegv() {

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -16,7 +16,7 @@ class JsonLogger : vk::not_copyable {
 public:
   friend class vk::singleton<JsonLogger>;
 
-  void init(int64_t release_version) noexcept;
+  void init(int64_t release_version, int32_t script_timeout_seconds) noexcept;
 
   bool reopen_log_file(const char *log_file_name) noexcept;
 
@@ -26,9 +26,11 @@ public:
   void set_extra_info(vk::string_view extra_info) noexcept;
   void set_env(vk::string_view env) noexcept;
 
-  // ATTENTION: this function is used in signal handlers, therefore it is expected to be safe for them
+  // ATTENTION: this functions are used in signal handlers, therefore they are expected to be safe for them
   // Details: https://man7.org/linux/man-pages/man7/signal-safety.7.html
   void write_log(vk::string_view message, int type, int64_t created_at, void *const *trace, int64_t trace_size, bool uncaught) noexcept;
+  void write_stack_overflow_log(int type, bool uncaught) noexcept;
+  void write_script_timeout_log(int type, bool uncaught) noexcept;
 
   void reset_buffers() noexcept;
 
@@ -81,5 +83,7 @@ private:
     std::array<char, 32 * 1024> buffer_{{0}};
   };
   std::array<JsonBuffer, 8> buffers_;
+
+  std::array<char, 64> script_timeout_message_{{0}};
 };
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2295,6 +2295,8 @@ void init_all() {
   if (script_timeout == 0) {
     script_timeout = run_once ? 1e6 : DEFAULT_SCRIPT_TIMEOUT;
   }
+  const auto *tag = engine_tag ?: "0";
+  vk::singleton<JsonLogger>::get().init(string::to_int(tag, static_cast<string::size_type>(strlen(tag))), script_timeout);
 
   global_init_runtime_libs();
   global_init_php_scripts();

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -561,7 +561,11 @@ void sigabrt_handler(int) {
   const int64_t cur_time = time(nullptr);
   void *trace[64];
   const int trace_size = backtrace(trace, 64);
-  vk::singleton<JsonLogger>::get().write_log("SIGABRT terminating program", -1, cur_time, trace, trace_size, true);
+  vk::string_view msg{dl_get_assert_message()};
+  if (msg.empty()) {
+    msg = "SIGABRT terminating program";
+  }
+  vk::singleton<JsonLogger>::get().write_log(msg, -1, cur_time, trace, trace_size, true);
   vk::singleton<JsonLogger>::get().fsync_log_file();
 
   print_prologue(cur_time);

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -92,7 +92,6 @@ const char *php_script_get_error(void *ptr);
 long long php_script_memory_get_total_usage(void *ptr);
 
 /** script **/
-php_immediate_stats_t *get_immediate_stats();
 php_immediate_stats_t *get_imm_stats();
 void custom_server_status(const char *status, int status_len);
 void server_status_rpc(int port, long long actor_id, double start_time);

--- a/tests/python/tests/json_logs/php/index.php
+++ b/tests/python/tests/json_logs/php/index.php
@@ -26,6 +26,12 @@ function do_stack_overflow(int $x): int {
   return $z;
 }
 
+function do_long_work(int $duration) {
+  $s = time();
+  while(time() - $s <= $duration) {
+  }
+}
+
 function main() {
   foreach (json_decode(file_get_contents('php://input')) as $action) {
     switch ($action["op"]) {
@@ -43,6 +49,9 @@ function main() {
         break;
       case "stack_overflow":
         do_stack_overflow(1);
+        break;
+      case "long_work":
+        do_long_work((int)$action["duration"]);
         break;
       default:
         echo "unknown operation";

--- a/tests/python/tests/json_logs/test_timeouts.py
+++ b/tests/python/tests/json_logs/test_timeouts.py
@@ -1,0 +1,34 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJsonLogTimeouts(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+        cls.kphp_server.update_options({
+            "--time-limit": 1
+        })
+
+    def test_timeout_no_context(self):
+        resp = self.kphp_server.http_post(json=[{"op": "long_work", "duration": 2}])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
+                "msg": "Maximum execution time of 1 second exceeded",
+            }])
+
+    def test_timeout_with_context(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "set_context", "env": "efg", "tags": {"a": "b"}, "extra_info": {"c": "d"}},
+                {"op": "long_work", "duration": 2}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "efg",  "tags": {"a": "b", "uncaught": True}, "extra_info": {"c": "d"},
+                "msg": "Maximum execution time of 1 second exceeded",
+            }])


### PR DESCRIPTION
Hello!

1) Enable an ability to log server timeout events
2) Remove recursion from stack overflow logs (otherwise it's an impossible to find the stack overflow reason)
3) Add assertion details to SIGABRT log