### PR TITLE
Get rid of >, >=, !=, <> operations from AST.

### DIFF
--- a/common/php-functions.h
+++ b/common/php-functions.h
@@ -210,5 +210,5 @@ inline int string_raw(char *dest, int dest_len, const char *src, int src_len) {
 template<class T>
 inline constexpr int three_way_comparison(const T &lhs, const T &rhs) {
   return lhs < rhs ? -1 :
-         (lhs > rhs ?  1 : 0);
+         (rhs < lhs ?  1 : 0);
 }

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -439,9 +439,7 @@ void compile_binary_op(VertexAdaptor<meta_op_binary> root, CodeGenerator &W) {
   if (rhs_is_bool ^ lhs_is_bool) {
     static const std::unordered_map<int, const char *, std::hash<int>> tp_to_str{
       {op_lt,   "lt"},
-      {op_gt,   "gt"},
       {op_le,   "leq"},
-      {op_ge,   "geq"},
       {op_eq2,  "eq2"},
       {op_neq2, "neq2"},
     };

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -441,7 +441,6 @@ void compile_binary_op(VertexAdaptor<meta_op_binary> root, CodeGenerator &W) {
       {op_lt,   "lt"},
       {op_le,   "leq"},
       {op_eq2,  "eq2"},
-      {op_neq2, "neq2"},
     };
 
     auto str_repr_it = tp_to_str.find(root->type());

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -678,6 +678,9 @@ TokenType transform_compare_operation_token(TokenType token) noexcept {
       return tok_lt;
     case tok_ge:
       return tok_le;
+    case tok_neq_lg:
+    case tok_neq2:
+      return tok_eq2;
     default:
       return token;
   }
@@ -759,6 +762,10 @@ VertexPtr GenTree::get_binary_op(int op_priority_cur, bool till_ternary) {
     }
 
     left.set_location(expr_location);
+    if (vk::any_of_equal(origin_token, tok_neq2, tok_neq_lg)) {
+      left = VertexAdaptor<op_log_not>::create(left).set_location(expr_location);
+    }
+
     if (!(left_to_right || ternary)) {
       break;
     }

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -510,9 +510,7 @@ void ExprNodeRecalc::recalc_expr(VertexPtr expr) {
     case op_neq2:
     case op_neq3:
     case op_lt:
-    case op_gt:
     case op_le:
-    case op_ge:
     case op_isset:
       recalc_ptype<tp_bool>();
       break;

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -507,7 +507,6 @@ void ExprNodeRecalc::recalc_expr(VertexPtr expr) {
     case op_true:
     case op_eq2:
     case op_eq3:
-    case op_neq2:
     case op_neq3:
     case op_lt:
     case op_le:

--- a/compiler/operation.cpp
+++ b/compiler/operation.cpp
@@ -90,7 +90,6 @@ void OpInfo::init_static() {
   curP++;
 
   add_binary_op(curP, tok_eq2, op_eq2);
-  add_binary_op(curP, tok_neq2, op_neq2);
   add_binary_op(curP, tok_eq3, op_eq3);
   add_binary_op(curP, tok_neq3, op_neq3);
   add_binary_op(curP, tok_spaceship, op_spaceship);
@@ -98,7 +97,6 @@ void OpInfo::init_static() {
 
   add_binary_op(curP, tok_lt, op_lt);
   add_binary_op(curP, tok_le, op_le);
-  add_binary_op(curP, tok_neq_lg, op_neq2);
   curP++;
 
   add_binary_op(curP, tok_shr, op_shr);

--- a/compiler/operation.cpp
+++ b/compiler/operation.cpp
@@ -97,9 +97,7 @@ void OpInfo::init_static() {
   curP++;
 
   add_binary_op(curP, tok_lt, op_lt);
-  add_binary_op(curP, tok_gt, op_gt);
   add_binary_op(curP, tok_le, op_le);
-  add_binary_op(curP, tok_ge, op_ge);
   add_binary_op(curP, tok_neq_lg, op_neq2);
   curP++;
 

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -31,7 +31,7 @@ bool is_pure_nary_operation(VertexPtr vertex) noexcept {
                           op_add, op_mul, op_sub, op_div, op_mod, op_pow,
                           op_and, op_or, op_xor, op_shl, op_shr,
                           op_log_xor_let, op_log_and_let, op_log_or_let, op_log_and, op_log_or,
-                          op_eq2, op_neq2, op_eq3, op_neq3, op_le, op_ge, op_lt, op_gt,
+                          op_eq2, op_neq2, op_eq3, op_neq3, op_le, op_lt,
                           op_spaceship, op_null_coalesce, op_ternary, op_isset, op_string_build);
 }
 

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -31,7 +31,7 @@ bool is_pure_nary_operation(VertexPtr vertex) noexcept {
                           op_add, op_mul, op_sub, op_div, op_mod, op_pow,
                           op_and, op_or, op_xor, op_shl, op_shr,
                           op_log_xor_let, op_log_and_let, op_log_or_let, op_log_and, op_log_or,
-                          op_eq2, op_neq2, op_eq3, op_neq3, op_le, op_lt,
+                          op_eq2, op_eq3, op_neq3, op_le, op_lt,
                           op_spaceship, op_null_coalesce, op_ternary, op_isset, op_string_build);
 }
 

--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -399,11 +399,10 @@ void CFG::create_condition_cfg(VertexPtr tree_node, Node *res_start, Node *res_t
             add_type_check_usage(invert ? *res_true : *res_false, ifi_any_type & ~ifi_is_false, var);
           }
         }
-      } else if (vk::any_of_equal(tree_node->type(),  op_eq2, op_neq2)) {
+      } else if (tree_node->type() == op_eq2) {
         if (auto var = tree_node.try_as<meta_op_binary>()->lhs().try_as<op_var>()) {
           if (vk::any_of_equal(tree_node.try_as<meta_op_binary>()->rhs()->type(), op_false, op_null)) {
-            bool invert = (tree_node->type() == op_neq2);
-            add_type_check_usage(invert ? *res_true : *res_false, ifi_any_type & ~(ifi_is_false|ifi_is_null), var);
+            add_type_check_usage(*res_false, ifi_any_type & ~(ifi_is_false|ifi_is_null), var);
           }
         }
       }
@@ -449,8 +448,7 @@ void CFG::create_cfg(VertexPtr tree_node, Node *res_start, Node *res_finish, boo
     }
     case op_neq3:
     case op_eq3:
-    case op_eq2:
-    case op_neq2: {
+    case op_eq2: {
       auto op = tree_node.as<meta_op_binary>();
       if (op->rhs()->type() == op_false || op->rhs()->type() == op_null) {
         Node first_finish, second_start;

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -256,7 +256,7 @@ VertexPtr FinalCheckPass::on_enter_vertex(VertexPtr vertex) {
   if (vk::any_of_equal(vertex->type(), op_eq3, op_neq3)) {
     check_eq3_neq3(vertex.as<meta_op_binary>()->lhs(), vertex.as<meta_op_binary>()->rhs(), vertex->type());
   }
-  if (vk::any_of_equal(vertex->type(), op_lt, op_le, op_spaceship, op_eq2, op_neq2)) {
+  if (vk::any_of_equal(vertex->type(), op_lt, op_le, op_spaceship, op_eq2)) {
     check_comparisons(vertex.as<meta_op_binary>()->lhs(), vertex.as<meta_op_binary>()->rhs(), vertex->type());
   }
   if (vertex->type() == op_add) {
@@ -502,7 +502,7 @@ void FinalCheckPass::check_comparisons(VertexPtr lhs, VertexPtr rhs, Operation o
   auto rhs_t = tinf::get_type(rhs);
 
   if (lhs_t->ptype() == tp_Class) {
-    if (vk::any_of_equal(op, op_eq2, op_neq2)) {
+    if (op == op_eq2) {
       kphp_error(false, fmt_format("instance {} {} is unsupported", OpInfo::desc(op), rhs_t->as_human_readable()));
     } else {
       kphp_error(false, fmt_format("comparison instance with {} is prohibited (operation: {})", rhs_t->as_human_readable(), OpInfo::desc(op)));
@@ -511,8 +511,7 @@ void FinalCheckPass::check_comparisons(VertexPtr lhs, VertexPtr rhs, Operation o
     kphp_error(vk::any_of_equal(rhs_t->get_real_ptype(), tp_array, tp_bool, tp_mixed),
                fmt_format("{} is always > than {} used operator {}", lhs_t->as_human_readable(), rhs_t->as_human_readable(), OpInfo::desc(op)));
   } else if (lhs_t->ptype() == tp_tuple) {
-    bool can_compare_with_tuple = vk::any_of_equal(op, op_eq2, op_neq2) &&
-                                  rhs_t->ptype() == tp_tuple && lhs_t->get_tuple_max_index() == rhs_t->get_tuple_max_index();
+    bool can_compare_with_tuple = op == op_eq2 && rhs_t->ptype() == tp_tuple && lhs_t->get_tuple_max_index() == rhs_t->get_tuple_max_index();
     kphp_error(can_compare_with_tuple,
                fmt_format("You may not compare {} with {} used operator {}", lhs_t->as_human_readable(), rhs_t->as_human_readable(), OpInfo::desc(op)));
   } else if (lhs_t->ptype() == tp_shape) {

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -256,7 +256,7 @@ VertexPtr FinalCheckPass::on_enter_vertex(VertexPtr vertex) {
   if (vk::any_of_equal(vertex->type(), op_eq3, op_neq3)) {
     check_eq3_neq3(vertex.as<meta_op_binary>()->lhs(), vertex.as<meta_op_binary>()->rhs(), vertex->type());
   }
-  if (vk::any_of_equal(vertex->type(), op_lt, op_le, op_gt, op_ge, op_spaceship, op_eq2, op_neq2)) {
+  if (vk::any_of_equal(vertex->type(), op_lt, op_le, op_spaceship, op_eq2, op_neq2)) {
     check_comparisons(vertex.as<meta_op_binary>()->lhs(), vertex.as<meta_op_binary>()->rhs(), vertex->type());
   }
   if (vertex->type() == op_add) {

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -908,18 +908,6 @@
     }
   },
   {
-    "comment": "lsh() >= rhs()",
-    "name": "op_ge",
-    "base_name": "meta_op_binary",
-    "props": {
-      "rl": "rl_op",
-      "cnst": "cnst_const_func",
-      "type": "binary_op",
-      "str": ">=",
-      "description": ">="
-    }
-  },
-  {
     "comment": "lsh() < rhs()",
     "name": "op_lt",
     "base_name": "meta_op_binary",
@@ -929,18 +917,6 @@
       "type": "binary_op",
       "str": "<",
       "description": "<"
-    }
-  },
-  {
-    "comment": "lsh() > rhs()",
-    "name": "op_gt",
-    "base_name": "meta_op_binary",
-    "props": {
-      "rl": "rl_op",
-      "cnst": "cnst_const_func",
-      "type": "binary_op",
-      "str": ">",
-      "description": ">"
     }
   },
   {

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -860,18 +860,6 @@
     }
   },
   {
-    "comment": "lsh() != rhs()",
-    "name": "op_neq2",
-    "base_name": "meta_op_binary",
-    "props": {
-      "rl": "rl_op",
-      "cnst": "cnst_const_func",
-      "type": "binary_func_op",
-      "str": "neq2",
-      "description": "!="
-    }
-  },
-  {
     "comment": "lsh() === rhs()",
     "name": "op_eq3",
     "base_name": "meta_op_binary",

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -1189,7 +1189,7 @@ void f$shuffle(array<T> &a) {
 template<class T>
 struct sort_compare {
   bool operator()(const T &h1, const T &h2) const {
-    return gt(h1, h2);
+    return lt(h2, h1);
   }
 };
 

--- a/runtime/comparison_operators.inl
+++ b/runtime/comparison_operators.inl
@@ -509,11 +509,6 @@ inline bool equals(int32_t lhs, const T &rhs) {
   return equals(int64_t{lhs}, rhs);
 }
 
-template<class T1, class T2>
-inline bool neq2(const T1 &lhs, const T2 &rhs) {
-  return !eq2(lhs, rhs);
-}
-
 inline bool lt(const bool &lhs, const bool &rhs) {
   return lhs < rhs;
 }

--- a/runtime/comparison_operators.inl
+++ b/runtime/comparison_operators.inl
@@ -578,18 +578,9 @@ inline bool lt(const array<T1> &lhs, const array<T2> &rhs) {
 }
 
 template<class T1, class T2>
-inline bool gt(const T1 &lhs, const T2 &rhs) {
-  return lt(rhs, lhs);
-}
-
-template<class T1, class T2>
 inline bool leq(const T1 &lhs, const T2 &rhs) {
-  return !gt(lhs, rhs);
-}
-
-template<class T1, class T2>
-inline bool geq(const T1 &lhs, const T2 &rhs) {
-  return leq(rhs, lhs);
+  // (lhs <= rhs) === (!(rhs < lhs))
+  return !lt(rhs, lhs);
 }
 
 namespace impl_ {

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1744,7 +1744,7 @@ const Stream STDERR("php://stderr", 12);
 
 static Stream php_fopen(const string &stream, const string &mode) {
   if (eq2(stream, STDOUT) || eq2(stream, STDERR)) {
-    if (neq2(mode, string("w")) && neq2(mode, string("a"))) {
+    if (!eq2(mode, string("w")) && !eq2(mode, string("a"))) {
       php_warning("%s should be opened in write or append mode", stream.to_string().c_str());
       return false;
     }
@@ -1752,7 +1752,7 @@ static Stream php_fopen(const string &stream, const string &mode) {
   }
 
   if (eq2(stream, INPUT)) {
-    if (neq2(mode, string("r"))) {
+    if (!eq2(mode, string("r"))) {
       php_warning("%s should be opened in read mode", stream.to_string().c_str());
       return false;
     }

--- a/runtime/kphp_core.h
+++ b/runtime/kphp_core.h
@@ -767,10 +767,10 @@ int64_t modulo(const T1 &lhs, const T2 &rhs) {
   int64_t div = f$intval(lhs);
   int64_t mod = f$intval(rhs);
 
-  if (neq2(div, lhs)) {
+  if (!eq2(div, lhs)) {
     php_warning("First parameter of operator %% is not an integer");
   }
-  if (neq2(mod, rhs)) {
+  if (!eq2(mod, rhs)) {
     php_warning("Second parameter of operator %% is not an integer");
   }
 

--- a/runtime/math_functions.h
+++ b/runtime/math_functions.h
@@ -147,7 +147,7 @@ T f$max(const array<T> &a) {
   typename array<T>::const_iterator p = a.begin();
   T res = p.get_value();
   for (++p; p != a.end(); ++p) {
-    if (gt(p.get_value(), res)) {
+    if (lt(res, p.get_value())) {
       res = p.get_value();
     }
   }
@@ -171,7 +171,7 @@ T f$max(const T &arg1) {
 
 template<class T, class ...Args>
 T f$max(const T &arg1, const T &arg2, Args&& ...args) {
-  return f$max<T>(gt(arg1, arg2) ? arg1 : arg2, std::forward<Args>(args)...);
+  return f$max<T>(lt(arg2, arg1) ? arg1 : arg2, std::forward<Args>(args)...);
 }
 
 double f$acos(double v) {

--- a/runtime/mixed.inl
+++ b/runtime/mixed.inl
@@ -1699,16 +1699,8 @@ inline bool operator<(const mixed &lhs, const mixed &rhs) {
   return lhs.compare(rhs) < 0;
 }
 
-inline bool operator>(const mixed &lhs, const mixed &rhs) {
-  return rhs < lhs;
-}
-
 inline bool operator<=(const mixed &lhs, const mixed &rhs) {
   return !(rhs < lhs);
-}
-
-inline bool operator>=(const mixed &lhs, const mixed &rhs) {
-  return rhs <= lhs;
 }
 
 inline void swap(mixed &lhs, mixed &rhs) {


### PR DESCRIPTION
Hi, this patch replaces some compare operations, and removes them from AST.
1) `$a  > $b`  to `$b < $a`
2) `$a  >= $b`  to `$b <= $a`
3) `$a  != $b`  to `!($b == $a)`
4) `$a  <> $b`  to `!($b == $a)`