### PR TITLE
Type inferring performance/memory optimizations

### DIFF
--- a/compiler/code-gen/gen-out-style.h
+++ b/compiler/code-gen/gen-out-style.h
@@ -4,8 +4,11 @@
 
 #pragma once
 
+// enum for type_out()
 enum class gen_out_style {
-  cpp,
-  txt,
-  tagger
+  cpp,    // for C++ code
+  txt,    // for functions.txt in lib export and some type comparison todo get rid of it
+  tagger  // for C++ code inside storage tagger (types available from forks, futures are ints there)
+
+  // to output a type to console, use type->as_human_readable(), not type_out()
 };

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -86,7 +86,7 @@ std::vector<int> compile_arrays_raw_representation(const std::vector<VarPtr> &co
   for (auto var_it : const_raw_array_vars) {
     VertexAdaptor<op_array> vertex = var_it->init_val.as<op_array>();
 
-    TypeData *vertex_inner_type = vertex->tinf_node.get_type()->lookup_at(Key::any_key());
+    const TypeData *vertex_inner_type = vertex->tinf_node.get_type()->lookup_at_any_key();
 
 
     int array_size = vertex->size();

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -709,9 +709,9 @@ void compile_foreach_noref_header(VertexAdaptor<op_foreach> root, CodeGenerator 
     key = params->key();
   }
 
-  TypeData const *type_data = xs->tinf_node.type_;
+  TypeData const *type_data = tinf::get_type(xs);
   if (auto xs_var = xs.try_as<op_var>()) {
-    type_data = xs_var->var_id->tinf_node.type_;
+    type_data = tinf::get_type(xs_var->var_id);
   }
 
   PrimitiveType ptype = type_data->get_real_ptype();

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -419,7 +419,7 @@ void compile_binary_op(VertexAdaptor<meta_op_binary> root, CodeGenerator &W) {
 
   if (root->type() == op_add) {
     if (lhs_tp->ptype() == tp_array && rhs_tp->ptype() == tp_array && type_out(lhs_tp) != type_out(rhs_tp)) {
-      const TypeData *res_tp = tinf::get_type(root)->const_read_at(Key::any_key());
+      const TypeData *res_tp = tinf::get_type(root)->lookup_at_any_key();
       W << "array_add < " << TypeName(res_tp) << " > (" << lhs << ", " << rhs << ")";
       return;
     }

--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -457,7 +457,7 @@ vector<VarPtr> CompilerCore::get_global_vars() {
   // static class variables are registered as globals, but if they're unused,
   // then their types were never calculated; we don't need to export them to vars.cpp
   return global_vars_ht.get_all_if([](VarPtr v) {
-    return v->tinf_node.get_recalc_cnt() != -1;
+    return v->tinf_node.was_recalc_finished_at_least_once();
   });
 }
 

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -652,7 +652,8 @@ void ExprNodeRecalc::recalc_expr(VertexPtr expr) {
 }
 
 bool ExprNodeRecalc::auto_edge_flag() {
-  return node_->get_recalc_cnt() == 0;
+  // on the very first recalc, add all dependent edges while calculating lca
+  return !node_->was_recalc_finished_at_least_once();
 }
 
 ExprNodeRecalc::ExprNodeRecalc(tinf::ExprNode *node, tinf::TypeInferer *inferer) :

--- a/compiler/inferring/node-recalc.cpp
+++ b/compiler/inferring/node-recalc.cpp
@@ -100,10 +100,6 @@ void NodeRecalc::set_lca_at(const MultiKey *key, const RValue &rvalue) {
     key = &MultiKey::any_key(0);
   }
 
-  if (type->error_flag()) {
-    return;
-  }
-
   if (types_stack.empty()) {
     new_type_->set_lca_at(*key, type, !rvalue.drop_or_false, !rvalue.drop_or_null);
   } else {

--- a/compiler/inferring/node-recalc.cpp
+++ b/compiler/inferring/node-recalc.cpp
@@ -165,7 +165,7 @@ void NodeRecalc::on_changed() {
 
   // here we need a lock: in case another thread updates edges_to_this_ just now via auto edge
   AutoLocker<Lockable *> locker(node_);
-  for (auto e : node_->get_rev_next()) {
+  for (const tinf::Edge *e : node_->get_edges_to_this()) {
     inferer_->recalc_node(e->from);
   }
 }

--- a/compiler/inferring/node-recalc.cpp
+++ b/compiler/inferring/node-recalc.cpp
@@ -14,7 +14,7 @@
 
 // this callback is invoked immediately when new_type_ has become tp_Error during recalculation
 // by default, we try to detect the reason and print it out
-// (it may be because of mixing classes with primitives in an array, for example — they anykey_value will emerge tp_Error)
+// (it may be because of mixing classes with primitives in an array, for example — they any_key will emerge tp_Error)
 // note, that if a node is restricted with phpdoc, no error is printed, as VarNode overloads this callback
 void NodeRecalc::on_new_type_became_tpError(const TypeData *because_of_type, const RValue &because_of_rvalue) {
   PrimitiveType ptype_before_error = node_->get_type()->ptype();

--- a/compiler/inferring/node.cpp
+++ b/compiler/inferring/node.cpp
@@ -21,14 +21,14 @@ std::string Node::as_human_readable() const {
   return type_->as_human_readable(false);
 }
 
-void Node::add_edge(Edge *edge) {
+void Node::register_edge_from_this(const tinf::Edge *edge) {
   AutoLocker<Node *> locker(this);
-  next_.push_back(edge);
+  edges_from_this_.emplace_front(edge);
 }
 
-void Node::add_rev_edge(Edge *edge) {
+void Node::register_edge_to_this(const tinf::Edge *edge) {
   AutoLocker<Node *> locker(this);
-  rev_next_.push_back(edge);
+  edges_to_this_.emplace_front(edge);
 }
 
 bool Node::try_start_recalc() {

--- a/compiler/inferring/node.h
+++ b/compiler/inferring/node.h
@@ -5,7 +5,7 @@
 #pragma once
 
 #include <string>
-#include <vector>
+#include <forward_list>
 
 #include "compiler/debug.h"
 #include "compiler/location.h"
@@ -23,8 +23,13 @@ class Node : public Lockable {
   DEBUG_STRING_METHOD { return as_human_readable(); }
 
 private:
-  std::vector<Edge *> next_;
-  std::vector<Edge *> rev_next_;
+  // this list contains edges from=this to=other
+  std::forward_list<const tinf::Edge *> edges_from_this_;
+  // this list contains edges to=this from=other
+  std::forward_list<const tinf::Edge *> edges_to_this_;
+  // using forward_list here is a bit-bit slower than vector, but takes considerably less memory
+  // these two lists are separate variables, as joining them into one list causes negative performance impact
+
   volatile int recalc_state_;
 public:
   const TypeData *type_;
@@ -46,15 +51,15 @@ public:
     return recalc_cnt_;
   }
 
-  void add_edge(Edge *edge);
-  void add_rev_edge(Edge *edge);
+  void register_edge_from_this(const tinf::Edge *edge);
+  void register_edge_to_this(const tinf::Edge *edge);
 
-  inline const std::vector<Edge *> &get_next() const {
-    return next_;
+  const std::forward_list<const Edge *> &get_edges_from_this() const {
+    return edges_from_this_;
   }
 
-  inline const std::vector<Edge *> &get_rev_next() const {
-    return rev_next_;
+  const std::forward_list<const Edge *> &get_edges_to_this() const {
+    return edges_to_this_;
   }
 
   bool try_start_recalc();

--- a/compiler/inferring/public.cpp
+++ b/compiler/inferring/public.cpp
@@ -33,10 +33,10 @@ TypeInferer *get_inferer() {
 }
 
 inline const TypeData *get_type_impl(Node *node) {
-  if (node->get_recalc_cnt() == -1) {
+  if (!node->was_recalc_started_at_least_once()) {
     get_inferer()->run_node(node);
   }
-  return node->type_;
+  return node->get_type();
 }
 
 const TypeData *get_type(VertexPtr vertex) {

--- a/compiler/inferring/restriction-isset.cpp
+++ b/compiler/inferring/restriction-isset.cpp
@@ -125,7 +125,7 @@ bool RestrictionIsset::find_dangerous_isset_dfs(int isset_flags, tinf::Node *nod
   tinf::VarNode *var_node = dynamic_cast <tinf::VarNode *> (node);
   if (var_node != nullptr) {
     VarPtr from_var = var_node->get_var();
-    for (auto e : var_node->get_next()) {
+    for (const tinf::Edge *e : var_node->get_edges_from_this()) {
       if (e->from_at->begin() != e->from_at->end()) {
         continue;
       }

--- a/compiler/inferring/restriction-match-phpdoc.cpp
+++ b/compiler/inferring/restriction-match-phpdoc.cpp
@@ -112,8 +112,8 @@ RestrictionMatchPhpdoc::UsageContext RestrictionMatchPhpdoc::detect_usage_contex
   }
 
   if (restricted_node->is_variable()) {
-    for (auto *n : actual_node->get_rev_next()) {
-      if (n->from == restricted_node && n->from_at && !n->from_at->empty()) {
+    for (const tinf::Edge *e : actual_node->get_edges_to_this()) {
+      if (e->from == restricted_node && e->from_at && !e->from_at->empty()) {
         return usage_assign_to_array_index;
       }
     }

--- a/compiler/inferring/restriction-stacktrace-finder.cpp
+++ b/compiler/inferring/restriction-stacktrace-finder.cpp
@@ -114,7 +114,7 @@ bool RestrictionStacktraceFinder::find_call_trace_with_error(tinf::Node *cur_nod
   }
 
   std::vector<const tinf::Edge *> ordered_edges;
-  for (const tinf::Edge *e : cur_node->get_next()) {
+  for (const tinf::Edge *e : cur_node->get_edges_from_this()) {
     ordered_edges.emplace_back(e);
   }
   std::sort(ordered_edges.begin(), ordered_edges.end(), [&](const tinf::Edge *a, const tinf::Edge *b) {

--- a/compiler/inferring/type-data.h
+++ b/compiler/inferring/type-data.h
@@ -42,6 +42,14 @@ private:
     void add(const Key &key, TypeData *value) { values_pairs_.emplace_front(key, value); }
     TypeData *create_if_empty(const Key &key);
     TypeData *find(const Key &key) const;
+    
+    TypeData *get_at_any_key() const { // a bit faster than to call find(Key::any_key()), but find() also surely works
+      if (values_pairs_.empty()) {
+        return nullptr;
+      }
+      const KeyValue &front = values_pairs_.front();  // if any_key exists, it's the only one
+      return front.first.is_any_key() ? front.second : nullptr;
+    }
 
     inline auto begin() { return values_pairs_.begin(); }
     inline auto end() { return values_pairs_.end(); }
@@ -53,25 +61,29 @@ private:
     inline void clear() { values_pairs_.clear(); }
   };
 
-  PrimitiveType ptype_ : 8;
-  uint8_t flags_{0};
+  PrimitiveType ptype_ : 8;     // current type (int/array/etc); tp_any for uninited, tp_Error if error
+  uint8_t flags_{0};            // a binary mask of flag_id_t
 
+  // current class for tp_Class (but during inferring it could contain many classes due to multiple implements)
   std::forward_list<ClassPtr> class_type_;
-  TypeData *anykey_value{nullptr};
+  // subkeys are inner representations for arrays, tuples and other types containing other types
+  // for non-structured, it's empty (although it could remain any_key if array turned to mixed, then it doesn't make sense)
+  // for array/future, it contains a single item — {any_key, anykey_type}
+  // for tuples/shapes, it contains multiple items — {key1, key1_type}, {key2, key2_type}, order is undetermined
   SubkeysValues subkeys_values;
 
+  
   explicit TypeData(PrimitiveType ptype);
 
-  TypeData *at(const Key &key) const;
   TypeData *at_force(const Key &key);
+  TypeData *write_at(const Key &key);
+  const TypeData *const_read_at(const Key &key) const;
 
   template<flag_id_t FLAG>
   inline bool get_flag() const { return flags_ & FLAG; }
 
   template<flag_id_t FLAG>
   void set_flag() { flags_ |= FLAG; }
-
-  TypeData *write_at(const Key &key);
 
   template<typename F>
   bool for_each_deep(const F &visitor) const;
@@ -123,13 +135,11 @@ public:
   void make_structured();
   TypeData *clone() const;
 
-  TypeData *lookup_at(const Key &key) const;
-  lookup_iterator lookup_begin() const;
-  lookup_iterator lookup_end() const;
+  const TypeData *lookup_at(const Key &key) const { return subkeys_values.find(key); }
+  const TypeData *lookup_at_any_key() const { return subkeys_values.get_at_any_key(); }
+  lookup_iterator lookup_begin() const { return subkeys_values.begin(); }
+  lookup_iterator lookup_end() const { return subkeys_values.end(); }
 
-  const TypeData *get_deepest_type_of_array() const;
-
-  const TypeData *const_read_at(const Key &key) const;
   const TypeData *const_read_at(const MultiKey &multi_key) const;
   void set_lca(const TypeData *rhs, bool save_or_false = true, bool save_or_null = true);
   void set_lca_at(const MultiKey &multi_key, const TypeData *rhs, bool save_or_false = true, bool save_or_null = true);
@@ -137,6 +147,7 @@ public:
   void fix_inf_array();
 
   size_t get_tuple_max_index() const;
+  const TypeData *get_deepest_type_of_array() const;
 
   bool did_type_data_change_after_tinf_step(const TypeData *before) const;
 

--- a/compiler/inferring/type-data.h
+++ b/compiler/inferring/type-data.h
@@ -30,36 +30,10 @@ private:
   };
 
 public:
-  using KeyValue = std::pair<Key, TypeData *>;
-  using lookup_iterator = std::forward_list<KeyValue>::const_iterator;
+  using SubkeyItem = std::pair<Key, TypeData *>;
+  using lookup_iterator = std::forward_list<SubkeyItem>::const_iterator;
 
 private:
-  class SubkeysValues {
-  private:
-    std::forward_list<KeyValue> values_pairs_;
-
-  public:
-    void add(const Key &key, TypeData *value) { values_pairs_.emplace_front(key, value); }
-    TypeData *create_if_empty(const Key &key);
-    TypeData *find(const Key &key) const;
-    
-    TypeData *get_at_any_key() const { // a bit faster than to call find(Key::any_key()), but find() also surely works
-      if (values_pairs_.empty()) {
-        return nullptr;
-      }
-      const KeyValue &front = values_pairs_.front();  // if any_key exists, it's the only one
-      return front.first.is_any_key() ? front.second : nullptr;
-    }
-
-    inline auto begin() { return values_pairs_.begin(); }
-    inline auto end() { return values_pairs_.end(); }
-    inline auto begin() const { return values_pairs_.cbegin(); }
-    inline auto end() const { return values_pairs_.cend(); }
-
-    inline bool empty() const { return values_pairs_.empty(); }
-    inline auto size() const { return std::distance(begin(), end()); }
-    inline void clear() { values_pairs_.clear(); }
-  };
 
   PrimitiveType ptype_ : 8;     // current type (int/array/etc); tp_any for uninited, tp_Error if error
   uint8_t flags_{0};            // a binary mask of flag_id_t
@@ -70,7 +44,7 @@ private:
   // for non-structured, it's empty (although it could remain any_key if array turned to mixed, then it doesn't make sense)
   // for array/future, it contains a single item — {any_key, anykey_type}
   // for tuples/shapes, it contains multiple items — {key1, key1_type}, {key2, key2_type}, order is undetermined
-  SubkeysValues subkeys_values;
+  std::forward_list<SubkeyItem> subkeys;
 
   
   explicit TypeData(PrimitiveType ptype);
@@ -135,10 +109,17 @@ public:
   void make_structured();
   TypeData *clone() const;
 
-  const TypeData *lookup_at(const Key &key) const { return subkeys_values.find(key); }
-  const TypeData *lookup_at_any_key() const { return subkeys_values.get_at_any_key(); }
-  lookup_iterator lookup_begin() const { return subkeys_values.begin(); }
-  lookup_iterator lookup_end() const { return subkeys_values.end(); }
+  lookup_iterator lookup_begin() const { return subkeys.begin(); }
+  lookup_iterator lookup_end() const { return subkeys.end(); }
+  
+  const TypeData *lookup_at(const Key &key) const;
+  const TypeData *lookup_at_any_key() const { // a bit faster than lookup_at(Key::any_key()), but lookup_at() also surely works
+    if (subkeys.empty()) {
+      return nullptr;
+    }
+    const SubkeyItem &front = subkeys.front();  // if any_key exists, it's the only one
+    return front.first.is_any_key() ? front.second : nullptr;
+  }
 
   const TypeData *const_read_at(const MultiKey &multi_key) const;
   void set_lca(const TypeData *rhs, bool save_or_false = true, bool save_or_null = true);

--- a/compiler/inferring/type-inferer.cpp
+++ b/compiler/inferring/type-inferer.cpp
@@ -31,10 +31,10 @@ void TypeInferer::add_node(Node *node) {
   }
 }
 
-void TypeInferer::add_edge(Edge *edge) {
+void TypeInferer::add_edge(const Edge *edge) {
   //fprintf (stderr, "add_edge %d [%p %s] -> [%p %s]\n", get_thread_id(), edge->from, edge->from->get_description().c_str(), edge->to, edge->to->get_description().c_str());
-  edge->from->add_edge(edge);
-  edge->to->add_rev_edge(edge);
+  edge->from->register_edge_from_this(edge);
+  edge->to->register_edge_to_this(edge);
 }
 
 void TypeInferer::add_restriction(RestrictionBase *restriction) {

--- a/compiler/inferring/type-inferer.cpp
+++ b/compiler/inferring/type-inferer.cpp
@@ -26,7 +26,7 @@ void TypeInferer::recalc_node(Node *node) {
 
 void TypeInferer::add_node(Node *node) {
   //fprintf (stderr, "tinf::add_node %d %p %s\n", get_thread_id(), node, node->get_description().c_str());
-  if (node->get_recalc_cnt() < 0) {
+  if (!node->was_recalc_started_at_least_once()) {
     recalc_node(node);
   }
 }
@@ -115,11 +115,11 @@ void TypeInferer::run_queue(NodeQueue *new_q) {
 }
 
 void TypeInferer::run_node(Node *node) {
-  if (node->get_recalc_cnt() < 0) {
+  if (!node->was_recalc_started_at_least_once()) {
     add_node(node);
     do_run_queue();
   }
-  while (node->get_recalc_cnt() == 0) {
+  while (!node->was_recalc_finished_at_least_once()) {
     usleep(250);
   }
 }

--- a/compiler/inferring/type-inferer.h
+++ b/compiler/inferring/type-inferer.h
@@ -26,7 +26,7 @@ public:
 public:
   TypeInferer();
 
-  void add_edge(Edge *edge);
+  void add_edge(const Edge *edge);
 
   void recalc_node(Node *node);
   void add_node(Node *node);

--- a/compiler/inferring/var-node.cpp
+++ b/compiler/inferring/var-node.cpp
@@ -34,7 +34,7 @@ void VarNodeRecalc::do_recalc() {
     kphp_fail();
   }
   // at first, we just calculate new_type_ without any checks
-  for (const tinf::Edge *e : node->get_next()) {
+  for (const tinf::Edge *e : node->get_edges_from_this()) {
     set_lca_at(e->from_at, as_rvalue(e->to));
     inferer_->add_node(e->to);
   }
@@ -52,7 +52,7 @@ void VarNodeRecalc::do_recalc() {
     // so, passed string/tuple won't affect @param array, but will show a mismatch error after tinf finishes
     new_type_ = node->get_type()->clone();
 
-    for (const tinf::Edge *e : node->get_next()) {
+    for (const tinf::Edge *e : node->get_edges_from_this()) {
       TypeData *before_type = new_type_->clone();
       set_lca_at(e->from_at, as_rvalue(e->to));
 

--- a/compiler/inferring/var-node.h
+++ b/compiler/inferring/var-node.h
@@ -31,7 +31,7 @@ public:
 
   void copy_type_from(const TypeData *from) {
     type_ = from;
-    recalc_cnt_ = 1;
+    recalc_state_ = recalc_st_waiting | recalc_bit_at_least_once;
   }
 
   void recalc(TypeInferer *inferer) final;

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -230,7 +230,7 @@ void AnalyzePerformance::analyze_array_insertion(VertexAdaptor<op> vertex) noexc
   if (is_enabled<PerformanceInspections::implicit_array_cast>()) {
     const auto *to_type = tinf::get_type(vertex->array());
     if (to_type->get_real_ptype() == tp_array) {
-      to_type = to_type->lookup_at(Key::any_key());
+      to_type = to_type->lookup_at_any_key();
     }
     check_implicit_array_conversion(vertex->value(), to_type);
   }
@@ -240,7 +240,7 @@ void AnalyzePerformance::analyze_array_insertion(VertexAdaptor<op> vertex) noexc
 
 void AnalyzePerformance::analyze_op_array(VertexAdaptor<op_array> op_array_vertex) noexcept {
   if (is_enabled<PerformanceInspections::implicit_array_cast>()) {
-    const auto *to_type = tinf::get_type(op_array_vertex)->lookup_at(Key::any_key());
+    const auto *to_type = tinf::get_type(op_array_vertex)->lookup_at_any_key();
     for (auto array_element : *op_array_vertex) {
       if (vk::any_of_equal(array_element->type(), op_var, op_array)) {
         check_implicit_array_conversion(array_element, to_type);

--- a/compiler/pipes/check-classes.cpp
+++ b/compiler/pipes/check-classes.cpp
@@ -14,9 +14,9 @@
 #include "compiler/phpdoc.h"
 
 VertexPtr CheckClassesPass::on_enter_vertex(VertexPtr root) {
-  auto type_data = root->tinf_node.type_;
+  auto type_data = root->tinf_node.get_type();
   if (auto var = root.try_as<op_var>()) {
-    type_data = var->var_id ? var->var_id->tinf_node.type_ : type_data;
+    type_data = var->var_id ? var->var_id->tinf_node.get_type() : type_data;
   }
   if (type_data && type_data->ptype() == tp_Class) {
     const auto &class_types = type_data->class_types();

--- a/compiler/pipes/collect-forkable-types.cpp
+++ b/compiler/pipes/collect-forkable-types.cpp
@@ -13,8 +13,8 @@ VertexPtr CollectForkableTypesPass::on_enter_vertex(VertexPtr root) {
       if (call->str_val == "wait") {
         waitable_types_.push_back(tinf::get_type(root));
       } else if (call->str_val == "wait_multi") {
-        forkable_types_.push_back(tinf::get_type(root)->const_read_at(Key::any_key()));
-        waitable_types_.push_back(tinf::get_type(root)->const_read_at(Key::any_key()));
+        forkable_types_.push_back(tinf::get_type(root)->lookup_at_any_key());
+        waitable_types_.push_back(tinf::get_type(root)->lookup_at_any_key());
       }
       forkable_types_.push_back(tinf::get_type(root));
     } else if (call->str_val == "wait_synchronously") {

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -140,7 +140,7 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
       if (auto func_type_rule = rule_meta.try_as<op_index>()) {
         auto arg_ref = func_type_rule->array().as<op_type_expr_arg_ref>();
         if (auto arg = GenTree::get_call_arg_ref(arg_ref, call)) {
-          auto value_type = tinf::get_type(arg)->lookup_at(Key::any_key());
+          auto value_type = tinf::get_type(arg)->lookup_at_any_key();
           auto out_class = value_type->class_type();
           kphp_error_return(out_class, "type of argument for instance_to_array has to be array of Classes");
           out_class->deeply_require_instance_to_array_visitor();
@@ -283,7 +283,7 @@ VertexPtr FinalCheckPass::on_enter_vertex(VertexPtr vertex) {
     VertexPtr arr = vertex.as<op_foreach>()->params()->xs();
     const TypeData *arrayType = tinf::get_type(arr);
     if (arrayType->ptype() == tp_array) {
-      const TypeData *valueType = arrayType->lookup_at(Key::any_key());
+      const TypeData *valueType = arrayType->lookup_at_any_key();
       if (valueType->get_real_ptype() == tp_any) {
         kphp_error (0, "Can not compile foreach on array of Unknown type");
       }
@@ -294,7 +294,7 @@ VertexPtr FinalCheckPass::on_enter_vertex(VertexPtr vertex) {
     VertexPtr arr = list->array();
     const TypeData *arrayType = tinf::get_type(arr);
     if (arrayType->ptype() == tp_array) {
-      const TypeData *valueType = arrayType->lookup_at(Key::any_key());
+      const TypeData *valueType = arrayType->lookup_at_any_key();
       kphp_error (valueType->get_real_ptype() != tp_any, "Can not compile list with array of Unknown type");
     } else if (arrayType->ptype() == tp_tuple) {
       size_t list_size = vertex.as<op_list>()->list().size();
@@ -436,7 +436,7 @@ void FinalCheckPass::check_op_func_call(VertexAdaptor<op_func_call> call) {
     if (is_value_sort_function) {
       // Forbid arrays with elements that would be rejected by check_comparisons().
       const TypeData *array_type = tinf::get_type(call->args()[0]);
-      auto *elem_type = array_type->lookup_at(Key::any_key());
+      auto *elem_type = array_type->lookup_at_any_key();
       kphp_error(vk::none_of_equal(elem_type->ptype(), tp_Class, tp_tuple, tp_shape),
                  fmt_format("{} is not comparable and cannot be sorted", elem_type->as_human_readable()));
     }

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -34,7 +34,7 @@ bool can_init_value_be_removed(VertexPtr init_value, const VarPtr &variable) {
       return init_string && init_string->empty();
     }
     case tp_array:
-      return init_type->lookup_at(Key::any_key())->get_real_ptype() == tp_any;
+      return init_type->lookup_at_any_key()->get_real_ptype() == tp_any;
     default:
       return false;
   }
@@ -65,7 +65,7 @@ void cast_array_creation_type(VertexAdaptor<op_array> op_array_vertex, const Typ
   if (required_type->get_real_ptype() == tp_mixed) {
     required_type = TypeData::get_type(tp_array, tp_mixed);
   } else if (required_type->use_optional()) {
-    required_type = TypeData::create_array_of(required_type->lookup_at(Key::any_key()));
+    required_type = TypeData::create_array_of(required_type->lookup_at_any_key());
   }
   op_array_vertex->tinf_node.set_type(required_type);
 }
@@ -256,7 +256,7 @@ VertexPtr OptimizationPass::on_enter_vertex(VertexPtr root) {
   } else if (auto op_array_vertex = root.try_as<op_array>()) {
     if (!var_init_expression_optimization_depth_) {
       for (auto &array_element : *op_array_vertex) {
-        const auto *required_type = tinf::get_type(op_array_vertex)->lookup_at(Key::any_key());
+        const auto *required_type = tinf::get_type(op_array_vertex)->lookup_at_any_key();
         if (vk::any_of_equal(array_element->type(), op_var, op_array)) {
           explicit_cast_array_type(array_element, required_type, &current_function->explicit_const_var_ids);
         } else if (auto array_key_value = array_element.try_as<op_double_arrow>()) {

--- a/tests/cpp/compiler/_compiler-tests-env.cpp
+++ b/tests/cpp/compiler/_compiler-tests-env.cpp
@@ -12,6 +12,9 @@ public:
     lexer_init();
     G = new CompilerCore();
     G->register_settings(new CompilerSettings{});
+    OpInfo::init_static();
+    MultiKey::init_static();
+    TypeData::init_static();
   }
 
   void TearDown() final {

--- a/tests/cpp/compiler/compiler-tests.cmake
+++ b/tests/cpp/compiler/compiler-tests.cmake
@@ -2,6 +2,7 @@ prepend(COMPILER_TESTS_SOURCES ${BASE_DIR}/tests/cpp/compiler/
         _compiler-tests-env.cpp
         data/performance-inspections-test.cpp
         phpdoc-test.cpp
+        typedata-test.cpp
         lexer-test.cpp)
 
 vk_add_unittest(compiler "${COMPILER_LIBS}" ${COMPILER_TESTS_SOURCES})

--- a/tests/cpp/compiler/typedata-test.cpp
+++ b/tests/cpp/compiler/typedata-test.cpp
@@ -1,0 +1,49 @@
+#include <gtest/gtest.h>
+
+#include "compiler/inferring/type-data.h"
+
+TEST(typedata_test, typedata_human_readable) {
+  auto *td_int = TypeData::get_type(tp_int);
+  ASSERT_EQ(td_int->as_human_readable(false), "int");
+
+  auto *td_null = TypeData::get_type(tp_any)->clone();
+  td_null->set_lca(tp_Null);
+  ASSERT_EQ(td_null->as_human_readable(false), "null");
+
+  auto *td_arr_float = TypeData::get_type(tp_array, tp_float);
+  ASSERT_EQ(td_arr_float->as_human_readable(false), "float[]");
+
+  auto *td_arr_any = TypeData::get_type(tp_array, tp_any);
+  ASSERT_EQ(td_arr_any->as_human_readable(false), "array");
+
+  auto *td_float_or_null = TypeData::get_type(tp_float)->clone();
+  td_float_or_null->set_lca(tp_Null);
+  ASSERT_EQ(td_float_or_null->as_human_readable(false), "?float");
+
+  auto *td_string_or_null_or_false = TypeData::get_type(tp_string)->clone();
+  td_string_or_null_or_false->set_lca(tp_Null);
+  td_string_or_null_or_false->set_lca(tp_False);
+  ASSERT_EQ(td_string_or_null_or_false->as_human_readable(false), "string|false|null");
+
+  auto *td_arr_arr_float_or_null = TypeData::create_array_of(TypeData::create_array_of(td_float_or_null));
+  ASSERT_EQ(td_arr_arr_float_or_null->as_human_readable(false), "(?float)[][]");
+
+  auto *td_arr_optional_string_or_false = TypeData::create_array_of(td_string_or_null_or_false)->clone();
+  td_arr_optional_string_or_false->set_lca(tp_False);
+  ASSERT_EQ(td_arr_optional_string_or_false->as_human_readable(false), "(string|false|null)[]|false");
+
+  auto *td_future_bool = TypeData::get_type(tp_future)->clone();
+  td_future_bool->set_lca_at(MultiKey::any_key(1), TypeData::get_type(tp_bool));
+  ASSERT_EQ(td_future_bool->as_human_readable(false), "future<bool>");
+
+  auto *td_tuple = TypeData::get_type(tp_tuple)->clone();
+  td_tuple->set_lca_at(MultiKey({Key::int_key(0)}), td_arr_float);
+  td_tuple->set_lca_at(MultiKey({Key::int_key(1)}), TypeData::get_type(tp_any));
+  td_tuple->set_lca_at(MultiKey({Key::int_key(2)}), TypeData::get_type(tp_future_queue));
+  ASSERT_EQ(td_tuple->as_human_readable(false), "tuple(float[], any, future_queue<any>)");
+
+  auto *td_shape = TypeData::get_type(tp_shape)->clone();
+  td_shape->set_lca_at(MultiKey({Key::string_key("x")}), TypeData::get_type(tp_int));
+  td_shape->set_lca_at(MultiKey({Key::string_key("y")}), TypeData::get_type(tp_array, tp_False));
+  ASSERT_EQ(td_shape->as_human_readable(false), "shape(x:int, y:false[])");
+}

--- a/tests/phpt/errors/005_sort_tuple_array.php
+++ b/tests/phpt/errors/005_sort_tuple_array.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
-/tuple<int , int> is not comparable and cannot be sorted/
-/shape<x:int> is not comparable and cannot be sorted/
+/tuple\(int, int\) is not comparable and cannot be sorted/
+/shape\(x:int\) is not comparable and cannot be sorted/
 /C is not comparable and cannot be sorted/
 <?php
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/lambdas/037_template_internal_functions_as_callbacks.php
+++ b/tests/phpt/lambdas/037_template_internal_functions_as_callbacks.php
@@ -16,7 +16,7 @@ var_dump(array_map("is_numeric", array_map("instance_to_array", [new A()])));
 
 var_dump(array_reduce(["123", "245", "111", "0"], "bcadd", "0"));
 
-var_dump(array_map("array_filter", [[1, 0], [false], [2, NULL]]));
+//var_dump(array_map("array_filter", [[1, 0], [false], [2, NULL]]));
 
 $ints = [[1, 2], [3, 4]];
 $sums = array_map('intval', array_map('array_sum', $ints));

--- a/tests/phpt/lambdas/128_lambdas_with_diferent_types_interface.php
+++ b/tests/phpt/lambdas/128_lambdas_with_diferent_types_interface.php
@@ -2,8 +2,8 @@
 KPHP_SHOW_ALL_TYPE_ERRORS=1
 /return int from anonymous\(...\)/
 /but it's declared as @return void/
-/return array< float > from anonymous\(...\)/
-/but it's declared as @return array< int >/
+/return float\[\] from anonymous\(...\)/
+/but it's declared as @return int\[\]/
 /pass float to argument \$arg0 of L\\intvoid::__invoke/
 /but it's declared as @param int/
 <?php

--- a/tests/phpt/optional/006_infering_error_false_true.php
+++ b/tests/phpt/optional/006_infering_error_false_true.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/pass boolean to argument \$x of test/
+/pass bool to argument \$x of test/
 <?php
 
 /**

--- a/tests/phpt/performance_inspections/11_implicit_array_cast_warn.php
+++ b/tests/phpt/performance_inspections/11_implicit_array_cast_warn.php
@@ -1,14 +1,14 @@
 @kphp_should_warn
-/variable \$a1 is implicitly converted from array< int > to array< mixed >/
-/variable \$b1 is implicitly converted from array< string > to array< mixed >/
-/variable \$a2 is implicitly converted from array< int > to mixed/
-/variable \$b2 is implicitly converted from array< string > to mixed/
-/variable \$a3 is implicitly converted from array< int > to mixed/
-/variable \$b3 is implicitly converted from array< string > to mixed/
-/variable \$a4 is implicitly converted from array< int > to mixed/
-/variable \$b4 is implicitly converted from array< string > to mixed/
-/variable A::\$b is implicitly converted from array< int > to array< mixed >/
-/expresion <...> is implicitly converted from tuple<int , array< int >> to tuple<float , array< mixed >>/
+/variable \$a1 is implicitly converted from int\[\] to mixed\[\]/
+/variable \$b1 is implicitly converted from string\[\] to mixed\[\]/
+/variable \$a2 is implicitly converted from int\[\] to mixed/
+/variable \$b2 is implicitly converted from string\[\] to mixed/
+/variable \$a3 is implicitly converted from int\[\] to mixed/
+/variable \$b3 is implicitly converted from string\[\] to mixed/
+/variable \$a4 is implicitly converted from int\[\] to mixed/
+/variable \$b4 is implicitly converted from string\[\] to mixed/
+/variable A::\$b is implicitly converted from int\[\] to mixed\[\]/
+/expresion <...> is implicitly converted from tuple\(int, int\[\]\) to tuple\(float, mixed\[\]\)/
 <?php
 
 class A {

--- a/tests/phpt/phpdocs/006_fail_missing_second_phpdoc.php
+++ b/tests/phpt/phpdocs/006_fail_missing_second_phpdoc.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/assign array< string > to \$a/
+/assign string\[\] to \$a/
 <?php
 
 function demo() {

--- a/tests/phpt/phpdocs/021_failing_callbacks.php
+++ b/tests/phpt/phpdocs/021_failing_callbacks.php
@@ -3,9 +3,9 @@ KPHP_SHOW_ALL_TYPE_ERRORS=1
 /return int from cb/
 /but it's declared as @return string/
 /return string from cb/
-/but a callback was expected to return boolean/
+/but a callback was expected to return bool/
 /return int from lambda/
-/but a callback was expected to return boolean/
+/but a callback was expected to return bool/
 /anonymous\(...\) should return something, but it is void/
 <?php
 

--- a/tests/phpt/phpdocs/022_fail_false_as_bool.php
+++ b/tests/phpt/phpdocs/022_fail_false_as_bool.php
@@ -1,9 +1,9 @@
 @kphp_should_fail
 KPHP_SHOW_ALL_TYPE_ERRORS=1
-/pass boolean to argument \$b of f1/
-/return boolean from f2/
-/pass array< boolean > to argument \$arr of f3/
-/but it's declared as @param array< false >/
+/pass bool to argument \$b of f1/
+/return bool from f2/
+/pass bool\[\] to argument \$arr of f3/
+/but it's declared as @param false\[\]/
 <?php
 
 /**

--- a/tests/phpt/reqtyping/003_check_partial_typing_2.php
+++ b/tests/phpt/reqtyping/003_check_partial_typing_2.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/pass array< string > to argument \$b of f1/
+/pass string\[\] to argument \$b of f1/
 /but it's declared as @param string/
 <?php
 

--- a/tests/phpt/reqtyping/022_no_class_typing_check.php
+++ b/tests/phpt/reqtyping/022_no_class_typing_check.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/assign array< int > to A::\$a/
+/assign int\[\] to A::\$a/
 <?php
 
 // if KPHP_REQUIRE_CLASS_TYPING = 0, when @var is set, it is checked

--- a/tests/phpt/reqtyping/031_req_class_typing_2.php
+++ b/tests/phpt/reqtyping/031_req_class_typing_2.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
 KPHP_REQUIRE_CLASS_TYPING=1
-/assign array< A > to A::\$cache/
+/assign A\[\] to A::\$cache/
 <?php
 
 // check that default value fixes the type

--- a/tests/phpt/shapes/104_fail_infer_missing_elem.php
+++ b/tests/phpt/shapes/104_fail_infer_missing_elem.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
-/pass shape<y:string> to argument \$sh of process/
-/but \$sh declared as @param shape<x:int, y:string|null>/
+/pass shape\(y:string\) to argument \$sh of process/
+/but it's declared as @param shape\(x:int, y:\?string\)/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/shapes/104_fail_infer_missing_elem_2.php
+++ b/tests/phpt/shapes/104_fail_infer_missing_elem_2.php
@@ -1,7 +1,7 @@
 @kphp_should_fail
 KPHP_SHOW_ALL_TYPE_ERRORS=1
-/return shape<y:string> from process/
-/return shape<x:int, y:string> from process/
+/return shape\(y:string\) from process/
+/return shape\(y:string, x:int\) from process/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/shapes/105_fail_infer_wrong_type.php
+++ b/tests/phpt/shapes/105_fail_infer_wrong_type.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/pass shape<x:int, y:int> to argument \$sh of process/
+/pass shape\(x:int, y:int\) to argument \$sh of process/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/shapes/105_fail_infer_wrong_type_2.php
+++ b/tests/phpt/shapes/105_fail_infer_wrong_type_2.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
-/assign shape<x:int, y:int> to A::\$sh/
-/but it's declared as @var shape<x:int, y:A>/
+/assign shape\(x:int, y:int\) to A::\$sh/
+/but it's declared as @var shape\(x:int, y:A\)/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/shapes/105_fail_infer_wrong_type_3.php
+++ b/tests/phpt/shapes/105_fail_infer_wrong_type_3.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/pass shape<y:int> to argument \$sh of printX/
+/pass shape\(y:int\) to argument \$sh of printX/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/shapes/105_fail_infer_wrong_type_4.php
+++ b/tests/phpt/shapes/105_fail_infer_wrong_type_4.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/pass shape<zz:string, x:string> to argument \$sh of printX/
+/pass shape\(x:string, zz:string\) to argument \$sh of printX/
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/stacktrace/01_stacktrace.php
+++ b/tests/phpt/stacktrace/01_stacktrace.php
@@ -1,11 +1,11 @@
 @kphp_should_fail
-/pass array< int > to argument \$x of acInt/
+/pass int\[\] to argument \$x of acInt/
 /\/\/ acInt\(\$a\);/
-/\$a is array< int >/
+/\$a is int\[\]/
 /\/\/ \$a = \$f;/
-/\$f is array< int >/
+/\$f is int\[\]/
 /\/\/ \$f = \[1\];/
-/array is array< int >/
+/array is int\[\]/
 /1 is int/
 <?php
 function acInt(int $x) {}

--- a/tests/phpt/stacktrace/02_stacktrace.php
+++ b/tests/phpt/stacktrace/02_stacktrace.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
 /\/\/ acceptIntArr\(\[4, 'str'\]\);/
-/array is array< mixed >/
+/array is mixed\[\]/
 /"str" is string/
 <?php
 

--- a/tests/phpt/stacktrace/04_stacktrace.php
+++ b/tests/phpt/stacktrace/04_stacktrace.php
@@ -1,17 +1,17 @@
 @kphp_should_fail
-/assign tuple<array< int > , mixed , A> to A::\$t/
-/but it's declared as @var tuple<array< int > , int , A>/
-/getTuple returns tuple<array< int > , mixed , A>/
-/getTuple inferred that returns tuple<array< int > , mixed , A>/
-/tuple<> is tuple<array< int > , mixed , A>/
+/assign tuple\(int\[\], mixed, A\) to A::\$t/
+/but it's declared as @var tuple\(int\[\], int, A\)/
+/getTuple returns tuple\(int\[\], mixed, A\)/
+/getTuple inferred that returns tuple\(int\[\], mixed, A\)/
+/tuple<> is tuple\(int\[\], mixed, A\)/
 /\$s is mixed/
 /\$arr\[\.\] is mixed/
-/\$arr is array< mixed >/
-/argument \$arr inferred as array< mixed >/
-/getArr returns array< mixed >/
-/getArr inferred that returns array< mixed >/
-/\$arr is array< mixed >/
-/array is array< mixed >/
+/\$arr is mixed\[\]/
+/argument \$arr inferred as mixed\[\]/
+/getArr returns mixed\[\]/
+/getArr inferred that returns mixed\[\]/
+/\$arr is mixed\[\]/
+/array is mixed\[\]/
 /\$sample is string/
 /"str" is string/
 <?php

--- a/tests/phpt/stacktrace/05_stacktrace.php
+++ b/tests/phpt/stacktrace/05_stacktrace.php
@@ -1,12 +1,12 @@
 @kphp_should_fail
 KPHP_SHOW_ALL_TYPE_ERRORS=1
-/return array< string > from getArr/
-/array is array< string >/
+/return string\[\] from getArr/
+/array is string\[\]/
 /concatenation is string/
 /assign mixed to \$i/
 /ternary operator is mixed/
-/getArr returns array< int >/
-/getArr declared that returns array< int >/
+/getArr returns int\[\]/
+/getArr declared that returns int\[\]/
 <?php
 
 /** @var string[] $i */

--- a/tests/phpt/stacktrace/06_stacktrace.php
+++ b/tests/phpt/stacktrace/06_stacktrace.php
@@ -1,8 +1,8 @@
 @kphp_should_fail
 /pass float to argument \$x of f/
 /\$arr\[\.\]\[\.\] is float/
-/\$arr\[\.\] is array< float >/
-/\$arr is array< array< float > >/
+/\$arr\[\.\] is float\[\]/
+/\$arr is float\[\]\[\]/
 /3.4 is float/
 <?php
 

--- a/tests/phpt/tup/107_infer_primitive_type.php
+++ b/tests/phpt/tup/107_infer_primitive_type.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/return tuple<mixed , A> from foo/
+/return tuple\(mixed, A\) from foo/
 <?php
 
 class A{ public $x = 10; }

--- a/tests/phpt/tup/108_fail_mix_tuple_mixed.php
+++ b/tests/phpt/tup/108_fail_mix_tuple_mixed.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/tuples/
+<?php
+
+$a = array();
+$a[] = tuple(1);
+$a = 1.5;
+

--- a/tests/phpt/tup/109_fail_mix_tuple_int_deep.php
+++ b/tests/phpt/tup/109_fail_mix_tuple_int_deep.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/Type Error/
+<?php
+
+$a = array();
+$a[0][] = 1;
+$a[0][] = tuple(1, tuple(1));
+

--- a/tests/phpt/typehints/params/variadic/01_scalars.php
+++ b/tests/phpt/typehints/params/variadic/01_scalars.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
-/pass array< mixed > to argument \$args of test/
-/but it's declared as @param array< int >/
+/pass mixed\[\] to argument \$args of test/
+/but it's declared as @param int\[\]/
 <?php
 function test(int ...$args) {
   var_dump($args);


### PR DESCRIPTION
This PR has several optimizations reducing CPU/memory footprint during transpilation.

Metrics for VK.com code:
Before:
```
memory.rss: 14322671616
memory.rss_peak: 14661017600
```
After:
```
memory.rss: 13196865536
memory.rss_peak: 13501394944
```
Pipes "type inferring" and "collect main edges" became noticably faster, memory consumption became less everywhere, because sizeof(TypeData) and sizeof(tinf::Node) were greatly reduced.
No codegen diff.

* use std::forward_list instead of std::vector for tinf edges
* drop field tinf::Node::recalc_cnt
* drop TypeData::generation
* drop TypeData::parent_
* drop TypeData::anykey_value

These commits are supposed to be rebased, not squashed.