### PR TITLE
fix race condition "called do_recalc on finished inferer"

### DIFF
--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -46,9 +46,9 @@ VarPtr cast_const_array_type(VertexPtr &type_acceptor, const TypeData *required_
   std::string name = ss.str();
   bool is_new = true;
   VarPtr var_id = G->get_global_var(name, VarData::var_const_t, type_acceptor, &is_new);
+  var_id->tinf_node.copy_type_from(required_type);  // not inside if(is_new) to avoid race conditions when one thread creates and another uses faster
   if (is_new) {
     var_id->dependency_level = type_acceptor.as<op_var>()->var_id->dependency_level + 1;
-    var_id->tinf_node.copy_type_from(required_type);
   }
 
   auto casted_var = VertexAdaptor<op_var>::create();


### PR DESCRIPTION
Very-very seldom, but we had occasions, that build fails with an error

> called do_recalc on finished inferer in optimization-pass

It's a fluck, and relauching the compilation always helped.
Probably I have found the reason, here is the fix.

It could happen after type inferring (in optimization pass),
when multiple threads implicitly casted arrays to one and the same variable,
and the first thread created this variable but didn't reach setting tinf node,
and the second thread used that variable with the same name without creation.