### PR TITLE
implement type hints compatibility checks for methods implementation

### DIFF
--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -113,6 +113,7 @@ prepend(KPHP_COMPILER_PIPES_SOURCES pipes/
         check-function-calls.cpp
         check-modifications-of-const-vars.cpp
         check-nested-foreach.cpp
+        check-type-hint-variance.cpp
         check-tl-classes.cpp
         check-ub.cpp
         clone-strange-const-params.cpp

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -40,6 +40,7 @@
 #include "compiler/pipes/calc-val-ref.h"
 #include "compiler/pipes/cfg-end.h"
 #include "compiler/pipes/cfg.h"
+#include "compiler/pipes/check-type-hint-variance.h"
 #include "compiler/pipes/check-abstract-function-defaults.h"
 #include "compiler/pipes/check-access-modifiers.h"
 #include "compiler/pipes/check-classes.h"
@@ -235,6 +236,7 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PipeC<SplitSwitchF>{}
     >> PipeC<CollectRequiredAndClassesF>{} >> use_nth_output_tag<0>{}
     >> SyncC<CheckRequires>{}
+    >> PipeC<CheckTypeHintVariance>{}
     >> PassC<CalcLocationsPass>{}
     >> PassC<ResolveSelfStaticParentPass>{}
     >> PassC<RegisterDefinesPass>{}

--- a/compiler/pipes/check-type-hint-variance.cpp
+++ b/compiler/pipes/check-type-hint-variance.cpp
@@ -1,0 +1,82 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/pipes/check-type-hint-variance.h"
+#include "compiler/data/class-data.h"
+#include "compiler/data/function-data.h"
+#include "compiler/type-hint.h"
+
+#include "common/containers/final_action.h"
+
+namespace {
+
+FunctionPtr get_derived_method(FunctionPtr base_function, ClassPtr derived_class) {
+  if (base_function->modifiers.is_static()) {
+    auto *member = derived_class->members.get_static_method(base_function->local_name());
+    return member ? member->function : FunctionPtr{};
+  }
+  auto *member = derived_class->members.get_instance_method(base_function->local_name());
+  return member ? member->function : FunctionPtr{};
+}
+
+} // namespace
+
+void CheckTypeHintVariance::execute(FunctionPtr f, DataStream<FunctionPtr> &os) {
+  stage::set_name("Child method signature check");
+  stage::set_function(f);
+  stage::set_line(f->root->get_location().line);
+
+  auto forward_function_next = vk::finally([&] { os << f; });
+
+  if (!f->class_id) {
+    return;
+  }
+  if (f->modifiers.is_final() || f->class_id->derived_classes.empty()) {
+    return;
+  }
+
+  // constructors don't follow the same variance rules;
+  // methods from functions.txt may use type hints like `mixed` that can't
+  // be expressed in PHP7.4, so we skip it for now
+  if (f->is_constructor() || f->is_extern()) {
+    return;
+  }
+
+  // for every non-final class method check that derived classes override
+  // it carefully, so PHP won't give a fatal error about mismatching typehints;
+  //
+  // we do an actual type checking in GenerateVirtualMethods pass
+
+  for (const auto &derived_class : f->class_id->derived_classes) {
+    const FunctionPtr derived_f = get_derived_method(f, derived_class);
+    if (!derived_f) {
+      continue;
+    }
+
+    // if a base method has a return type hint, derived method should have it too
+    kphp_error(!f->return_typehint || derived_f->return_typehint,
+               fmt_format("{}() should provide a return type hint compatible with {}()",
+                          derived_f->get_human_readable_name(),
+                          f->get_human_readable_name()));
+
+    // if base methods doesn't have a param type hint, derived method can't have it too
+    const auto &params = f->get_params();
+    const auto &derived_params = derived_f->get_params();
+    if (params.size() != derived_params.size()) {
+      continue;
+    }
+    int first_param = f->modifiers.is_static() ? 0 : 1;
+    for (int i = first_param; i < params.size(); ++i) {
+      auto p = params[i].as<op_func_param>();
+      auto derived_p = derived_params[i].as<op_func_param>();
+      if (!p->type_hint) {
+        kphp_error(!derived_p->type_hint,
+                   fmt_format("{}() should not have a ${} param type hint, it would be incompatible with {}()",
+                              derived_f->get_human_readable_name(),
+                              derived_p->var()->get_string(),
+                              f->get_human_readable_name()));
+      }
+    }
+  }
+}

--- a/compiler/pipes/check-type-hint-variance.h
+++ b/compiler/pipes/check-type-hint-variance.h
@@ -1,0 +1,26 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "compiler/data/data_ptr.h"
+#include "compiler/threading/data-stream.h"
+
+// CheckTypeHintVariance checks that type hints that were used in
+// child methods are compatible with PHP and would not lead to a fatal error.
+//
+// In KPHP, type information can be provided from both phpdocs and type hints;
+// in PHP we can only use type hints. KPHP checks the signature types compatibility
+// using the full type info (phpdoc + type hints) while PHP relies on type hints only.
+// This means that sometimes KPHP can allow omitting the type hint as the information
+// can be inferred from the phpdoc. That would be incompatible with PHP as you
+// would get a fatal error for such code. This pass checks that we have a high chance
+// of being compatible with PHP in terms of type hints placement, but it doesn't
+// perform an actual signature types comparison (it happens later in the pipeline).
+//
+// https://www.php.net/manual/en/language.oop5.variance.php
+class CheckTypeHintVariance {
+public:
+  void execute(FunctionPtr interface_function, DataStream<FunctionPtr> &os);
+};

--- a/tests/phpt/interfaces/019_with_static_interface_inheritance.php
+++ b/tests/phpt/interfaces/019_with_static_interface_inheritance.php
@@ -19,7 +19,7 @@ interface ITwo extends IOne {
   /**
    * @param int $x
    * @param int $y
-   * @return mixed
+   * @return int[]|int
    */
   public function two($x, $y);
 }
@@ -28,7 +28,7 @@ interface IThree extends IOne {
   /**
    * @param int $x
    * @param int $y
-   * @return mixed
+   * @return int|null
    */
   public function three($x, $y);
 }
@@ -44,10 +44,11 @@ class ImplTwo implements ITwo {
   /**
    * @param int $x
    * @param int $y
-   * @return void|mixed
+   * @return int[]
    */
   public function two($x, $y) {
     var_dump($x + $y);
+    return [1];
   }
 
   public static function static_one($x, $y) {
@@ -66,10 +67,11 @@ class ImplThree implements IThree {
   /**
    * @param int $x
    * @param int $y
-   * @return void|mixed
+   * @return int
    */
   public function three($x, $y) {
     var_dump($x + $y);
+    return 10;
   }
 
   /**

--- a/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic.php
@@ -1,0 +1,25 @@
+@ok php7_4
+<?php
+
+// Variadic params follow the same rules.
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract function f(B ...$params);
+  public abstract function g(int ...$params);
+}
+
+class Impl1 extends Base {
+  public function f(A ...$params) {}
+  public function g(?int ...$params) {}
+}
+
+class Impl2 extends Base {
+  public function f(B ...$params) {}
+  public function g(int ...$params) {}
+}
+
+/** @var Base[] $list */
+$list = [new Impl1(), new Impl2()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+class A {}
+
+abstract class Base {
+  public abstract function f(A ...$params);
+}
+
+class Impl extends Base {
+  public function f(A $params) {}
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error2.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+class A {}
+class B {}
+
+abstract class Base {
+  public abstract function f(B ...$params);
+}
+
+class Impl extends Base {
+  public function f(A ...$params) {}
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_param_variadic_error3.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+class A {}
+
+abstract class Base {
+  public abstract function f(A $params);
+}
+
+class Impl extends Base {
+  public function f(A ...$params) {}
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_return.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_return.php
@@ -1,0 +1,22 @@
+@ok
+<?php
+
+class Foo {}
+
+abstract class Base {
+  /** @return Foo[] */
+  public abstract function f();
+}
+
+class Impl1 extends Base {
+  /** @return Foo[] */
+  public function f(): array { return [new Foo()]; }
+}
+
+class Impl2 extends Base {
+  /** @return Foo[] */
+  public function f() { return [new Foo()]; }
+}
+
+/** @var Base[] $list */
+$list = [new Impl1(), new Impl2()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_return_derived.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_return_derived.php
@@ -1,0 +1,16 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract function f(): A;
+}
+
+class Impl extends Base {
+  public function f(): B { return new B(); }
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_return_error.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+class A {}
+class B {}
+
+abstract class Base {
+  public abstract function f(): A;
+}
+
+class Impl extends Base {
+  public function f(): B { return new B(); }
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_return_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_return_error2.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/Declaration of C::f\(\) must be compatible with B::f\(\)/
+<?php
+
+abstract class A {
+  abstract function f();
+}
+
+class B extends A {
+  function f(): int {}
+}
+
+class C extends B {
+  function f(): string {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/abstract_return_orfalse.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_return_orfalse.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class BaseClass {
+  /** @return string|false */
+  public function getGroupName() {
+    return false;
+  }
+}
+
+class DerivedClass extends BaseClass {
+  /** @return string */
+  public function getGroupName() { return 'foo'; }
+}
+
+$v = new DerivedClass();
+var_dump($v->getGroupName());

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_param.php
@@ -1,0 +1,17 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract static function f(B $x);
+}
+
+class Impl extends Base {
+  public static function f(A $x) {}
+}
+
+Impl::f(new A());
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+/Base parameter \$x type: B/
+/Impl parameter \$x type: int/
+<?php
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract static function f(B $x);
+}
+
+class Impl extends Base {
+  public static function f(int $x) {}
+}
+
+Impl::f(0);
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error2.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/Impl::f\(\) should not have a \$x param type hint, it would be incompatible with Base::f\(\)/
+<?php
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract static function f($x);
+}
+
+class Impl extends Base {
+  public static function f(int $x) {}
+}
+
+Impl::f(0);
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_param_error3.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/Impl::f\(\) should not have a \$p1 param type hint, it would be incompatible with Base::f\(\)/
+<?php
+
+class A {}
+class B extends A {}
+
+// Params $p1 and $p2 are swapped on purpose.
+
+abstract class Base {
+  public abstract static function f($p1, $p2);
+}
+
+class Impl extends Base {
+  public static function f($p2, int $p1) {}
+}
+
+Impl::f(0, 0);
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_return_derived.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_return_derived.php
@@ -1,0 +1,16 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+abstract class Base {
+  public abstract static function f(): A;
+}
+
+class Impl extends Base {
+  public static function f(): B { return new B(); }
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/abstract_static_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/abstract_static_return_error.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+class A {}
+class B {}
+
+abstract class Base {
+  public abstract static function f(): A;
+}
+
+class Impl extends Base {
+  public static function f(): B { return new B(); }
+}
+
+$_ = Impl::f();
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/any_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/any_param.php
@@ -1,0 +1,23 @@
+@ok
+<?php
+
+class Foo {}
+class Bar extends Foo {}
+
+abstract class A {
+  /** @param Bar $x */
+  public abstract function f($x);
+}
+
+class B extends A {
+  /** @param any $x */
+  public function f($x) {}
+}
+
+class C extends A {
+  /** @param Foo $x */
+  public function f($x) {}
+}
+
+/** @var A[] $list */
+$list = [new B(), new C()];

--- a/tests/phpt/interfaces/signature_compatibility/any_param_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/any_param_error.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of B::f\(\) must be compatible with A::f\(\)/
+<?php
+
+class Foo {}
+
+abstract class A {
+  /** @return any */
+  public abstract function f($x);
+}
+
+class B extends A {
+  /** @param int $x */
+  public function f($x) {}
+}
+
+$_ = new B();

--- a/tests/phpt/interfaces/signature_compatibility/any_return.php
+++ b/tests/phpt/interfaces/signature_compatibility/any_return.php
@@ -1,0 +1,27 @@
+@ok
+<?php
+
+class Foo {}
+
+abstract class A {
+  /** @return any */
+  public abstract function f();
+}
+
+class B extends A {
+  /** @return Foo */
+  public function f() { return new Foo(); }
+}
+
+class C extends A {
+  /** @return int */
+  public function f() { return 50; }
+}
+
+class D extends A {
+  /** @return int[] */
+  public function f() { return [1]; }
+}
+
+/** @var A[] $list */
+$list = [new B(), new C(), new D()];

--- a/tests/phpt/interfaces/signature_compatibility/any_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/any_return_error.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/Declaration of B::f\(\) must be compatible with A::f\(\)/
+<?php
+
+class Foo {}
+
+abstract class A {
+  /** @return Foo */
+  public abstract function f();
+}
+
+class B extends A {
+  /** @return any */
+  public function f() { return 10; }
+}

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_derived_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_derived_error.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+/Iface parameter \$x type: A/
+/Impl parameter \$x type: B/
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function f(A $x);
+}
+
+class Impl implements Iface {
+  public function f(B $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_identical.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_identical.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class A {}
+
+interface Iface {
+  public function f(A $x);
+  public function g(int $x);
+}
+
+class Impl implements Iface {
+  public function f(A $x) {}
+  public function g(int $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_no_type_hints.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_no_type_hints.php
@@ -1,0 +1,13 @@
+@ok
+<?php
+
+interface Iface {
+  public function f(int $x);
+}
+
+class Impl implements Iface {
+  public function f($x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_no_type_hints_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_no_type_hints_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Impl::f\(\) should not have a \$x param type hint, it would be incompatible with Iface::f\(\)/
+<?php
+
+interface Iface {
+  public function f($x);
+}
+
+class Impl implements Iface {
+  public function f(int $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class A {}
+
+interface Iface {
+  public function f(?int $x);
+  public function g(?A $x);
+}
+
+class Impl implements Iface {
+  public function f(?int $x) {}
+  public function g(?A $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable2.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class A {}
+
+interface Iface {
+  public function f(int $x);
+  public function g(A $x);
+}
+
+class Impl implements Iface {
+  public function f(?int $x) {}
+  public function g(?A $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+
+interface Iface {
+  public function f(?int $x);
+}
+
+class Impl implements Iface {
+  public function f(int $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error2.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+
+interface Iface {
+  public function f(?A $x);
+}
+
+class Impl implements Iface {
+  public function f(A $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error3.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function f(?A $x);
+}
+
+class Impl implements Iface {
+  public function f(?B $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error4.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_param_nullable_error4.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function f(?A $x);
+}
+
+class Impl implements Iface {
+  public function f(B $x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_derived.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_derived.php
@@ -1,0 +1,16 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function f(): A;
+}
+
+class Impl implements Iface {
+  public function f(): B { return new B(); }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_duplicate.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_duplicate.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+interface Iface1 {
+  public function foo(): int;
+}
+
+interface Iface2 extends Iface1 {
+  public function foo(): int;
+}
+
+class C implements Iface2 {
+  public function foo(): int { return 0; }
+}
+
+$c = new C();

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+interface Iface {
+  public function f($x) : int;
+}
+
+class Impl implements Iface {
+  public function f($x) : void {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_error2.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Impl::f\(\) should provide a return type hint compatible with Iface::f\(\)/
+<?php
+
+// If base method has a return type hint,
+// derived method should have it as well.
+
+interface Iface {
+  public function f($x) : int;
+}
+
+class Impl implements Iface {
+  public function f($x) {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_error3.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+// It's not allowed to mix unrelated classes.
+
+class A {}
+class B {}
+
+interface Iface {
+  public function f($x) : A;
+}
+
+class Impl implements Iface {
+  public function f($x) : B {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_error4.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_error4.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function f($x) : B;
+}
+
+class Impl implements Iface {
+  public function f($x) : A {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_error5.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_error5.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of B::f\(\) must be compatible with A::f\(\)/
+<?php
+
+interface I {
+  public function f();
+}
+
+class A implements I {
+  public function f(): int {} // compatible with I::f
+}
+
+class B extends A {
+  public function f(): string {} // compatible with I::f
+}
+

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_identical.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_identical.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class A {}
+
+interface Iface {
+  public function f() : array;
+  public function g() : A;
+}
+
+class Impl implements Iface {
+  public function f() : array { return 0; }
+  public function g() : A { return new A(); }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_no_type_hints.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_no_type_hints.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+// A sanity test that checks that empty signatures cause no havoc.
+
+interface Iface {
+  public function f();
+}
+
+class Impl implements Iface {
+  public function f() {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_no_type_hints2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_no_type_hints2.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+// It's allowed to add incompatible return type hints
+// if the base type method doesn't specify it.
+
+interface Iface {
+  public function f($x);
+}
+
+class Impl implements Iface {
+  public function f($x): void {}
+}
+
+class Impl2 implements Iface {
+  public function f($x): int { return 10; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl(), new Impl2()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+// PHP allows to override ?T return type as T.
+// But not the other way around.
+
+class A {}
+
+interface Iface {
+  public function f($x) : ?int;
+  public function g(): ?A;
+}
+
+class Impl implements Iface {
+  public function f($x) : int { return 0; }
+  public function g() : A { return new A(); }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable2.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class A {}
+
+interface Iface {
+  public function f($x) : ?int;
+  public function g(): ?A;
+}
+
+class Impl implements Iface {
+  public function f($x) : ?int { return null; }
+  public function g() : ?A { return null; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable3.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable3.php
@@ -1,0 +1,16 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function g(): ?A;
+}
+
+class Impl implements Iface {
+  public function g() : ?B { return null; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable4.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable4.php
@@ -1,0 +1,16 @@
+@ok php7_4
+<?php
+
+class A {}
+class B extends A {}
+
+interface Iface {
+  public function g(): ?A;
+}
+
+class Impl implements Iface {
+  public function g() : B { return new B(); }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+interface Iface {
+  public function f($x) : ?int;
+}
+
+class Impl implements Iface {
+  public function f($x) : string {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error2.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+class B {}
+
+interface Iface {
+  public function f($x) : ?A;
+}
+
+class Impl implements Iface {
+  public function f($x) : B {}
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error3.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+// PHP allows to override ?T return type as T.
+
+class A {}
+
+interface Iface {
+  public function f($x) : int;
+  public function g(): A;
+}
+
+class Impl implements Iface {
+  public function f($x) : ?int { return null; }
+  public function g() : ?A { return null; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error4.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error4.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+
+interface Iface {
+  public function f($x) : A;
+}
+
+class Impl implements Iface {
+  public function f($x) : ?A { return null; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error5.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error5.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of Foo::stringOrNull\(\) must be compatible with Iface::stringOrNull\(\)/
+<?php
+
+// In PHP, a standalone `null` type can't be used.
+
+interface Iface {
+  /** @return string|null */
+  public static function stringOrNull();
+}
+
+class Foo implements Iface {
+  public static function stringOrNull(): null { return null; }
+}
+
+$_ = new Foo();
+var_dump(Foo::stringOrNull());

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error6.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_nullable_error6.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+/Declaration of Foo::stringOrNull\(\) must be compatible with Iface::stringOrNull\(\)/
+<?php
+
+// In PHP, a standalone `null` type can't be used.
+
+interface Iface {
+  /** @return ?string */
+  public static function stringOrNull();
+}
+
+class Foo implements Iface {
+  /** @return null */
+  public static function stringOrNull() { return null; }
+}
+
+$_ = new Foo();
+var_dump(Foo::stringOrNull());

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_number.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_number.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+// Documentation tells that this code *should* compile,
+// but PHP7.2, PHP7.4 and PHP8.0 ignore this fact and fail to execute it;
+// we reject it at the compile time to be compatible
+
+interface Iface {
+  public function f($x) : int|float;
+}
+
+class Impl implements Iface {
+  public function f($x) : int { return 0; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_number_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_number_error.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+
+interface Iface {
+  public function f($x) : int;
+}
+
+class Impl implements Iface {
+  public function f($x) : float { return 0; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_number_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_number_error2.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Iface::f\(\)/
+<?php
+
+class A {}
+
+interface Iface {
+  public function f($x) : ?int;
+}
+
+class Impl implements Iface {
+  public function f($x) : ?float { return 0; }
+}
+
+/** @var Iface[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_orfalse.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_orfalse.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+interface Iface {
+  /** @return string|false */
+  public function get();
+}
+
+class Impl implements Iface {
+  /** @return string */
+  public function get() { return 'foo'; }
+}
+
+$v = new Impl();
+var_dump($v->get());

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_override_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_override_error.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of C::f\(\) must be compatible with Iface1::f\(\)/
+<?php
+
+interface Iface1 {
+  public function f(): int;
+}
+
+interface Iface2 extends Iface1 {
+  public function f(): string;
+}
+
+class C implements Iface2 {
+  public function f(): string { return 0; }
+}
+
+$c = new C();

--- a/tests/phpt/interfaces/signature_compatibility/mixed_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/mixed_param.php
@@ -1,0 +1,14 @@
+@ok
+<?php
+
+abstract class A {
+  /** @param mixed[]|mixed $x */
+  public abstract function f($x);
+}
+
+class B extends A {
+  /** @param mixed|mixed[] $x */
+  public function f($x) {}
+}
+
+$b = new B();

--- a/tests/phpt/interfaces/signature_compatibility/mixed_return.php
+++ b/tests/phpt/interfaces/signature_compatibility/mixed_return.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+// TODO: replace mixed phpdoc comment with a type hint in PHP8
+
+abstract class A {
+  /** @return mixed */
+  public abstract function f();
+}
+
+class B extends A {
+  public function f(): int {}
+}
+
+$b = new B();

--- a/tests/phpt/interfaces/signature_compatibility/mixed_return2.php
+++ b/tests/phpt/interfaces/signature_compatibility/mixed_return2.php
@@ -1,0 +1,24 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+class Foo {}
+
+abstract class A {
+  /** @return tuple(any, int) */
+  public abstract function f();
+}
+
+class B extends A {
+  /** @return tuple(Foo, int) */
+  public function f() { return tuple(new Foo(), 10); }
+}
+
+class C extends A {
+  /** @return tuple(string, int) */
+  public function f() { return tuple("abc", 20); }
+}
+
+$b = new B();
+$c = new C();

--- a/tests/phpt/interfaces/signature_compatibility/mixed_return3.php
+++ b/tests/phpt/interfaces/signature_compatibility/mixed_return3.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+abstract class A {
+  /** @return mixed|false */
+  public abstract function f();
+}
+
+class B extends A {
+  /** @return int|false */
+  public function f() { return false; }
+}
+
+class C extends A {
+  /** @return ?string|false */
+  public function f() { return null; }
+}
+
+$b = new B();
+$c = new C();

--- a/tests/phpt/interfaces/signature_compatibility/mixed_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/mixed_return_error.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/Declaration of B::f\(\) must be compatible with A::f\(\)/
+<?php
+
+require_once 'kphp_tester_include.php';
+
+abstract class A {
+  /** @return mixed */
+  public abstract function f();
+}
+
+class B extends A {
+  /** @return tuple(int) */
+  public function f() { return tuple(1); }
+}
+
+$b = new B();

--- a/tests/phpt/interfaces/signature_compatibility/phpdoc_param_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/phpdoc_param_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/B::f\(\) should not have a \$x param type hint, it would be incompatible with A::f\(\)/
+<?php
+
+class A {
+  /** @param float $x */
+  public function f($x) {}
+}
+
+class B extends A {
+  public function f(int $x) {}
+}
+
+$b = new B();

--- a/tests/phpt/interfaces/signature_compatibility/phpdoc_param_union.php
+++ b/tests/phpt/interfaces/signature_compatibility/phpdoc_param_union.php
@@ -1,0 +1,32 @@
+@ok
+<?php
+
+class A {}
+class B {}
+
+abstract class Base {
+  /** @param int $x */
+  public abstract function f($x);
+
+  /** @param A $x */
+  public abstract function g($x);
+}
+
+class Derived1 extends Base {
+  /** @param int|string $x */
+  public function f($x) {}
+
+  /** @param A|B $x */
+  public function g($x) {}
+}
+
+class Derived2 extends Base {
+  /** @param string|int $x */
+  public function f($x) {}
+
+  /** @param B|A $x */
+  public function g($x) {}
+}
+
+/** @var Base[] $list */
+$list = [new Derived1(), new Derived2()];

--- a/tests/phpt/interfaces/signature_compatibility/phpdoc_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/phpdoc_return_error.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/Declaration of B::f\(\) must be compatible with A::f\(\)/
+<?php
+
+// Works in PHP, but fails in KPHP
+
+class A {
+  /** @return float */
+  public function f() {
+    return 0.5;
+  }
+}
+
+class B extends A {
+  public function f(): int {
+    return 0;
+  }
+}
+
+$b = new B();

--- a/tests/phpt/interfaces/signature_compatibility/phpdoc_return_union.php
+++ b/tests/phpt/interfaces/signature_compatibility/phpdoc_return_union.php
@@ -1,0 +1,30 @@
+@ok
+<?php
+
+class A {}
+class B {}
+
+abstract class Base {
+  /** @return int|string */
+  public abstract function f();
+
+  /** @return A|B */
+  public abstract function g();
+}
+
+class Derived1 extends Base {
+  /** @return int */
+  public function f() { return 10; }
+
+  /** @return A */
+  public function g() { return new A(); }
+}
+
+class Derived2 extends Base {
+  public function f(): string { return 'foo'; }
+
+  public function g(): B { return new B(); }
+}
+
+/** @var Base[] $list */
+$list = [new Derived1(), new Derived2()];

--- a/tests/phpt/interfaces/signature_compatibility/return_null.php
+++ b/tests/phpt/interfaces/signature_compatibility/return_null.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+// TODO: this code should probably fail;
+// If we move types info from phpdoc to typehints,
+// PHP will give a fatal error.
+
+class Foo {}
+
+interface Iface {
+  /** @return Foo */
+  public function get();
+}
+
+class Impl implements Iface {
+  /** @return null */
+  public function get() { return null; }
+}
+
+

--- a/tests/phpt/interfaces/signature_compatibility/static_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/static_param.php
@@ -1,0 +1,20 @@
+@ok
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+<?php
+
+class A {
+  /**
+   * @param int $x
+   * @param string $y
+   */
+  public static function f($x, $y) {
+  }
+}
+
+class B extends A {}
+
+class C extends B {}
+
+A::f(1, 'foo');
+B::f(1, 'foo');
+C::f(1, 'foo');

--- a/tests/phpt/interfaces/signature_compatibility/trait_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/trait_param.php
@@ -1,0 +1,19 @@
+@ok
+<?php
+
+trait TraitFoo1 {
+  public abstract function foo(int $a);
+}
+
+trait TraitFoo2 {
+  public abstract function foo(int $a);
+}
+
+class C {
+  use TraitFoo1;
+  use TraitFoo2;
+
+  public function foo(int $a) {}
+}
+
+$c = new C();

--- a/tests/phpt/interfaces/signature_compatibility/trait_param_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/trait_param_error2.php
@@ -1,0 +1,37 @@
+@kphp_should_fail
+/pass int to argument \$x of C::foo/
+/declared as @param string/
+<?php
+
+// PHP is OK with this code *unless* strict_types=1 are used;
+// in that case, we'll get an error when passing 10 as a string.
+// We forbid such code since it's not a useful behavior.
+
+trait TraitFoo1 {
+  public abstract function foo(int $a);
+
+  public function test1() {
+    $this->foo(10);
+  }
+}
+
+trait TraitFoo2 {
+  public abstract function foo(int $a);
+
+  public function test2() {
+    $this->foo(10);
+  }
+}
+
+class C {
+  use TraitFoo1;
+  use TraitFoo2;
+
+  public function foo(string $x) {
+    var_dump($x);
+  }
+}
+
+$c = new C();
+$c->test1();
+$c->test2();

--- a/tests/phpt/interfaces/signature_compatibility/typehints_param.php
+++ b/tests/phpt/interfaces/signature_compatibility/typehints_param.php
@@ -1,0 +1,30 @@
+@ok
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+<?php
+
+interface Iface {}
+
+abstract class BaseBase implements Iface {}
+
+abstract class Base extends BaseBase {
+  /**
+   * @param int $id
+   * @param array $array
+   * @return bool
+   */
+  abstract public function f($id, $array);
+}
+
+class Derived extends Base {
+  /**
+   * @param int $id
+   * @param array $array
+   * @return bool
+   */
+  public function f($id, $array) {
+    return false;
+  }
+}
+
+$d = new Derived();
+$d->f(1, []);

--- a/tests/phpt/interfaces/signature_compatibility/typehints_param_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/typehints_param_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/Impl::f\(\) should not have a \$x param type hint, it would be incompatible with Base::f\(\)/
+<?php
+
+// Error: no param type hint in a base method, but it's specified in derived method
+
+abstract class Base {
+  public abstract function f($x);
+}
+
+class Impl extends Base {
+  public function f(int $x) {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/typehints_param_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/typehints_param_error2.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/C::f\(\) should not have a \$y param type hint, it would be incompatible with B::f\(\)/
+<?php
+
+class A {
+  public function f(int $x, $y) {}
+}
+
+class B extends A {
+  public function f(int $x, $y) {}
+}
+
+class C extends B {
+  public function f(int $x, int $y) {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/typehints_return_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/typehints_return_error.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/Impl::f\(\) should provide a return type hint compatible with Base::f\(\)/
+<?php
+
+// Error: return type hint in a base method, but not in derived method
+
+class Foo {}
+
+abstract class Base {
+  /** @return Foo[] */
+  public abstract function f(): array;
+}
+
+class Impl extends Base {
+  /** @return Foo[] */
+  public function f() { return [new Foo()]; }
+}
+
+/** @var Base[] $list */
+$list = [new Impl()];

--- a/tests/phpt/interfaces/signature_compatibility/typehints_return_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/typehints_return_error2.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/C::f\(\) should provide a return type hint compatible with B::f\(\)/
+<?php
+
+class A {
+  public function f(): int {}
+}
+
+class B extends A {
+  public function f(): int {}
+}
+
+class C extends B {
+  public function f() {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/unused_abstract_method.php
+++ b/tests/phpt/interfaces/signature_compatibility/unused_abstract_method.php
@@ -1,0 +1,13 @@
+@ok
+<?php
+
+abstract class ConfigReader {
+  /** @return bool */
+  abstract public static function getBool();
+}
+
+class Config extends ConfigReader {
+  public static function getBool() {
+    return false;
+  }
+}

--- a/tests/phpt/interfaces/signature_compatibility/unused_method.php
+++ b/tests/phpt/interfaces/signature_compatibility/unused_method.php
@@ -1,0 +1,13 @@
+@ok
+<?php
+
+interface ConfigReaderInterface {
+  /** @return bool */
+  public static function getBool();
+}
+
+class Config implements ConfigReaderInterface {
+  public static function getBool() {
+    return false;
+  }
+}

--- a/tests/phpt/interfaces/signature_compatibility/unused_method2.php
+++ b/tests/phpt/interfaces/signature_compatibility/unused_method2.php
@@ -1,0 +1,14 @@
+@ok
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+<?php
+
+interface ConfigReaderInterface {
+  /** @return bool */
+  public static function getBool();
+}
+
+class Config implements ConfigReaderInterface {
+  public static function getBool() {
+    return false;
+  }
+}

--- a/tests/phpt/interfaces/signature_compatibility/usecase_builder.php
+++ b/tests/phpt/interfaces/signature_compatibility/usecase_builder.php
@@ -1,0 +1,21 @@
+@kphp_should_fail
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+/Declaration of ExampleBuilder::create\(\) must be compatible with Builder::create\(\)/
+<?php
+
+// Builder::create() is not type-annotated, so it's implied
+// that it returns void; ExampleBuilder::create overrides that
+// type with ExampleBuilder and this it's incompatible with void
+
+abstract class Builder {
+  abstract public static function create();
+}
+
+class ExampleBuilder extends Builder {
+  /** @return ExampleBuilder */
+  public static function create() {
+    return new ExampleBuilder();
+  }
+}
+
+$b = ExampleBuilder::create();

--- a/tests/phpt/interfaces/signature_compatibility/zend_test_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/zend_test_error.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Declaration of Bar::testChildClass\(\) must be compatible with Foo::testChildClass\(\)/
+<?php
+
+// Zend/tests/type_declarations/parameter_type_variance.phpt
+
+class Foo {
+    function testParentClass(Foo $foo) {}
+    function testBothClass(Foo $foo) {}
+    function testChildClass(Foo $foo) {}
+    function testNoneClass(Foo $foo) {}
+}
+
+class Bar extends Foo {
+    function testParentClass(Foo $foo) {}
+    function testBothClass(Foo $foo) {}
+    function testChildClass(Bar $foo) {}
+    function testNoneClass(Foo $foo) {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/zend_test_error2.php
+++ b/tests/phpt/interfaces/signature_compatibility/zend_test_error2.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Declaration of B4::method\(\) must be compatible with A4::method\(\)/
+<?php
+
+// Zend/tests/type_declarations/variance/parent_in_class_failure2.phpt
+
+// Illegal: B4::parent == A4 is subclass of A4::parent == P4 in contravariant position
+class P4 {}
+class A4 extends P4 {
+    public function method(parent $x) {}
+}
+class B4 extends A4 {
+    public function method(parent $x) {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/zend_test_error3.php
+++ b/tests/phpt/interfaces/signature_compatibility/zend_test_error3.php
@@ -1,0 +1,39 @@
+@kphp_should_fail
+/Declaration of Bar4::setSelf\(\) must be compatible with Foo4::setSelf\(\)/
+<?php
+
+// Zend/tests/bug60573.phpt
+
+class Foo1 {
+  public function setSelf(self $s) {}
+}
+
+class Bar1 extends Foo1 {
+  public function setSelf(parent $s) {}
+}
+
+class Foo2 {
+  public function setSelf(Foo2 $s) {}
+}
+
+class Bar2 extends Foo2 {
+  public function setSelf(parent $s) {}
+}
+
+class Base {}
+
+class Foo3 extends Base{
+  public function setSelf(parent $s) {}
+}
+
+class Bar3 extends Foo3 {
+  public function setSelf(Base $s) {}
+}
+
+class Foo4 {
+  public function setSelf(self $s) {}
+}
+
+class Bar4 extends Foo4 {
+  public function setSelf(self $s) {}
+}

--- a/tests/phpt/interfaces/signature_compatibility/zend_test_error4.php
+++ b/tests/phpt/interfaces/signature_compatibility/zend_test_error4.php
@@ -1,0 +1,43 @@
+@kphp_should_fail
+/Declaration of Bar5::setSelf\(\) must be compatible with Foo5::setSelf\(\)/
+<?php
+
+// Zend/tests/bug60573_2.phpt
+
+class Foo1 {
+  public function setSelf(self $s) {}
+}
+
+class Bar1 extends Foo1 {
+  public function setSelf(parent $s) {}
+}
+
+class Foo2 {
+  public function setSelf(Foo2 $s) {}
+}
+
+class Bar2 extends Foo2 {
+  public function setSelf(parent $s) {}
+}
+
+class Base {}
+
+class Foo3 extends Base{
+  public function setSelf(parent $s) {}
+}
+
+class Bar3 extends Foo3 {
+  public function setSelf(Base $s) {}
+}
+
+class Foo4 {
+  public function setSelf(self $s) {}
+}
+
+class Foo5 extends Base {
+  public function setSelf(parent $s) {}
+}
+
+class Bar5 extends Foo5 {
+  public function setSelf(parent $s) {}
+}

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -53,8 +53,6 @@ Zend/tests/bug47596.phpt
 Zend/tests/bug52355.phpt
 Zend/tests/bug53632.phpt
 Zend/tests/bug55135.phpt
-Zend/tests/bug60573.phpt
-Zend/tests/bug60573_2.phpt
 Zend/tests/bug61095.phpt
 Zend/tests/bug61225.phpt
 Zend/tests/bug62956.phpt
@@ -159,10 +157,8 @@ Zend/tests/traits/no_static_arg_binding.phpt
 Zend/tests/traits/static_001.phpt
 Zend/tests/traits/static_003.phpt
 Zend/tests/type_declarations/default_boolean_hint_values.phpt
-Zend/tests/type_declarations/parameter_type_variance.phpt
 Zend/tests/type_declarations/parent_is_not_proto.phpt
 Zend/tests/type_declarations/scalar_float_with_integer_default_weak.phpt
-Zend/tests/type_declarations/variance/parent_in_class_failure2.phpt
 Zend/tests/unset_cv01.phpt
 Zend/tests/unset_cv03.phpt
 Zend/tests/unset_cv11.phpt


### PR DESCRIPTION
implement type hints compatibility checks for methods implementation

This change makes KPHP compiler give an error if implemented methods
do not satisfy PHP signatures compatibility rules.

Signature compatibility rules:

> https://www.php.net/manual/en/language.oop5.basic.php#language.oop.lsp

Since PHP7.4, these rules were improved and it became possible to
use more specific types as implementation return type and
less specific types as implementation param types.

PHP covariance and contravariance:

> https://www.php.net/manual/en/language.oop5.variance.php

These tests were removed from the Zend test list:

        Zend/tests/type_declarations/parameter_type_variance.phpt
        Zend/tests/type_declarations/variance/parent_in_class_failure2.phpt
        Zend/tests/bug60573.phpt
        Zend/tests/bug60573_2.phpt

They test that PHP would give an error for the incompatible signatures;
KPHP gives a compile-time error, so we can't map these tests directly.

They're ported as:

        Zend/tests/type_declarations/parameter_type_variance.phpt -> zend_test_error.php
        Zend/tests/type_declarations/variance/parent_in_class_failure2.phpt -> zend_test_error1.php
        Zend/tests/bug60573.phpt -> zend_test_error2.php
        Zend/tests/bug60573_2.phpt -> zend_test_error3.php