### PR TITLE
add a check that all inner classes are serializable

### DIFF
--- a/tests/phpt/msgpack_serialize/111_non_serializable_inner_class.php
+++ b/tests/phpt/msgpack_serialize/111_non_serializable_inner_class.php
@@ -1,0 +1,25 @@
+@kphp_should_fail
+/class B must be serializable as it is used in field A::b/
+<?php
+require_once 'kphp_tester_include.php';
+
+class B {
+  /** @var int */
+  public $x = 0;
+}
+
+/** @kphp-serializable */
+class A {
+  /**
+   * @kphp-serialized-field 1
+   * @var \tuple(B)
+   */
+  public $b;
+
+  public function __construct() {
+    $this->b = tuple(new B());
+  }
+}
+
+instance_serialize(new A());
+


### PR DESCRIPTION
Add a compile-time check that all fields in `kphp-serializable` classes do not contain `non-serializable` instances