### PR TITLE
Fix warning in array_rand when num less then array size

### DIFF
--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -924,11 +924,9 @@ mixed f$array_rand(const array<T> &a, int64_t num) {
   }
 
   int64_t size = a.count();
-  if (num > size) {
-    num = size;
-  }
-  if (unlikely(num <= 0)) {
-    php_warning("Parameter num of array_rand must be positive");
+
+  if (unlikely(num <= 0 || num > size)) {
+    php_warning("Second argument has to be between 1 and the number of elements in the array");
     return {};
   }
 

--- a/tests/phpt/array/014_array_rand.php
+++ b/tests/phpt/array/014_array_rand.php
@@ -1,0 +1,47 @@
+@ok
+<?php
+function test_array_rand() {
+  $array = [1, 2, 3];
+  $result = array_rand($array, 3);
+  if (is_array($result) && count($result) === 3) {
+    var_dump($result);
+  }
+}
+
+function test_array_rand_no_num_val() {
+  $array = [1, 2, 3];
+  $result = array_rand($array);
+  if (is_int($result)) {
+    var_dump('int result');
+  }
+}
+
+function test_array_rand_null_zero_num() {
+  $array = [1, 2, 3];
+  $result = @array_rand($array, 0);
+  if ($result === null) {
+    var_dump('result is null, cause num is equals to zero');
+  }
+}
+
+function test_array_rand_null_empty_array() {
+  $array = [];
+  $result = @array_rand($array, 2);
+  if ($result === null) {
+    var_dump('result is null, cause array is empty');
+  }
+}
+
+function test_array_rand_null_num_greater_then_array_size() {
+  $array = [1, 2];
+  $result = @array_rand($array, 3);
+  if ($result === null) {
+    var_dump('result is null, cause num is greater then len of array size');
+  }
+}
+
+test_array_rand();
+test_array_rand_no_num_val();
+test_array_rand_null_zero_num();
+test_array_rand_null_empty_array();
+test_array_rand_null_num_greater_then_array_size();


### PR DESCRIPTION
Php throw warning, if you pass in array_rand NUM that greater then array size.
Kphp does not throw it. But throws only when array size. == 0.
Message looks like: Parameter num of array_rand must be positive.
That happens cause
if num > size: we make num equal to size
so if we have num 5, size == 0, then we have num == 0
and that errors triggers.
I've made fix for right alert.