### PR TITLE
implemented negative offsets for regexps + offset overflow errors

### DIFF
--- a/tests/phpt/regexp/003_preg_match_neg_offset.php
+++ b/tests/phpt/regexp/003_preg_match_neg_offset.php
@@ -1,0 +1,33 @@
+@ok
+<?php
+
+// https://github.com/VKCOM/kphp/issues/145
+
+function test_negative_offset1() {
+  var_dump(preg_match('/\d+/', 'hello world', $m, 0, -1));
+  var_dump($m);
+  var_dump(preg_last_error());
+}
+
+function test_negative_offset2($flags) {
+  var_dump(preg_match('/world/', 'hello world', $m, $flags, -1));
+  var_dump($m);
+  var_dump(preg_last_error());
+
+  var_dump(preg_match('/world/', 'hello world', $m2, $flags, -6));
+  var_dump($m2);
+  var_dump(preg_last_error());
+
+  var_dump(preg_match('/hello/', 'hello world', $m3, $flags, -6));
+  var_dump($m3);
+  var_dump(preg_last_error());
+
+  // too negative
+  var_dump(preg_match('/world/', 'hello world', $m4, $flags, -500));
+  var_dump($m4);
+  var_dump(preg_last_error());
+}
+
+test_negative_offset1();
+test_negative_offset2(0);
+test_negative_offset2(PREG_OFFSET_CAPTURE);

--- a/tests/phpt/regexp/004_preg_match_high_offset.php
+++ b/tests/phpt/regexp/004_preg_match_high_offset.php
@@ -1,0 +1,7 @@
+@ok
+<?php
+
+// https://github.com/VKCOM/kphp/issues/145
+var_dump(preg_match('/\d+/', 'hello world', $m, 0, 100));
+var_dump($m);
+var_dump(preg_last_error());


### PR DESCRIPTION
Negative offset is interpreted as an offset from the end of the string.

If offset exceeds the `$subject` length, PHP returns false
with `PHP_PCRE_INTERNAL_ERROR` error (internally, it sets `PCRE2_ERROR_BADOFFSET`).

This behavior is tested on `PHP7.2`, `PHP7.4` and `PHP8.0`.

Fixes #145

----

Could be useful for the review: https://github.com/php/php-src/blob/2dc2436e08e1c80247a940dedeae67135e1c233a/ext/pcre/php_pcre.c#L1224-L1237