### PR TITLE
support php 7.4 class type hints

### DIFF
--- a/compiler/data/class-members.cpp
+++ b/compiler/data/class-members.cpp
@@ -51,10 +51,11 @@ std::string ClassMemberInstanceMethod::get_hash_name() const {
   return hash_name(local_name());
 }
 
-inline ClassMemberStaticField::ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str) :
+inline ClassMemberStaticField::ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) :
   modifiers(modifiers),
   root(root),
-  phpdoc_str(phpdoc_str) {
+  phpdoc_str(phpdoc_str),
+  type_hint(type_hint) {
 
   std::string global_var_name = replace_backslashes(klass->name) + "$$" + root->get_string();
   var = G->get_global_var(global_var_name, VarData::var_global_t, def_val);
@@ -91,10 +92,11 @@ std::string ClassMemberInstanceField::get_hash_name() const {
   return hash_name(local_name());
 }
 
-ClassMemberInstanceField::ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str) :
+ClassMemberInstanceField::ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) :
   modifiers(modifiers),
   root(root),
-  phpdoc_str(phpdoc_str) {
+  phpdoc_str(phpdoc_str),
+  type_hint(type_hint) {
 
   std::string local_var_name = root->get_string();
   var = G->create_var(local_var_name, VarData::var_instance_t);
@@ -172,12 +174,12 @@ void ClassMembersContainer::add_instance_method(FunctionPtr function) {
   }
 }
 
-void ClassMembersContainer::add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str) {
-  append_member(ClassMemberStaticField{klass, root, def_val, modifiers, phpdoc_str});
+void ClassMembersContainer::add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) {
+  append_member(ClassMemberStaticField{klass, root, def_val, modifiers, phpdoc_str, type_hint});
 }
 
-void ClassMembersContainer::add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str) {
-  append_member(ClassMemberInstanceField{klass, root, def_val, modifiers, phpdoc_str});
+void ClassMembersContainer::add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) {
+  append_member(ClassMemberInstanceField{klass, root, def_val, modifiers, phpdoc_str, type_hint});
 }
 
 void ClassMembersContainer::add_constant(const std::string &const_name, VertexPtr value, AccessModifiers access) {

--- a/compiler/data/class-members.h
+++ b/compiler/data/class-members.h
@@ -72,9 +72,9 @@ struct ClassMemberStaticField {
   VertexAdaptor<op_var> root;
   VarPtr var;
   vk::string_view phpdoc_str;
-  const TypeHint *type_hint{nullptr};  // from @var or from default value, class type hints from PHP 7.4 are unsupported yet
+  const TypeHint *type_hint{nullptr};  // from @var / php 7.4 type hint / default value
 
-  ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str);
+  ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
 
   vk::string_view local_name() const &;
   static std::string hash_name(vk::string_view name);
@@ -87,11 +87,11 @@ struct ClassMemberInstanceField {
   VertexAdaptor<op_var> root;
   VarPtr var;
   vk::string_view phpdoc_str;
-  const TypeHint *type_hint{nullptr};  // from @var or from default value, class type hints from PHP 7.4 are unsupported yet
+  const TypeHint *type_hint{nullptr};  // from @var / php 7.4 type hint / default value
   int8_t serialization_tag = -1;
   bool serialize_as_float32{false};
 
-  ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str);
+  ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
 
   vk::string_view local_name() const &;
   vk::string_view local_name() const && = delete;
@@ -189,8 +189,8 @@ public:
 
   void add_static_method(FunctionPtr function);
   void add_instance_method(FunctionPtr function);
-  void add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str);
-  void add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str);
+  void add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
+  void add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
   void add_constant(const std::string &const_name, VertexPtr value, AccessModifiers access);
 
   void safe_add_instance_method(FunctionPtr function);

--- a/compiler/data/lambda-generator.cpp
+++ b/compiler/data/lambda-generator.cpp
@@ -37,7 +37,7 @@ LambdaGenerator &LambdaGenerator::add_uses(std::vector<VertexAdaptor<op_func_par
   for (auto param_as_use : uses) {
     auto variable_in_use = VertexAdaptor<op_var>::create().set_location(created_location);
     variable_in_use->str_val = param_as_use->var()->get_string();
-    generated_lambda->members.add_instance_field(variable_in_use, {}, FieldModifiers{}.set_private(), vk::string_view{});
+    generated_lambda->members.add_instance_field(variable_in_use, {}, FieldModifiers{}.set_private(), vk::string_view{}, nullptr);
 
     auto field = generated_lambda->members.get_instance_field(variable_in_use->get_string());
     field->var->marked_as_const = true;
@@ -74,7 +74,7 @@ LambdaGenerator &LambdaGenerator::add_constructor_from_uses() {
 }
 
 LambdaGenerator &LambdaGenerator::add_invoke_method_which_call_method(FunctionPtr called_method) {
-  generated_lambda->members.add_instance_field(get_var_of_captured_array_arg<op_var>(), {}, FieldModifiers{}.set_private(), vk::string_view{});
+  generated_lambda->members.add_instance_field(get_var_of_captured_array_arg<op_var>(), {}, FieldModifiers{}.set_private(), vk::string_view{}, nullptr);
 
   add_uses_for_captured_class_from_array();
   auto lambda_params = create_params_for_invoke_which_call_method(called_method);

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -85,7 +85,7 @@ public:
   VertexPtr get_expression();
   VertexPtr get_statement(vk::string_view phpdoc_str = vk::string_view{});
   VertexAdaptor<op_catch> get_catch();
-  void get_instance_var_list(vk::string_view phpdoc_str, FieldModifiers modifiers);
+  void get_instance_var_list(vk::string_view phpdoc_str, FieldModifiers modifiers, const TypeHint *type_hint);
   void get_traits_uses();
   void get_use();
   void get_seq(std::vector<VertexPtr> &seq_next);
@@ -155,7 +155,7 @@ private:
 
   VertexAdaptor<op_func_param_list> parse_cur_function_param_list();
 
-  VertexAdaptor<op_empty> get_static_field_list(vk::string_view phpdoc_str, FieldModifiers modifiers);
+  VertexAdaptor<op_empty> get_static_field_list(vk::string_view phpdoc_str, FieldModifiers modifiers, const TypeHint *type_hint);
   VertexAdaptor<op_var> get_function_use_var_name_ref();
   VertexPtr get_foreach_value();
   std::pair<VertexAdaptor<op_foreach_param>, VertexPtr> get_foreach_param();

--- a/compiler/pipes/sort-and-inherit-classes.cpp
+++ b/compiler/pipes/sort-and-inherit-classes.cpp
@@ -322,11 +322,11 @@ void SortAndInheritClassesF::clone_members_from_traits(std::vector<TraitPtr> &&t
     traits[i]->members.for_each([&](ClassMemberStaticMethod   &m) { check_other_traits_doesnt_contain_method_and_clone(m.function); });
 
     traits[i]->members.for_each([&](const ClassMemberInstanceField &f) {
-      ready_class->members.add_instance_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str);
+      ready_class->members.add_instance_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str, f.type_hint);
     });
 
     traits[i]->members.for_each([&](const ClassMemberStaticField &f) {
-      ready_class->members.add_static_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str);
+      ready_class->members.add_static_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str, f.type_hint);
     });
   }
 

--- a/tests/phpt/cl/005_cast_instance_to_array.php
+++ b/tests/phpt/cl/005_cast_instance_to_array.php
@@ -1,4 +1,4 @@
-@ok
+@ok php7_4
 <?php
 
 require_once 'kphp_tester_include.php';
@@ -21,8 +21,7 @@ class A {
 
 class B {
     public $s_b = "asdf";
-    /** @var A */
-    public $a_b;
+    public A $a_b;
     /** @var A[]|false */
     public $arr_a_b = false;
     public function __construct() { 

--- a/tests/phpt/cl/008_fields_default_value.php
+++ b/tests/phpt/cl/008_fields_default_value.php
@@ -1,4 +1,4 @@
-@ok
+@ok php7_4
 <?php
 
 require_once 'kphp_tester_include.php';
@@ -11,12 +11,9 @@ function test_empty_string_default_value() {
   class EmptyStringDefault {
     const EMPTY = "";
 
-    /** @var string */
-    public $empty_str1 = "";
-    /** @var string */
-    public $empty_str2 = EmptyStringDefault::EMPTY;
-    /** @var string */
-    public $empty_str3;
+    public string $empty_str1 = "";
+    public string $empty_str2 = EmptyStringDefault::EMPTY;
+    public string $empty_str3;
 
     public function __construct() {
       $this->empty_str3 = "";
@@ -37,17 +34,19 @@ function test_optional_string_default_value() {
     /** @var string|false */
     public $str_or_false3 = OptionalStringDefault::EMPTY;
 
-    /** @var string|null */
-    public $str_or_null1 = null;
-    /** @var string|null */
-    public $str_or_null2 = "";
-    /** @var string|null */
-    public $str_or_null3 = OptionalStringDefault::EMPTY;
-    /** @var string|null */
-    public $str_or_null4;
+    public ?string $str_or_null1 = null;
+    public ?string $str_or_null2 = "";
+    public ?string $str_or_null3 = OptionalStringDefault::EMPTY;
+    public ?string $str_or_null4;
   }
 
-  var_dump(instance_to_array(new OptionalStringDefault));
+  $o = new OptionalStringDefault;
+  // since php 7.4 (with class fields), not uninialized fields are not dumped with (array)$obj
+  // that's why (array)$o won't output $str_or_null4 if not set, which will diff with kphp
+  #ifndef KPHP
+  $o->str_or_null4 = null;
+  #endif
+  var_dump(instance_to_array($o));
 }
 
 function test_empty_array_default_value() {

--- a/tests/phpt/cl/025_class_depends_kphp_inline.php
+++ b/tests/phpt/cl/025_class_depends_kphp_inline.php
@@ -1,9 +1,9 @@
-@ok
+@ok php7_4
 <?php
 
 class A {
   /** @var A[] */
-  private static $b = [];
+  private static array $b = [];
 
   public function __construct() {}
 

--- a/tests/phpt/msgpack_serialize/000_primitives.php
+++ b/tests/phpt/msgpack_serialize/000_primitives.php
@@ -40,7 +40,7 @@ class PrimitiveHolder {
      * @kphp-serialized-field 6
      * @var bool
      */
-    public $bool_true_f = false;
+    public $bool_true_f = true;
 
     /**
      * @kphp-serialized-field 7

--- a/tests/phpt/msgpack_serialize/000_primitives_hints.php
+++ b/tests/phpt/msgpack_serialize/000_primitives_hints.php
@@ -1,0 +1,116 @@
+@ok php7_4
+<?php
+require_once 'kphp_tester_include.php';
+
+/**
+ * @kphp-serializable
+ * @kphp-reserved-fields [3]
+ **/
+class PrimitiveHolder {
+    public static int $unused_x = 20;
+
+    /**
+     * @kphp-serialized-field 1
+     */
+    public int $int_f = 11;
+
+    /**
+     * @kphp-serialized-field 2
+     */
+    public float $float_f = 20.123;
+
+    /**
+     * @kphp-serialized-field 4
+     */
+    public float $float_NaN_f = NAN;
+
+    /**
+     * @kphp-serialized-field 5
+     */
+    public bool $bool_false_f = false;
+
+    /**
+     * @kphp-serialized-field 6
+     */
+    public bool $bool_true_f = true;
+
+    /**
+     * @kphp-serialized-field 7
+     */
+    public int $negative_int_f = -12312323;
+
+    /**
+     * @kphp-serialized-field 8
+     */
+    public ?string $s_null_null = NULL;
+
+    /**
+     * @kphp-serialized-field 9
+     */
+    public ?string $s_null_s = 'ss';
+
+    /**
+     * @kphp-serialized-field 10
+     */
+    public ?bool $b_null_null = null;
+
+    /**
+     * @kphp-serialized-field 11
+     */
+    public ?bool $b_null_b = true;
+
+    /**
+     * @kphp-serialized-field 12
+     */
+    public ?int $i_null_null = null;
+
+    /**
+     * @kphp-serialized-field 13
+     */
+    public ?int $i_null_0 = 0;
+
+
+    /**
+     * @param $another PrimitiveHolder
+     * @return bool
+     */
+    public function equal_to($another) {
+        var_dump($another->int_f);
+        var_dump($another->float_f);
+        var_dump($another->float_NaN_f);
+        var_dump($another->bool_false_f);
+        var_dump($another->bool_true_f);
+        var_dump($another->negative_int_f);
+        var_dump($another->s_null_null);
+        var_dump($another->s_null_s);
+        var_dump($another->b_null_null);
+        var_dump($another->b_null_b);
+        var_dump($another->i_null_null);
+        var_dump($another->i_null_0);
+
+        return $this->int_f === $another->int_f
+            && $this->float_f === $another->float_f
+            && is_nan($this->float_NaN_f) && is_nan($another->float_NaN_f)
+            && $this->bool_false_f === $another->bool_false_f
+            && $this->bool_true_f === $another->bool_true_f
+            && $this->negative_int_f === $another->negative_int_f
+            && $this->s_null_null === $another->s_null_null
+            && $this->s_null_s === $another->s_null_s
+            && $this->b_null_null === $another->b_null_null
+            && $this->b_null_b === $another->b_null_b
+            && $this->i_null_null === $another->i_null_null
+            && $this->i_null_0 === $another->i_null_0
+            ;
+    }
+}
+
+function run() {
+    $b = new PrimitiveHolder();
+    $serialized = instance_serialize($b);
+    var_dump(base64_encode($serialized));
+    $b_new = instance_deserialize($serialized, PrimitiveHolder::class);
+
+    var_dump($b->equal_to($b_new));
+}
+
+run();

--- a/tests/phpt/msgpack_serialize/005_with_namespaces_hints.php
+++ b/tests/phpt/msgpack_serialize/005_with_namespaces_hints.php
@@ -1,0 +1,56 @@
+@ok php7_4
+<?php
+
+require_once 'kphp_tester_include.php';
+
+use Classes\A, Classes2\A as A2;
+
+/** 
+ * @kphp-serializable
+ **/
+class AHolder {
+    /**
+     * @kphp-serialized-field 1
+     */
+    public A $a_f;
+
+    /**
+     * @kphp-serialized-field 2
+     */
+    public \Classes\A $a_f2;
+
+    /**
+     * @kphp-serialized-field 3
+     */
+    public A2 $a2_f;
+
+    public function __construct() {
+      $this->a_f = new \Classes\A;
+      $this->a_f2 = new A();
+      $this->a2_f = new A2();
+    }
+
+  public function equal_to(AHolder $another): bool {
+        return $this->a_f->equal_to($another->a_f)
+            && $this->a_f2->equal_to($another->a_f2)
+            && $this->a2_f->equal_to($another->a2_f);
+    }
+}
+
+function run() {
+    $aholder = new AHolder();
+    $serialized = instance_serialize($aholder);
+    var_dump(base64_encode($serialized));
+    $aholder_new = instance_deserialize($serialized, AHolder::class);
+
+    var_dump($aholder->equal_to($aholder_new));
+
+    $a = new Classes\A();
+    $serialized = instance_serialize($a);
+    var_dump(base64_encode($serialized));
+    $a_new = instance_deserialize($serialized, Classes\A::class);
+
+    var_dump($a->equal_to($a_new));
+}
+
+run();

--- a/tests/phpt/reqtyping/030_req_class_typing_1.php
+++ b/tests/phpt/reqtyping/030_req_class_typing_1.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
 KPHP_REQUIRE_CLASS_TYPING=1
-/Specify @var or default value to A::\$a/
+/Specify @var or type hint or default value to A::\$a/
 <?php
 
 // when class typing required, use @var or default value

--- a/tests/phpt/stacktrace/07_stacktrace.php
+++ b/tests/phpt/stacktrace/07_stacktrace.php
@@ -1,11 +1,10 @@
-@kphp_should_fail
+@kphp_should_fail php7_4
 /assign int to A::\$name/
 /but it's declared as @var string/
 <?php
 
 class A {
-  /** @var string */
-  public $name = 0;
+  public string $name = 0;
 }
 
 new A;

--- a/tests/phpt/stacktrace/09_stacktrace.php
+++ b/tests/phpt/stacktrace/09_stacktrace.php
@@ -1,0 +1,16 @@
+@kphp_should_fail php7_4
+/insert string into A::\$ids\[\]/
+<?php
+
+class A {
+    /** @var int[] */
+    public array $ids = [1,2,3];
+
+    function f($x) {
+        $this->ids[] = $x;
+    }
+}
+
+$a = new A;
+$v = '3';
+$a->f($v);

--- a/tests/phpt/typehints/fields/01_field_type_hint.php
+++ b/tests/phpt/typehints/fields/01_field_type_hint.php
@@ -1,0 +1,38 @@
+@ok php7_4
+<?php
+
+class A {
+    public int $i;
+    private ?string $s = '';
+    public B $b;
+
+    public function __construct(int $i) {
+        $this->i = $i;
+        $this->b = new B($this);
+    }
+}
+
+class B {
+    static int $count = 0;
+
+    var ?A $a = null;
+
+    public function __construct(?A $a) {
+        $this->a = $a;
+        self::$count++;
+    }
+}
+
+function demo() {
+    $a1 = new A(10);
+    echo $a1->i, "\n";
+    echo $a1->b->a->i, "\n";
+    echo $a1->b->a->b->a->i, "\n";
+
+    $a2 = new A(20);
+    echo $a2->b->a->i, "\n";
+
+    echo B::$count;
+}
+
+demo();

--- a/tests/phpt/typehints/fields/02_field_type_hint_self.php
+++ b/tests/phpt/typehints/fields/02_field_type_hint_self.php
@@ -1,0 +1,39 @@
+@ok php7_4
+<?php
+
+trait T {
+    public self $s;
+}
+
+abstract class A1 {
+    use T;
+
+    function f() {}
+}
+
+class A extends A1 {
+}
+
+$a = new A;
+$a->s = new A;
+$a->s->f();
+
+
+class Test {
+  public static ?self $instance = null;
+
+  public static function create() {
+    if (!self::$instance) {
+      self::$instance = new self();
+    }
+    return self::$instance;
+  }
+
+  public function just() {
+    return "Do it\n";
+  }
+}
+
+Test::create();
+echo Test::$instance->just();
+

--- a/tests/phpt/typehints/fields/03_field_type_hint_array.php
+++ b/tests/phpt/typehints/fields/03_field_type_hint_array.php
@@ -1,0 +1,21 @@
+@ok php7_4
+<?php
+
+class A {
+    /** @var A[] */
+    public array $instances = [];
+
+    public array $ids = [1,2,3];
+
+    function f() {
+        echo "A f\n";
+    }
+}
+
+$a = new A;
+$a->instances[] = new A;
+foreach ($a->instances as $i) {
+    $i->f();
+}
+$a->f();
+$a->ids[] = '3';


### PR DESCRIPTION
Now we can write simple types near class fields instead of `@var`:
```
class A {
  public int $field = 0;
  public ?self $me = null;
```
Both for instance and static fields.

KPHP can parse any syntaxically correct type hints (int[] and string|false for example), but PHP supports only some primitives and nullable (and union since php 8).
