### PR TITLE
Check if array is pseudo vector for msgpack serialization.

### DIFF
--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -629,6 +629,20 @@ bool array<T>::is_vector() const {
 }
 
 template<class T>
+bool array<T>::is_pseudo_vector() const {
+  if (p->string_size) {
+    return false;
+  }
+  int64_t n = 0;
+  for (auto element : *this) {
+    if (element.get_key().as_int() != n++) {
+      return false;
+    }
+  }
+  return n == count();
+}
+
+template<class T>
 bool array<T>::mutate_if_vector_shared(uint32_t mul) {
   return mutate_to_size_if_vector_shared(mul * int64_t{p->int_size});
 }

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -261,6 +261,7 @@ public:
   inline void clear() __attribute__ ((always_inline));
 
   inline bool is_vector() const __attribute__ ((always_inline));
+  inline bool is_pseudo_vector() const __attribute__ ((always_inline));
 
   T &operator[](int64_t int_key);
   T &operator[](int32_t key) { return (*this)[int64_t{key}]; }

--- a/runtime/json-functions.h
+++ b/runtime/json-functions.h
@@ -41,20 +41,11 @@ template<class T>
 bool JsonEncoder::encode(const array<T> &arr) const noexcept {
   bool is_vector = arr.is_vector();
   const bool force_object = static_cast<bool>(JSON_FORCE_OBJECT & options_);
-  if (!force_object && !is_vector && arr.size().string_size == 0) {
-    int n = 0;
-    for (auto p : arr) {
-      if (p.get_key().to_int() != n) {
-        break;
-      }
-      n++;
-    }
-    if (n == arr.count()) {
-      if (arr.get_next_key() == arr.count()) {
-        is_vector = true;
-      } else {
-        php_warning("Corner case in json conversion, [] could be easy transformed to {}");
-      }
+  if (!force_object && !is_vector && arr.is_pseudo_vector()) {
+    if (arr.get_next_key() == arr.count()) {
+      is_vector = true;
+    } else {
+      php_warning("Corner case in json conversion, [] could be easy transformed to {}");
     }
   }
   is_vector &= !force_object;

--- a/runtime/msgpack-serialization.h
+++ b/runtime/msgpack-serialization.h
@@ -149,7 +149,7 @@ template<class T>
 struct pack<array<T>> {
   template <typename Stream>
   packer<Stream>& operator()(msgpack::packer<Stream>& packer, const array<T>& arr) const noexcept {
-    if (arr.is_vector()) {
+    if (arr.is_vector() || arr.is_pseudo_vector()) {
       packer.pack_array(static_cast<uint32_t>(arr.count()));
       for (const auto &it : arr) {
         pack_value(packer, it.get_value());

--- a/tests/phpt/msgpack_serialize/024_serialize_vector.php
+++ b/tests/phpt/msgpack_serialize/024_serialize_vector.php
@@ -1,0 +1,58 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+function arrayKeysToWin(array $val): array {
+  foreach($val as $k => $v) {
+    unset($val[$k]);
+    $val[vk_utf8_to_win($k)] = $v;
+  }
+  return $val;
+}
+
+function test_vector() {
+  $a1 = [1, 2, 3, 4, 5];
+  $serialized1 = msgpack_serialize_safe($a1);
+  var_dump(base64_encode($serialized1));
+
+  $a2 = [0 => 1, 1 => 2, 2 => 3, 3 => 4, 4 => 5];
+  $serialized2 = msgpack_serialize_safe($a2);
+  assert_true($serialized1 === $serialized2);
+  var_dump(base64_encode($serialized2));
+
+  $a3 = ["0" => 1, "1" => 2, "2" => 3, "3" => 4, "4" => 5];
+  $serialized3 = msgpack_serialize_safe($a3);
+  assert_true($serialized1 === $serialized3);
+  var_dump(base64_encode($serialized3));
+
+  $a4 = ["0" => 1, 1 => 2, "2" => 3, 3 => 4, "4" => 5];
+  $serialized4 = msgpack_serialize_safe($a4);
+  assert_true($serialized1 === $serialized4);
+  var_dump(base64_encode($serialized4));
+
+  $a5 = [];
+  $a5[] = 1;
+  $a5[1] = 2;
+  $a5["2"] = 3;
+  $a5[] = 4;
+  $a5[4] = 5;
+  $serialized5 = msgpack_serialize_safe($a5);
+  assert_true($serialized1 === $serialized5);
+  var_dump(base64_encode($serialized5));
+
+  $a6 = [1 => 2];
+  $a6[0] = 1;
+  $a6[2] = 3;
+  $a6[3] = 4;
+  $a6[4] = 5;
+  $serialized6 = msgpack_serialize_safe($a6);
+  assert_false($serialized1 === $serialized6);
+  var_dump(base64_encode($serialized6));
+
+  $a7 = arrayKeysToWin($a1);
+  $serialized7 = msgpack_serialize_safe($a7);
+  assert_true($serialized1 === $serialized7);
+  var_dump(base64_encode($serialized7));
+}
+
+test_vector();


### PR DESCRIPTION
Hi!
This small patch allows encode pseudo vectors as vectors for msgpack serialization.
So it works the same way as in a vanilla php implementation.