### PR TITLE
allow literals and '()'-expressions to be postfix expr operands

### DIFF
--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -90,7 +90,7 @@ public:
   VertexAdaptor<op_var> get_var_name();
   VertexAdaptor<op_var> get_var_name_ref();
   VertexPtr get_expr_top(bool was_arrow);
-  VertexPtr get_postfix_expression(VertexPtr res);
+  VertexPtr get_postfix_expression(VertexPtr res, bool parenthesized);
   VertexPtr get_unary_op(int op_priority_cur, Operation unary_op_tp, bool till_ternary);
   VertexPtr get_binary_op(int op_priority_cur, bool till_ternary);
   VertexPtr get_expression_impl(bool till_ternary);

--- a/compiler/pipes/calc-rl.cpp
+++ b/compiler/pipes/calc-rl.cpp
@@ -196,8 +196,7 @@ void rl_calc(VertexPtr root, RLValueType expected_rl_type) {
           break;
         case val_r:
         case val_none:
-          kphp_error (array->type() == op_var || array->type() == op_index ||
-                      array->type() == op_func_call || array->type() == op_instance_prop,
+          kphp_error (vk::any_of_equal(array->type(), op_var, op_index, op_func_call, op_instance_prop, op_array),
                       "op_index has to be used on lvalue");
           rl_calc(array, val_r);
 

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -102,6 +102,11 @@ TEST(lexer_test, test_php_tokens) {
     // strings: simple syntax doesn't support indexing of the accessed instance member
     {R"("$x->y[0]")", {"tok_str_begin(\")", "tok_expr_begin", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end", "tok_str([0])", "tok_str_end(\")"}},
 
+    {"'a'[0]", {"tok_str(a)", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])"}},
+    {"[$a][0]", {"tok_opbrk([)", "tok_var_name($a)", "tok_clbrk(])", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])"}},
+    {"$a[0]", {"tok_var_name($a)", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])"}},
+    {"('a' . 'b')[0]", {"tok_oppar(()", "tok_str(a)", "tok_dot(.)", "tok_str(b)", "tok_clpar())", "tok_opbrk([)", "tok_int_const(0)", "tok_clbrk(])"}},
+
     {"[1]", {"tok_opbrk([)", "tok_int_const(1)", "tok_clbrk(])"}},
     {"array(1)", {"tok_array(array)", "tok_oppar(()", "tok_int_const(1)", "tok_clpar())"}},
 

--- a/tests/phpt/parse_errors/fail_parens_dec.php
+++ b/tests/phpt/parse_errors/fail_parens_dec.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/Expected variable, found parenthesized expression/
+<?php
+
+$x = 10;
+var_dump(($x)--);

--- a/tests/phpt/parse_errors/fail_parens_inc.php
+++ b/tests/phpt/parse_errors/fail_parens_inc.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/Expected variable, found parenthesized expression/
+<?php
+
+$x = 10;
+var_dump(($x)++);

--- a/tests/phpt/parse_errors/fail_string_indexing.php
+++ b/tests/phpt/parse_errors/fail_string_indexing.php
@@ -1,0 +1,7 @@
+@kphp_should_fail
+/Expected '\)', found '\['/
+/Failed to parse statement. Expected `;`/
+<?php
+
+$x = 'a';
+var_dump("$x"[0]); // forbidden in PHP as well

--- a/tests/phpt/phc/parsing/iife.php
+++ b/tests/phpt/phc/parsing/iife.php
@@ -1,0 +1,14 @@
+@ok
+<?php
+
+// Immediately invoked function expression.
+
+function test() {
+  $x = (function() { return 10; })();
+  var_dump($x);
+
+  $y = (function($x) { return $x + 1; })(534);
+  var_dump($y);
+}
+
+test();

--- a/tests/phpt/phc/parsing/literal_indexing.php
+++ b/tests/phpt/phc/parsing/literal_indexing.php
@@ -1,0 +1,71 @@
+@ok
+<?php
+
+const STR_CONST = 'strconst';
+const ARR_CONST = [1, 2];
+
+function string_indexing1() {
+  var_dump('a'[0]);
+  var_dump("b"[0]);
+  var_dump("bar"[2]);
+
+  var_dump('a' . 'b'[0]);
+  var_dump(('a' . 'b')[1]);
+
+  var_dump(('abc')[1]);
+
+  var_dump((STR_CONST)[0]);
+}
+
+function array_indexing1() {
+  var_dump(array('a')[0]);
+  var_dump(['a'][0]);
+
+  var_dump((array('a'))[0]);
+  var_dump((['a'])[0]);
+
+  var_dump(['a' => ['b' => 10]]['a']['b']);
+  var_dump((['a' => ['b' => 10]]['a'])['b']);
+
+  // non-const arrays
+  $x = 10;
+  var_dump(array($x => 'foo')[10]);
+  var_dump([$x => 'foo'][10]);
+  var_dump([$x => 'foo'][$x]);
+  var_dump(([$x => 'foo'])[$x]);
+  var_dump([$x => [$x + 1 => 'ok']][$x][$x+1]);
+  var_dump([$x => [$x + 1 => 'ok']][$x][$x+1][0]);
+  var_dump([$x => [$x + 1 => 'ok']][$x][$x+1][1]);
+
+  var_dump([
+    $x === 0 => 'a',
+    $x === 5 => 'b',
+    $x === 10 => 'c',
+  ][true]);
+
+  var_dump([
+    $x === 5 => 'b',
+    $x === 10 => 'c',
+    $x === 0 => 'a',
+  ][true]);
+
+  var_dump((ARR_CONST)[0]);
+}
+
+function array_indexing2() {
+  var_dump([1, 2, 3, 4,][3]);
+  var_dump([array(1,2,3), [4, 5, 6]][1][2]);
+  foreach (array([1, 2, 3])[0] as $v) {
+    var_dump($v);
+  }
+
+  var_dump(array(1, 2, 3, 4,) [3]);
+  var_dump(array(array(1,2,3), array(4, 5, 6))[1][2]);
+  foreach (array(array(1, 2, 3))[0] as $v) {
+    var_dump($v);
+  }
+}
+
+string_indexing1();
+array_indexing1();
+array_indexing2();

--- a/tests/phpt/phc/parsing/literal_indexing_error.php
+++ b/tests/phpt/phc/parsing/literal_indexing_error.php
@@ -1,0 +1,5 @@
+@kphp_should_fail
+/op_index has to be used on lvalue/
+<?php
+
+var_dump((1)[0]);

--- a/tests/phpt/phc/parsing/literal_indexing_error2.php
+++ b/tests/phpt/phc/parsing/literal_indexing_error2.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/\$x is int, can not get element/
+<?php
+
+$x = 1;
+var_dump((($x))[0]);

--- a/tests/phpt/phc/parsing/parenthesized_postfix_expr.php
+++ b/tests/phpt/phc/parsing/parenthesized_postfix_expr.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+
+class Foo {
+  public $x = 10;
+}
+
+function test_arrow() {
+  var_dump((new Foo())->x);
+
+  $foo = new Foo();
+  var_dump(($foo)->x);
+}
+
+function test_call() {
+  $fn = function() { return 'ok'; };
+  var_dump(($fn)());
+}
+
+test_arrow();
+test_call();


### PR DESCRIPTION
This change allows these expressions to be parsed:

	"foo"[index]         string literal indexing
	[$a, $b][index]      array literal indexing
	("foo")[index]       parentheses expr indexing
	(function() {...})() immediately invoked function expressions
	(new Foo())->f()     parenthesized expr arrow access

All cases above are valid in PHP.

These are not valid in PHP, therefore they are forbidden in KPHP as well:

	($x)++
	($x)--

No codegen diff on vkcom.