### PR TITLE
User friendly resumable expressions.

### DIFF
--- a/compiler/pipes/extract-resumable-calls.h
+++ b/compiler/pipes/extract-resumable-calls.h
@@ -9,8 +9,12 @@
 class ExtractResumableCallsPass final : public FunctionPassBase {
 private:
   static VertexPtr *skip_conv_and_sets(VertexPtr *replace) noexcept;
-  static VertexPtr try_save_resumable_func_call_in_temp_var(VertexPtr vertex) noexcept;
+  static bool is_resumable_expr(VertexPtr vertex) noexcept;
+  static VertexPtr *extract_resumable_expr(VertexPtr vertex) noexcept;
   static VertexAdaptor<op_var> make_temp_resumable_var(const TypeData *type) noexcept;
+
+  static VertexPtr replace_set_ternary(VertexAdaptor<op_set_modify> set_vertex, VertexAdaptor<op_ternary> rhs_ternary) noexcept;
+  static VertexPtr replace_resumable_expr_with_temp_var(VertexPtr *resumable_expr, VertexPtr expr_user) noexcept;
 
 public:
   string get_description() override {

--- a/compiler/pipes/extract-resumable-calls.h
+++ b/compiler/pipes/extract-resumable-calls.h
@@ -8,9 +8,9 @@
 
 class ExtractResumableCallsPass final : public FunctionPassBase {
 private:
-  static void skip_conv_and_sets(VertexPtr *&replace);
-  static VertexPtr *get_resumable_func_for_replacement(VertexPtr vertex);
-  static VertexAdaptor<op_var> make_temp_resumable_var(const TypeData *type);
+  static VertexPtr *skip_conv_and_sets(VertexPtr *replace) noexcept;
+  static VertexPtr try_save_resumable_func_call_in_temp_var(VertexPtr vertex) noexcept;
+  static VertexAdaptor<op_var> make_temp_resumable_var(const TypeData *type) noexcept;
 
 public:
   string get_description() override {

--- a/compiler/pipes/extract-resumable-calls.h
+++ b/compiler/pipes/extract-resumable-calls.h
@@ -11,9 +11,10 @@ private:
   static VertexPtr *skip_conv_and_sets(VertexPtr *replace) noexcept;
   static bool is_resumable_expr(VertexPtr vertex) noexcept;
   static VertexPtr *extract_resumable_expr(VertexPtr vertex) noexcept;
-  static VertexAdaptor<op_var> make_temp_resumable_var(const TypeData *type) noexcept;
+  static std::pair<VertexAdaptor<op_move>, VertexAdaptor<op_set>> make_temp_resumable_var(VertexPtr init) noexcept;
 
   static VertexPtr replace_set_ternary(VertexAdaptor<op_set_modify> set_vertex, VertexAdaptor<op_ternary> rhs_ternary) noexcept;
+  static VertexPtr replace_set_logical_operation(VertexAdaptor<op_set_modify> set_vertex, VertexAdaptor<meta_op_binary> operation) noexcept;
   static VertexPtr replace_resumable_expr_with_temp_var(VertexPtr *resumable_expr, VertexPtr expr_user) noexcept;
 
 public:

--- a/tests/phpt/fork/019_ternary_operator_in_resumable_expr.php
+++ b/tests/phpt/fork/019_ternary_operator_in_resumable_expr.php
@@ -1,0 +1,223 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+function ret_bool(int $line, bool $res) : bool {
+  echo "call ret_bool:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function ret_string(int $line, string $res) : string {
+  echo "call ret_string:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function ret_array(int $line, array $res) : array {
+  echo "call ret_array:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function ret_int(int $line, int $res) : int {
+  echo "call ret_int:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function test_ternary_true_case() {
+  $s = 1 ? ret_string(__LINE__, "aaaaaaa") : "bbbbbb";
+  var_dump($s);
+
+  $s = 0 ? ret_string(__LINE__, "ccccccc") : "dddddd";
+  var_dump($s);
+  return null;
+}
+
+function test_ternary_false_case() {
+  $s = 1 ? "eeeeee" : ret_string(__LINE__, "fffffff");
+  var_dump($s);
+
+  $s = 0 ? "gggggg" : ret_string(__LINE__, "hhhhhhhh");
+  var_dump($s);
+  return null;
+}
+
+function test_ternary_true_false_case() {
+  $s = 1 ? ret_string(__LINE__, "++++++++++")
+         : ret_string(__LINE__, "----------");
+  var_dump($s);
+
+  $s = 0 ? ret_string(__LINE__, "****************")
+         : ret_string(__LINE__, "//////////");
+  var_dump($s);
+  return null;
+}
+
+function test_ternary_condition() {
+  $s = ret_bool(__LINE__, true) ? "11111" : "22222";
+  var_dump($s);
+
+  $s = ret_bool(__LINE__, false) ? "333333" : "444444";
+  var_dump($s);
+
+  $s = !ret_bool(__LINE__, true) ? "aaaaaa" : "bbbbbb";
+  var_dump($s);
+
+  $s = !ret_bool(__LINE__, false) ? "zzzzzz" : "yyyyyyy";
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "1") ? "555555" : "666666";
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "0") ? "77777" : "88888888";
+  var_dump($s);
+  return null;
+}
+
+function test_ternary_condition_true_case() {
+  $s = ret_bool(__LINE__, true) ? ret_string(__LINE__, "aaaaaaa") : "bbbbbb";
+  var_dump($s);
+
+  $s = ret_bool(__LINE__, false) ? ret_string(__LINE__, "ccccccc") : "dddddd";
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "ccccccc") ?: "dddddd";
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "0") ?: "dddddd";
+  var_dump($s);
+  return null;
+}
+
+
+function test_ternary_condition_false_case() {
+  $s = ret_bool(__LINE__, true) ? "xxxxxxx" : ret_string(__LINE__, "yyyyyyyyy");
+  var_dump($s);
+
+  $s = ret_bool(__LINE__, true) ? "1111111" : ret_string(__LINE__, "2222222");
+  var_dump($s);
+  return null;
+}
+
+function test_ternary_condition_true_false_case() {
+  $s = ret_bool(__LINE__, true) ? ret_string(__LINE__, "aaaaaaaaa")
+                                : ret_string(__LINE__, "bbbbbbbb");
+  var_dump($s);
+
+  $s = ret_bool(__LINE__, true) ? ret_string(__LINE__, "111111111")
+                                : ret_string(__LINE__, "22222222");
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "ccccccc")
+        ?: ret_string(__LINE__, "dddddddd");
+  var_dump($s);
+
+  $s = ret_string(__LINE__, "0")
+        ?: ret_string(__LINE__, "ffffffff");
+  var_dump($s);
+
+  $b = !ret_bool(__LINE__, true) ? !ret_string(__LINE__, "0")
+                                 : !ret_string(__LINE__, "1");
+  var_dump($b);
+
+  $i = ret_bool(__LINE__, true) ? (int)ret_string(__LINE__, "10")
+                                 : (int)ret_string(__LINE__, "20");
+  var_dump($i);
+  return null;
+}
+
+function test_array_insertion_operation() {
+  $a = [];
+  $a[] = ret_bool(__LINE__, true) ? ret_string(__LINE__, "aaaaaaaaa")
+                                  : ret_string(__LINE__, "bbbbbbbb");
+  $a["xxx"] = ret_bool(__LINE__, true) ? ret_string(__LINE__, "111111111")
+                                       : ret_string(__LINE__, "22222222");
+  var_dump($a);
+  return null;
+}
+
+function test_in_if() {
+  if (ret_bool(__LINE__, true) ? !ret_string(__LINE__, "1")
+                               : ret_string(__LINE__, "0")) {
+    echo "if body\n";
+  } else {
+    echo "else body\n";
+  }
+  return null;
+}
+
+
+function test_in_return_impl() {
+  return ret_bool(__LINE__, true) ? ret_string(__LINE__, "1111111111")
+                                  : ret_string(__LINE__, "0000000000000");
+}
+
+function test_in_return() {
+  $x = test_in_return_impl();
+  var_dump($x);
+  return null;
+}
+
+function test_in_list() {
+  [$x, $y, $z] = ret_bool(__LINE__, true) ? ret_array(__LINE__, ["xxx", "yyy", "zzz"])
+                                          : ret_array(__LINE__, ["aaa", "bbb", "ccc"]);
+  var_dump($x);
+  var_dump($y);
+  var_dump($z);
+  return null;
+}
+
+function test_with_logical_op() {
+  $a = (ret_bool(__LINE__, true) ||
+        ret_bool(__LINE__, false))
+        ? ret_array(__LINE__, ["xxx", "yyy", "zzz"])
+        : ret_array(__LINE__, ["aaa", "bbb", "ccc"]);
+  var_dump($a);
+
+  $a = (ret_bool(__LINE__, true) &&
+        ret_bool(__LINE__, false))
+        ? ret_array(__LINE__, ["111", "222", "333"])
+        : ret_array(__LINE__, ["444", "555", "666"]);
+  var_dump($a);
+  return null;
+}
+
+function test_other_op_set() {
+  $a = ret_bool(__LINE__, true) ? ret_int(__LINE__, 1)
+                                : ret_int(__LINE__, 42);
+  var_dump($a);
+
+  $a += ret_bool(__LINE__, true) ? ret_int(__LINE__, 412)
+                                 : ret_int(__LINE__, 12);
+  var_dump($a);
+
+  $a -= ret_bool(__LINE__, false) ? ret_int(__LINE__, 200)
+                                  : ret_int(__LINE__, 400);
+  var_dump($a);
+
+  $a *= ret_int(__LINE__, 3)
+        ?: ret_int(__LINE__, 2);
+  var_dump($a);
+
+  $a &= ret_int(__LINE__, 0)
+        ?: ret_int(__LINE__, 15);
+  var_dump($a);
+  return null;
+}
+
+wait(fork(test_ternary_true_case()));
+wait(fork(test_ternary_false_case()));
+wait(fork(test_ternary_true_false_case()));
+wait(fork(test_ternary_condition()));
+wait(fork(test_ternary_condition_true_case()));
+wait(fork(test_ternary_condition_false_case()));
+wait(fork(test_ternary_condition_true_false_case()));
+wait(fork(test_array_insertion_operation()));
+wait(fork(test_in_if()));
+wait(fork(test_in_return()));
+wait(fork(test_in_list()));
+wait(fork(test_with_logical_op()));
+wait(fork(test_other_op_set()));

--- a/tests/phpt/fork/020_logical_operators_in_resumable_expr.php
+++ b/tests/phpt/fork/020_logical_operators_in_resumable_expr.php
@@ -1,0 +1,259 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+function ret_bool(int $line, bool $res) : bool {
+  echo "call ret_bool:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function test_lhs(bool $always_false, bool $always_true) {
+  $x = ret_bool(__LINE__, true) || $always_false;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) || $always_false;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) || $always_true;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) || $always_true;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) && $always_false;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) && $always_false;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) && $always_true;
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) && $always_true;
+  var_dump($x);
+  return null;
+}
+
+function test_lhs_neg(bool $always_false, bool $always_true) {
+  $x = !ret_bool(__LINE__, true) || $always_false;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) || $always_false;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) || $always_true;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) || $always_true;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) && $always_false;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) && $always_false;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) && $always_true;
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) && $always_true;
+  var_dump($x);
+  return null;
+}
+
+
+function test_rhs(bool $always_false, bool $always_true) {
+  $x = $always_false || ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_false || ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_true || ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_true || ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_false && ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_false && ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_true && ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_true && ret_bool(__LINE__, false);
+  var_dump($x);
+  return null;
+}
+
+function test_rhs_neg(bool $always_false, bool $always_true) {
+  $x = $always_false || !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_false || !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_true || !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_true || !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_false && !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_false && !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = $always_true && !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = $always_true && !ret_bool(__LINE__, false);
+  var_dump($x);
+  return null;
+}
+
+function test_lhs_rhs() {
+  $x = ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) &&
+       ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, false) &&
+       ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, false);
+  var_dump($x);
+  return null;
+}
+
+function test_lhs_rhs_neg() {
+  $x = !ret_bool(__LINE__, true) ||
+       !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) ||
+       !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) ||
+       !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) ||
+       !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) &&
+       !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) &&
+       !ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, false) &&
+       !ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = !ret_bool(__LINE__, true) &&
+       !ret_bool(__LINE__, false);
+  var_dump($x);
+  return null;
+}
+
+function test_long_expresion() {
+  $x = ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, false) ||
+       !ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, false);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true) &&
+       !ret_bool(__LINE__, false) &&
+       ret_bool(__LINE__, false) &&
+       ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true);
+  var_dump($x);
+
+  $x = ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, false) ||
+       !ret_bool(__LINE__, false) ||
+       ret_bool(__LINE__, true) &&
+       ret_bool(__LINE__, true) ||
+       ret_bool(__LINE__, true);
+  var_dump($x);
+  return null;
+}
+
+function test_in_if() {
+  if (ret_bool(__LINE__, true) &&
+      ret_bool(__LINE__, true) &&
+      !ret_bool(__LINE__, false)) {
+    echo "if body1\n";
+  } else {
+    echo "else body1\n";
+  }
+
+  if (ret_bool(__LINE__, false) ||
+      !ret_bool(__LINE__, true) ||
+      ret_bool(__LINE__, true)) {
+    echo "if body2\n";
+  } else {
+    echo "else body2\n";
+  }
+
+  if (ret_bool(__LINE__, false) &&
+      ret_bool(__LINE__, true) ||
+      ret_bool(__LINE__, true)) {
+    echo "if body3\n";
+  } else if (ret_bool(__LINE__, false) ||
+             ret_bool(__LINE__, true)) {
+    echo "else if body3\n";
+  } else {
+    echo "else body3\n";
+  }
+  return null;
+}
+
+wait(fork(test_lhs(false, true)));
+wait(fork(test_lhs_neg(false, true)));
+wait(fork(test_rhs(false, true)));
+wait(fork(test_rhs_neg(false, true)));
+wait(fork(test_lhs_rhs()));
+wait(fork(test_lhs_rhs_neg()));
+wait(fork(test_long_expresion()));
+wait(fork(test_in_if()));

--- a/tests/phpt/fork/021_null_coalesce_in_resumable_expr.php
+++ b/tests/phpt/fork/021_null_coalesce_in_resumable_expr.php
@@ -1,0 +1,33 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+function ret_string_or_null(int $line, ?string $res) : ?string {
+  echo "call ret_string_or_null:$line\n";
+  sched_yield();
+  return $res;
+}
+
+function test_lhs() {
+  $x = ret_string_or_null(__LINE__, "123") ?? "456";
+  var_dump($x);
+
+  $x = ret_string_or_null(__LINE__, null) ?? "xxxxx";
+  var_dump($x);
+  return null;
+}
+
+function test_in_if() {
+  if ($x = ret_string_or_null(__LINE__, "123") ?? "NULLLL") {
+    echo "if body\n";
+    var_dump($x);
+  } else {
+    echo "else body\n";
+    var_dump($x);
+  }
+  return null;
+}
+
+wait(fork(test_lhs()));
+wait(fork(test_in_if()));


### PR DESCRIPTION
Hi there! 
This patch enables the following resumable call expressions:
1) For ternary operator
2) For && and || operations
3) For lhs of ?? operator

It forbids complex expressions in the lhs part of op_set with the resumable rhs: only non global vars are allowed.

So, the following code examples are available now (imagine that all functions are resumable)

```php
$v = check() ? true_case() : false_case();
$v = check() ?: false_case();
 
$a[] = check() ? true_case() : false_case();
$a[$key] = check() ? true_case() : false_case();

$i->a = check() ? true_case() : false_case();

if (check() ? true_case() : false_case()) {
// ...
}
```

```php
$v = check1() && check2();
$v = check1() || check2();
 
if ((check1() && check2()) || (check3() && check4())) {
// ...
}
```

```php
$v = get() ?? "null";
```

```php
if ((check1() && check2()) ? true_case() : (get() ?? "null")) {
// ...
}
```

The following code examples are forbidden (imagine that all functions are resumable)

```php
$v = get() ?? fallback();

// function_call() is not resumable
$a[function_call()] = check() ? true_case() : false_case();

$a[$global_var] = get() ?? "null";

// get_instance() is not resumable
get_instance()->a = resumable_func_call();

```

