### PR TITLE
allow `T->regexp` implicit casts even with `strict_types=1`

### DIFF
--- a/compiler/pipes/check-conversions.cpp
+++ b/compiler/pipes/check-conversions.cpp
@@ -34,6 +34,7 @@ const std::multimap<Operation, PrimitiveType> CheckConversionsPass::forbidden_co
   {op_conv_string,   tp_tuple},
   {op_conv_string_l, tp_tuple},
   {op_conv_object,   tp_tuple},
+  {op_conv_regexp,   tp_tuple},
 
   {op_conv_bool,     tp_shape},
   {op_conv_int,      tp_shape},

--- a/tests/phpt/declare/10_strict_types_enabled.php
+++ b/tests/phpt/declare/10_strict_types_enabled.php
@@ -1,0 +1,3 @@
+@ok
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/10_strict_types_enabled.php.inc
+++ b/tests/phpt/declare/10_strict_types_enabled.php.inc
@@ -1,0 +1,18 @@
+<?php
+
+/** @kphp-strict-types-enable */
+declare(strict_types=1);
+
+function test_regexp_string(string $re) {
+  var_dump(preg_match($re, '123') > 0);
+  var_dump(preg_match_all($re, '123') > 0);
+}
+
+/** @param mixed $re */
+function test_regexp_mixed($re) {
+  var_dump(preg_match($re, '123') > 0);
+  var_dump(preg_match_all($re, '123') > 0);
+}
+
+test_regexp_string('/\d/');
+test_regexp_mixed('/\d/');

--- a/tests/phpt/declare/11_strict_types_enabled_error.php
+++ b/tests/phpt/declare/11_strict_types_enabled_error.php
@@ -1,0 +1,4 @@
+@kphp_should_fail
+/conversion from tuple\(int\) to regexp is forbidden/
+<?php
+require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/11_strict_types_enabled_error.php.inc
+++ b/tests/phpt/declare/11_strict_types_enabled_error.php.inc
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+class A {
+  public $x = 1;
+}
+
+function test_regexp_crap($re) {
+  var_dump(preg_match($re, '123') > 0);
+  var_dump(preg_match_all($re, '123') > 0);
+}
+
+test_regexp_crap(tuple(1));


### PR DESCRIPTION
When `strict_types=1` is used, there will be no implicit `string->regexp` and `mixed->regexp`
conversions, but in fact we don't need them as there are various overloadings
that can work with all such types (string, regexp, mixed).
    
With this change, it will be possible to use string-typed arguments
to `preg_*` functions when `declare(strict_types=1)` is used.