### PR TITLE
Implement zstd api.

### DIFF
--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -14,7 +14,7 @@ RUN apt-get update && \
       python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
       libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
-    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist && \
+    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist zstandard && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.focal
+++ b/.github/workflows/Dockerfile.focal
@@ -11,7 +11,7 @@ RUN apt-get update && \
       python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
       libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev && \
-    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist && \
+    pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist zstandard && \
     rm -rf /var/lib/apt/lists/*
 
 RUN useradd -ms /bin/bash kitten

--- a/common/smart_ptrs/unique_ptr_with_delete_function.h
+++ b/common/smart_ptrs/unique_ptr_with_delete_function.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdlib>
 #include <memory>
 
 namespace vk {

--- a/functions.txt
+++ b/functions.txt
@@ -1353,3 +1353,9 @@ function kphp_job_worker_fetch_request() ::: KphpJobWorkerRequest;
 function kphp_job_worker_store_response(KphpJobWorkerResponse $response) ::: void;
 
 function is_kphp_job_workers_enabled() ::: bool;
+
+// zstd api
+function zstd_compress(string $data, int $level = 3) ::: string | false;
+function zstd_uncompress(string $data) ::: string | false;
+function zstd_compress_dict(string $data, string $dict) ::: string | false;
+function zstd_uncompress_dict(string $data, string $dict) ::: string | false;

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -65,7 +65,8 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         url.cpp
         vkext.cpp
         vkext_stats.cpp
-        zlib.cpp)
+        zlib.cpp
+        zstd.cpp)
 
 set_source_files_properties(
         ${BASE_DIR}/server/php-runner.cpp

--- a/runtime/zstd.cpp
+++ b/runtime/zstd.cpp
@@ -1,0 +1,158 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#define ZSTD_STATIC_LINKING_ONLY
+
+#include <zstd.h>
+
+#include "common/smart_ptrs/unique_ptr_with_delete_function.h"
+
+#include "runtime/string_functions.h"
+
+#include "runtime/zstd.h"
+
+namespace {
+
+static_assert(2 * ZSTD_BLOCKSIZE_MAX < PHP_BUF_LEN, "double block size is expected to be less then buffer size");
+
+ZSTD_customMem make_custom_alloc() noexcept {
+  return ZSTD_customMem{
+    [](void *, size_t size) { return dl::script_allocator_malloc(size); },
+    [](void *, void *address) { dl::script_allocator_free(address); },
+    nullptr
+  };
+}
+
+template<class T, size_t (*Deleter)(T *)>
+void free_ctx_wrapper(T *ptr) { Deleter(ptr); }
+
+using ZSTD_CCtxPtr = vk::unique_ptr_with_delete_function<ZSTD_CStream, free_ctx_wrapper<ZSTD_CCtx, ZSTD_freeCCtx>>;
+using ZSTD_DCtxPtr = vk::unique_ptr_with_delete_function<ZSTD_DCtx, free_ctx_wrapper<ZSTD_DCtx, ZSTD_freeDCtx>>;
+
+Optional<string> zstd_compress_impl(const string &data, int64_t level = DEFAULT_COMPRESS_LEVEL, const string &dict = string{}) noexcept {
+  ZSTD_CCtxPtr ctx{ZSTD_createCCtx_advanced(make_custom_alloc())};
+  if (!ctx) {
+    php_warning("zstd_compress: can not create context");
+    return false;
+  }
+
+  size_t result = ZSTD_CCtx_setParameter(ctx.get(), ZSTD_c_compressionLevel, static_cast<int>(level));
+  if (ZSTD_isError(result)) {
+    php_warning("zstd_compress: can not init context: %s", ZSTD_getErrorName(result));
+    return false;
+  }
+
+  result = ZSTD_CCtx_loadDictionary_byReference(ctx.get(), dict.c_str(), dict.size());
+  if (ZSTD_isError(result)) {
+    php_warning("zstd_compress: can not load dict: %s", ZSTD_getErrorName(result));
+    return false;
+  }
+
+  php_assert(ZSTD_CStreamOutSize() <= PHP_BUF_LEN);
+  ZSTD_outBuffer out{php_buf, PHP_BUF_LEN, 0};
+  ZSTD_inBuffer in{data.c_str(), data.size(), 0};
+
+  string encoded_string;
+  do {
+    result = ZSTD_compressStream2(ctx.get(), &out, &in, ZSTD_e_end);
+    if (ZSTD_isError(result)) {
+      php_warning("zstd_compress: got zstd stream compression error: %s", ZSTD_getErrorName(result));
+      return false;
+    }
+    encoded_string.append(static_cast<char *>(out.dst), out.pos);
+    out.pos = 0;
+  } while (result);
+  return encoded_string;
+}
+
+Optional<string> zstd_uncompress_impl(const string &data, const string &dict = string{}) noexcept {
+  auto size = ZSTD_getFrameContentSize(data.c_str(), data.size());
+  if (size == ZSTD_CONTENTSIZE_ERROR) {
+    php_warning("zstd_uncompress: it was not compressed by zstd");
+    return false;
+  }
+
+  ZSTD_DCtxPtr ctx{ZSTD_createDCtx_advanced(make_custom_alloc())};
+  if (!ctx) {
+    php_warning("zstd_uncompress: can not create context");
+    return false;
+  }
+
+  size_t result = ZSTD_DCtx_loadDictionary_byReference(ctx.get(), dict.c_str(), dict.size());
+  if (ZSTD_isError(result)) {
+    php_warning("zstd_uncompress: can not load dict: %s", ZSTD_getErrorName(result));
+    return false;
+  }
+
+  if (size != ZSTD_CONTENTSIZE_UNKNOWN) {
+    if (size > string::max_size()) {
+      php_warning("zstd_uncompress: trying to uncompress too large data");
+      return false;
+    }
+    string decompressed{static_cast<string::size_type>(size), false};
+    result = ZSTD_decompressDCtx(ctx.get(), decompressed.buffer(), size, data.c_str(), data.size());
+    if (ZSTD_isError(result)) {
+      php_warning("zstd_uncompress: got zstd error: %s", ZSTD_getErrorName(result));
+      return false;
+    }
+    return decompressed;
+  }
+
+  if (ZSTD_isError(result)) {
+    php_warning("zstd_uncompress: can not init stream: %s", ZSTD_getErrorName(result));
+    return false;
+  }
+
+  php_assert(ZSTD_DStreamOutSize() <= PHP_BUF_LEN);
+  ZSTD_inBuffer in{data.c_str(), data.size(), 0};
+  ZSTD_outBuffer out{php_buf, PHP_BUF_LEN, 0};
+
+  string decoded_string;
+  while (in.pos < in.size) {
+    if (out.pos == out.size) {
+      decoded_string.append(static_cast<char *>(out.dst), static_cast<string::size_type>(out.pos));
+      out.pos = 0;
+    }
+
+    result = ZSTD_decompressStream(ctx.get(), &out, &in);
+    if (ZSTD_isError(result)) {
+      php_warning("zstd_uncompress: can not decompress stream: %s", ZSTD_getErrorName(result));
+      return false;
+    }
+    if (result == 0) {
+      break;
+    }
+  }
+  decoded_string.append(static_cast<char *>(out.dst), static_cast<string::size_type>(out.pos));
+  return decoded_string;
+}
+
+} // namespace
+
+Optional<string> f$zstd_compress(const string &data, int64_t level) noexcept {
+  if (!level) {
+    return data;
+  }
+
+  const int min_level = ZSTD_minCLevel();
+  const int max_level = ZSTD_maxCLevel();
+  if (min_level > level || level > max_level) {
+    php_warning("zstd_compress: compression level (%" PRIi64 ") must be within %d..%d or equal to 0", level, min_level, max_level);
+    return false;
+  }
+
+  return zstd_compress_impl(data, level);
+}
+
+Optional<string> f$zstd_uncompress(const string &data) noexcept {
+  return zstd_uncompress_impl(data);
+}
+
+Optional<string> f$zstd_compress_dict(const string &data, const string &dict) noexcept {
+  return zstd_compress_impl(data, DEFAULT_COMPRESS_LEVEL, dict);
+}
+
+Optional<string> f$zstd_uncompress_dict(const string &data, const string &dict) noexcept {
+  return zstd_uncompress_impl(data, dict);
+}

--- a/runtime/zstd.h
+++ b/runtime/zstd.h
@@ -1,0 +1,18 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/kphp_core.h"
+#include "runtime/optional.h"
+
+constexpr int DEFAULT_COMPRESS_LEVEL = 3;
+
+Optional<string> f$zstd_compress(const string &data, int64_t level = DEFAULT_COMPRESS_LEVEL) noexcept;
+
+Optional<string> f$zstd_uncompress(const string &data) noexcept;
+
+Optional<string> f$zstd_compress_dict(const string &data, const string &dict) noexcept;
+
+Optional<string> f$zstd_uncompress_dict(const string &data, const string &dict) noexcept;

--- a/tests/cpp/runtime/runtime-tests.cmake
+++ b/tests/cpp/runtime/runtime-tests.cmake
@@ -12,7 +12,8 @@ prepend(RUNTIME_TESTS_SOURCES ${BASE_DIR}/tests/cpp/runtime/
         memory_resource/details/memory_chunk_tree-test.cpp
         memory_resource/details/memory_ordered_chunk_list-test.cpp
         memory_resource/unsynchronized_pool_resource-test.cpp
-        string-test.cpp)
+        string-test.cpp
+        zstd-test.cpp)
 
 allow_deprecated_declarations_for_apple(${BASE_DIR}/tests/cpp/runtime/inter-process-mutex-test.cpp)
 vk_add_unittest(runtime "${RUNTIME_LIBS};${RUNTIME_LINK_TEST_LIBS}" ${RUNTIME_TESTS_SOURCES})

--- a/tests/cpp/runtime/zstd-test.cpp
+++ b/tests/cpp/runtime/zstd-test.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+
+#include <zstd.h>
+
+#include "runtime/string_functions.h"
+
+TEST(zstd_test, test_bounds) {
+  ASSERT_LE(ZSTD_CStreamOutSize(), PHP_BUF_LEN);
+  ASSERT_LE(ZSTD_CStreamInSize(), PHP_BUF_LEN);
+
+  ASSERT_LE(ZSTD_DStreamOutSize(), PHP_BUF_LEN);
+  ASSERT_LE(ZSTD_DStreamInSize(), PHP_BUF_LEN);
+}

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -92,6 +92,7 @@ class KphpRunOnceRunner(KphpBuilder):
             ("extension", "curl.so"),
             ("extension", "tokenizer.so"),
             ("extension", "h3.so"),
+            ("extension", "zstd.so"),
             ("extension", vkext_so)
         ]
         return php_bin, extensions

--- a/tests/phpt/zstd/1_compress.php
+++ b/tests/phpt/zstd/1_compress.php
@@ -1,0 +1,19 @@
+@ok
+<?php
+
+function test_compress_levels() {
+  var_dump(zstd_compress("foo bar baz", 23));
+
+  for ($i = -100; $i < 23; ++$i) {
+    echo "Level $i: ", base64_encode(zstd_compress(str_repeat("foo bar baz", 1000), $i)), "\n";
+  }
+}
+
+function test_compress_dict() {
+  var_dump(zstd_compress_dict("foo bar baz", ""));
+  var_dump(zstd_compress_dict("foo bar baz", "foo"));
+  var_dump(zstd_compress_dict("foo bar baz", "foo bar baz"));
+}
+
+test_compress_levels();
+test_compress_dict();

--- a/tests/phpt/zstd/2_uncompress.php
+++ b/tests/phpt/zstd/2_uncompress.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+function test_uncompress() {
+  var_dump(zstd_uncompress("foo bar baz"));
+}
+
+function test_uncompress_dict() {
+  var_dump(zstd_uncompress_dict("foo bar baz", ""));
+  var_dump(zstd_uncompress_dict("foo bar baz", "foo"));
+  var_dump(zstd_uncompress_dict("foo bar baz", "foo bar baz"));
+}
+
+test_uncompress();
+test_uncompress_dict();

--- a/tests/phpt/zstd/3_compress_uncompress.php
+++ b/tests/phpt/zstd/3_compress_uncompress.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+function test_compress_uncompress() {
+  var_dump(zstd_uncompress((string)zstd_compress("foo bar baz")));
+
+  var_dump(zstd_uncompress((string)zstd_compress(str_repeat("foo bar baz", 10000))));
+
+  $random_data = (string)openssl_random_pseudo_bytes(1024*1024*20);
+  assert_true(zstd_uncompress((string)zstd_compress($random_data)) === $random_data);
+}
+
+
+test_compress_uncompress();

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -19,6 +19,22 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
   echo "after sleep";
 } else if ($_SERVER["PHP_SELF"] === "/store-in-instance-cache") {
   echo instance_cache_store("test_key" . rand(), new A);
+} else if ($_SERVER["PHP_SELF"] === "/test_zstd") {
+  $res = "";
+  switch($_GET["type"]) {
+    case "uncompress":
+      $res = zstd_uncompress((string)file_get_contents("in.dat")); break;
+    case "uncompress_dict":
+      $res = zstd_uncompress_dict((string)file_get_contents("in.dat"), (string)file_get_contents($_GET["dict"])); break;
+    case "compress":
+      $res = zstd_compress((string)file_get_contents("in.dat"), (int)$_GET["level"]); break;
+    case "compress_dict":
+      $res = zstd_compress_dict((string)file_get_contents("in.dat"), (string)file_get_contents($_GET["dict"])); break;
+    default:
+      echo "ERROR"; return;
+  }
+  file_put_contents("out.dat", $res === false ? "false" : $res);
+  echo "OK";
 } else {
   echo "Hello world!";
 }

--- a/tests/python/tests/http_server/test_zstd.py
+++ b/tests/python/tests/http_server/test_zstd.py
@@ -1,0 +1,155 @@
+import zstandard
+import random
+import string
+import os
+import gzip
+
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestZstd(KphpServerAutoTestCase):
+    # size of this string is 460
+    some_string = """
+        KPHP is a PHP compiler. It compiles a limited subset of PHP to a native binary running faster than PHP.
+        KPHP takes your PHP source code and converts it to a C++ equivalent, 
+        then compiles the generated C++ code and runs it within an embedded HTTP server. 
+        You could call KPHP a transpiler, but we call it a compiler.
+        KPHP is not JIT-oriented: all types are inferred at compile time. It has no “slow startup” phase.
+    """.encode()
+
+    @classmethod
+    def _make_name(cls, file_name):
+        return os.path.join(cls.kphp_server_working_dir, file_name)
+
+    @classmethod
+    def make_dict(cls, file_name, samples):
+        train_set = [samples[i % len(samples)] for i in range(512)]
+        d = zstandard.train_dictionary(1024 * 1024, train_set)
+        with open(cls._make_name(file_name), 'wb') as f:
+            f.write(d.as_bytes())
+        return d
+
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--hard-memory-limit": "350m"
+        })
+        cls.dict = cls.make_dict("dict", (cls.some_string, b"is", b"PHP", b"KPHP", b"call"))
+        cls.dict_other = cls.make_dict("dict.other", (b"ab " * 10, b"foo " * 100, b"bar " * 1000, b"baz " * 100))
+        cls.dict_bad = b"foo bar baz"
+        with open(cls._make_name("dict.bad"), 'wb') as f:
+            f.write(cls.dict_bad)
+        cls.huge_random_string = ''.join(random.choice(string.ascii_letters) for _ in range(1024 * 1024 * 17)).encode()
+        cls.examples = (
+            (b"hello world", zstandard.MAX_COMPRESSION_LEVEL + 1, 1),
+            (cls.some_string, zstandard.MAX_COMPRESSION_LEVEL + 1, 1),
+            (cls.some_string * 100000, 15, 3),
+            (cls.huge_random_string, 15, 4)
+        )
+
+    @classmethod
+    def extra_class_teardown(cls):
+        for f in ("dict", "dict.other", "dict.bad", "in.dat", "out.dat"):
+            try:
+                os.unlink(cls._make_name(f))
+            except:
+                pass
+
+    def _call_php(self, test_type, expected_code=200, expected_msg="OK", level=0, dictionary="dict"):
+        resp = self.kphp_server.http_get("/test_zstd?type={}&level={}&dict={}".format(test_type, level, dictionary))
+        self.assertEqual(resp.status_code, expected_code)
+        self.assertEqual(resp.text, expected_msg)
+
+    def _write_in_file(self, body):
+        with open(self._make_name("in.dat"), 'wb') as f:
+            f.write(body)
+
+    def _read_out_file(self):
+        with open(self._make_name("out.dat"), 'rb') as f:
+            return f.read()
+
+    def test_uncompress(self):
+        for s, max_level, step in self.examples:
+            for i in range(1, max(2, max_level), step):
+                cxt = zstandard.ZstdCompressor(level=i)
+                self._write_in_file(cxt.compress(s))
+                self._call_php("uncompress")
+                self.assertEqual(self._read_out_file(), s)
+
+    def test_uncompress_data_compressed_by_other_algo(self):
+        self._write_in_file(gzip.compress(self.some_string))
+        self._call_php("uncompress")
+        self.kphp_server.assert_log(["Warning: zstd_uncompress: it was not compressed by zstd"])
+        self.assertEqual(self._read_out_file(), b"false")
+
+    def test_uncompress_non_compressed_data(self):
+        self._write_in_file(self.some_string)
+        self._call_php("uncompress")
+        self.kphp_server.assert_log(["Warning: zstd_uncompress: it was not compressed by zstd"])
+        self.assertEqual(self._read_out_file(), b"false")
+
+    def test_uncompress_compressed_data_with_dict(self):
+        ctx = zstandard.ZstdCompressor(dict_data=self.dict)
+        self._write_in_file(ctx.compress(self.some_string))
+        self._call_php("uncompress")
+        self.kphp_server.assert_log(["Warning: zstd_uncompress: got zstd error: Dictionary mismatch"])
+        self.assertEqual(self._read_out_file(), b"false")
+
+    def test_compress(self):
+        ctx = zstandard.ZstdDecompressor()
+        for s, max_level, step in self.examples:
+            for i in range(1, max(2, max_level), step):
+                self._write_in_file(s)
+                self._call_php("compress", level=i)
+                self.assertEqual(ctx.decompress(self._read_out_file()), s)
+
+    def test_compress_oom(self):
+        self._write_in_file(self.huge_random_string)
+        self._call_php("compress", 500, "ERROR", zstandard.MAX_COMPRESSION_LEVEL)
+        self.kphp_server.assert_log([
+            "Warning: Can't allocate \\d+ bytes",
+            "Critical error during script execution: memory limit exit"
+        ])
+
+    def test_compress_bad_level(self):
+        self._write_in_file(self.some_string)
+        bad_level = zstandard.MAX_COMPRESSION_LEVEL+1
+        self._call_php("compress", level=bad_level)
+        self.kphp_server.assert_log([
+            "zstd_compress: compression level \\({}\\) must be within -\\d*..22 or equal to 0".format(bad_level),
+        ])
+        self.assertEqual(self._read_out_file(), b"false")
+
+    def test_uncompress_dict(self):
+        for s, max_level, step in self.examples:
+            for i in range(1, max(2, max_level), step):
+                ctx = zstandard.ZstdCompressor(dict_data=self.dict, level=i)
+                self._write_in_file(ctx.compress(s))
+                self._call_php("uncompress_dict")
+                self.assertEqual(self._read_out_file(), s)
+
+    def test_uncompress_dict_compressed_with_other_dict(self):
+        ctx = zstandard.ZstdCompressor(dict_data=self.dict_other)
+        self._write_in_file(ctx.compress(self.some_string))
+        self._call_php("uncompress_dict")
+        self.kphp_server.assert_log(["Warning: zstd_uncompress: got zstd error: Dictionary mismatch"])
+        self.assertEqual(self._read_out_file(), b"false")
+
+    def test_uncompress_dict_compressed_without_dict(self):
+        ctx = zstandard.ZstdCompressor()
+        self._write_in_file(ctx.compress(self.some_string))
+        self._call_php("uncompress_dict")
+        self.assertEqual(self._read_out_file(), self.some_string)
+
+    def test_compress_dict(self):
+        ctx = zstandard.ZstdDecompressor(dict_data=self.dict)
+        for s, _, _ in self.examples:
+            self._write_in_file(s)
+            self._call_php("compress_dict")
+            self.assertEqual(ctx.decompress(self._read_out_file()), s)
+
+    def test_compress_bad_dict(self):
+        ctx = zstandard.ZstdDecompressor()
+        self._write_in_file(self.some_string)
+        self._call_php("compress_dict", dictionary="dict.bad")
+        self.assertEqual(ctx.decompress(self._read_out_file()), self.some_string)


### PR DESCRIPTION
This patch adds basic zstd functions for KPHP:

```php
function zstd_compress(string $data, int $level = 3) : string|false;
function zstd_uncompress(string $data) : string | false;
function zstd_compress_dict(string $data, string $dict) : string | false;
function zstd_uncompress_dict(string $data, string $dict) : string | false;
```

They have the same meaning as the functions from the PHP binding https://github.com/kjdev/php-ext-zstd