### PR TITLE
Ignore make_clone() call in performance analysis.

### DIFF
--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -17,6 +17,12 @@ VertexPtr remove_conv_wrap(VertexPtr vertex) noexcept {
   if (OpInfo::type(vertex->type()) == conv_op) {
     return remove_conv_wrap(vertex.as<meta_op_unary>()->expr());
   }
+  if (auto func_call = vertex.try_as<op_func_call>()) {
+    if (func_call->str_val == "make_clone") {
+      kphp_assert(func_call->args().size() == 1);
+      return remove_conv_wrap(func_call->args().front());
+    }
+  }
   return vertex;
 }
 

--- a/tests/phpt/performance_inspections/11_implicit_array_cast_warn.php
+++ b/tests/phpt/performance_inspections/11_implicit_array_cast_warn.php
@@ -7,12 +7,14 @@
 /variable \$b3 is implicitly converted from array< string > to mixed/
 /variable \$a4 is implicitly converted from array< int > to mixed/
 /variable \$b4 is implicitly converted from array< string > to mixed/
+/variable A::\$b is implicitly converted from array< int > to array< mixed >/
 /expresion <...> is implicitly converted from tuple<int , array< int >> to tuple<float , array< mixed >>/
 <?php
 
 class A {
     /** @var tuple(float, mixed[]) */
     public $a;
+    public $b = [1, 2, 3, 4];
 }
 
 function call_with_implicit_array_cast(array $x) {
@@ -49,7 +51,9 @@ function test() {
     }
   }
 
-  (new A)->a = tuple(4, [1,2,3]);
+  $a = new A;
+  call_with_implicit_array_cast($a->b);
+  $a->a = tuple(4, [1, 2, 3]);
 
   return $c;
 }


### PR DESCRIPTION
In terms of performance analysis, `make_clone()` does nothing, so it makes sense to ignore it.