### PR TITLE
make preg_quote escape '#' sign

### DIFF
--- a/runtime/regexp.cpp
+++ b/runtime/regexp.cpp
@@ -1062,6 +1062,7 @@ string f$preg_quote(const string &str, const string &delimiter) {
       case '|':
       case ':':
       case '-':
+      case '#':
         static_SB.append_char('\\');
         static_SB.append_char(str[i]);
         break;

--- a/tests/phpt/dl/496_regex.php
+++ b/tests/phpt/dl/496_regex.php
@@ -124,11 +124,6 @@ $str = 'hypertext language programming';
 $chars = preg_split('/ /', $str, -1, PREG_SPLIT_OFFSET_CAPTURE);
 print_r($chars);
 
-$range = implode ('', range (chr(0), chr (255)));
-
-var_dump (preg_quote ($range));
-var_dump (preg_quote ($range, '/'));
-
 var_dump (preg_replace ('~a|~', 'b', 'a'));
 var_dump (preg_replace ('~a|~', 'a', 'b'));
 

--- a/tests/phpt/regexp/006_preg_quote.php
+++ b/tests/phpt/regexp/006_preg_quote.php
@@ -1,0 +1,20 @@
+@ok php7_4
+<?php
+
+// Starting with PHP 7.3, preg_quote does escape '#' sign.
+
+function test1() {
+  $chars = range(chr(0), chr (255));
+  foreach ($chars as $ch) {
+    var_dump(["$ch(" . ord($ch) . ')' => preg_quote($ch)]);
+  }
+}
+
+function test2() {
+  $range = implode ('', range (chr(0), chr (255)));
+  var_dump (preg_quote ($range));
+  var_dump (preg_quote ($range, '/'));
+}
+
+test1();
+test2();

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -212,7 +212,6 @@ ext/pcre/tests/bug70232.phpt
 ext/pcre/tests/bug71537.phpt
 ext/pcre/tests/bug72463_2.phpt
 ext/pcre/tests/bug72688.phpt
-ext/pcre/tests/bug75355.phpt
 ext/pcre/tests/bug76512.phpt
 ext/pcre/tests/bug78338.phpt
 ext/pcre/tests/dollar_endonly.phpt


### PR DESCRIPTION
This behavior is consistent with PHP7.3+

	Output for 7.3.0 - 7.3.27, 7.4.0 - 7.4.16, 8.0.0 - 8.0.3
	    string(2) "\#"
	Output for 5.6.0 - 5.6.40, 7.0.0 - 7.0.33, 7.1.0 - 7.1.33, 7.2.0 - 7.2.34
	    string(1) "#"

Part of the PHP7.2 -> PHP7.4 transition.