### PR TITLE
Improve backtrace experience

### DIFF
--- a/common/smart_ptrs/intrusive_ptr.h
+++ b/common/smart_ptrs/intrusive_ptr.h
@@ -50,7 +50,7 @@ public:
     return *this;
   }
 
-  ~intrusive_ptr() __attribute__((always_inline)){
+  ~intrusive_ptr() noexcept {
     if (ptr) {
       ptr->release();
     }

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -217,7 +217,7 @@ private:
   template<class T1>
   inline void move_from(array<T1> &&other) noexcept;
 
-  inline void destroy() __attribute__ ((always_inline));
+  inline void destroy();
 
 public:
   friend class array_iterator<T>;

--- a/runtime/mixed.cpp
+++ b/runtime/mixed.cpp
@@ -1,0 +1,29 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/kphp_core.h"
+
+void mixed::destroy() noexcept {
+  switch (get_type()) {
+    case type::STRING:
+      as_string().~string();
+      break;
+    case type::ARRAY:
+      as_array().~array<mixed>();
+      break;
+    default: {
+    }
+  }
+}
+
+void mixed::clear() noexcept {
+  destroy();
+  type_ = type::NUL;
+}
+
+// Don't move this destructor to the headers, it spoils addr2line traces
+mixed::~mixed() noexcept {
+  clear();
+}
+

--- a/runtime/mixed.inl
+++ b/runtime/mixed.inl
@@ -1,3 +1,7 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
 #pragma once
 
 #include "common/algorithms/find.h"
@@ -481,34 +485,6 @@ mixed &mixed::append(const string &v) {
   as_string().append(v);
   return *this;
 }
-
-
-void mixed::destroy() {
-  switch (get_type()) {
-    case type::STRING:
-      as_string().~string();
-      break;
-    case type::ARRAY:
-      as_array().~array<mixed>();
-      break;
-    default: {
-    }
-  }
-}
-
-mixed::~mixed() {
-  // do not remove copy-paste from clear.
-  // It makes stacktraces unreadable
-  destroy();
-  type_ = type::NUL;
-}
-
-
-void mixed::clear() {
-  destroy();
-  type_ = type::NUL;
-}
-
 
 const mixed mixed::to_numeric() const {
   switch (get_type()) {

--- a/runtime/mixed_decl.inl
+++ b/runtime/mixed_decl.inl
@@ -1,3 +1,7 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
 #pragma once
 
 #ifndef INCLUDED_FROM_KPHP_CORE
@@ -117,10 +121,10 @@ public:
   inline void unset(const mixed &v);
   inline void unset(double double_key);
 
-  inline void destroy();
-  inline ~mixed();
+  void destroy() noexcept;
+  ~mixed() noexcept;
 
-  inline void clear();
+  void clear() noexcept;
 
   inline const mixed to_numeric() const;
   inline bool to_bool() const;

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -40,6 +40,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         memcache.cpp
         memory_usage.cpp
         misc.cpp
+        mixed.cpp
         msgpack-serialization.cpp
         mysql.cpp
         net_events.cpp
@@ -53,6 +54,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         serialize-functions.cpp
         storage.cpp
         streams.cpp
+        string.cpp
         string_buffer.cpp
         string_cache.cpp
         string_functions.cpp

--- a/runtime/string.cpp
+++ b/runtime/string.cpp
@@ -1,0 +1,10 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/kphp_core.h"
+
+// Don't move this destructor to the headers, it spoils addr2line traces
+string::~string() noexcept {
+  destroy();
+}

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -1,3 +1,7 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
 #pragma once
 
 #include <cctype>
@@ -259,11 +263,6 @@ string::string(double f) {
     php_warning("Maximum length of float (%d) exceeded", MAX_LEN);
     p = string_cache::empty_string().ref_data();
   }
-}
-
-
-string::~string() {
-  destroy();
 }
 
 string &string::operator=(const string &str) noexcept {

--- a/runtime/string_decl.inl
+++ b/runtime/string_decl.inl
@@ -75,7 +75,7 @@ public:
   inline explicit string(double f);
 
 
-  inline ~string();
+  ~string() noexcept;
 
   inline string &operator=(const string &str) noexcept;
   inline string &operator=(string &&str) noexcept;


### PR DESCRIPTION
The aim of the patch is to improve the sentry backtraces. 

The main pain is that we have a over-inlining of the compiled code and as a result addr2line misses and produces very wired traces, e.g. a custom function call from the mixed destructor. 

I've made some experiments and found that a moving the mixed destructor to the cpp file helps here and after that addr2line shows fine traces.

So, I suggest:
- move string and mixed desctructors to cpp files
- remove force inlining from some descturtors

Yeh, it's unclear how it would affect the performance, but I believe, that we won't notice it, may be only with micro benchmarks.