### PR TITLE
Serialize double as float

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,6 +2,7 @@
 Checks: |-
   *,
   -android-*,
+  -altera-*,
   -*-bool-pointer-implicit-conversion,
   -cert-dcl50-cpp,
   -cert-dcl59-cpp,

--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -591,7 +591,7 @@ void ClassDeclaration::compile_serialize(CodeGenerator &W, ClassPtr klass) {
 
   klass->members.for_each([&](ClassMemberInstanceField &field) {
     if (field.serialization_tag != -1) {
-      body += fmt_format("packer.pack({}); packer.pack(${});\n", field.serialization_tag, field.var->name);
+      body += fmt_format("packer.pack({}); pack_value({}, packer, ${});\n", field.serialization_tag, field.serialize_as_float32, field.var->name);
       cnt_fields += 2;
     }
   });

--- a/compiler/data/class-members.h
+++ b/compiler/data/class-members.h
@@ -86,6 +86,7 @@ struct ClassMemberInstanceField {
   VarPtr var;
   vk::string_view phpdoc_str;
   int8_t serialization_tag = -1;
+  bool serialize_as_float32{false};
 
   ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str);
 

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -168,11 +168,6 @@ std::string get_default_cxx() noexcept {
 }
 
 std::string with_extra_flag(std::string flags) {
-#ifdef KPHP_HAS_NO_PIE
-  if (strlen(KPHP_HAS_NO_PIE)) {
-    flags.append(" " KPHP_HAS_NO_PIE);
-  }
-#endif
 #if ASAN_ENABLED
   flags.append(" -fsanitize=address");
 #endif
@@ -187,7 +182,11 @@ std::string get_default_extra_cxxflags() noexcept {
 }
 
 std::string get_default_extra_ldflags() noexcept {
-  return with_extra_flag("-L${KPHP_PATH}/objs/flex -ggdb");
+  std::string flags{"-L${KPHP_PATH}/objs/flex -ggdb"};
+#ifdef KPHP_HAS_NO_PIE
+  flags += " " KPHP_HAS_NO_PIE;
+#endif
+  return with_extra_flag(std::move(flags));
 }
 
 } // namespace

--- a/compiler/make/make-runner.cpp
+++ b/compiler/make/make-runner.cpp
@@ -88,7 +88,7 @@ void MakeRunner::require_target(Target *target) {
 }
 
 static int run_cmd(const string &cmd) {
-  //fprintf (stdout, "%s\n", cmd.c_str());
+  // fmt_print("{}\n", cmd);
   vector<string> args = split(cmd);
   vector<char *> argv(args.size() + 1);
   for (int i = 0; i < (int)args.size(); i++) {

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -49,6 +49,7 @@ const std::map<string, php_doc_tag::doc_type> php_doc_tag::str2doc_type = {
   {"@kphp-serializable",         kphp_serializable},
   {"@kphp-reserved-fields",      kphp_reserved_fields},
   {"@kphp-serialized-field",     kphp_serialized_field},
+  {"@kphp-serialized-float32",   kphp_serialized_float32},
   {"@kphp-profile",              kphp_profile},
   {"@kphp-profile-allow-inline", kphp_profile_allow_inline},
 };

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -43,6 +43,7 @@ struct php_doc_tag {
     kphp_serializable,
     kphp_reserved_fields,
     kphp_serialized_field,
+    kphp_serialized_float32,
     kphp_profile,
     kphp_profile_allow_inline
   };

--- a/compiler/pipes/check-classes.cpp
+++ b/compiler/pipes/check-classes.cpp
@@ -79,25 +79,33 @@ void CheckClassesPass::check_serialized_fields(ClassPtr klass) {
   fill_reserved_serialization_tags(used_serialization_tags_for_fields, klass);
 
   klass->members.for_each([&](ClassMemberInstanceField &f) {
-    if (auto kphp_serialized_field_str = phpdoc_find_tag_as_string(f.phpdoc_str, php_doc_tag::kphp_serialized_field)) {
-      if (!vk::string_view(*kphp_serialized_field_str).starts_with("none")) {
-        kphp_error_return(klass->is_serializable, fmt_format("you may not use @kphp-serialized-field inside non-serializable klass: {}", klass->name));
-        try {
-          size_t processed_pos{0};
-          auto kphp_serialized_field = std::stoi(*kphp_serialized_field_str, &processed_pos);
-          if (processed_pos != kphp_serialized_field_str->size() && vk::none_of_equal((*kphp_serialized_field_str)[processed_pos], ' ', '/', '#', '\n')) {
-            throw std::invalid_argument("");
-          }
-          kphp_error_return(0 <= kphp_serialized_field && kphp_serialized_field < max_serialization_tag_value, fmt_format("kphp-serialized-field({}) must be >=0 and < than {}", kphp_serialized_field, max_serialization_tag_value + 0));
-          kphp_error_return(!used_serialization_tags_for_fields[kphp_serialized_field], fmt_format("kphp-serialized-field: {} is already in use", kphp_serialized_field));
-          f.serialization_tag = kphp_serialized_field;
-          used_serialization_tags_for_fields[kphp_serialized_field] = true;
-        } catch (std::logic_error &) {
-          kphp_error_return(false, fmt_format("bad kphp-serialized-field: '{}'", *kphp_serialized_field_str));
-        }
+    auto kphp_serialized_field_str = phpdoc_find_tag_as_string(f.phpdoc_str, php_doc_tag::kphp_serialized_field);
+    if (!kphp_serialized_field_str) {
+      kphp_error(!klass->is_serializable, fmt_format("kphp-serialized-field is required for field: {}", f.local_name()));
+      return;
+    }
+
+    kphp_error_return(klass->is_serializable, fmt_format("you may not use @kphp-serialized-field inside non-serializable klass: {}", klass->name));
+    if (vk::string_view(*kphp_serialized_field_str).starts_with("none")) {
+        return;
+    }
+
+    try {
+      size_t processed_pos{0};
+      auto kphp_serialized_field = std::stoi(*kphp_serialized_field_str, &processed_pos);
+      if (processed_pos != kphp_serialized_field_str->size() && vk::none_of_equal((*kphp_serialized_field_str)[processed_pos], ' ', '/', '#', '\n')) {
+        throw std::invalid_argument("");
       }
-    } else {
-      kphp_error_return(!klass->is_serializable, fmt_format("kphp-serialized-field is required for field: {}", f.local_name()));
+      if (kphp_serialized_field < 0 || max_serialization_tag_value <= kphp_serialized_field) {
+        kphp_error_return(false, fmt_format("kphp-serialized-field({}) must be >=0 and < than {}", kphp_serialized_field, max_serialization_tag_value + 0));
+      }
+      if (used_serialization_tags_for_fields[kphp_serialized_field]) {
+        kphp_error_return(false, fmt_format("kphp-serialized-field: {} is already in use", kphp_serialized_field));
+      }
+      f.serialization_tag = kphp_serialized_field;
+      used_serialization_tags_for_fields[kphp_serialized_field] = true;
+    } catch (std::logic_error &) {
+      kphp_error_return(false, fmt_format("bad kphp-serialized-field: '{}'", *kphp_serialized_field_str));
     }
   });
 

--- a/compiler/pipes/check-classes.cpp
+++ b/compiler/pipes/check-classes.cpp
@@ -87,7 +87,7 @@ void CheckClassesPass::check_serialized_fields(ClassPtr klass) {
 
     kphp_error_return(klass->is_serializable, fmt_format("you may not use @kphp-serialized-field inside non-serializable klass: {}", klass->name));
     if (vk::string_view(*kphp_serialized_field_str).starts_with("none")) {
-        return;
+      return;
     }
 
     try {
@@ -103,6 +103,7 @@ void CheckClassesPass::check_serialized_fields(ClassPtr klass) {
         kphp_error_return(false, fmt_format("kphp-serialized-field: {} is already in use", kphp_serialized_field));
       }
       f.serialization_tag = kphp_serialized_field;
+      f.serialize_as_float32 = phpdoc_tag_exists(f.phpdoc_str, php_doc_tag::kphp_serialized_float32);
       used_serialization_tags_for_fields[kphp_serialized_field] = true;
     } catch (std::logic_error &) {
       kphp_error_return(false, fmt_format("bad kphp-serialized-field: '{}'", *kphp_serialized_field_str));
@@ -110,7 +111,8 @@ void CheckClassesPass::check_serialized_fields(ClassPtr klass) {
   });
 
   klass->members.for_each([&](ClassMemberStaticField &f) {
-    kphp_error_return(!phpdoc_tag_exists(f.phpdoc_str, php_doc_tag::kphp_serialized_field),
+    kphp_error_return(!phpdoc_tag_exists(f.phpdoc_str, php_doc_tag::kphp_serialized_field) &&
+                      !phpdoc_tag_exists(f.phpdoc_str, php_doc_tag::kphp_serialized_float32),
                       fmt_format("kphp-serialized-field is allowed only for instance fields: {}", f.local_name()));
   });
 }

--- a/runtime/msgpack-serialization.cpp
+++ b/runtime/msgpack-serialization.cpp
@@ -4,6 +4,8 @@
 
 #include "runtime/msgpack-serialization.h"
 
+uint32_t serialize_as_float32{0};
+
 namespace msgpack {
 MSGPACK_API_VERSION_NAMESPACE(MSGPACK_DEFAULT_API_NS) {
 namespace adaptor {

--- a/tests/phpt/msgpack_serialize/021_serialize_float32.php
+++ b/tests/phpt/msgpack_serialize/021_serialize_float32.php
@@ -1,0 +1,51 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+/** 
+ * @kphp-serializable
+ **/
+class PrimitiveHolder {
+    /**
+     * @kphp-serialized-field 3
+     * @var int
+     */
+    public $int_f = 536;
+
+    /**
+     * @kphp-serialized-field 2
+     * @kphp-serialized-float32
+     * @var float
+     */
+    public $float32_f = 20.123;
+
+    /**
+     * @kphp-serialized-field 1
+     * @var float
+     */
+    public $float_f = 20.123;
+
+
+    public function equal_to(PrimitiveHolder $another): bool {
+        var_dump($another->float_f);
+        var_dump($another->float32_f);
+        var_dump($another->int_f);
+
+        return $this->int_f === $another->int_f
+            && $this->float_f === $another->float_f
+            && ($this->float32_f - $another->float32_f) < 0.01;
+    }
+}
+
+function run() {
+    $b = new PrimitiveHolder();
+    $serialized = instance_serialize($b);
+    var_dump(base64_encode($serialized));
+    var_dump(strlen($serialized));
+    $b_new = instance_deserialize($serialized, PrimitiveHolder::class);
+
+    var_dump($b->equal_to($b_new));
+}
+
+run();

--- a/tests/phpt/msgpack_serialize/022_cmp_float32_float.php
+++ b/tests/phpt/msgpack_serialize/022_cmp_float32_float.php
@@ -1,0 +1,32 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+/** @kphp-serializable **/
+class A {
+    /**
+     * @kphp-serialized-field 1
+     * @kphp-serialized-float32
+     * @var float
+     */
+    public $x = 20.123;
+}
+
+/** @kphp-serializable **/
+class B {
+    /**
+     * @kphp-serialized-field 1
+     * @var float
+     */
+    public $x = 20.123;
+}
+
+$byte_for_cnt_elements_in_array = 1;
+$byte_for_field_tag = 1;
+
+$bytes_for_float = 1 + 8;
+$bytes_for_float32 = 1 + 4;
+
+var_dump(strlen(instance_serialize(new B)) == $byte_for_cnt_elements_in_array + $byte_for_field_tag + $bytes_for_float);
+var_dump(strlen(instance_serialize(new A)) == $byte_for_cnt_elements_in_array + $byte_for_field_tag + $bytes_for_float32);

--- a/tests/phpt/msgpack_serialize/023_compound_float32.php
+++ b/tests/phpt/msgpack_serialize/023_compound_float32.php
@@ -1,0 +1,48 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+/** @kphp-serializable **/
+class FloatHolder {
+    /**
+     * @kphp-serialized-field 1
+     * @kphp-serialized-float32
+     * @var float[]
+     */
+    public $float32_f = [20.123, .536, .536];
+
+    /**
+     * @kphp-serialized-field 2
+     * @var tuple(float, int)
+     */
+    public $tup;
+
+    public function __construct() {
+        $this->tup = tuple(.536, 20);
+    }
+}
+
+/** @kphp-serializable **/
+class A {
+    /**
+     * @kphp-serialized-field 1
+     * @kphp-serialized-float32
+     * @var FloatHolder
+     */
+    public $float_f = null;
+
+    public function __construct() {
+        $this->float_f = new FloatHolder();
+    }
+}
+
+$a = new A();
+$serialized = instance_serialize($a);
+var_dump(base64_encode($serialized));
+var_dump(strlen($serialized));
+
+$h = new FloatHolder();
+$serialized = instance_serialize($h);
+var_dump(base64_encode($serialized));
+var_dump(strlen($serialized));


### PR DESCRIPTION
The new annotation for fields of serializable classes is implemented in the PR.
It should be used wisely in cases where you are 100% sure what you are doing.

Classes that are annotated as `@kphp-serializable` could use the tag `@kphp-serialized-float32` to let KPHP know which fields contain float value inside and will be serialized as 32-bit floats.
Sacrificing precision 4 bytes per float of a payload can be saved.