### PR TITLE
Allow subnormal floats usage in json_encode functions.

### DIFF
--- a/runtime/json-functions.cpp
+++ b/runtime/json-functions.cpp
@@ -240,15 +240,15 @@ bool JsonEncoder::encode(int64_t i) const noexcept {
 }
 
 bool JsonEncoder::encode(double d) const noexcept {
-  if (is_ok_float(d)) {
-    static_SB << (simple_encode_ ? f$number_format(d, 6, string{"."}, string()) : string(d));
-  } else {
+  if (vk::any_of_equal(std::fpclassify(d), FP_INFINITE, FP_NAN)) {
     php_warning("strange double %lf in function json_encode", d);
     if (options_ & JSON_PARTIAL_OUTPUT_ON_ERROR) {
       static_SB.append("0", 1);
     } else {
       return false;
     }
+  } else {
+    static_SB << (simple_encode_ ? f$number_format(d, 6, string{"."}, string{}) : string{d});
   }
   return true;
 }

--- a/tests/phpt/dl/395_subnormal_doubles_in_json.php
+++ b/tests/phpt/dl/395_subnormal_doubles_in_json.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+function test_json_encode() {
+  $x = ["xx" => (2 ** -1050)];
+  var_dump(json_decode(json_encode($x), true));
+}
+
+function test_vk_json_encode() {
+  $x = ["xx" => (2 ** -1050)];
+  var_dump(vk_json_encode($x));
+}
+
+test_json_encode();
+test_vk_json_encode();


### PR DESCRIPTION
Subnormal floats works in json_encode for vanilla PHP, so now it works for KPHP as well.