### PR TITLE
make `strict_types=1` disable automatic cast insertion for a current file

### DIFF
--- a/compiler/data/src-file.h
+++ b/compiler/data/src-file.h
@@ -22,6 +22,7 @@ public:
   std::string unified_dir_name;
   bool loaded{false};
   bool is_required{false};
+  bool is_strict_types{false}; // whether declare(strict_types=1) is set
 
   std::string main_func_name;
   FunctionPtr main_function;

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -55,6 +55,7 @@ const std::map<string, php_doc_tag::doc_type> php_doc_tag::str2doc_type = {
   {"@kphp-serialized-float32",   kphp_serialized_float32},
   {"@kphp-profile",              kphp_profile},
   {"@kphp-profile-allow-inline", kphp_profile_allow_inline},
+  {"@kphp-strict-types-enable",  kphp_strict_types_enable},
 };
 
 vector<php_doc_tag> parse_php_doc(vk::string_view phpdoc) {

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -46,7 +46,8 @@ struct php_doc_tag {
     kphp_serialized_field,
     kphp_serialized_float32,
     kphp_profile,
-    kphp_profile_allow_inline
+    kphp_profile_allow_inline,
+    kphp_strict_types_enable, // TODO: remove when strict_types=1 are enabled by default
   };
 
 public:

--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -396,7 +396,10 @@ private:
         kphp_error_act(call_arg->type() != op_varg,
                        fmt_format("Passed unpacked arguments to a non-vararg function"), continue);
 
-        if (param->is_cast_param) {   // ::: cast param in functions.txt or @kphp-infer cast function
+        // for cast params (::: in functions.txt or '@kphp-infer cast') we add
+        // conversions automatically (implicit casts), unless the file from where
+        // we're calling this function is annotated with strict_types=1
+        if (!current_function->file_id->is_strict_types && param->is_cast_param) {
           call_arg = GenTree::conv_to_cast_param(call_arg, param->type_hint, param->var()->ref_flag);
         }
 

--- a/docs/kphp-language/static-type-system/type-casting.md
+++ b/docs/kphp-language/static-type-system/type-casting.md
@@ -225,3 +225,5 @@ No matter whether a native function accepts strings / ints / arrays — casts wi
 ```
 
 **Why is it done in such a way?** Almost because when executed in plain PHP, standard library functions check input arguments, and if you pass something wrong — you'll see it while development, as opposed to functions written in PHP with auto inferred types. Moreover, such an approach requires less manual casts when using *mixed*, though it seems a bit incorrectly. Maybe, this behavior will be controlled by an option in the future.
+
+When `declare(strict_types=1)` is used, implicit casting is disabled for that file. This applies to both native functions and functions annotated with `@kphp-infer cast`.

--- a/tests/phpt/declare/01_strict_types.php
+++ b/tests/phpt/declare/01_strict_types.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/01_strict_types.php.inc
+++ b/tests/phpt/declare/01_strict_types.php.inc
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=0);
+
+var_dump(strcmp(54, 10));

--- a/tests/phpt/declare/02_strict_types2.php
+++ b/tests/phpt/declare/02_strict_types2.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/02_strict_types2.php.inc
+++ b/tests/phpt/declare/02_strict_types2.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+var_dump(strcmp(54, 10));

--- a/tests/phpt/declare/03_strict_types_error.php
+++ b/tests/phpt/declare/03_strict_types_error.php
@@ -1,0 +1,5 @@
+@kphp_should_fail
+/pass int to argument \$str1 of strcmp/
+/but it's declared as @param string/
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/03_strict_types_error.php.inc
+++ b/tests/phpt/declare/03_strict_types_error.php.inc
@@ -1,0 +1,5 @@
+<?php
+/** @kphp-strict-types-enable */
+declare(strict_types=1);
+
+var_dump(strcmp(54, 10));

--- a/tests/phpt/declare/04_strict_types_kphpinfercast.php
+++ b/tests/phpt/declare/04_strict_types_kphpinfercast.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/04_strict_types_kphpinfercast.php.inc
+++ b/tests/phpt/declare/04_strict_types_kphpinfercast.php.inc
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=0);
+
+/**
+ * @kphp-infer cast
+ * @param string $s
+ */
+function f($s) {}
+
+f(24);

--- a/tests/phpt/declare/05_strict_types_kphpinfercast2.php
+++ b/tests/phpt/declare/05_strict_types_kphpinfercast2.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/05_strict_types_kphpinfercast2.php.inc
+++ b/tests/phpt/declare/05_strict_types_kphpinfercast2.php.inc
@@ -1,0 +1,8 @@
+<?php
+/**
+ * @kphp-infer cast
+ * @param string $s
+ */
+function f($s) {}
+
+f(24);

--- a/tests/phpt/declare/06_strict_types_kphpinfercast_error.php
+++ b/tests/phpt/declare/06_strict_types_kphpinfercast_error.php
@@ -1,0 +1,5 @@
+@kphp_should_fail
+/pass int to argument \$s of f/
+/but it's declared as @param string/
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/06_strict_types_kphpinfercast_error.php.inc
+++ b/tests/phpt/declare/06_strict_types_kphpinfercast_error.php.inc
@@ -1,0 +1,13 @@
+<?php
+/** @kphp-strict-types-enable */
+declare(strict_types=1);
+
+// If we remove strict_types=1, this could would work
+
+/**
+ * @kphp-infer cast
+ * @param string $s
+ */
+function f($s) {}
+
+f(24);

--- a/tests/phpt/declare/07_strict_types_kphpinfercast_error.php
+++ b/tests/phpt/declare/07_strict_types_kphpinfercast_error.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/pass string to argument \$s of infercast_int_param/
+/but it's declared as @param int/
+<?php
+
+require_once __DIR__ . '/infercast_func.php.inc';
+require_once __DIR__ . '/can_call_with_cast.php.inc'; // OK
+require_once __DIR__ . '/cant_call_with_cast.php.inc'; // Error

--- a/tests/phpt/declare/08_strict_types_kphpinfercast.php
+++ b/tests/phpt/declare/08_strict_types_kphpinfercast.php
@@ -1,0 +1,10 @@
+@ok
+<?php
+
+// infercast_func.php uses strict_types=1, but it doesn't apply here
+
+require_once __DIR__ . '/infercast_func.php.inc';
+require_once __DIR__ . '/can_call_with_cast.php.inc';
+
+infercast_string_param(43);
+infercast_int_param('foo');

--- a/tests/phpt/declare/09_strict_types_not_enabled.php
+++ b/tests/phpt/declare/09_strict_types_not_enabled.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/09_strict_types_not_enabled.php.inc
+++ b/tests/phpt/declare/09_strict_types_not_enabled.php.inc
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+function f($cond) {
+  if ($cond) {
+    var_dump(strcmp(40, 23));
+  }
+}
+
+f(false);

--- a/tests/phpt/declare/can_call_with_cast.php.inc
+++ b/tests/phpt/declare/can_call_with_cast.php.inc
@@ -1,0 +1,3 @@
+<?php
+
+infercast_string_param(43);

--- a/tests/phpt/declare/cant_call_with_cast.php.inc
+++ b/tests/phpt/declare/cant_call_with_cast.php.inc
@@ -1,0 +1,6 @@
+<?php
+
+/** @kphp-strict-types-enable */
+declare(strict_types=1);
+
+infercast_int_param('foo');

--- a/tests/phpt/declare/infercast_func.php.inc
+++ b/tests/phpt/declare/infercast_func.php.inc
@@ -1,0 +1,16 @@
+<?php
+
+/** @kphp-strict-types-enable */
+declare(strict_types=1);
+
+/**
+ * @kphp-infer cast
+ * @param string $s
+ */
+function infercast_string_param($s) {}
+
+/**
+ * @kphp-infer cast
+ * @param int $s
+ */
+function infercast_int_param($s) {}


### PR DESCRIPTION
In PHP, strict_types=1 would break the code at the run time if given
argument types mismatch expected types (expressed via type hints).

Previously, in KPHP it would silently cast these types and we'll
get inconsistent behavior between PHP and KPHP.

This change makes KPHP code a little bit closer to PHP,
but instead of failing at the run time we enable more type checking
for cast params in `strict_types=1` files.

A lot of existing PHP code is not prepared for this, so
this behavior is activated only if `declare()` has a phpdoc
with `@kphp-strict-types-enabled`.

As in PHP, strict_types is checked at the call site.