### PR TITLE
Confdata fixes

### DIFF
--- a/runtime/zlib.cpp
+++ b/runtime/zlib.cpp
@@ -121,7 +121,7 @@ static string::size_type zlib_decode_raw(vk::string_view s, int encoding) {
     inflateEnd(&strm);
     dl::leave_critical_section();
 
-    php_critical_error ("size of unpacked data is greater then %d. Can't decode.", PHP_BUF_LEN);
+    php_warning("size of unpacked data is greater then %d. Can't decode.", PHP_BUF_LEN);
     return -1;
   }
 

--- a/tests/phpt/dl/464_gzip.php
+++ b/tests/phpt/dl/464_gzip.php
@@ -8,20 +8,39 @@ function gzdecode($string) {
 }
 }
 #endif
-  $s = gzcompress ("Hello world");
 
-  $f = fopen ("test.gz", "w");
-  fwrite ($f, $s);
-  fclose ($f);
 
-  var_dump (gzuncompress (file_get_contents ("test.gz")));
+function test_basic() {
+  $s = gzcompress("Hello world");
 
-  $s = gzencode ("Hello world");
+  $f = fopen("test.gz", "w");
+  fwrite($f, $s);
+  fclose($f);
 
-  $f = fopen ("test.gz", "w");
-  fwrite ($f, $s);
-  fclose ($f);
+  var_dump(gzuncompress(file_get_contents("test.gz")));
 
-  var_dump (gzdecode (file_get_contents ("test.gz")));
+  $s = gzencode("Hello world");
 
-  unlink ("test.gz");
+  $f = fopen("test.gz", "w");
+  fwrite($f, $s);
+  fclose($f);
+
+  var_dump(gzdecode(file_get_contents("test.gz")));
+
+  unlink("test.gz");
+}
+
+function test_large_string() {
+  $s = str_repeat("x", 1 + 8*1024*1024);
+  $compressed = gzcompress($s);
+  var_dump(strlen($compressed));
+
+  $unc = gzuncompress($compressed);
+#ifndef KPHP
+  $unc = "";
+#endif
+  var_dump($unc);
+}
+
+test_basic();
+test_large_string();


### PR DESCRIPTION
1) Fix confdata SIGSEGV on worker's termination and a possible shared memory corruption.
2) Don't crash zlib deconding on large data, because it is used on confdata loading. The warning will be written to json log.