### PR TITLE
Emit more info about warm up on graceful restart

### DIFF
--- a/server/php-master-warmup.h
+++ b/server/php-master-warmup.h
@@ -12,6 +12,21 @@
 
 class WarmUpContext : public vk::singleton<WarmUpContext> {
 public:
+  double calc_final_instance_cache_sizes_ratio() const {
+    if (final_old_instance_cache_size_ == 0) {
+      return -0.1;
+    }
+    return static_cast<double>(final_new_instance_cache_size_) / final_old_instance_cache_size_;
+  }
+
+  void update_final_instance_cache_sizes() {
+    if (!final_instance_cache_sizes_saved_) {
+      final_new_instance_cache_size_ = me->instance_cache_elements_stored;
+      final_old_instance_cache_size_ = other->instance_cache_elements_stored;
+      final_instance_cache_sizes_saved_ = true;
+    }
+  }
+
   void try_start_warmup() {
     if (me_running_workers_n > 0 && !timer_.is_started()) {
       timer_.start();
@@ -20,6 +35,9 @@ public:
 
   void reset() {
     timer_.reset();
+    final_new_instance_cache_size_ = 0;
+    final_old_instance_cache_size_ = 0;
+    final_instance_cache_sizes_saved_ = false;
   }
 
   bool need_more_workers_for_warmup() const {
@@ -51,6 +69,10 @@ private:
   std::chrono::duration<double> warm_up_max_time_{5.0};
 
   vk::SteadyTimer<std::chrono::milliseconds> timer_{};
+
+  uint32_t final_new_instance_cache_size_{0};
+  uint32_t final_old_instance_cache_size_{0};
+  bool final_instance_cache_sizes_saved_{false};
 
   WarmUpContext() = default;
 

--- a/server/php-master-warmup.h
+++ b/server/php-master-warmup.h
@@ -12,11 +12,12 @@
 
 class WarmUpContext : public vk::singleton<WarmUpContext> {
 public:
-  double calc_final_instance_cache_sizes_ratio() const {
-    if (final_old_instance_cache_size_ == 0) {
-      return -0.1;
-    }
-    return static_cast<double>(final_new_instance_cache_size_) / final_old_instance_cache_size_;
+  uint32_t get_final_new_instance_cache_size() const {
+    return final_new_instance_cache_size_;
+  }
+
+  uint32_t get_final_old_instance_cache_size() const {
+    return final_old_instance_cache_size_;
   }
 
   void update_final_instance_cache_sizes() {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1536,6 +1536,8 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
   add_histogram_stat_double(stats, "requests.incoming_queries_per_second", qps_calculator.get_incoming_qps());
   add_histogram_stat_double(stats, "requests.outgoing_queries_per_second", qps_calculator.get_outgoing_qps());
 
+  add_histogram_stat_double(stats, "graceful_restart.warmup.final_instance_cache_sizes_ratio", WarmUpContext::get().calc_final_instance_cache_sizes_ratio());
+
   update_mem_stats();
   unsigned long long max_vms = 0;
   unsigned long long max_rss = 0;
@@ -1713,8 +1715,13 @@ void run_master_on() {
       bool warmup_timeout_expired       = warm_up_ctx.warmup_timeout_expired();
       if (set_to_kill > 0 && (need_more_workers_for_warmup || is_instance_cache_hot_enough || warmup_timeout_expired)) {
         // new master tells to old master how many workers it must kill
-        vkprintf(1, "[set_to_kill = %d] [need_more_workers_for_warmup = %d] [is_instance_cache_hot_enough = %d] [warmup_timeout_expired = %d]\n",
-                     set_to_kill, need_more_workers_for_warmup, is_instance_cache_hot_enough, warmup_timeout_expired);
+        vkprintf(1, "[set_to_kill = %d] [need_more_workers_for_warmup = %d] [is_instance_cache_hot_enough = %d] [new_instance_cache_size / old_instance_cache_size = %u / %u] [warmup_timeout_expired = %d]\n",
+                        set_to_kill, need_more_workers_for_warmup,
+                        is_instance_cache_hot_enough, me->instance_cache_elements_stored, other->instance_cache_elements_stored,
+                        warmup_timeout_expired);
+        if (!need_more_workers_for_warmup && (is_instance_cache_hot_enough || warmup_timeout_expired)) {
+          warm_up_ctx.update_final_instance_cache_sizes();
+        }
         me->to_kill = set_to_kill;
         me->to_kill_generation = generation;
         changed = 1;

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1536,7 +1536,8 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
   add_histogram_stat_double(stats, "requests.incoming_queries_per_second", qps_calculator.get_incoming_qps());
   add_histogram_stat_double(stats, "requests.outgoing_queries_per_second", qps_calculator.get_outgoing_qps());
 
-  add_histogram_stat_double(stats, "graceful_restart.warmup.final_instance_cache_sizes_ratio", WarmUpContext::get().calc_final_instance_cache_sizes_ratio());
+  add_histogram_stat_double(stats, "graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
+  add_histogram_stat_double(stats, "graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());
 
   update_mem_stats();
   unsigned long long max_vms = 0;


### PR DESCRIPTION
For tuning warm up parameters we need to know 'hotness' of instance cache at the end of warm up, e.g. when warm up timeout is expired. Here are 2 things to help with this:

- new stat metrics `new IC size` and `old IC size`, where `IC size` is the size of instance cache in corresponding master (new or old) at the end of warm up on graceful restart
- log instance cache sizes during warm up 