### PR TITLE
Support performance inspections enabling for classes

### DIFF
--- a/compiler/data/performance-inspections.cpp
+++ b/compiler/data/performance-inspections.cpp
@@ -35,7 +35,7 @@ PerformanceInspections::PerformanceInspections(Inspections enabled) noexcept
   : enabled_inspections_(enabled) {
 }
 
-void PerformanceInspections::add_from_php_doc(vk::string_view php_doc_tag) {
+void PerformanceInspections::set_from_php_doc(vk::string_view php_doc_tag) {
   const auto raw_inspections = split_skipping_delimeters(php_doc_tag);
   if (raw_inspections.empty()) {
     throw std::runtime_error{"there are no any inspection"};
@@ -51,8 +51,8 @@ void PerformanceInspections::add_from_php_doc(vk::string_view php_doc_tag) {
       enabled_inspections |= string2inspection(inspection);
     }
   }
-  enabled_inspections_ |= enabled_inspections;
-  disabled_inspections_ |= disabled_inspections;
+  enabled_inspections_ = enabled_inspections;
+  disabled_inspections_ = disabled_inspections;
 }
 
 std::pair<PerformanceInspections::InheritStatus, PerformanceInspections::Inspections>

--- a/compiler/data/performance-inspections.h
+++ b/compiler/data/performance-inspections.h
@@ -20,7 +20,7 @@ public:
 
   explicit PerformanceInspections(Inspections enabled = Inspections::no_inspections) noexcept;
 
-  void add_from_php_doc(vk::string_view php_doc_tag);
+  void set_from_php_doc(vk::string_view php_doc_tag);
 
   bool has_their_own_inspections() const noexcept {
     return !inspections_are_merged_ && (enabled_inspections_ || disabled_inspections_);

--- a/compiler/pipes/parse-and-apply-phpdoc.cpp
+++ b/compiler/pipes/parse-and-apply-phpdoc.cpp
@@ -275,15 +275,16 @@ private:
 
       case php_doc_tag::kphp_warn_performance: {
         try {
-          f_->performance_inspections_for_warning.add_from_php_doc(tag.value);
+          f_->performance_inspections_for_warning.set_from_php_doc(tag.value);
         } catch (const std::exception &ex) {
           kphp_error(false, fmt_format("@kphp-warn-performance bad tag: {}", ex.what()));
         }
         break;
       }
+
       case php_doc_tag::kphp_analyze_performance: {
         try {
-          f_->performance_inspections_for_analysis.add_from_php_doc(tag.value);
+          f_->performance_inspections_for_analysis.set_from_php_doc(tag.value);
         } catch (const std::exception &ex) {
           kphp_error(false, fmt_format("@kphp-analyze-performance bad tag: {}", ex.what()));
         }
@@ -451,6 +452,32 @@ private:
 
       case php_doc_tag::kphp_tl_class:
         klass->is_tl_class = true;
+        break;
+
+      case php_doc_tag::kphp_warn_performance:
+        try {
+          klass->members.for_each([&tag](const ClassMemberInstanceMethod &f) {
+            f.function->performance_inspections_for_warning.set_from_php_doc(tag.value);
+          });
+          klass->members.for_each([&tag](const ClassMemberStaticMethod &f) {
+            f.function->performance_inspections_for_warning.set_from_php_doc(tag.value);
+          });
+        } catch (const std::exception &ex) {
+          kphp_error(false, fmt_format("@kphp-warn-performance bad tag: {}", ex.what()));
+        }
+        break;
+
+      case php_doc_tag::kphp_analyze_performance:
+        try {
+          klass->members.for_each([&tag](const ClassMemberInstanceMethod &f) {
+            f.function->performance_inspections_for_analysis.set_from_php_doc(tag.value);
+          });
+          klass->members.for_each([&tag](const ClassMemberStaticMethod &f) {
+            f.function->performance_inspections_for_analysis.set_from_php_doc(tag.value);
+          });
+        } catch (const std::exception &ex) {
+          kphp_error(false, fmt_format("@kphp-analyze-performance bad tag: {}", ex.what()));
+        }
         break;
 
       default:

--- a/tests/cpp/compiler/data/performance-inspections-test.cpp
+++ b/tests/cpp/compiler/data/performance-inspections-test.cpp
@@ -8,51 +8,51 @@ TEST(performance_inspections_test, test_parse) {
   PI inspections;
   ASSERT_EQ(inspections.inspections(), 0);
 
-  inspections.add_from_php_doc("all");
+  inspections.set_from_php_doc("all");
   ASSERT_EQ(inspections.inspections(), PI::all_inspections);
 
   inspections = PI{};
-  inspections.add_from_php_doc("implicit-array-cast");
+  inspections.set_from_php_doc("implicit-array-cast");
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   inspections = PI{};
-  inspections.add_from_php_doc("all !implicit-array-cast");
+  inspections.set_from_php_doc("all !implicit-array-cast");
   ASSERT_EQ(inspections.inspections(), PI::array_merge_into | PI::array_reserve | PI::constant_execution_in_loop);
 
   inspections = PI{};
-  inspections.add_from_php_doc("!all implicit-array-cast");
+  inspections.set_from_php_doc("!all implicit-array-cast");
   ASSERT_EQ(inspections.inspections(), 0);
 
   inspections = PI{};
-  inspections.add_from_php_doc("!array-merge-into array-merge-into implicit-array-cast");
+  inspections.set_from_php_doc("!array-merge-into array-merge-into implicit-array-cast");
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 }
 
 TEST(performance_inspections_test, test_merge) {
   PI caller_inspections;
-  caller_inspections.add_from_php_doc("implicit-array-cast");
+  caller_inspections.set_from_php_doc("implicit-array-cast");
 
   PI inspections;
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::ok, PI::no_inspections));
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   caller_inspections = PI{};
-  caller_inspections.add_from_php_doc("!implicit-array-cast");
+  caller_inspections.set_from_php_doc("!implicit-array-cast");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::conflict, PI::implicit_array_cast));
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   caller_inspections = PI{};
-  caller_inspections.add_from_php_doc("!array-merge-into");
+  caller_inspections.set_from_php_doc("!array-merge-into");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::ok, PI::no_inspections));
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   caller_inspections = PI{};
-  caller_inspections.add_from_php_doc("array-merge-into");
+  caller_inspections.set_from_php_doc("array-merge-into");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::conflict, PI::array_merge_into));
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   caller_inspections = PI{};
-  caller_inspections.add_from_php_doc("all");
+  caller_inspections.set_from_php_doc("all");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::conflict, PI::array_merge_into));
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
@@ -60,20 +60,20 @@ TEST(performance_inspections_test, test_merge) {
   ASSERT_EQ(inspections.inspections(), PI::implicit_array_cast);
 
   inspections = PI{};
-  caller_inspections.add_from_php_doc("all !implicit-array-cast");
+  caller_inspections.set_from_php_doc("all !implicit-array-cast");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::ok, PI::no_inspections));
   ASSERT_EQ(inspections.inspections(), PI::array_merge_into | PI::array_reserve | PI::constant_execution_in_loop);
 
   caller_inspections = PI{};
-  caller_inspections.add_from_php_doc("all");
+  caller_inspections.set_from_php_doc("all");
   ASSERT_EQ(inspections.merge_with_caller(caller_inspections), std::make_pair(PI::InheritStatus::conflict, PI::implicit_array_cast));
 }
 
 TEST(performance_inspections_test, test_bad_parse) {
   PI inspections;
 
-  ASSERT_THROW(inspections.add_from_php_doc("abc"), std::runtime_error);
-  ASSERT_THROW(inspections.add_from_php_doc("  "), std::runtime_error);
-  ASSERT_THROW(inspections.add_from_php_doc("!"), std::runtime_error);
+  ASSERT_THROW(inspections.set_from_php_doc("abc"), std::runtime_error);
+  ASSERT_THROW(inspections.set_from_php_doc("  "), std::runtime_error);
+  ASSERT_THROW(inspections.set_from_php_doc("!"), std::runtime_error);
   ASSERT_EQ(inspections.inspections(), 0);
 }

--- a/tests/phpt/performance_inspections/13_warn_tag_for_class.php
+++ b/tests/phpt/performance_inspections/13_warn_tag_for_class.php
@@ -1,0 +1,34 @@
+@kphp_should_warn
+/variable \$y1 can be reserved with array_reserve functions family out of loop/
+/Performance inspection 'array\-reserve' enabled by: Test::member_function/
+/expression \$x = array_merge\(\$x, <...>\) can be replaced with array_merge_into\(\$x, <...>\)/
+/Performance inspection 'array\-merge\-into' enabled by: Test::static_function/
+<?php
+
+/**
+ * @kphp-warn-performance array-reserve array-merge-into
+ */
+class Test {
+  public function member_function() {
+    $y1 = [];
+    for ($i = 0; $i != 1000; ++$i) {
+      $y1[] = $i;
+    }
+    return $y1;
+  }
+
+  static public function static_function() {
+    $x = [1, 2, 3 ,4];
+    if (1) {
+      $x = array_merge($x, [1]);
+    }
+    return $x;
+  }
+}
+
+function test() {
+  (new Test)->member_function();
+  Test::static_function();
+}
+
+test();

--- a/tests/phpt/performance_inspections/14_warn_tag_for_interface.php
+++ b/tests/phpt/performance_inspections/14_warn_tag_for_interface.php
@@ -1,0 +1,40 @@
+@kphp_should_warn
+/variable \$y1 can be reserved with array_reserve functions family out of loop/
+/Performance inspection 'array\-reserve' enabled by: TestInterface::interface_function \-> TestInterfaceImpl1::interface_function/
+/expression \$x = array_merge\(\$x, <...>\) can be replaced with array_merge_into\(\$x, <...>\)/
+/Performance inspection 'array\-merge\-into' enabled by: TestInterface::interface_function \-> TestInterfaceImpl2::interface_function/
+<?php
+
+/**
+ * @kphp-warn-performance array-reserve array-merge-into
+ */
+interface TestInterface {
+  public function interface_function();
+}
+
+class TestInterfaceImpl1 implements TestInterface {
+  public function interface_function() {
+    $y1 = [];
+    for ($i = 0; $i != 1000; ++$i) {
+      $y1[] = $i;
+    }
+    return $y1;
+  }
+}
+
+class TestInterfaceImpl2 implements TestInterface {
+  public function interface_function() {
+    $x = [1, 2, 3 ,4];
+    if (1) {
+      $x = array_merge($x, [1]);
+    }
+    return $x;
+  }
+}
+
+function test() {
+  $i = 1 ? new TestInterfaceImpl1 : new TestInterfaceImpl2;
+  $i->interface_function();
+}
+
+test();

--- a/tests/phpt/performance_inspections/7_array_reserve_warn.php
+++ b/tests/phpt/performance_inspections/7_array_reserve_warn.php
@@ -1,9 +1,9 @@
 @kphp_should_warn
-/variable \$y1 can be reserved with array_reserve or array_reserve_from out of loop/
-/variable \$y2 can be reserved with array_reserve or array_reserve_from out of loop/
-/variable \$y3 can be reserved with array_reserve or array_reserve_from out of loop/
-/variable \$y4 can be reserved with array_reserve or array_reserve_from out of loop/
-/variable \$y5 can be reserved with array_reserve or array_reserve_from out of loop/
+/variable \$y1 can be reserved with array_reserve functions family out of loop/
+/variable \$y2 can be reserved with array_reserve functions family out of loop/
+/variable \$y3 can be reserved with array_reserve functions family out of loop/
+/variable \$y4 can be reserved with array_reserve functions family out of loop/
+/variable \$y5 can be reserved with array_reserve functions family out of loop/
 <?php
 
 /**

--- a/tests/phpt/performance_inspections/8_array_reserve_no_warn.php
+++ b/tests/phpt/performance_inspections/8_array_reserve_no_warn.php
@@ -2,6 +2,8 @@
 KPHP_ERROR_ON_WARNINGS=1
 <?php
 
+require_once 'kphp_tester_include.php';
+
 $y2 = [];
 
 class A {
@@ -10,7 +12,7 @@ class A {
 /**
  * @kphp-warn-performance array-reserve
  */
-function test() {
+function test1() {
   global $y2;
 
   $y1 = ["hello" => []];
@@ -44,4 +46,41 @@ function test() {
   } while ($i--);
 }
 
-test();
+/**
+ * @kphp-warn-performance array-reserve
+ */
+function test2() {
+  $y1 = [];
+  array_reserve($y1, 1000, 0, true);
+  for ($i = 0; $i != 1000; ++$i) {
+    $y1[] = $i + 2;
+  }
+
+  $y2 = [];
+  array_reserve_from($y2, $y1);
+  foreach ($y1 as $v) {
+    $y2[] = $v;
+  }
+
+  $y3 = [];
+  array_reserve_map_int_keys($y3, count($y2));
+  foreach ($y2 as $k => $v) {
+    $y3[$k] = $v;
+  }
+
+  $y4 = [];
+  $i = 1;
+  array_reserve_map_string_keys($y4, 1000);
+  while ($i < 1000) {
+    $y4["$i xx"] = ++$i;
+  }
+
+  $y5 = [];
+  array_reserve_vector($y5, $i);
+  do {
+    $y5[] = $i;
+  } while ($i--);
+}
+
+test1();
+test2();


### PR DESCRIPTION
1) Support performance inspections enabling for classes
2) Not retailed, but important: support new array_reserve_* functions.