### PR TITLE
instance_to_array with class names

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -1260,7 +1260,7 @@ function make_clone ($x ::: any) ::: ^1;
 /** @kphp-extern-func-info cpp_template_call */
 function instance_cast($instance ::: any, $to_type ::: string) ::: instance<^2>;
 
-function instance_to_array($instance ::: any) ::: mixed[];
+function instance_to_array($instance ::: any, $with_class_names ::: bool = false) ::: mixed[];
 
 /** Instance cache interface (like APC) **/
 /** @kphp-extern-func-info cpp_template_call */

--- a/runtime/kphp_core.h
+++ b/runtime/kphp_core.h
@@ -14,6 +14,7 @@
 #include "runtime/allocator.h"
 #include "runtime/include.h"
 #include "runtime/kphp_type_traits.h"
+#include "runtime/shape.h"
 
 // order of includes below matters, be careful
 

--- a/tests/phpt/cl/009_instance_to_array_with_class_names.php
+++ b/tests/phpt/cl/009_instance_to_array_with_class_names.php
@@ -1,0 +1,80 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class Empty1
+{
+
+}
+
+class Empty2
+{
+
+}
+
+interface IA
+{
+
+}
+
+class A1 implements IA
+{
+  public $field = "hello";
+}
+
+class A2 implements IA
+{
+  public $field = "hello";
+}
+
+class WithInner
+{
+  /**
+   * @var IA
+   */
+  public $inner = null;
+  public $field = "hello";
+
+  /**
+   * @param IA $inner
+   */
+  public function __construct(IA $inner)
+  {
+    $this->inner = $inner;
+  }
+}
+
+
+/**
+ * @kphp-template $a
+ * @kphp-template $b
+ * @param object $a
+ * @param object $b
+ */
+function check_instance_to_array_with_class_names($a, $b)
+{
+  echo "======= checking " . get_class($a) . " and " . get_class($b) . " ======= \n";
+  $arr_a = instance_to_array($a);
+  $arr_b = instance_to_array($b);
+
+  if (kphp === 1) {
+    var_dump($arr_a === $arr_b);
+  } else {
+    echo "bool(true)\n";
+  }
+
+  $arr_a = instance_to_array($a, true);
+  $arr_b = instance_to_array($b, true);
+  var_dump($arr_a);
+  var_dump($arr_b);
+
+  if (kphp === 1) {
+    var_dump($arr_a === $arr_b);
+  } else {
+    echo "bool(false)\n";
+  }
+}
+
+check_instance_to_array_with_class_names(new Empty1, new Empty2);
+check_instance_to_array_with_class_names(new A1, new A2);
+check_instance_to_array_with_class_names(new WithInner(new A1), new WithInner(new A2));


### PR DESCRIPTION
Sometimes it's useful to get result of `instance_to_array` with class names. For example, it can be used as unique identifier of an object as `serialize(instance_to_array($obj, true))`. Instances of classes with the same set of fields are indistinguishable after `instance_to_array` without class names.

PR to kphp-polyfills: https://github.com/VKCOM/kphp-polyfills/pull/7