### PR TITLE
fix `preg_match($pat, $s)` overloading

### DIFF
--- a/runtime/regexp.cpp
+++ b/runtime/regexp.cpp
@@ -637,7 +637,7 @@ int64_t regexp::exec(const string &subject, int64_t offset, bool second_try) con
 }
 
 
-Optional<int64_t> regexp::match(const string &subject, bool all_matches __attribute__((unused))) const {
+Optional<int64_t> regexp::match(const string &subject, bool all_matches) const {
   pcre_last_error = 0;
 
   check_pattern_compilation_warning();
@@ -669,6 +669,10 @@ Optional<int64_t> regexp::match(const string &subject, bool all_matches __attrib
     }
 
     result++;
+
+    if (!all_matches) {
+      break;
+    }
 
     second_try = (submatch[0] == submatch[1]);
 

--- a/tests/phpt/regexp/005_regexp_match2.php
+++ b/tests/phpt/regexp/005_regexp_match2.php
@@ -1,0 +1,48 @@
+@ok
+<?php
+
+// Tests for the preg_match and preg_match_all function overloading with 2 args (without $matches).
+
+function test_preg_match($re, $s) {
+  var_dump(["preg_match('$re', $s)" => preg_match($re, $s)]);
+}
+
+function test_preg_match_all($re, $s) {
+  var_dump(["preg_match_all('$re', $s)" => preg_match_all($re, $s)]);
+}
+
+$patterns = [
+  '/\d/',
+  '/\d+/',
+  '/^\d+$/',
+  '/.*/',
+  '/\s/',
+  '/\s+/',
+  '/\s*/',
+  '/\w+/',
+  '/\w*/',
+  '/foo/',
+  '/^foo$/',
+  '/\bfoo\b/',
+];
+
+$inputs = [
+  '',
+  ' ',
+  '   ',
+  '1',
+  '123',
+  '1 2',
+  '12 34',
+  'foo',
+  'foofoo',
+  'foo foo',
+  '<foo>foofoo',
+];
+
+foreach ($patterns as $pattern) {
+  foreach ($inputs as $s) {
+    test_preg_match($pattern, $s);
+    test_preg_match_all($pattern, $s);
+  }
+}


### PR DESCRIPTION
`$match_all` param was ignored, so `preg_match` behaved like `preg_match_all`;
this led to return value being different from PHP.

```php
preg_match('/\d/', '123');
// => 1 in PHP
// => 3 in KPHP
```

It also led to a degraded performance as we did repeated regexp execution
to find all matches.

Here is a comparison of the old implementation (preg_match like preg_match_all)
and new implementation (that does not try to find all matches):

	name            old time/op  new time/op  delta
	PregMatchShort  1.39µs ± 3%  0.65µs ± 7%  -53.34%  (p=0.000 n=10+8)
	PregMatchLong   47.2µs ± 1%   0.5µs ± 2%  -99.33%  (p=0.000 n=10+9)

Performance results are collected with ktest utility.