### PR TITLE
Fix race condition in task (lease) communication protocol

### DIFF
--- a/common/pid.h
+++ b/common/pid.h
@@ -31,4 +31,8 @@ typedef enum pid_match pid_match_t;
 
 pid_match_t matches_pid (const struct process_id *X, const struct process_id *Y);
 
+inline pid_match_t matches_pid_ref (const process_id_t &X, const process_id_t &Y) {
+  return matches_pid(&X, &Y);
+}
+
 #endif

--- a/common/pid.h
+++ b/common/pid.h
@@ -31,8 +31,4 @@ typedef enum pid_match pid_match_t;
 
 pid_match_t matches_pid (const struct process_id *X, const struct process_id *Y);
 
-inline pid_match_t matches_pid_ref (const process_id_t &X, const process_id_t &Y) {
-  return matches_pid(&X, &Y);
-}
-
 #endif

--- a/common/tl/constants/kphp.h
+++ b/common/tl/constants/kphp.h
@@ -13,6 +13,7 @@
 #define                                          TL_KPHP_START_LEASE_V2 0x896e46e9U
 #define                                              TL_KPHP_STOP_LEASE 0x183bf49dU
 #define                                              TL_KPHP_STOP_READY 0x59d86654U
+#define                               TL_KPHP_STOP_READY_ACKNOWLEDGMENT 0x4b7503efU
 
 #include <cstdint>
 namespace vk {

--- a/server/lease-config-parser.cpp
+++ b/server/lease-config-parser.cpp
@@ -10,7 +10,7 @@
 #include "common/tl/constants/kphp.h"
 #include "common/wrappers/optional.h"
 
-#include "server/php-engine-vars.h"
+#include "server/lease-context.h"
 
 vk::optional<QueueTypesLeaseWorkerMode> LeaseConfigParser::get_lease_mode_from_config(const YAML::Node &node) {
   vk::optional<QueueTypesLeaseWorkerMode> lease_worker_mode;
@@ -58,7 +58,7 @@ int LeaseConfigParser::parse_lease_options_config(const char *lease_config) noex
     YAML::Node node = YAML::LoadFile(lease_config);
     const auto &rpc_clients = LeaseConfigParser::get_rpc_clients_from_config(node);
     RpcClients::get().rpc_clients.insert(RpcClients::get().rpc_clients.end(), rpc_clients.begin(), rpc_clients.end());
-    cur_lease_mode = LeaseConfigParser::get_lease_mode_from_config(node);
+    vk::singleton<LeaseContext>::get().cur_lease_mode = LeaseConfigParser::get_lease_mode_from_config(node);
   } catch (const std::exception &e) {
     kprintf("-S option, incorrect lease config '%s'\n%s\n", lease_config, e.what());
     return -1;

--- a/server/lease-context.h
+++ b/server/lease-context.h
@@ -1,0 +1,21 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+#include "common/kphp-tasks-lease/lease-worker-mode.h"
+
+
+class LeaseContext : vk::not_copyable {
+public:
+  vk::optional<QueueTypesLeaseWorkerMode> cur_lease_mode;
+  double rpc_stop_ready_timeout{0};
+
+  friend class vk::singleton<LeaseContext>;
+
+private:
+  LeaseContext() = default;
+};

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -72,7 +72,6 @@ int force_clear_sql_connection = 0;
 long long static_buffer_length_limit = -1;
 int use_madvise_dontneed = 0;
 long long memory_used_to_recreate_script = LLONG_MAX;
-vk::optional<QueueTypesLeaseWorkerMode> cur_lease_mode;
 
 /***
   save of stdout/stderr fd

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -7,7 +7,6 @@
 // for: struct in_addr
 #include <netinet/in.h>
 
-#include "common/kphp-tasks-lease/lease-worker-mode.h"
 #include "common/version-string.h"
 
 // Names and versions
@@ -104,7 +103,6 @@ extern int force_clear_sql_connection;
 extern long long static_buffer_length_limit;
 extern int use_madvise_dontneed;
 extern long long memory_used_to_recreate_script;
-extern vk::optional<QueueTypesLeaseWorkerMode> cur_lease_mode;
 
 #define RPC_PHP_IMMEDIATE_STATS 0x3d27a21b
 #define RPC_PHP_FULL_STATS 0x1f8ae120

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -54,6 +54,7 @@
 #include "net/net-tcp-rpc-server.h"
 
 #include "runtime/interface.h"
+#include "server/job-workers/shared-memory-manager.h"
 #include "runtime/profiler.h"
 #include "runtime/rpc.h"
 #include "server/cluster-name.h"
@@ -64,6 +65,7 @@
 #include "server/job-workers/shared-memory-manager.h"
 #include "server/json-logger.h"
 #include "server/lease-config-parser.h"
+#include "server/lease-context.h"
 #include "server/php-engine-vars.h"
 #include "server/php-lease.h"
 #include "server/php-master-warmup.h"
@@ -883,7 +885,7 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
   c->last_response_time = precise_now;
 
   auto MAX_RPC_QUERY_LEN = 126214400;
-  if (len < sizeof(long long) || MAX_RPC_QUERY_LEN < len) {
+  if ((len < sizeof(long long) && op != TL_KPHP_STOP_READY_ACKNOWLEDGMENT) || MAX_RPC_QUERY_LEN < len) {
     return 0;
   }
 
@@ -891,6 +893,14 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
   process_id remote_pid = TCP_RPC_DATA(c)->remote_pid;
 
   switch (static_cast<unsigned int>(op)) {
+    case TL_KPHP_STOP_READY_ACKNOWLEDGMENT: {
+      if (!check_tasks_invoker_pid(remote_pid)) {
+        kprintf("Got TL_KPHP_STOP_READY_ACKNOWLEDGMENT from invalid task invoker\n");
+        return 0;
+      }
+      do_rpc_finish_lease();
+      break;
+    }
     case TL_KPHP_STOP_LEASE: {
       if (in_sigterm) {
         return 0;
@@ -2098,6 +2108,14 @@ int main_args_handler(int i) {
       }
       return 0;
     }
+    case 2018: {
+      double stop_ready_timeout = parse_double_option("--lease-stop-ready-timeout", 0, 10);
+      if (std::isnan(stop_ready_timeout)) {
+        return -1;
+      }
+      vk::singleton<LeaseContext>::get().rpc_stop_ready_timeout = stop_ready_timeout;
+      return 0;
+    }
     default:
       return -1;
   }
@@ -2167,6 +2185,7 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("warmup-timeout", required_argument, 2015, "the maximum time for the instance cache warm up in seconds");
   parse_option("job-workers-num", required_argument, 2016, "number of job workers to run");
   parse_option("job-workers-shared-memory-size", required_argument, 2017, "total size of shared memory used for job workers related communication");
+  parse_option("lease-stop-ready-timeout", required_argument, 2018, "timeout for RPC_STOP_READY acknowledgement waiting in seconds (default: 0)");
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);
 }

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -895,7 +895,7 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
   switch (static_cast<unsigned int>(op)) {
     case TL_KPHP_STOP_READY_ACKNOWLEDGMENT: {
       if (!check_tasks_invoker_pid(remote_pid)) {
-        kprintf("Got TL_KPHP_STOP_READY_ACKNOWLEDGMENT from invalid task invoker\n");
+        kprintf("Got TL_KPHP_STOP_READY_ACKNOWLEDGMENT from invalid task invoker pid = %s\n", pid_to_print(&remote_pid));
         return 0;
       }
       do_rpc_finish_lease();

--- a/server/php-lease.h
+++ b/server/php-lease.h
@@ -7,10 +7,12 @@
 #include "common/kphp-tasks-lease/lease-worker-mode.h"
 #include "common/kphp-tasks-lease/lease-worker-settings.h"
 #include "common/pid.h"
-#include "common/wrappers/optional.h"
 
 #include "server/lease-rpc-client.h"
 #include "server/php-worker.h"
+
+bool check_tasks_invoker_pid(process_id_t tasks_invoker_pid);
+bool check_tasks_manager_pid(process_id_t tasks_manager_pid);
 
 void lease_on_worker_finish(php_worker *worker);
 void lease_set_ready();

--- a/server/php-lease.h
+++ b/server/php-lease.h
@@ -11,15 +11,14 @@
 #include "server/lease-rpc-client.h"
 #include "server/php-worker.h"
 
-bool check_tasks_invoker_pid(process_id_t tasks_invoker_pid);
-bool check_tasks_manager_pid(process_id_t tasks_manager_pid);
-
 void lease_on_worker_finish(php_worker *worker);
 void lease_set_ready();
 void lease_on_stop();
 void run_rpc_lease();
+
 void do_rpc_stop_lease();
 int do_rpc_start_lease(process_id_t pid, double timeout, int actor_id);
+void do_rpc_finish_lease();
 void lease_cron();
 void set_main_target(const LeaseRpcClient &client);
 int get_current_target();

--- a/server/php-lease.h
+++ b/server/php-lease.h
@@ -4,12 +4,15 @@
 
 #pragma once
 
+#include "common/kprintf.h"
 #include "common/kphp-tasks-lease/lease-worker-mode.h"
 #include "common/kphp-tasks-lease/lease-worker-settings.h"
 #include "common/pid.h"
 
 #include "server/lease-rpc-client.h"
 #include "server/php-worker.h"
+
+DECLARE_VERBOSITY(lease);
 
 void lease_on_worker_finish(php_worker *worker);
 void lease_set_ready();


### PR DESCRIPTION
Here is a try to fix bug with error -2005, "Task invoker is invalid".
It seems that this bug happens, because KPHP treats old lease target incorrect immediately after send `STOP_READY` to it on changing lease target, then gets task from lease target that was sent before `STOP_READY` receiving and rejects it.

To fix this, we will wait with some timeout for an acknowledgement that `STOP_READY` was received, and only after that treat lease target incorrect.