### PR TITLE
Implement function for waiting all forks on finish & resumable minor refactoring.

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1073,8 +1073,7 @@ void compile_function_resumable(VertexAdaptor<op_function> func_root, CodeGenera
   //FORK FUNCTION
   W << FunctionForkDeclaration(func, false) << " " <<
     BEGIN;
-  W << "return fork_resumable < " << FunctionClassName(func) << "::ReturnT >" <<
-    "(new " << FunctionClassName(func) << "(";
+  W << "return fork_resumable(new " << FunctionClassName(func) << "(";
   W << JoinValues(func->param_ids, ", ", join_mode::one_line, var_name_gen);
   W << "));" << NL;
   W << END << NL;

--- a/docs/kphp-internals/kphp-architecture/internals-runtime.md
+++ b/docs/kphp-internals/kphp-architecture/internals-runtime.md
@@ -202,7 +202,7 @@ mixed f$selectUser(int64_t v$id) noexcept {
   return start_resumable < c$selectUser::ReturnT >(new c$selectUser(v$id));
 }
 int64_t f$fork$selectUser(int64_t v$id) noexcept {
-  return fork_resumable < c$selectUser::ReturnT >(new c$selectUser(v$id));
+  return fork_resumable(new c$selectUser(v$id));
 }
 ```
 

--- a/functions.txt
+++ b/functions.txt
@@ -946,6 +946,8 @@ function get_fork_stat(future<any> $fork) ::: mixed[] | false;
 
 function query_x2 ($x ::: int) ::: int;
 
+function set_wait_all_forks_on_finish(bool $wait = true) ::: bool;
+
 /**
  * conversions
  * they should be there to work in array_map and similar

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -45,6 +45,8 @@ void f$setrawcookie(const string &name, const string &value, int64_t expire = 0,
 
 void f$register_shutdown_function(const shutdown_function_type &f);
 
+bool f$set_wait_all_forks_on_finish(bool wait = true) noexcept;
+
 void f$fastcgi_finish_request(int64_t exit_code = 0);
 
 __attribute__((noreturn))

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -193,18 +193,19 @@ void php_out_of_memory_warning(char const *message, ...) {
   va_end(args);
 }
 
-const char *php_uncaught_exception_error(const class_instance<C$Throwable> &ex) noexcept {
+const char *php_uncaught_exception_error(const class_instance<C$Throwable> &ex, bool from_fork) noexcept {
   const int64_t current_time = time(nullptr);
   const char *message = ex->$message.empty() ? "(empty)" : ex->$message.c_str();
+  const char *fork_msg = from_fork ? " in fork" : "";
   const char *src_file = kbasename(ex->$file.c_str());
   vk::singleton<JsonLogger>::get().write_log(
-    dl_pstr("Unhandled %s from %s:%" PRIi64 "; Error %" PRIi64 "; Message: %s", ex->get_class(), src_file, ex->$line, ex->$code, message),
+    dl_pstr("Unhandled %s%s from %s:%" PRIi64 "; Error %" PRIi64 "; Message: %s", ex->get_class(), fork_msg, src_file, ex->$line, ex->$code, message),
     E_ERROR, current_time, ex->raw_trace.get_const_vector_pointer(), ex->raw_trace.count(), true);
 
-  const char *msg = dl_pstr("%s%" PRIi64 "%sError %" PRIi64 ": %s.\nUnhandled %s caught in file %s at line %" PRIi64 ".\n"
+  const char *msg = dl_pstr("%s%" PRIi64 "%sError %" PRIi64 ": %s.\nUnhandled %s%s caught in file %s at line %" PRIi64 ".\n"
                             "Backtrace:\n%s",
                             engine_tag, current_time, engine_pid,
-                            ex->$code, message, ex->get_class(), src_file, ex->$line,
+                            ex->$code, message, ex->get_class(), fork_msg, src_file, ex->$line,
                             exception_trace_as_string(ex).c_str());
   fprintf(stderr, "%s", msg);
   fprintf(stderr, "-------------------------------\n\n");

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -24,6 +24,11 @@ void php_warning(char const *message, ...) __attribute__ ((format (printf, 1, 2)
 void php_error(char const *message, ...) __attribute__ ((format (printf, 1, 2)));
 void php_out_of_memory_warning(char const *message, ...) __attribute__ ((format (printf, 1, 2)));
 
+template<class T>
+class class_instance;
+struct C$Throwable;
+const char *php_uncaught_exception_error(const class_instance<C$Throwable> &ex) noexcept;
+
 void php_assert__(const char *msg, const char *file, int line) __attribute__((noreturn));
 void raise_php_assert_signal__();
 

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -27,7 +27,7 @@ void php_out_of_memory_warning(char const *message, ...) __attribute__ ((format 
 template<class T>
 class class_instance;
 struct C$Throwable;
-const char *php_uncaught_exception_error(const class_instance<C$Throwable> &ex) noexcept;
+const char *php_uncaught_exception_error(const class_instance<C$Throwable> &ex, bool from_fork = false) noexcept;
 
 void php_assert__(const char *msg, const char *file, int line) __attribute__((noreturn));
 void raise_php_assert_signal__();

--- a/runtime/resumable.h
+++ b/runtime/resumable.h
@@ -90,6 +90,8 @@ void unregister_wait_queue(int64_t queue_id);
 int64_t wait_queue_push_unsafe(int64_t queue_id, int64_t resumable_id);
 Optional<int64_t> wait_queue_next_synchronously(int64_t queue_id);
 
+void wait_all_forks() noexcept;
+
 void global_init_resumable_lib();
 void init_resumable_lib();
 

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -366,21 +366,7 @@ void PHPScriptBase::run() {
   if (CurException.is_null()) {
     set_script_result(nullptr);
   } else {
-    const Throwable &e = CurException;
-    const int64_t current_time = time(nullptr);
-    const char *message = e->$message.empty() ? "(empty)" : e->$message.c_str();
-    vk::singleton<JsonLogger>::get().write_log(
-      dl_pstr("Unhandled %s from %s:%" PRIi64 "; Error %" PRIi64 "; Message: %s", e->get_class(), e->$file.c_str(), e->$line, e->$code, message),
-      E_ERROR, current_time, e->raw_trace.get_const_vector_pointer(), e->raw_trace.count(), true);
-
-    const char *msg = dl_pstr("%s%" PRIi64 "%sError %" PRIi64 ": %s.\nUnhandled %s caught in file %s at line %" PRIi64 ".\n"
-                              "Backtrace:\n%s",
-                              engine_tag, current_time, engine_pid,
-                              e->$code, message, e->get_class(), e->$file.c_str(), e->$line,
-                              exception_trace_as_string(e).c_str());
-    fprintf(stderr, "%s", msg);
-    fprintf(stderr, "-------------------------------\n\n");
-    error(msg, script_error_t::exception);
+    error(php_uncaught_exception_error(CurException), script_error_t::exception);
   }
 }
 

--- a/tests/phpt/fork/019_wait_all_forks_on_finish.php
+++ b/tests/phpt/fork/019_wait_all_forks_on_finish.php
@@ -1,0 +1,96 @@
+@ok
+<?php
+
+function function_return_void(string $msg) {
+  echo "start function_return_void($msg)\n";
+  sched_yield();
+  echo "finish function_return_void($msg)\n";
+  return null;
+}
+
+function function_return_string(string $msg) {
+  echo "start function_return_string($msg)\n";
+  sched_yield();
+  echo "finish function_return_string($msg)\n";
+  return "done $msg";
+}
+
+function function_with_wait(string $msg) {
+  echo "start function_with_wait($msg)\n";
+  $x = fork(function_return_void($msg));
+  echo "work function_with_wait($msg)\n";
+  wait($x);
+  echo "finish function_with_wait($msg)\n";
+  return null;
+}
+
+function function_with_exception1(string $msg) {
+  echo "start function_with_exception1($msg)\n";
+  sched_yield();
+  throw new Exception("Exception $msg");
+  echo "finish function_with_exception1($msg)\n";
+  return null;
+}
+
+function function_with_exception2(string $msg) {
+  echo "start function_with_exception2($msg)\n";
+  throw new Exception("Exception $msg");
+  sched_yield();
+  echo "finish function_with_exception2($msg)\n";
+  return null;
+}
+
+function test_kphp() {
+  fork(function_return_void("111"));
+  fork(function_return_void("222"));
+
+  fork(function_return_string("333"));
+  fork(function_return_string("444"));
+
+  fork(function_with_wait("555"));
+  fork(function_with_wait("666"));
+
+  fork(function_with_exception1("777"));
+  fork(function_with_exception2("888"));
+
+  set_wait_all_forks_on_finish();
+}
+
+#ifndef KPHP
+
+function test_php() {
+  echo "start function_return_void(111)\n";
+  echo "start function_return_void(222)\n";
+
+  echo "start function_return_string(333)\n";
+  echo "start function_return_string(444)\n";
+
+  echo "start function_with_wait(555)\n";
+  echo "start function_return_void(555)\n";
+  echo "work function_with_wait(555)\n";
+
+  echo "start function_with_wait(666)\n";
+  echo "start function_return_void(666)\n";
+  echo "work function_with_wait(666)\n";
+
+  echo "start function_with_exception1(777)\n";
+  echo "start function_with_exception2(888)\n";
+
+  echo "finish function_return_void(111)\n";
+  echo "finish function_return_void(222)\n";
+
+  echo "finish function_return_string(333)\n";
+  echo "finish function_return_string(444)\n";
+
+  echo "finish function_return_void(555)\n";
+  echo "finish function_with_wait(555)\n";
+
+  echo "finish function_return_void(666)\n";
+  echo "finish function_with_wait(666)\n";
+}
+
+test_php();
+return;
+#endif
+
+test_kphp();

--- a/tests/python/tests/json_logs/test_exceptions.py
+++ b/tests/python/tests/json_logs/test_exceptions.py
@@ -13,7 +13,7 @@ class TestJsonLogsExceptions(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
-                "msg": "Unhandled ServerException from .+index.php:\\d+; Error 123; Message: hello",
+                "msg": "Unhandled ServerException from index.php:\\d+; Error 123; Message: hello",
             }])
 
     def test_exception_with_context(self):
@@ -27,7 +27,7 @@ class TestJsonLogsExceptions(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": 1, "env": "efg",  "tags": {"a": "b", "uncaught": True}, "extra_info": {"c": "d"},
-                "msg": "Unhandled ServerException from .+index.php:\\d+; Error 3456; Message: world",
+                "msg": "Unhandled ServerException from index.php:\\d+; Error 3456; Message: world",
             }])
 
     def test_exception_with_special_chars(self):
@@ -41,5 +41,5 @@ class TestJsonLogsExceptions(KphpServerAutoTestCase):
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": 1, "env": "efg",  "tags": {"a": "b\\c\"d\n", "uncaught": True}, "extra_info": {"c": "\\\\xxx\""},
-                "msg": "Unhandled ServerException from .+index.php:\\d+; Error 123; Message: \\\\a\\\\b  c\"d ?",
+                "msg": "Unhandled ServerException from index.php:\\d+; Error 123; Message: \\\\a\\\\b  c\"d ?",
             }])


### PR DESCRIPTION
Hi!

1) I've made some style refactoring of resumable (for better understanding what's going on there)
2) I've added a function which enables waiting of all unfinished forks after finish request
```
bool set_wait_all_forks_on_finish(bool $wait);
```
It doesn't wait in case of
- critical errors: OOM, internal assertions, calling virtual methods on nullptr
- timeouts
- unhandled exceptions

Request is terminated in case of
- critical errors (look above) in the fork
- request timeouts during waiting the fork

In case of an exception from the fork, the request is not terminated, however the logs (json and plain) are written.