### PR TITLE
Support sha224, sha384, sha512 for hash() and hash_hmac().

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -437,7 +437,7 @@ function mt_rand ($l ::: int = TODO_OVERLOAD, $r ::: int = TODO_OVERLOAD) ::: in
 function mt_getrandmax() ::: int;
 
 function hash_algos () ::: string[];
-function hash_equals(string $known_string, string $user_string) ::: bool;
+function hash_hmac_algos () ::: string[];
 function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
 function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
 function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
@@ -445,6 +445,7 @@ function md5 ($s ::: string, $raw_output ::: bool = false) ::: string;
 function md5_file ($s ::: string, $raw_output ::: bool = false) ::: string | false;
 function crc32 ($s ::: string) ::: int;
 function crc32_file ($s ::: string) ::: int;
+function hash_equals(string $known_string, string $user_string) ::: bool;
 /** @kphp-pure-function */
 function cp1251 ($utf8_string ::: string) ::: string;
 

--- a/runtime/openssl.h
+++ b/runtime/openssl.h
@@ -21,17 +21,17 @@ enum openssl_algo {
   OPENSSL_ALGO_RMD160 = 10,
 };
 
-array<string> f$hash_algos();
+array<string> f$hash_algos() noexcept;
 
-bool f$hash_equals(const string &known_string, const string &user_string) noexcept;
+array<string> f$hash_hmac_algos() noexcept;
 
-string f$hash(const string &algo, const string &s, bool raw_output = false);
+string f$hash(const string &algo, const string &s, bool raw_output = false) noexcept;
 
-string f$hash_hmac(const string &algo, const string &data, const string &key, bool raw_output = false);
+string f$hash_hmac(const string &algo, const string &data, const string &key, bool raw_output = false) noexcept;
 
-string f$sha1(const string &s, bool raw_output = false);
+string f$sha1(const string &s, bool raw_output = false) noexcept;
 
-string f$md5(const string &s, bool raw_output = false);
+string f$md5(const string &s, bool raw_output = false) noexcept;
 
 Optional<string> f$md5_file(const string &file_name, bool raw_output = false);
 
@@ -39,6 +39,7 @@ int64_t f$crc32(const string &s);
 
 int64_t f$crc32_file(const string &file_name);
 
+bool f$hash_equals(const string &known_string, const string &user_string) noexcept;
 
 bool f$openssl_public_encrypt(const string &data, string &result, const string &key);
 

--- a/tests/phpt/openssl/5_hash.php
+++ b/tests/phpt/openssl/5_hash.php
@@ -8,7 +8,7 @@
 
 function test_hash_basic() {
   hash_algos();
-  $algos = array ("md5", "sha1", "sha256");
+  $algos = array ("md5", "sha1", "sha224", "sha256", "sha384", "sha512");
 
 
   $a = array("", "asdasd", "abacaba", "1", NULL, false, true, "asdasdasdasdasd42n3jb23jkb2k3vb2hj3v41hj 13hj j23hbr j42hb j42hb jh43b rjh1hb 12jb 3jh4 b32 b24");
@@ -21,16 +21,15 @@ function test_hash_basic() {
     var_dump (md5 ($s, false));
     var_dump (md5 ($s, true));
     var_dump (md5 ($s));
-    var_dump (hash_hmac ('sha1', $s, $s, true));
-    var_dump (hash_hmac ('sha1', $s, $s));
-    var_dump (hash_hmac ('sha256', $s, $s, true));
-    var_dump (hash_hmac ('sha256', $s, $s));
-    var_dump (hash_hmac ('sha256', $s, "dummy", true));
-    var_dump (hash_hmac ('sha256', $s, "dummy"));
-    var_dump (hash_hmac ('sha256', "dummy", $s, true));
-    var_dump (hash_hmac ('sha256', "dummy", $s));
 
     foreach ($algos as $a) {
+      var_dump (hash_hmac ($a, $s, $s, true));
+      var_dump (hash_hmac ($a, $s, $s));
+      var_dump (hash_hmac ($a, $s, "dummy", true));
+      var_dump (hash_hmac ($a, $s, "dummy"));
+      var_dump (hash_hmac ($a, "dummy", $s, true));
+      var_dump (hash_hmac ($a, "dummy", $s));
+
       var_dump (hash ($a, $s, true));
       var_dump (hash ($a, $s, false));
     }


### PR DESCRIPTION
This patch enables `sha224`, `sha384`, `sha512` algorithms for `hash()` and `hash_hmac()`.
Also `hash_hmac_algos()` was implemented.