### PR TITLE
use elements_cached instead of elements_stored in warmup on graceful restart

### DIFF
--- a/server/php-master-restart.cpp
+++ b/server/php-master-restart.cpp
@@ -180,7 +180,7 @@ void master_init(master_data_t *me, master_data_t *other) {
   me->ask_http_fd_generation = 0;
   me->sent_http_fd_generation = 0;
 
-  me->instance_cache_elements_stored = 0;
+  me->instance_cache_elements_cached = 0;
 
   me->is_alive = true; //NB: must be the last operation.
 }

--- a/server/php-master-restart.h
+++ b/server/php-master-restart.h
@@ -31,7 +31,7 @@ struct master_data_t {
   int ask_http_fd_generation;
   int sent_http_fd_generation;
 
-  uint32_t instance_cache_elements_stored;
+  uint32_t instance_cache_elements_cached;
 
   int reserved[50 - 1];
 };

--- a/server/php-master-warmup.h
+++ b/server/php-master-warmup.h
@@ -22,8 +22,8 @@ public:
 
   void update_final_instance_cache_sizes() {
     if (!final_instance_cache_sizes_saved_) {
-      final_new_instance_cache_size_ = me->instance_cache_elements_stored;
-      final_old_instance_cache_size_ = other->instance_cache_elements_stored;
+      final_new_instance_cache_size_ = me->instance_cache_elements_cached;
+      final_old_instance_cache_size_ = other->instance_cache_elements_cached;
       final_instance_cache_sizes_saved_ = true;
     }
   }
@@ -46,7 +46,7 @@ public:
   }
 
   bool is_instance_cache_hot_enough() const {
-    return me->instance_cache_elements_stored >= target_instance_cache_elements_part_ * other->instance_cache_elements_stored;
+    return me->instance_cache_elements_cached >= target_instance_cache_elements_part_ * other->instance_cache_elements_cached;
   }
 
   bool warmup_timeout_expired() const {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1536,8 +1536,8 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
   add_histogram_stat_double(stats, "requests.incoming_queries_per_second", qps_calculator.get_incoming_qps());
   add_histogram_stat_double(stats, "requests.outgoing_queries_per_second", qps_calculator.get_outgoing_qps());
 
-  add_histogram_stat_double(stats, "graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
-  add_histogram_stat_double(stats, "graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());
+  add_histogram_stat_long(stats, "graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
+  add_histogram_stat_long(stats, "graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());
 
   update_mem_stats();
   unsigned long long max_vms = 0;
@@ -1718,7 +1718,7 @@ void run_master_on() {
         // new master tells to old master how many workers it must kill
         vkprintf(1, "[set_to_kill = %d] [need_more_workers_for_warmup = %d] [is_instance_cache_hot_enough = %d] [new_instance_cache_size / old_instance_cache_size = %u / %u] [warmup_timeout_expired = %d]\n",
                         set_to_kill, need_more_workers_for_warmup,
-                        is_instance_cache_hot_enough, me->instance_cache_elements_stored, other->instance_cache_elements_stored,
+                        is_instance_cache_hot_enough, me->instance_cache_elements_cached, other->instance_cache_elements_cached,
                         warmup_timeout_expired);
         if (!need_more_workers_for_warmup && (is_instance_cache_hot_enough || warmup_timeout_expired)) {
           warm_up_ctx.update_final_instance_cache_sizes();
@@ -1947,7 +1947,7 @@ void run_master() {
 
     me->running_workers_n = me_running_workers_n;
     me->dying_workers_n = me_dying_workers_n;
-    me->instance_cache_elements_stored = static_cast<uint32_t>(instance_cache_get_stats().elements_stored.load(std::memory_order_relaxed));
+    me->instance_cache_elements_cached = static_cast<uint32_t>(instance_cache_get_stats().elements_cached.load(std::memory_order_relaxed));
 
     if (state != master_state::off_in_graceful_shutdown) {
       if (changed && other->is_alive) {


### PR DESCRIPTION
`elements_stored` is the global number of elements stored in cache since server start, it always increases.
`elements_cached` is the current size of cache.