### PR TITLE
fix null file ptr crash

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -43,7 +43,10 @@ GenTree::GenTree(vector<Token> tokens, SrcFilePtr file, DataStream<FunctionPtr> 
 }
 
 Location GenTree::auto_location() const {
-  return Location{this->line_num};
+  if (cur_function) {
+    return {processing_file, cur_function, line_num};
+  }
+  return {processing_file, line_num};
 }
 
 VertexAdaptor<op_string> GenTree::generate_constant_field_class_value(ClassPtr klass) {

--- a/compiler/location.h
+++ b/compiler/location.h
@@ -18,6 +18,7 @@ public:
   Location() = default;
   explicit Location(int line) : line(line) {}
   Location(const SrcFilePtr &file, const FunctionPtr &function, int line);
+  Location(const SrcFilePtr &file, int line);
 
   void set_file(SrcFilePtr file);
   void set_function(FunctionPtr function);

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -101,6 +101,10 @@ Location::Location(const SrcFilePtr &file, const FunctionPtr &function, int line
   function(function),
   line(line) {}
 
+Location::Location(const SrcFilePtr &file, int line) :
+  file(file),
+  line(line) {}
+
 // return a location in the format: "{file}:{line}  in function {function}"
 std::string Location::as_human_readable() const {
   std::string out;

--- a/tests/phpt/phpdocs/023_fail_mismatching_types.php
+++ b/tests/phpt/phpdocs/023_fail_mismatching_types.php
@@ -1,0 +1,11 @@
+@kphp_should_fail
+/023_fail_mismatching_types.php:8/
+/4192 is int/
+<?php
+
+class Foo {
+  /** @var string */
+  public $s = 4192;
+}
+
+$foo = new Foo();


### PR DESCRIPTION
auto_location() returns a location without a file,
restriction-stacktrace-finder.cpp tries to access a file
and dereferences a null pointer in `loc.file->get_line`.

By making auto_location() return a more precise location,
we can fix that null pointer dereference *and* improve
error locations in many places (some parse errors had "unknown file"
in their error messages).