### PR TITLE
improve preg_replace and preg_replace_callback typing

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -404,8 +404,8 @@ define('PREG_SPLIT_OFFSET_CAPTURE', 32);
 
 function preg_match ($regex ::: regexp, $subject ::: string, &$matches ::: mixed = TODO, $flags ::: int = 0, $offset ::: int = 0) ::: int | false;//TODO
 function preg_match_all ($regex ::: regexp, $subject ::: string, &$matches ::: mixed = TODO, $flags ::: int = 0) ::: int | false;//TODO
-function preg_replace ($regex ::: regexp, $replace_val, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: mixed;
-function preg_replace_callback ($regex ::: regexp, callable(string[] $x):string $callback, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: mixed;
+function preg_replace ($regex ::: regexp, $replace_val, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: ^3|string|null|false;
+function preg_replace_callback ($regex ::: regexp, callable(string[] $x):string $callback, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: ^3|string|null;
 function preg_quote ($str ::: string, $delimiter ::: string = '') ::: string;
 function preg_last_error() ::: int;
 function preg_split ($pattern ::: regexp, $subject ::: string, $limit ::: int = -1, $flags ::: int = 0) ::: mixed[] | false;

--- a/runtime/regexp.h
+++ b/runtime/regexp.h
@@ -91,7 +91,7 @@ public:
   Optional<array<mixed>> split(const string &subject, int64_t limit, int64_t flags) const;
 
   template<class T>
-  mixed replace(const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) const;
+  Optional<string> replace(const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) const;
 
   static int64_t last_error();
 
@@ -143,38 +143,41 @@ inline Optional<int64_t> f$preg_match(const mixed &regex, const string &subject,
 inline Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches, int64_t flags);
 
 template<class T1, class T2, class T3, class = enable_if_t_is_optional<T3>>
-inline mixed f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline auto f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
-inline mixed f$preg_replace(const regexp &regex, const string &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline Optional<string> f$preg_replace(const regexp &regex, const string &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
-inline mixed f$preg_replace(const regexp &regex, const mixed &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline Optional<string> f$preg_replace(const regexp &regex, const mixed &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 inline mixed f$preg_replace(const regexp &regex, const string &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 inline mixed f$preg_replace(const regexp &regex, const mixed &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 template<class T1, class T2>
-inline mixed f$preg_replace(const string &regex, const T1 &replace_val, const T2 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline auto f$preg_replace(const string &regex, const T1 &replace_val, const T2 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
-inline mixed f$preg_replace(const mixed &regex, const string &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline Optional<string> f$preg_replace(const mixed &regex, const string &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 inline mixed f$preg_replace(const mixed &regex, const string &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
-inline mixed f$preg_replace(const mixed &regex, const mixed &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+inline Optional<string> f$preg_replace(const mixed &regex, const mixed &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 inline mixed f$preg_replace(const mixed &regex, const mixed &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
+template<class T1, class T2, class T3, class = enable_if_t_is_optional<T3>>
+auto f$preg_replace_callback(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+
 template<class T>
-mixed f$preg_replace_callback(const regexp &regex, const T &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+Optional<string> f$preg_replace_callback(const regexp &regex, const T &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 template<class T>
 mixed f$preg_replace_callback(const regexp &regex, const T &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 template<class T, class T2>
-mixed f$preg_replace_callback(const string &regex, const T &replace_val, const T2 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+auto f$preg_replace_callback(const string &regex, const T &replace_val, const T2 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 template<class T>
-mixed f$preg_replace_callback(const mixed &regex, const T &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
+Optional<string> f$preg_replace_callback(const mixed &regex, const T &replace_val, const string &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
 
 template<class T>
 mixed f$preg_replace_callback(const mixed &regex, const T &replace_val, const mixed &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
@@ -263,18 +266,18 @@ string regexp::get_replacement(const T &replace_val, const string &subject, int6
 
 
 template<class T>
-mixed regexp::replace(const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) const {
+Optional<string> regexp::replace(const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) const {
   pcre_last_error = 0;
   int64_t result_count = 0;//calls can be recursive, can't write to replace_count directly
 
   check_pattern_compilation_warning();
   if (pcre_regexp == nullptr && RE2_regexp == nullptr) {
-    return mixed();
+    return {};
   }
 
   if (is_utf8 && !mb_UTF8_check(subject.c_str())) {
     pcre_last_error = PCRE_ERROR_BADUTF8;
-    return mixed();
+    return {};
   }
 
   if (limit == 0 || limit == -1) {
@@ -318,7 +321,7 @@ mixed regexp::replace(const T &replace_val, const string &subject, int64_t limit
 
   replace_count = result_count;
   if (pcre_last_error) {
-    return mixed();
+    return {};
   }
 
   if (replace_count == 0) {
@@ -420,15 +423,15 @@ Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mi
 
 
 template<class T1, class T2, class T3, class>
-inline mixed f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit, int64_t &replace_count) {
+inline auto f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit, int64_t &replace_count) {
   return f$preg_replace(regex, replace_val, subject.val(), limit, replace_count);
 }
 
-mixed f$preg_replace(const regexp &regex, const string &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+Optional<string> f$preg_replace(const regexp &regex, const string &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
   return regex.replace(replace_val, subject, limit, replace_count);
 }
 
-mixed f$preg_replace(const regexp &regex, const mixed &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+Optional<string> f$preg_replace(const regexp &regex, const mixed &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
   if (replace_val.is_array()) {
     php_warning("Parameter mismatch, pattern is a string while replacement is an array");
     return false;
@@ -466,21 +469,21 @@ mixed f$preg_replace(const regexp &regex, const mixed &replace_val, const mixed 
 }
 
 template<class T1, class T2>
-mixed f$preg_replace(const string &regex, const T1 &replace_val, const T2 &subject, int64_t limit, int64_t &replace_count) {
+auto f$preg_replace(const string &regex, const T1 &replace_val, const T2 &subject, int64_t limit, int64_t &replace_count) {
   return f$preg_replace(regexp(regex), replace_val, subject, limit, replace_count);
 }
 
-mixed f$preg_replace(const mixed &regex, const string &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
-  return f$preg_replace(regex, mixed(replace_val), mixed(subject), limit, replace_count);
+Optional<string> f$preg_replace(const mixed &regex, const string &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+  return f$preg_replace(regex, mixed(replace_val), subject, limit, replace_count);
 }
 
 mixed f$preg_replace(const mixed &regex, const string &replace_val, const mixed &subject, int64_t limit, int64_t &replace_count) {
   return f$preg_replace(regex, mixed(replace_val), subject, limit, replace_count);
 }
 
-mixed f$preg_replace(const mixed &regex, const mixed &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+Optional<string> f$preg_replace(const mixed &regex, const mixed &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
   if (regex.is_array()) {
-    mixed result = subject;
+    Optional<string> result = subject;
 
     replace_count = 0;
     int64_t replace_count_one;
@@ -495,14 +498,14 @@ mixed f$preg_replace(const mixed &regex, const mixed &replace_val, const string 
           ++cur_replace_val;
         }
 
-        result = f$preg_replace(it.get_value().to_string(), replace_value, result.to_string(), limit, replace_count_one);
+        result = f$preg_replace(it.get_value().to_string(), replace_value, result, limit, replace_count_one);
         replace_count += replace_count_one;
       }
     } else {
       string replace_value = replace_val.to_string();
 
       for (array<mixed>::const_iterator it = regex.begin(); it != regex.end(); ++it) {
-        result = f$preg_replace(it.get_value().to_string(), replace_value, result.to_string(), limit, replace_count_one);
+        result = f$preg_replace(it.get_value().to_string(), replace_value, result, limit, replace_count_one);
         replace_count += replace_count_one;
       }
     }
@@ -537,8 +540,13 @@ mixed f$preg_replace(const mixed &regex, const mixed &replace_val, const mixed &
   }
 }
 
+template<class T1, class T2, class T3, class>
+auto f$preg_replace_callback(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit, int64_t &replace_count) {
+  return f$preg_replace_callback(regex, replace_val, subject.val(), limit, replace_count);
+}
+
 template<class T>
-mixed f$preg_replace_callback(const regexp &regex, const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+Optional<string> f$preg_replace_callback(const regexp &regex, const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
   return regex.replace(replace_val, subject, limit, replace_count);
 }
 
@@ -563,20 +571,20 @@ mixed f$preg_replace_callback(const regexp &regex, const T &replace_val, const m
 }
 
 template<class T, class T2>
-mixed f$preg_replace_callback(const string &regex, const T &replace_val, const T2 &subject, int64_t limit, int64_t &replace_count) {
+auto f$preg_replace_callback(const string &regex, const T &replace_val, const T2 &subject, int64_t limit, int64_t &replace_count) {
   return f$preg_replace_callback(regexp(regex), replace_val, subject, limit, replace_count);
 }
 
 template<class T>
-mixed f$preg_replace_callback(const mixed &regex, const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
+Optional<string> f$preg_replace_callback(const mixed &regex, const T &replace_val, const string &subject, int64_t limit, int64_t &replace_count) {
   if (regex.is_array()) {
-    mixed result = subject;
+    Optional<string> result = subject;
 
     replace_count = 0;
     int64_t replace_count_one;
 
     for (array<mixed>::const_iterator it = regex.begin(); it != regex.end(); ++it) {
-      result = f$preg_replace_callback(it.get_value().to_string(), replace_val, result.to_string(), limit, replace_count_one);
+      result = f$preg_replace_callback(it.get_value().to_string(), replace_val, result, limit, replace_count_one);
       replace_count += replace_count_one;
     }
 

--- a/tests/phpt/regexp/001_string_result.php
+++ b/tests/phpt/regexp/001_string_result.php
@@ -1,0 +1,147 @@
+@ok
+<?php
+
+function accept_string(string $s) { var_dump($s); }
+
+/** @param ?string $s */
+function accept_nullable_string($s) { var_dump($s); }
+
+/** @param string|null|false $s */
+function accept_string_or_null_or_false($s) { var_dump($s); }
+
+function test_preg_replace1(string $subject) {
+  $result = preg_replace('/_/', 'x', $subject);
+  accept_string_or_null_or_false($result);
+  if ($result) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+function test_preg_replace2(string $subject) {
+  $pattern = '/_/';
+  $result = preg_replace($pattern, 'x', $subject);
+  accept_string_or_null_or_false($result);
+  if ($result) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+/** @return mixed */
+function as_mixed($x) { return $x; }
+
+/**
+ * @kphp-infer
+ * @param mixed $name
+ * @return string
+ */
+function test_preg_replace3($name) {
+  $name = strtolower(as_mixed($name));
+  $name = preg_replace('/\s/', '-', $name);
+  $name = preg_replace('/[^a-z0-9-]/', '', $name);
+  if ($name) {
+    return $name;
+  }
+  return '';
+}
+
+function test_preg_replace4(string $text) {
+  $patterns = ['/_/', '/\s/'];
+  $result = preg_replace($patterns, '', $text);
+  accept_string_or_null_or_false($result);
+  if ($result) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+/** @param mixed $replace */
+function test_preg_replace5(string $subject, $replace) {
+  $result = preg_replace('/_/', $replace, $subject);
+  accept_string_or_null_or_false($result);
+  if ($result) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+function test_preg_replace_callback1(string $subject) {
+  $result = preg_replace_callback('/_/', function ($m) {
+    return '{' . $m[0] . '}';
+  }, $subject);
+  accept_nullable_string($result);
+  if ($result !== null) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+function test_preg_replace_callback2(string $subject) {
+  $pattern = '/_/';
+  $result = preg_replace_callback($pattern, function ($m) {
+    return '{' . $m[0] . '}';
+  }, $subject);
+  accept_nullable_string($result);
+  if ($result !== null) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+/**
+ * @kphp-infer
+ * @param mixed $name
+ * @return string
+ */
+function test_preg_replace_callback3($name) {
+  $name = strtolower(as_mixed($name));
+  $name = preg_replace_callback('/\s/', function ($m) { return '-'; }, $name);
+  $name = preg_replace_callback('/[^a-z0-9-]/', function ($m) { return ''; }, $name);
+  if ($name !== null) {
+    return $name;
+  }
+  return '';
+}
+
+function test_preg_replace_callback4(string $text) {
+  $patterns = ['/_/', '/\s/'];
+  $result = preg_replace_callback($patterns, function ($m) { return ''; }, $text);
+  accept_nullable_string($result);
+  if ($result !== null) {
+    accept_string($result);
+  }
+  if ($result) {
+    accept_string($result);
+  }
+}
+
+test_preg_replace1('hello_world');
+test_preg_replace1('foo');
+test_preg_replace2('hello_world');
+test_preg_replace2('foo');
+test_preg_replace3('foo @() -- 12');
+test_preg_replace4('hello _world_ ');
+test_preg_replace4('foo');
+test_preg_replace5('hello_world', '_');
+test_preg_replace5('foo', '_');
+
+test_preg_replace_callback1('hello_world');
+test_preg_replace_callback1('foo');
+test_preg_replace_callback2('hello_world');
+test_preg_replace_callback2('foo');
+test_preg_replace_callback3('foo @() -- 12');
+test_preg_replace_callback4('hello _world_ ');
+test_preg_replace_callback4('foo');

--- a/tests/phpt/regexp/002_null_error.php
+++ b/tests/phpt/regexp/002_null_error.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+function test_preg_replace_error() {
+  $result = preg_replace('/ds', '_', 'hello_world');
+  var_dump($result, $result === null);
+}
+
+function test_preg_replace_array_error() {
+  $result = preg_replace('/ds', [], 'hello_world');
+  var_dump($result, $result === false);
+}
+
+function test_preg_replace_callback_error() {
+  $result = preg_replace_callback('/ds/', function ($m) { return '_'; }, 'hello_world');
+  var_dump($result, $result === null);
+}
+
+test_preg_replace_error();
+test_preg_replace_callback_error();


### PR DESCRIPTION
If `$subject` is a string, the result will be `?string`, not `mixed`.

We achieve this by the same trick as in `str_replace` return type.

The `^3|string|null` will resolve into either `string|null` or `mixed`.
It's `?string` when `^3` is a string; otherwise, any T+string will result in `mixed`.