### PR TITLE
optimize bad_vars calculation performed in a single thread

### DIFF
--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -50,11 +50,10 @@ public:
   };
   func_type_t type = func_local;
 
-  vector<VarPtr> local_var_ids, global_var_ids, static_var_ids;
-  vector<VarPtr> *bad_vars = nullptr;
+  std::vector<VarPtr> local_var_ids, global_var_ids, static_var_ids, param_ids;
+  std::unordered_set<VarPtr> *bad_vars = nullptr;     // for check ub and safe operations wrapper, see comments in check-ub.cpp
   std::set<VarPtr> implicit_const_var_ids, explicit_const_var_ids, explicit_header_const_var_ids;
-  vector<VarPtr> param_ids;
-  vector<FunctionPtr> dep;
+  std::vector<FunctionPtr> dep;
   std::set<ClassPtr> class_dep;
   std::set<ClassPtr> exceptions_thrown; // exceptions that can be thrown by this function
   bool tl_common_h_dep = false;

--- a/compiler/data/var-data.h
+++ b/compiler/data/var-data.h
@@ -34,7 +34,7 @@ public:
   VertexPtr init_val;
   FunctionPtr holder_func;
   ClassPtr class_id;
-  std::vector<VarPtr> *bad_vars = nullptr;
+  std::unordered_set<VarPtr> *bad_vars = nullptr;
   bool is_reference = false;
   bool uninited_flag = false;
   bool optimize_flag = false;

--- a/compiler/pipes/calc-func-dep.h
+++ b/compiler/pipes/calc-func-dep.h
@@ -11,14 +11,14 @@
 #include "compiler/function-pass.h"
 
 struct DepData : private vk::movable_only {
-  std::vector<FunctionPtr> dep;
-  std::vector<VarPtr> used_global_vars;
+  std::vector<FunctionPtr> dep;               // functions accessible directly from the current (called or lambdas) (except extern)
+  std::vector<VarPtr> modified_global_vars;   // val_l globals for ub check later
 
-  std::vector<VarPtr> used_ref_vars;
-  std::vector<std::pair<VarPtr, VarPtr>> ref_ref_edges;
-  std::vector<std::pair<VarPtr, VarPtr>> global_ref_edges;
+  std::forward_list<VarPtr> ref_param_vars;                       // param &$refs from func declaration
+  std::forward_list<std::pair<VarPtr, VarPtr>> ref_ref_edges;     // calls to f($v) when $v is a reference
+  std::forward_list<std::pair<VarPtr, VarPtr>> global_ref_edges;  // calls to f($v) when $v is a global
 
-  std::vector<FunctionPtr> forks;
+  std::forward_list<FunctionPtr> forks;       // calls to fork(f(...)) to calc resumable graph later
 };
 
 static_assert(std::is_nothrow_move_constructible<DepData>::value, "DepData should be movable");

--- a/tests/phpt/warnings/1_ub_foreach_var_trycatch.php
+++ b/tests/phpt/warnings/1_ub_foreach_var_trycatch.php
@@ -1,5 +1,5 @@
 @kphp_should_warn
-/Dangerous undefined behaviour unset, \[foreach var = arr\]/
+/Dangerous undefined behaviour unset, \[foreach var = \$arr\]/
 <?php
 
 try {

--- a/tests/phpt/warnings/2_ub_foreach_var_trycatch2.php
+++ b/tests/phpt/warnings/2_ub_foreach_var_trycatch2.php
@@ -1,5 +1,5 @@
 @kphp_should_warn
-/Dangerous undefined behaviour unset, \[foreach var = arr\]/
+/Dangerous undefined behaviour unset, \[foreach var = \$arr\]/
 <?php
 
 class MyException1 extends Exception {}

--- a/tests/phpt/warnings/3_ub_var_trycatch.php
+++ b/tests/phpt/warnings/3_ub_var_trycatch.php
@@ -1,5 +1,5 @@
 @kphp_should_warn
-/Dangerous undefined behaviour \+, \[var = x\]/
+/Dangerous undefined behaviour \+, \[var = \$x\]/
 <?php
 
 try {

--- a/tests/phpt/warnings/5_ub_globals.php
+++ b/tests/phpt/warnings/5_ub_globals.php
@@ -1,0 +1,140 @@
+@kphp_should_fail
+KPHP_ERROR_ON_WARNINGS=1
+/test_global_bad_modification_1\(A::\$ids\[0\]\);/
+/Dangerous undefined behaviour function call, \[var = A::\$ids\]/
+/subcall3\(\$v\);/
+/Dangerous undefined behaviour function call, \[foreach var = \$yy3\]/
+/accepts5\(A::\$ids, \$v\);/
+/Dangerous undefined behaviour function call, \[var = A::\$ids\]/
+/A::\$ids\[\] = 0;/
+/Dangerous undefined behaviour push_back, \[foreach var = A::\$ids\]/
+/test_global_bad_modification_8\(\$a_id_ref\);/
+/Dangerous undefined behaviour function call, \[foreach var = A::\$ids\]/
+/test_global_bad_modification_18\(\$a_id_ref\);/
+/Dangerous undefined behaviour function call, \[foreach var = A::\$ids\]/
+/test_global_bad_modification_20\(A::\$ids\[0\]\);/
+/Dangerous undefined behaviour function call, \[var = A::\$ids\]/
+<?php
+
+class A {
+    static public $ids = [1,2,3];
+    static public $user_id = 100;
+}
+
+// --------------
+
+function subcall1() {
+    A::$ids[] = 1;
+}
+
+function test_global_bad_modification_1(&$v) {
+    subcall1();
+}
+
+function demo1() {
+    test_global_bad_modification_1(A::$ids[0]);
+}
+
+demo1();
+
+
+// --------------
+
+$yy3 = [];
+
+function subcall3(&$v) {
+    global $yy3;
+    $v = 1;
+    $yy3[] = $v;
+}
+
+function test_global_bad_modification_3(&$arr) {
+    foreach ($arr as &$v) {
+        subcall3($v);
+    }
+}
+
+test_global_bad_modification_3($yy3);
+
+// --------------
+
+function accepts5(&$a, &$b) {
+}
+
+function test_global_bad_modification_5(&$v) {
+    accepts5(A::$ids, $v);
+}
+
+test_global_bad_modification_5(A::$ids);     // unsafe, as there become two refs to a single global
+
+// --------------
+
+function test_global_bad_modification_6(&$arr) {
+    foreach ($arr as &$ref) {
+        A::$ids[] = 0;
+        $ref = 0;
+    }
+    var_dump($arr);
+}
+
+test_global_bad_modification_6(A::$ids);
+
+
+// --------------
+
+function test_global_bad_modification_8(&$v) {
+    A::$ids[] = 10;
+    echo $v;
+}
+
+foreach (A::$ids as &$a_id_ref) {
+    test_global_bad_modification_8($a_id_ref);
+}
+
+
+// --------------
+
+function test_global_bad_modification_18(&$v) {
+    A::$ids[] = 10;
+    echo $v;
+}
+
+function demo18(&$arr) {
+    foreach ($arr as &$a_id_ref) {
+        test_global_bad_modification_18($a_id_ref);
+    }
+}
+
+function wrap18(&$arr) {
+    demo18($arr);
+}
+
+wrap18(A::$ids);
+
+
+// --------------
+
+
+function subcall20_1() {
+    subcall20_2();
+}
+
+function subcall20_2() {
+    if (0) subcall20_1();
+    subcall20_3();
+}
+
+function subcall20_3() {
+    if (0) subcall20_1();
+    if (0) subcall20_2();
+    if (0) subcall20_3();
+    if (1) {
+        A::$ids[] = 1;
+    }
+}
+
+function test_global_bad_modification_20(&$item) {
+    subcall20_1();
+}
+
+test_global_bad_modification_20(A::$ids[0]);


### PR DESCRIPTION
# This PR speeds up "CalcBadVars on_finish" single-thread step

![image](https://user-images.githubusercontent.com/67757852/108995191-4dc50f00-76cf-11eb-96fa-dbe0e5597170.png)

"bad vars" for a function are used in check-ub.cpp.
They are modified non-primitive globals, that can lead to a potential ub when modified and accessed in subcalls.

Added comments about optimization points and some tests.