### PR TITLE
Pretty printers for lldb: enhance CLion debugging experience

### DIFF
--- a/.lldbinit
+++ b/.lldbinit
@@ -1,0 +1,38 @@
+# to make this (local) .lldbinit work, don't forget to add the following line to global ~/.lldbinit:
+# settings set target.load-cwd-lldbinit true
+
+command script import lldb_addons.py
+
+type summary add --python-function "lldb_addons.class_with_debug_string" FunctionData
+type summary add --python-function "lldb_addons.class_with_debug_string" ClassData
+type summary add --python-function "lldb_addons.class_with_debug_string" VarData
+type summary add --python-function "lldb_addons.class_with_debug_string" DefineData
+type summary add --python-function "lldb_addons.class_with_debug_string" LibData
+type summary add --python-function "lldb_addons.class_with_debug_string" SrcFile
+type summary add --python-function "lldb_addons.class_with_debug_string" Location
+type summary add --python-function "lldb_addons.class_with_debug_string" TypeData
+type summary add --python-function "lldb_addons.class_with_debug_string" tinf::Node
+type summary add --python-function "lldb_addons.class_with_debug_string" Assumption
+type summary add --python-function "lldb_addons.class_with_debug_string" Key
+type summary add --python-function "lldb_addons.class_with_debug_string" MultiKey
+
+type summary add --python-function "lldb_addons.token_printer" Token
+type summary add --python-function "lldb_addons.vk_string_view_printer" vk::string_view
+
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<FunctionData>  # FunctionPtr
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<ClassData>     # ClassPtr
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<VarData>       # VarPtr
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<DefineData>    # DefinePtr
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<LibData>       # LibPtr
+type summary add --python-function "lldb_addons.data_ptr_printer" Id<SrcFile>       # SrcFilePtr
+
+type synth add -l "lldb_addons.data_ptr_children" Id<FunctionData>  # FunctionPtr
+type synth add -l "lldb_addons.data_ptr_children" Id<ClassData>     # ClassPtr
+type synth add -l "lldb_addons.data_ptr_children" Id<VarData>       # VarPtr
+type synth add -l "lldb_addons.data_ptr_children" Id<DefineData>    # DefinePtr
+type synth add -l "lldb_addons.data_ptr_children" Id<LibData>       # LibPtr
+type synth add -l "lldb_addons.data_ptr_children" Id<SrcFile>       # SrcFilePtr
+
+type summary add --python-function "lldb_addons.vertex_printer" -x "^VertexAdaptor<.+>$"
+type synth add -l "lldb_addons.vertex_children" -x "^VertexAdaptor<.+>$"
+

--- a/compiler/class-assumptions.h
+++ b/compiler/class-assumptions.h
@@ -10,6 +10,7 @@
 
 #include "compiler/data/data_ptr.h"
 #include "compiler/data/vertex-adaptor.h"
+#include "compiler/debug.h"
 
 
 enum class AssumptionStatus {
@@ -19,6 +20,8 @@ enum class AssumptionStatus {
 };
 
 class Assumption : public vk::thread_safe_refcnt<Assumption> {
+  DEBUG_STRING_METHOD { return as_human_readable(); }
+
 public:
   virtual ~Assumption() = default;
 

--- a/compiler/data/class-data.h
+++ b/compiler/data/class-data.h
@@ -11,6 +11,7 @@
 #include "compiler/class-assumptions.h"
 #include "compiler/data/class-members.h"
 #include "compiler/data/class-modifiers.h"
+#include "compiler/debug.h"
 #include "compiler/location.h"
 #include "compiler/threading/data-stream.h"
 #include "compiler/threading/locks.h"
@@ -24,6 +25,8 @@ enum class ClassType {
 };
 
 class ClassData : public Lockable {
+  DEBUG_STRING_METHOD { return name; }
+  
 public:
   // extends/implements/use trait description in a string form (class_name)
   struct StrDependence {

--- a/compiler/data/define-data.h
+++ b/compiler/data/define-data.h
@@ -10,8 +10,11 @@
 #include "compiler/data/class-member-modifiers.h"
 #include "compiler/data/data_ptr.h"
 #include "compiler/data/vertex-adaptor.h"
+#include "compiler/debug.h"
 
 class DefineData : private vk::not_copyable {
+  DEBUG_STRING_METHOD { return name; }
+  
 public:
   enum DefineType {
     def_unknown,

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -18,11 +18,14 @@
 #include "compiler/data/function-modifiers.h"
 #include "compiler/data/performance-inspections.h"
 #include "compiler/data/vertex-adaptor.h"
+#include "compiler/debug.h"
 #include "compiler/inferring/var-node.h"
 #include "compiler/threading/data-stream.h"
 #include "compiler/vertex-meta_op_base.h"
 
 class FunctionData {
+  DEBUG_STRING_METHOD { return get_human_readable_name(); }
+  
   // code outside of the data/ should use FunctionData::create_function()
   FunctionData() = default;
   FunctionData& operator=(const FunctionData &other) = default;
@@ -102,7 +105,7 @@ public:
   bool warn_unused_result = false;
   bool is_flatten = false;
   bool is_pure = false;
-  
+
   enum class profiler_status : uint8_t {
     disable,
     // A function that is being profiled that starts and ends the profiling

--- a/compiler/data/lib-data.h
+++ b/compiler/data/lib-data.h
@@ -6,8 +6,11 @@
 #include <string>
 
 #include "compiler/data/data_ptr.h"
+#include "compiler/debug.h"
 
 class LibData {
+  DEBUG_STRING_METHOD { return lib_name_; }
+  
 public:
   LibData(const std::string &lib_name, const std::string &lib_dir);
   LibData(const std::string &lib_require_name);

--- a/compiler/data/src-file.h
+++ b/compiler/data/src-file.h
@@ -10,8 +10,11 @@
 
 #include "compiler/data/data_ptr.h"
 #include "compiler/data/vertex-adaptor.h"
+#include "compiler/debug.h"
 
 class SrcFile {
+  DEBUG_STRING_METHOD { return unified_file_name; }
+  
 public:
   int id{0};
   std::string text, file_name, short_file_name;

--- a/compiler/data/var-data.h
+++ b/compiler/data/var-data.h
@@ -8,9 +8,12 @@
 #include <string>
 
 #include "compiler/data/class-members.h"
+#include "compiler/debug.h"
 #include "compiler/inferring/var-node.h"
 
 class VarData {
+  DEBUG_STRING_METHOD { return get_human_readable_name(); }
+  
 public:
   enum Type {
     var_unknown_t = 0,

--- a/compiler/data/vertex-adaptor.h
+++ b/compiler/data/vertex-adaptor.h
@@ -159,4 +159,11 @@ public:
   VertexAdaptor &set_location_recursively(VertexAdaptor<Op2> v) {
     return set_location_recursively(v.impl->location);
   }
+
+  // use 'vertex.debugPrint()' anywhere in your code while development
+  // (in release it's not used and is not linked to a binary)
+  void debugPrint() const {
+    std::string debugVertexTree(VertexPtr root);   // implemented in debug.cpp
+    printf("%s", debugVertexTree(VertexPtr(*this)).c_str());
+  }
 };

--- a/compiler/debug.h
+++ b/compiler/debug.h
@@ -2,19 +2,8 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-#ifndef PHP_DEBUG_H
-#define PHP_DEBUG_H
+#pragma once
 
-#include "compiler/data/data_ptr.h"
-#include "compiler/data/vertex-adaptor.h"
-#include "compiler/operation.h"
-#include "compiler/token.h"
-
-std::string debugOperationName(Operation o);
-std::string debugTokenName(TokenType t);
-void debugPrintVertexTree(VertexPtr root, int level = 0);
-void debugPrintLocation(VertexPtr v);
-void debugPrintFunction(FunctionPtr function);
-std::string debugVertexMore(VertexPtr v);
-
-#endif //PHP_DEBUG_H
+// using this macro inside a class: DEBUG_STRING_METHOD { ... cpp code ...; return std::string }
+// that code is also embedded into a release binary, we decided not to do anything about it
+#define DEBUG_STRING_METHOD std::string _debug_string() const __attribute__((used))

--- a/compiler/inferring/key.cpp
+++ b/compiler/inferring/key.cpp
@@ -54,7 +54,7 @@ std::string Key::to_string() const {
     return *string_key_names_ht.at(id)->data;
   }
   if (is_any_key()) {
-    return "Any";
+    return "any_key";
   }
   kphp_assert(0);
   return "fail";

--- a/compiler/inferring/key.h
+++ b/compiler/inferring/key.h
@@ -6,7 +6,11 @@
 
 #include <string>
 
+#include "compiler/debug.h"
+
 class Key {
+  DEBUG_STRING_METHOD { return to_string(); }
+
 private:
   int id{-1};
 

--- a/compiler/inferring/multi-key.cpp
+++ b/compiler/inferring/multi-key.cpp
@@ -9,6 +9,9 @@
 #include "common/algorithms/string-algorithms.h"
 
 std::string MultiKey::to_string() const {
+  if (keys_.empty()) {
+    return "(empty)";
+  }
   return "[" + vk::join(*this, ",", std::mem_fn(&Key::to_string))+ "]";
 }
 

--- a/compiler/inferring/multi-key.h
+++ b/compiler/inferring/multi-key.h
@@ -7,10 +7,13 @@
 #include <string>
 #include <vector>
 
+#include "compiler/debug.h"
 #include "compiler/inferring/key.h"
 #include "compiler/kphp_assert.h"
 
 class MultiKey {
+  DEBUG_STRING_METHOD { return to_string(); }
+
 private:
   std::vector<Key> keys_;
   static std::vector<MultiKey> any_key_vec;

--- a/compiler/inferring/node.cpp
+++ b/compiler/inferring/node.cpp
@@ -17,6 +17,10 @@ Node::Node() :
   isset_was(0) {
 }
 
+std::string Node::as_human_readable() const {
+  return type_->as_human_readable(false);
+}
+
 void Node::add_edge(Edge *edge) {
   AutoLocker<Node *> locker(this);
   next_.push_back(edge);

--- a/compiler/inferring/node.h
+++ b/compiler/inferring/node.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <vector>
 
+#include "compiler/debug.h"
 #include "compiler/location.h"
 #include "compiler/threading/locks.h"
 
@@ -19,6 +20,8 @@ class Edge;
 class TypeInferer;
 
 class Node : public Lockable {
+  DEBUG_STRING_METHOD { return as_human_readable(); }
+
 private:
   std::vector<Edge *> next_;
   std::vector<Edge *> rev_next_;
@@ -36,6 +39,8 @@ public:
   };
 
   Node();
+
+  std::string as_human_readable() const;
 
   int get_recalc_cnt() const {
     return recalc_cnt_;

--- a/compiler/inferring/type-data.h
+++ b/compiler/inferring/type-data.h
@@ -10,6 +10,7 @@
 
 #include "compiler/code-gen/gen-out-style.h"
 #include "compiler/data/data_ptr.h"
+#include "compiler/debug.h"
 #include "compiler/inferring/key.h"
 #include "compiler/inferring/multi-key.h"
 #include "compiler/inferring/primitive-type.h"
@@ -18,6 +19,8 @@
 
 
 class TypeData {
+  DEBUG_STRING_METHOD { return as_human_readable(false); }
+
 private:
   enum flag_id_t : uint8_t {
     write_flag_e          = 0b00000001,

--- a/compiler/location.h
+++ b/compiler/location.h
@@ -5,8 +5,11 @@
 #pragma once
 
 #include "compiler/data/data_ptr.h"
+#include "compiler/debug.h"
 
 class Location {
+  DEBUG_STRING_METHOD { return as_human_readable(); }
+  
 public:
   SrcFilePtr file;
   FunctionPtr function;

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -209,6 +209,13 @@ public:
     str_val(s, t) {
   }
 
+  // use 'cur->debugPrint()' anywhere in gentree while development
+  // (in release it's not used and is not linked to a binary)
+  void debugPrint() const {
+    std::string debugTokenName(TokenType t);  // implemented in debug.cpp
+    printf("%s '%s'\n", debugTokenName(type_).c_str(), static_cast<std::string>(debug_str.empty() ? str_val : debug_str).c_str());
+  }
+
   inline TokenType &type() { return type_; }
   inline const TokenType &type() const { return type_; }
 

--- a/lldb_addons.py
+++ b/lldb_addons.py
@@ -1,0 +1,129 @@
+# noinspection PyUnresolvedReferences
+import lldb
+
+
+# print summary of a class with an implemented _debug_string() method:
+# DEBUG_STRING_METHOD { return ... }
+# after adding such method to a new class, don't forget to mention it in .lldbinit!
+def class_with_debug_string(valobj, internal_dict, options):
+    # assign the object to v
+    if valobj.TypeIsPointerType():
+        v = valobj.Dereference()
+        if not v.GetAddress().IsValid():
+            return "NULL"
+    else:
+        v = valobj
+    # s will be a formatted std::string — "content"
+    s = v.GetNonSyntheticValue().EvaluateExpression('_debug_string()').GetSummary()
+    # return it with trimmed quotes
+    return "" if s is None else str(s)[1:-1]
+
+
+# print summary of Token class
+# we don't use _debug_string() there — we print a enum value instead
+# (we can't print a enum value from C++)
+def token_printer(valobj, internal_dict, options):
+    return str(valobj.GetChildMemberWithName("type_").GetValue())
+
+
+# print summary of vk::string_view
+# we don't use _debug_string() there — it will be replaced with std::string_view somewhen
+def vk_string_view_printer(valobj, internal_dict, options):
+    data = valobj.GetChildMemberWithName("_data")
+    count = valobj.GetChildMemberWithName("_count").GetValueAsUnsigned()
+    string = data.GetPointeeData(0, count)          # not null-terminated
+    string.Append(lldb.SBData.CreateDataFromInt(0)) # make null-terminated
+    error = lldb.SBError()
+    string = string.GetString(error, 0)
+    return '"' + string + '"' if not error.Fail() else "error"  # + error.GetCString()
+
+
+# print summary of FunctionPtr, ClassPtr and other Id<*> classes
+# just dereference the 'ptr' field and return summary of a child
+def data_ptr_printer(valobj, internal_dict, options):
+    # GetNonSyntheticValue() is important, as children are overloaded below
+    v = valobj.GetNonSyntheticValue().GetChildMemberWithName("ptr").Dereference()
+    if not v.GetAddress().IsValid():
+        return "NULL"
+    desc = v.GetSummary()
+    return "" if desc is None else desc
+
+
+# handle expanding of FunctionPtr, ClassPtr and others
+# what we do is vanishing the 'ptr' field on expanding:
+# instead of having a hierarchy "item > ptr > name and other props",
+# we'll see "item > name and other props", which is very handy
+class data_ptr_children(object):
+    def __init__(self, valobj, dict):
+        self.ptr = valobj.GetChildMemberWithName("ptr")
+
+    def is_notnull(self):
+        return self.ptr.Dereference().GetAddress().IsValid()
+
+    def num_children(self, max_count):
+        return self.ptr.GetNumChildren() if self.is_notnull() else 0
+
+    def get_child_at_index(self, index):
+        return self.ptr.GetChildAtIndex(index)
+
+    def get_child_index(self, name):
+        return self.ptr.GetChildIndex(name)
+
+    def has_children(self):
+        return self.is_notnull()
+
+
+# print summary of VertexPtr and VertexAdaptor<*>
+# format: "{type} {str_val} ↓{n_children}"
+# we don't use _debug_string() there — we want op_name as a enum value
+def vertex_printer(valobj, internal_dict, options):
+    v = valobj.GetChildMemberWithName("impl").Dereference()
+    if not v.GetAddress().IsValid():
+        return "NULL"
+    op_name = v.GetChildMemberWithName("type_").GetValue()
+    n_children = v.GetChildMemberWithName("n").GetValueAsUnsigned()
+    if op_name in ["op_var", "op_func_name", "op_instance_prop", "op_int_const", "op_float_const", "op_func_call"]:
+        str_val = " " + str(v.EvaluateExpression('get_string()').GetSummary())
+    else:
+        str_val = ""
+    return op_name + str_val + (' ↓' + str(n_children) if n_children > 0 else ' ∅')
+
+
+# handle expanding of VertexPtr and VertexAdaptor<*>
+# here we insert fake children ith0, ith1 which can also be recursively expanded
+# so, a VertexPtr object will have (1+n) nodes in debugger: impl and ith-s
+class vertex_children(object):
+    def __init__(self, valobj, dict):
+        self.impl = valobj.GetChildMemberWithName("impl")
+        # we need the VertexPtr type to cast ith(i) calls to it
+        type = self.impl.GetTarget().FindFirstType("VertexPtr")
+        self.type_VertexPtr = type if type.IsValid() else None
+
+    def is_notnull(self):
+        return self.impl.Dereference().GetAddress().IsValid()
+
+    def num_children(self, max_count):
+        if not self.is_notnull():
+            return 0
+        if self.type_VertexPtr is None:
+            return 1
+        n = self.impl.GetChildMemberWithName("n").GetValueAsUnsigned()
+        return min(max_count, 1 + n)
+
+    def get_child_at_index(self, index):
+        if index == 0:
+            return self.impl
+        if index > 0:
+            ith_i = self.impl.Dereference().EvaluateExpression("ith(" + str(index - 1) + ")")
+            return self.impl.CreateValueFromData("ith" + str(index - 1), ith_i.GetData(), self.type_VertexPtr)
+        return None
+
+    def get_child_index(self, name):
+        if name == "impl":
+            return 0
+        if name.startswith("ith"):
+            return int(name[3:]) + 1
+        return None
+
+    def has_children(self):
+        return self.is_notnull()

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -4,6 +4,8 @@
 #include "compiler/debug.h"
 
 TEST(lexer_test, test_php_tokens) {
+  std::string debugTokenName(TokenType t);  // implemented in debug.cpp
+
   struct testCase {
     std::string input;
     std::vector<std::string> expected;

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -124,8 +124,6 @@ Zend/tests/inter_04.phpt
 Zend/tests/line_const_in_array.phpt
 Zend/tests/loop_free_on_return.phpt
 Zend/tests/lsb_001.phpt
-Zend/tests/magic_methods_003.phpt
-Zend/tests/magic_methods_009.phpt
 Zend/tests/nowdoc_016.phpt
 Zend/tests/nowdoc_017.phpt
 Zend/tests/objects_004.phpt


### PR DESCRIPTION
# This PR focuses on debugging tools

It brings up visualizers to several classes, that are seen right in debugger.

Without expanding, we see function/class names:
<img src="https://user-images.githubusercontent.com/67757852/105480293-1e8a3f00-5cd8-11eb-93a5-e1c5b74d232b.png" width="383">

As well as var names,
<img src="https://user-images.githubusercontent.com/67757852/105480354-395cb380-5cd8-11eb-8b16-178ec611e4b6.png" width="464">

... type data,
<img src="https://user-images.githubusercontent.com/67757852/105480511-6d37d900-5cd8-11eb-8102-3549e44b8a46.png" width="404">

... tokens,
<img src="https://user-images.githubusercontent.com/67757852/105480583-850f5d00-5cd8-11eb-8abf-8d476014b81b.png" width="273">

... and many others.

Note, that FunctionPtr/ClassPtr and others are actually classes with `T *ptr` and overloaded `operator ->` proxying calls to FunctionData/ClassData/etc, that's why before this MR we had to expand two levels of nesting (FunctionPtr -> ptr FunctionData -> properties[]), and now we have to expand only one, this is implemented with lldb fake children. Moreover, when FunctionPtr/ClassPtr points to null, earlier we had to expand them to one-level to see that ptr=null, now such pointers are not expanded, which is very cute.

And even more! Now you can traverse AST tree right in debugger: for non-leaf `VertexPtr` and `VertexAdaptor<*>` fake children are added: `ith0, ith1`, etc.
For example, given a function
```
function f(): int {
    $a = 4 + 5;
    return $a;
}
```
You can expand all notes of `op_function`:
<img src="https://user-images.githubusercontent.com/67757852/105481772-17643080-5cda-11eb-990b-ea5bd1095fcd.png" width="470">


# How to make a custom hint to your own class

My implementation calls the `_debug_string()` method expected to return `std::string`. There is a `DEBUG_STRING_METHOD` macro that expands all required annotations.
For example, if you have a cpp class
```
class Rectange {
  int width; 
  int height;
};
```
You can output "{w} x {h}" as a custom visualizer:
```
class Rectangle {
  DEBUG_STRING_METHOD { return std::to_string(width) + " x " + std::to_string(height); }
};
```
And all this class to a list in `.lldbinit`:
```
type summary add --python-function "lldb_addons.class_with_debug_string" Rectangle
```
<img src="https://user-images.githubusercontent.com/67757852/105484078-6069b400-5cdd-11eb-9833-c4346091a068.png" width="236">


Thus, FunctionData, ClassData, TypeData, Location and others have this method implemented.

To expand FunctionPtr without an intermediate `ptr` field, fake children are uses, as well as for VertexPtr. See `lldb_addons.py` for implementation.

GDB is not supported, LLDB only.