### PR TITLE
make strip_tags accept array as $allow, remove implicit cast from substr_replace

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -611,7 +611,7 @@ function ord ($c ::: string) ::: int;
 function strcasecmp ($str1 ::: string, $str2 ::: string) ::: int;
 function strcmp ($str1 ::: string, $str2 ::: string) ::: int;
 function stripslashes ($str ::: string) ::: string;
-function strip_tags ($str ::: string, $allow ::: string = "") ::: string;
+function strip_tags ($str ::: string, $allow ::: string|string[] = "") ::: string;
 function strncmp ($str1 ::: string, $str2 ::: string, $len ::: int) ::: int;
 function strnatcmp ($str1 ::: string, $str2 ::: string) ::: int;
 function wordwrap ($str ::: string, $width ::: int = 75, $break ::: string = '\n', $cut ::: bool = false) ::: string;
@@ -662,7 +662,7 @@ function strtolower ($str ::: string) ::: string;
 function strtoupper ($str ::: string) ::: string;
 function substr ($str ::: string, $start ::: int, $length ::: int = INT_MAX) ::: string | false;
 function substr_count ($haystack ::: string, $needle ::: string, $offset ::: int = 0, $length ::: int = INT_MAX) ::: int;
-function substr_replace ($str ::: string, $replacement ::: string, $start ::: int, $length ::: int = INT_MAX) ::: string | false;
+function substr_replace (string $str, string $replacement, $start ::: int, $length ::: int = INT_MAX) ::: string;
 function substr_compare ($main_str ::: string, $str ::: string, $offset ::: int, $length ::: int = INT_MAX, $case_insensitivity ::: bool = false) ::: int | false;
 
 function trim ($s ::: string, $what ::: string = " \n\r\t\v\0") ::: string;

--- a/runtime/string_functions.h
+++ b/runtime/string_functions.h
@@ -98,6 +98,9 @@ int64_t f$strcasecmp(const string &lhs, const string &rhs);
 
 int64_t f$strcmp(const string &lhs, const string &rhs);
 
+string f$strip_tags(const string &str, const array<Unknown> &allow);
+string f$strip_tags(const string &str, const mixed &allow);
+string f$strip_tags(const string &str, const array<string> &allow_list);
 string f$strip_tags(const string &str, const string &allow = string());
 
 Optional<int64_t> f$stripos(const string &haystack, const string &needle, int64_t offset = 0);
@@ -213,7 +216,7 @@ Optional<string> f$substr(const string &str, int64_t start, int64_t length = std
 
 int64_t f$substr_count(const string &haystack, const string &needle, int64_t offset = 0, int64_t length = std::numeric_limits<int64_t>::max());
 
-Optional<string> f$substr_replace(const string &str, const string &replacement, int64_t start, int64_t length = std::numeric_limits<int64_t>::max());
+string f$substr_replace(const string &str, const string &replacement, int64_t start, int64_t length = std::numeric_limits<int64_t>::max());
 
 Optional<int64_t> f$substr_compare(const string &main_str, const string &str, int64_t offset, int64_t length = std::numeric_limits<int64_t>::max(), bool case_insensitivity = false);
 

--- a/tests/phpt/string_functions/001_strip_tags_7_4.php
+++ b/tests/phpt/string_functions/001_strip_tags_7_4.php
@@ -1,0 +1,75 @@
+@ok php7_4
+<?php
+
+$strings = [
+  '',
+  ' ',
+  'string without tags',
+  '<p>incomplete tag',
+  'incomplete tag</p>',
+  '<p id="foo"></p>',
+  '< p id="foo" >< / p >',
+  ' <p id="foo">text</p> ',
+  'text<br>',
+  'text<br/>',
+  'text<br id="foo">',
+  'text<br id="foo"/>',
+  'text<br />',
+  '<br>',
+  '<br trap=">">',
+  ' <HTML><BODY><P>upper case tags</P> text</BODY></HTML>',
+  '<html><body><p>upper case tags</p> text</body></html> ',
+  '<HTML><Body><p>mixed case tags</p> text</Body></HTML>',
+  '<img class="emoji"><p>ok</p><img src="foo" class="emoji"><br><img src="foo">',
+];
+
+function run_string_test(string $s, string $allow) {
+  var_dump(["strip_tags('$s', '$allow')" => strip_tags($s, $allow)]);
+}
+
+/** @param string[] $allow */
+function run_array_test(string $s, array $allow) {
+  $parts = implode(',', $allow);
+  var_dump(["strip_tags('$s', [$parts])" => strip_tags($s, $allow)]);
+}
+
+foreach ($strings as $s) {
+  var_dump(strip_tags($s));
+  var_dump(strip_tags($s, ''));
+  var_dump(strip_tags($s, []));
+  var_dump(strip_tags($s, ['']));
+  var_dump(strip_tags($s, ['', '']));
+
+  // not a valid usage, but should fail in identical way;
+  // all these $allowed arguments are silently (sic) ignored
+  var_dump(strip_tags($s, 'p'));
+  var_dump(strip_tags($s, '<br/>'));
+  var_dump(strip_tags($s, '</br>'));
+  var_dump(strip_tags($s, '</body>'));
+  var_dump(strip_tags($s, '<p/>'));
+  var_dump(strip_tags($s, '?'));
+  var_dump(strip_tags($s, '< p >'));
+  var_dump(strip_tags($s, ' <p>'));
+  var_dump(strip_tags($s, '<img class="emoji">'));
+
+  // single string as allow filter
+  var_dump(strip_tags($s, '<br>'));
+  var_dump(strip_tags($s, '<Br>'));
+  var_dump(strip_tags($s, '<p>'));
+
+  // string with multiple tags as allow filter
+  var_dump(strip_tags($s, '<p><br>'));
+  var_dump(strip_tags($s, '<p><img>'));
+  var_dump(strip_tags($s, '<p><br><html>'));
+
+  // string array allowlist
+  run_array_test($s, ['p']);
+  run_array_test($s, ['p', 'BR']);
+  run_array_test($s, ['first' => 'p', 'second' => 'BR']);
+  run_array_test($s, ['p', 'br', 'HTML', 'body']);
+
+  // <> are not needed when arrays are used,
+  // '<' and '>' are appended to every string argument
+  // var_dump(strip_tags($s, ['<p>']));
+  run_array_test($s, ['<p>', '<BR/>']);
+}

--- a/tests/phpt/string_functions/002_substr_replace.php
+++ b/tests/phpt/string_functions/002_substr_replace.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+// test substr_replace with potentially incorrect arguments
+// to check that it handles corner cases in the same way as PHP does
+
+$strings = ['', '_', '__', 'example string'];
+$ints = [0, -1, 1, -2, 2, -100, 100];
+
+foreach ($strings as $s) {
+  foreach ($strings as $replacement) {
+    foreach ($ints as $start) {
+      foreach ($ints as $length) {
+        var_dump(substr_replace($s, $replacement, $start, $length));
+        var_dump(substr_replace($s, $replacement, $start, strlen($s)));
+        var_dump(substr_replace($s, $replacement, strlen($s), $length));
+      }
+    }
+  }
+}

--- a/tests/phpt/string_functions/003_strip_tags_mixed_arg.php
+++ b/tests/phpt/string_functions/003_strip_tags_mixed_arg.php
@@ -1,0 +1,12 @@
+@ok php7_4
+<?php
+
+/** @param mixed $x */
+function test(string $s, $x) {
+  var_dump(strip_tags($s, $x));
+}
+
+test('<hr><b>hello</b><br/>', ['b']);
+test('<hr><b>hello</b><br/>', ['br', 'b']);
+test('<hr><b>hello</b><br/>', '<b>');
+test('<hr><b>hello</b><br/>', '<br><b>');


### PR DESCRIPTION
This change makes `string_tags()` compatible with PHP7.4 version of that function.
$allow can accept array of allowed tags.

Also fixed an issue where self-closing tags were not ignored.
They are ignored since PHP5.3.4, so using them is a logical error.
Instead of `<br/>`, users should use `<br>` which will match both
`<br>` and `<br/>` tags.

For `substr_replace()` function, implicit casts for string arguments
are removed to avoid unwanted array->string conversions.
Result type changed from `Optional<string>` to just `string`;
the corner-case behavior is adjusted to be identical to what PHP does.

This code is an example of natural `substr_replace()` usage:
```php
$s = substr_replace($s, $rep, $offset);
```
If `substr_replace()` returns optional, `$s` stops being string here.

We may add support for the array arguments in the future, but for now it's
good enough to reject suspicious code that will behave differently
in KPHP and PHP7.4.

The problem with `substr_replace()` array signatures is that
there are multiple scalar vs array combinations, not all of them
are valid; even PHP does not check for all possible errors
(for example, when `$length` and `$offset` arrays have different sizes).