### PR TITLE
Replace histogram -> gauge stats.

### DIFF
--- a/common/stats/provider.cpp
+++ b/common/stats/provider.cpp
@@ -54,20 +54,24 @@ static void add_stat(const char type, stats_t *stats, const char *key, const cha
   va_end (ap);
 }
 
-#define add_histogram_stat(stats, key, value_format, ...) add_stat('h', stats, key, value_format, ##__VA_ARGS__)
+#define add_histogram_stat_impl(stats, key, value_format, ...) add_stat('h', stats, key, value_format, ##__VA_ARGS__)
 
-#define add_gauge_stat(stats, key, value_format, ...) add_stat('g', stats, key, value_format, ##__VA_ARGS__)
+#define add_gauge_stat_impl(stats, key, value_format, ...) add_stat('g', stats, key, value_format, ##__VA_ARGS__)
 
 void add_histogram_stat_long(stats_t *stats, const char *key, long long value) {
-  add_histogram_stat(stats, key, "%lld", value);
+  add_histogram_stat_impl(stats, key, "%lld", value);
 }
 
 void add_gauge_stat_long(stats_t *stats, const char *key, long long value) {
-  add_gauge_stat(stats, key, "%lld", value);
+  add_gauge_stat_impl(stats, key, "%lld", value);
+}
+
+void add_gauge_stat_double(stats_t *stats, const char *key, double value) {
+  add_gauge_stat_impl(stats, key, "%.3f", value);
 }
 
 void add_histogram_stat_double(stats_t *stats, const char *key, double value) {
-  add_histogram_stat(stats, key, "%.3f", value);
+  add_histogram_stat_impl(stats, key, "%.3f", value);
 }
 
 void add_general_stat(stats_t *stats, const char *key, const char *value_format, ...) {

--- a/runtime/memory_resource/memory_resource.cpp
+++ b/runtime/memory_resource/memory_resource.cpp
@@ -2,32 +2,19 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-#include <cassert>
-
 #include "runtime/memory_resource/memory_resource.h"
-
-namespace {
-
-void write_stat(stats_t *stats, const char *prefix, const char *suffix, size_t value) noexcept {
-  char buffer[256]{0};
-  const auto len = snprintf(buffer, sizeof(buffer) - 1, "%s.%s", prefix, suffix);
-  assert(len > 0 && sizeof(buffer) >= static_cast<size_t>(len + 1));
-  add_histogram_stat_long(stats, buffer, static_cast<int64_t>(value));
-};
-
-} // namespace
 
 namespace memory_resource {
 
 void MemoryStats::write_stats_to(stats_t *stats, const char *prefix) const noexcept {
-  write_stat(stats, prefix, "memory.limit", memory_limit);
-  write_stat(stats, prefix, "memory.used", memory_used);
-  write_stat(stats, prefix, "memory.used_max", max_memory_used);
-  write_stat(stats, prefix, "memory.real_used", real_memory_used);
-  write_stat(stats, prefix, "memory.real_used_max", max_real_memory_used);
-  write_stat(stats, prefix, "memory.defragmentation_calls", defragmentation_calls);
-  write_stat(stats, prefix, "memory.huge_memory_pieces", huge_memory_pieces);
-  write_stat(stats, prefix, "memory.small_memory_pieces", small_memory_pieces);
+  add_gauge_stat(stats, memory_limit, prefix, ".memory.limit");
+  add_gauge_stat(stats, memory_used, prefix, ".memory.used");
+  add_gauge_stat(stats, max_memory_used, prefix, ".memory.used_max");
+  add_gauge_stat(stats, real_memory_used, prefix, ".memory.real_used");
+  add_gauge_stat(stats, max_real_memory_used, prefix, ".memory.real_used_max");
+  add_gauge_stat(stats, defragmentation_calls, prefix, ".memory.defragmentation_calls");
+  add_gauge_stat(stats, huge_memory_pieces, prefix, ".memory.huge_memory_pieces");
+  add_gauge_stat(stats, small_memory_pieces, prefix, ".memory.small_memory_pieces");
 }
 
 } // namespace memory_resource

--- a/server/cluster-name.cpp
+++ b/server/cluster-name.cpp
@@ -1,0 +1,38 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include <algorithm>
+#include <cstring>
+#include <cctype>
+
+#include "server/cluster-name.h"
+
+ClusterName::ClusterName() {
+  set_cluster_name("default");
+}
+
+const char *ClusterName::set_cluster_name(const char *name) noexcept {
+  // reserved for shmem, statsd, socket suffixes and prefixes
+  constexpr size_t reserved = 32;
+  const auto name_len = std::strlen(name);
+  if (!name_len) {
+    return "empty cluster name";
+  }
+  if (name_len + reserved >= cluster_name_.size()) {
+    return "too long cluster name";
+  }
+  std::copy(name, name + name_len + 1, cluster_name_.begin());
+  std::replace_copy_if(name, name + name_len + 1, socket_name_.begin(),
+                       [](char c) { return c && !std::isalpha(c); }, '_');
+
+  std::strcpy(shmem_name_.data(), "/");
+  std::strcat(shmem_name_.data(), socket_name_.data());
+  std::strcat(shmem_name_.data(), "_kphp_shm");
+
+  std::strcpy(statsd_prefix_.data(), "kphp_stats.");
+  std::strcat(statsd_prefix_.data(), socket_name_.data());
+
+  std::strcat(socket_name_.data(), "_kphp_fd_transfer");
+  return nullptr;
+}

--- a/server/cluster-name.h
+++ b/server/cluster-name.h
@@ -1,0 +1,31 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <array>
+#include <climits>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+
+class ClusterName : vk::not_copyable {
+public:
+  const char *set_cluster_name(const char *cluster_name) noexcept;
+
+  const char *get_cluster_name() const noexcept { return cluster_name_.data(); }
+  const char *get_socket_name() const noexcept { return socket_name_.data(); }
+  const char *get_shmem_name() const noexcept { return shmem_name_.data(); }
+  const char *get_statsd_prefix() const noexcept { return statsd_prefix_.data(); }
+
+private:
+  ClusterName();
+
+  friend class vk::singleton<ClusterName>;
+
+  std::array<char, NAME_MAX> cluster_name_;
+  std::array<char, NAME_MAX> socket_name_;
+  std::array<char, NAME_MAX> shmem_name_;
+  std::array<char, NAME_MAX> statsd_prefix_;
+};

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -55,7 +55,6 @@ int sigterm_on = 0;
 int rpc_stopped = 0;
 
 /** master **/
-const char *cluster_name = "default";
 int master_port = -1;
 int master_sfd = -1;
 int master_sfd_inited = 0;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -65,7 +65,6 @@ extern int rpc_sfd;
 extern long long rpc_client_actor;
 
 /** master **/
-extern const char *cluster_name;
 extern int master_port;
 extern int master_sfd;
 extern int master_sfd_inited;

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -57,6 +57,7 @@
 #include "runtime/profiler.h"
 #include "runtime/job-workers/shared-memory-manager.h"
 #include "runtime/rpc.h"
+#include "server/cluster-name.h"
 #include "server/confdata-binlog-replay.h"
 #include "server/job-workers/job-worker-client.h"
 #include "server/job-workers/job-worker-server.h"
@@ -1892,7 +1893,10 @@ int main_args_handler(int i) {
       return 0;
     }
     case 's': {
-      cluster_name = optarg;
+      if (const char *err = vk::singleton<ClusterName>::get().set_cluster_name(optarg)) {
+        kprintf("-s option: %s\n", err);
+        return -1;
+      }
       return 0;
     }
     case 't': {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1535,63 +1535,63 @@ private:
 
 STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
   if (engine_tag) {
-    add_histogram_stat_long(stats, "kphp_version", atoll(engine_tag));
+    add_gauge_stat_long(stats, "kphp_version", atoll(engine_tag));
   }
 
-  add_histogram_stat_long(stats, "uptime", get_uptime());
+  add_gauge_stat_long(stats, "uptime", get_uptime());
 
   const auto worker_stats = WorkerStats::collect();
-  add_histogram_stat_long(stats, "workers.current.total", worker_stats.total_workers_n);
-  add_histogram_stat_long(stats, "workers.current.working", worker_stats.running_workers_n);
-  add_histogram_stat_long(stats, "workers.current.working_but_waiting", worker_stats.paused_workers_n);
-  add_histogram_stat_long(stats, "workers.current.ready_for_accept", worker_stats.ready_for_accept_workers_n);
+  add_gauge_stat_long(stats, "workers.current.total", worker_stats.total_workers_n);
+  add_gauge_stat_long(stats, "workers.current.working", worker_stats.running_workers_n);
+  add_gauge_stat_long(stats, "workers.current.working_but_waiting", worker_stats.paused_workers_n);
+  add_gauge_stat_long(stats, "workers.current.ready_for_accept", worker_stats.ready_for_accept_workers_n);
 
-  add_histogram_stat_long(stats, "workers.total.started", tot_workers_started);
-  add_histogram_stat_long(stats, "workers.total.dead", tot_workers_dead);
-  add_histogram_stat_long(stats, "workers.total.strange_dead", tot_workers_strange_dead);
-  add_histogram_stat_long(stats, "workers.total.killed", workers_killed);
-  add_histogram_stat_long(stats, "workers.total.hung", workers_hung);
-  add_histogram_stat_long(stats, "workers.total.terminated", workers_terminated);
-  add_histogram_stat_long(stats, "workers.total.failed", workers_failed);
+  add_gauge_stat_long(stats, "workers.total.started", tot_workers_started);
+  add_gauge_stat_long(stats, "workers.total.dead", tot_workers_dead);
+  add_gauge_stat_long(stats, "workers.total.strange_dead", tot_workers_strange_dead);
+  add_gauge_stat_long(stats, "workers.total.killed", workers_killed);
+  add_gauge_stat_long(stats, "workers.total.hung", workers_hung);
+  add_gauge_stat_long(stats, "workers.total.terminated", workers_terminated);
+  add_gauge_stat_long(stats, "workers.total.failed", workers_failed);
 
   const auto workers_stats = server_stats.misc[1].get_stat();
-  add_histogram_stat_double(stats, "workers.running.avg_1m", workers_stats.running_workers_avg);
-  add_histogram_stat_long(stats, "workers.running.max_1m", workers_stats.running_workers_max);
+  add_gauge_stat_double(stats, "workers.running.avg_1m", workers_stats.running_workers_avg);
+  add_gauge_stat_long(stats, "workers.running.max_1m", workers_stats.running_workers_max);
 
   const auto cpu_stats = server_stats.cpu[1].get_stat();
-  add_histogram_stat_double(stats, "cpu.stime", cpu_stats.cpu_s_usage);
-  add_histogram_stat_double(stats, "cpu.utime", cpu_stats.cpu_u_usage);
+  add_gauge_stat_double(stats, "cpu.stime", cpu_stats.cpu_s_usage);
+  add_gauge_stat_double(stats, "cpu.utime", cpu_stats.cpu_u_usage);
 
   instance_cache_get_memory_stats().write_stats_to(stats, "instance_cache");
-  add_histogram_stat_long(stats, "instance_cache.memory.buffer_swaps_ok", instance_cache_memory_swaps_ok);
-  add_histogram_stat_long(stats, "instance_cache.memory.buffer_swaps_fail", instance_cache_memory_swaps_fail);
+  add_gauge_stat_long(stats, "instance_cache.memory.buffer_swaps_ok", instance_cache_memory_swaps_ok);
+  add_gauge_stat_long(stats, "instance_cache.memory.buffer_swaps_fail", instance_cache_memory_swaps_fail);
 
   const auto &instance_cache_element_stats = instance_cache_get_stats();
-  add_histogram_stat_long(stats, "instance_cache.elements.stored",
+  add_gauge_stat_long(stats, "instance_cache.elements.stored",
                           instance_cache_element_stats.elements_stored.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.stored_with_delay",
+  add_gauge_stat_long(stats, "instance_cache.elements.stored_with_delay",
                           instance_cache_element_stats.elements_stored_with_delay.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.storing_skipped_due_recent_update",
+  add_gauge_stat_long(stats, "instance_cache.elements.storing_skipped_due_recent_update",
                           instance_cache_element_stats.elements_storing_skipped_due_recent_update.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.storing_delayed_due_mutex",
+  add_gauge_stat_long(stats, "instance_cache.elements.storing_delayed_due_mutex",
                           instance_cache_element_stats.elements_storing_delayed_due_mutex.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.fetched",
+  add_gauge_stat_long(stats, "instance_cache.elements.fetched",
                           instance_cache_element_stats.elements_fetched.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.missed",
+  add_gauge_stat_long(stats, "instance_cache.elements.missed",
                           instance_cache_element_stats.elements_missed.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.missed_earlier",
+  add_gauge_stat_long(stats, "instance_cache.elements.missed_earlier",
                           instance_cache_element_stats.elements_missed_earlier.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.expired",
+  add_gauge_stat_long(stats, "instance_cache.elements.expired",
                           instance_cache_element_stats.elements_expired.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.created",
+  add_gauge_stat_long(stats, "instance_cache.elements.created",
                           instance_cache_element_stats.elements_created.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.destroyed",
+  add_gauge_stat_long(stats, "instance_cache.elements.destroyed",
                           instance_cache_element_stats.elements_destroyed.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.cached",
+  add_gauge_stat_long(stats, "instance_cache.elements.cached",
                           instance_cache_element_stats.elements_cached.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.logically_expired_and_ignored",
+  add_gauge_stat_long(stats, "instance_cache.elements.logically_expired_and_ignored",
                           instance_cache_element_stats.elements_logically_expired_and_ignored.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "instance_cache.elements.logically_expired_but_fetched",
+  add_gauge_stat_long(stats, "instance_cache.elements.logically_expired_but_fetched",
                           instance_cache_element_stats.elements_logically_expired_but_fetched.load(std::memory_order_relaxed));
 
   write_confdata_stats_to(stats);
@@ -1600,29 +1600,29 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
 
   static QPSCalculator qps_calculator{FULL_STATS_PERIOD * 2};
   qps_calculator.update(my_now, server_stats.worker_stats);
-  add_histogram_stat_double(stats, "requests.incoming_queries_per_second", qps_calculator.get_incoming_qps());
-  add_histogram_stat_double(stats, "requests.outgoing_queries_per_second", qps_calculator.get_outgoing_qps());
+  add_gauge_stat_double(stats, "requests.incoming_queries_per_second", qps_calculator.get_incoming_qps());
+  add_gauge_stat_double(stats, "requests.outgoing_queries_per_second", qps_calculator.get_outgoing_qps());
 
-  add_histogram_stat_long(stats, "graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
-  add_histogram_stat_long(stats, "graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());
+  add_gauge_stat_long(stats, "graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
+  add_gauge_stat_long(stats, "graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());
 
   const auto &job_workers_stats = job_workers::JobStats::get();
-  add_histogram_stat_long(stats, "job_workers.job_queue_size", job_workers_stats.job_queue_size.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.currently_memory_slices_used", job_workers_stats.currently_memory_slices_used.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.max_shared_memory_slices_count", vk::singleton<job_workers::SharedMemoryManager>::get().get_total_slices_count());
-  add_histogram_stat_long(stats, "job_workers.jobs_sent", job_workers_stats.jobs_sent.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.jobs_replied", job_workers_stats.jobs_replied.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.job_queue_size", job_workers_stats.job_queue_size.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.currently_memory_slices_used", job_workers_stats.currently_memory_slices_used.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.max_shared_memory_slices_count", vk::singleton<job_workers::SharedMemoryManager>::get().get_total_slices_count());
+  add_gauge_stat_long(stats, "job_workers.jobs_sent", job_workers_stats.jobs_sent.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.jobs_replied", job_workers_stats.jobs_replied.load(std::memory_order_relaxed));
 
-  add_histogram_stat_long(stats, "job_workers.errors_pipe_server_write", job_workers_stats.errors_pipe_server_write.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.errors_pipe_server_read", job_workers_stats.errors_pipe_server_read.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.errors_pipe_client_write", job_workers_stats.errors_pipe_client_write.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.errors_pipe_client_read", job_workers_stats.errors_pipe_client_read.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.errors_pipe_server_write", job_workers_stats.errors_pipe_server_write.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.errors_pipe_server_read", job_workers_stats.errors_pipe_server_read.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.errors_pipe_client_write", job_workers_stats.errors_pipe_client_write.load(std::memory_order_relaxed));
+  add_gauge_stat_long(stats, "job_workers.errors_pipe_client_read", job_workers_stats.errors_pipe_client_read.load(std::memory_order_relaxed));
 
-  add_histogram_stat_long(stats, "job_workers.job_worker_skip_job_due_another_is_running",
+  add_gauge_stat_long(stats, "job_workers.job_worker_skip_job_due_another_is_running",
                           job_workers_stats.job_worker_skip_job_due_another_is_running.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.job_worker_skip_job_due_overload",
+  add_gauge_stat_long(stats, "job_workers.job_worker_skip_job_due_overload",
                           job_workers_stats.job_worker_skip_job_due_overload.load(std::memory_order_relaxed));
-  add_histogram_stat_long(stats, "job_workers.job_worker_skip_job_due_steal",
+  add_gauge_stat_long(stats, "job_workers.job_worker_skip_job_due_steal",
                           job_workers_stats.job_worker_skip_job_due_steal.load(std::memory_order_relaxed));
 
   update_mem_stats();
@@ -1639,9 +1639,9 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, STATS_TAG_KPHP_SERVER) {
     }
   }
 
-  add_histogram_stat_long(stats, "memory.vms_max", max_vms * 1024);
-  add_histogram_stat_long(stats, "memory.rss_max", max_rss * 1024);
-  add_histogram_stat_long(stats, "memory.shared_max", max_shared * 1024);
+  add_gauge_stat_long(stats, "memory.vms_max", max_vms * 1024);
+  add_gauge_stat_long(stats, "memory.rss_max", max_rss * 1024);
+  add_gauge_stat_long(stats, "memory.shared_max", max_shared * 1024);
 }
 
 int php_master_http_execute(struct connection *c, int op) {

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -1,4 +1,5 @@
 prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
+        cluster-name.cpp
         confdata-binlog-replay.cpp
         confdata-stats.cpp
         json-logger.cpp

--- a/tests/cpp/server/cluster-name-test.cpp
+++ b/tests/cpp/server/cluster-name-test.cpp
@@ -1,0 +1,52 @@
+#include <gtest/gtest.h>
+
+#include "server/cluster-name.h"
+
+TEST(cluster_name_test, test_usage) {
+  ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("kphp_engine"), nullptr);
+
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "kphp_engine");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_engine_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/kphp_engine_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.kphp_engine");
+}
+
+TEST(cluster_name_test, test_long_name) {
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
+
+  const std::string long_cluster_name = "kphp" + std::string(250, '_') + "_engine";
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(long_cluster_name.c_str()), "too long cluster name");
+
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
+}
+
+TEST(cluster_name_test, test_empty_name) {
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
+
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(""), "empty cluster name");
+
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
+}
+
+TEST(cluster_name_test, test_special_chars) {
+  ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("a-b1c*d/e+f~g<h?i"), nullptr);
+
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "a-b1c*d/e+f~g<h?i");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "a_b_c_d_e_f_g_h_i_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/a_b_c_d_e_f_g_h_i_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.a_b_c_d_e_f_g_h_i");
+}

--- a/tests/cpp/server/server-tests.cmake
+++ b/tests/cpp/server/server-tests.cmake
@@ -1,4 +1,5 @@
 prepend(SERVER_TESTS_SOURCES ${BASE_DIR}/tests/cpp/server/
+        cluster-name-test.cpp
         confdata-binlog-events-test.cpp
         php-engine-test.cpp)
 

--- a/tests/python/lib/stats_receiver.py
+++ b/tests/python/lib/stats_receiver.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import signal
 import time
+import re
 
 import psutil
 
@@ -73,5 +74,6 @@ class StatsReceiver:
             return False
         if self._stats and len(self._stats) > len(new_stats):
             raise RuntimeError("Got inconsistent stats count: old={} new={}".format(len(self._stats), len(new_stats)))
-        self._stats = new_stats
+        # HACK: replace prefix for kphp server stats
+        self._stats = {re.sub("^kphp_stats\\..+\\.", "kphp_server.", k): v for k, v in new_stats.items()}
         return True


### PR DESCRIPTION
Hi!
This patch replaces stats histogram -> gauge, so they look more stable in grafana.

UPDATE:
I've also enabled an ability to use cluster name as prefix for stats: it's useful, because it allows to split stats from several kphp servers on one host.