### PR TITLE
Function colors and palette

### DIFF
--- a/compiler/compiler-core.h
+++ b/compiler/compiler-core.h
@@ -19,6 +19,7 @@
 #include "compiler/threading/hash-table.h"
 #include "compiler/tl-classes.h"
 #include "compiler/composer.h"
+#include "compiler/function-colors.h"
 
 class CompilerCore {
 private:
@@ -36,6 +37,7 @@ private:
   TlClasses tl_classes;
   std::vector<std::string> kphp_runtime_opts;
   bool is_untyped_rpc_tl_used{false};
+  function_palette::Palette function_palette;
 
   inline bool try_require_file(SrcFilePtr file);
 
@@ -106,6 +108,14 @@ public:
 
   void add_kphp_runtime_opt(std::string opt) { kphp_runtime_opts.emplace_back(std::move(opt)); }
   const std::vector<std::string> &get_kphp_runtime_opts() const { return kphp_runtime_opts; }
+
+  void set_function_palette(function_palette::Palette &&palette) {
+    function_palette = palette;
+  }
+
+  function_palette::Palette &get_function_palette() {
+    return function_palette;
+  }
 
   void set_untyped_rpc_tl_used() {
     is_untyped_rpc_tl_used = true;

--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -168,6 +168,7 @@ prepend(KPHP_COMPILER_SOURCES ${KPHP_COMPILER_DIR}/
         cpp-dest-dir-initializer.cpp
         debug.cpp
         compiler-settings.cpp
+        function-colors.cpp
         gentree.cpp
         index.cpp
         lexer.cpp

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -241,6 +241,7 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PassC<ResolveSelfStaticParentPass>{}
     >> PassC<RegisterDefinesPass>{}
     >> SyncC<CalcRealDefinesValuesF>{}
+    >> SyncC<RegisterKphpConfiguration>{}
     >> PassC<EraseDefinesDeclarationsPass>{}
     >> PassC<InlineDefinesUsagesPass>{}
     >> PassC<PreprocessEq3Pass>{}
@@ -290,7 +291,6 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PassC<CheckAccessModifiersPass>{}
     >> PassC<AnalyzePerformance>{}
     >> PassC<FinalCheckPass>{}
-    >> PassC<RegisterKphpConfiguration>{}
     >> PassC<CollectForkableTypesPass>{}
     >> SyncC<CodeGenF>{}              // create all codegen commands and launch them in "just calc hashes" mode
     >> PipeC<CodeGenForDiffF>{}       // re-launch codegen commands that diff from the previous kphp launch

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -148,7 +148,7 @@ void ClassData::create_constructor_with_parent_call(DataStream<FunctionPtr> &os)
 }
 
 void ClassData::create_default_constructor_if_required(DataStream<FunctionPtr> &os) {
-  if (!is_class() || modifiers.is_abstract() || construct_function) {
+  if (!is_class() || modifiers.is_abstract() || construct_function || name == "KphpConfiguration") {
     return;
   }
 

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -19,6 +19,7 @@
 #include "compiler/data/performance-inspections.h"
 #include "compiler/data/vertex-adaptor.h"
 #include "compiler/debug.h"
+#include "compiler/function-colors.h"
 #include "compiler/inferring/var-node.h"
 #include "compiler/threading/data-stream.h"
 #include "compiler/vertex-meta_op_base.h"
@@ -104,6 +105,9 @@ public:
   bool warn_unused_result = false;
   bool is_flatten = false;
   bool is_pure = false;
+
+  function_palette::ColorContainer colors{};            // colors specified with @kphp-color
+  std::vector<FunctionPtr> *next_with_colors{nullptr};  // next colored functions reachable via call graph
 
   enum class profiler_status : uint8_t {
     disable,

--- a/compiler/function-colors.cpp
+++ b/compiler/function-colors.cpp
@@ -1,0 +1,79 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/function-colors.h"
+
+#include "common/algorithms/string-algorithms.h"
+
+using namespace function_palette;
+
+PaletteRule::PaletteRule(std::vector<color_t> &&colors, std::string error)
+  : colors(std::move(colors))
+  , error(std::move(error)) {
+
+  for (color_t color : this->colors) {
+    mask |= color;
+  }
+}
+
+std::string PaletteRule::as_human_readable(const Palette &palette) const {
+  return vk::join(colors, " ", [palette](auto color) { return palette.get_name_by_color(color); });
+}
+
+// --------------------------------------------
+
+color_t Palette::register_color_name(const std::string &color_name) {
+  auto found = color_names_mapping.find(color_name);
+  if (found != color_names_mapping.end()) {
+    return found->second;
+  }
+
+  int bit_shift = 1 + color_names_mapping.size();
+  color_t color = 1ULL << bit_shift;
+
+  color_names_mapping[color_name] = color;
+  kphp_error(color_names_mapping.size() != 62, "Reached limit of colors in palette — more than 62 colors");
+  return color;
+}
+
+color_t Palette::get_color_by_name(const std::string &color_name) const {
+  const auto found = color_names_mapping.find(color_name);
+  kphp_assert(found != color_names_mapping.end());
+  return found->second;
+}
+
+std::string Palette::get_name_by_color(color_t color) const {
+  for (const auto &pair : color_names_mapping) {
+    if (pair.second == color) {
+      return pair.first;
+    }
+  }
+  return std::to_string(color);
+}
+
+// --------------------------------------------
+
+void ColorContainer::add(color_t color) {
+  // append color to the end of forward list
+  // a bit inconvenient, but we use forward_list intentionally to consume only 8 bytes on emptiness (the most common case)
+  auto before_end = std::next(sep_colors.before_begin(), std::distance(sep_colors.begin(), sep_colors.end()));
+  sep_colors.emplace_after(before_end, color);
+}
+
+bool ColorContainer::contains(color_t color) const {
+  return std::any_of(sep_colors.begin(), sep_colors.end(), [=](color_t c) { return c == color; });
+}
+
+std::string ColorContainer::to_string(const Palette &palette, colors_mask_t with_highlights) const {
+  std::string desc;
+
+  for (color_t color : sep_colors) {
+    if (with_highlights == 0 || with_highlights & color) {
+      desc += "@";
+      desc += palette.get_name_by_color(color);
+    }
+  }
+
+  return desc;
+}

--- a/compiler/function-colors.h
+++ b/compiler/function-colors.h
@@ -1,0 +1,88 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <forward_list>
+#include <map>
+
+#include "common/termformat/termformat.h"
+#include "compiler/stage.h"
+
+namespace function_palette {
+
+using color_t = uint64_t;
+using colors_mask_t = uint64_t;
+
+class Palette;
+
+// rules are representation of human-written "api has-curl" => "error text" or "api allow-curl has-curl" => 1
+// all colors are pre-converted to numeric while reading strings
+struct PaletteRule {
+  std::vector<color_t> colors;
+  colors_mask_t mask{0};
+  std::string error;
+
+  PaletteRule(std::vector<color_t> &&colors, std::string error);
+
+  std::string as_human_readable(const Palette &palette) const;
+
+  bool is_error() const {
+    return !error.empty();
+  }
+
+  bool contains_in(colors_mask_t colors_mask) const {
+    return (mask & colors_mask) == mask;
+  }
+};
+
+// a ruleset is a group of rules, order is important
+// typically, it looks like one error rule and some "exceptions" — more specific color chains with no error
+using PaletteRuleset = std::vector<PaletteRule>;
+
+// a palette is a group of rulesets
+// all colors are stored as numbers, not as strings:
+// they are numbers 1<<n, as we want to use bitmasks to quickly test whether to check a rule for callstack
+class Palette {
+  std::vector<PaletteRuleset> rulesets;
+  std::map<std::string, color_t> color_names_mapping;
+
+public:
+  color_t register_color_name(const std::string &color_name);
+
+  void add_ruleset(PaletteRuleset &&ruleset) {
+    rulesets.emplace_back(std::move(ruleset));
+  }
+
+  const std::vector<PaletteRuleset> &get_rulesets() const {
+    return rulesets;
+  }
+
+  bool color_exists(const std::string &color_name) const {
+    return color_names_mapping.find(color_name) != color_names_mapping.end();
+  }
+
+  color_t get_color_by_name(const std::string &color_name) const;
+  std::string get_name_by_color(color_t color) const;
+};
+
+// a class containing colors after @kphp-color parsing above each function (order is important)
+class ColorContainer {
+  std::forward_list<color_t> sep_colors; // empty almost everywhere
+
+public:
+  ColorContainer() = default;
+
+  bool empty() const { return sep_colors.empty(); }
+
+  auto begin() const { return sep_colors.begin(); }
+  auto end() const { return sep_colors.end(); }
+
+  void add(color_t color);
+  bool contains(color_t color) const;
+
+  std::string to_string(const Palette &palette, colors_mask_t with_highlights) const;
+};
+
+} // namespace function_palette

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -56,6 +56,7 @@ const std::map<string, php_doc_tag::doc_type> php_doc_tag::str2doc_type = {
   {"@kphp-profile",              kphp_profile},
   {"@kphp-profile-allow-inline", kphp_profile_allow_inline},
   {"@kphp-strict-types-enable",  kphp_strict_types_enable},
+  {"@kphp-color",                kphp_color},
 };
 
 vector<php_doc_tag> parse_php_doc(vk::string_view phpdoc) {

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -48,6 +48,7 @@ struct php_doc_tag {
     kphp_profile,
     kphp_profile_allow_inline,
     kphp_strict_types_enable, // TODO: remove when strict_types=1 are enabled by default
+    kphp_color,
   };
 
 public:

--- a/compiler/pipes/calc-bad-vars.cpp
+++ b/compiler/pipes/calc-bad-vars.cpp
@@ -116,12 +116,255 @@ struct FuncCallGraph {
   }
 };
 
+class CallstackOfColoredFunctions {
+  std::vector<FunctionPtr> stack;                       // functions placed in order, only colored functions
+  std::vector<function_palette::color_t> colors_chain;  // blended colors of stacked functions, one-by-one
+  std::unordered_set<FunctionPtr> index_set;            // a quick index for contains(), has the same elements as stack
+  function_palette::colors_mask_t colors_mask{0};       // mask of all colors_chain
+
+  void recalc_mask() {
+    colors_mask = 0;
+    for (function_palette::color_t c : colors_chain) {
+      colors_mask |= c;
+    }
+  }
+
+public:
+  CallstackOfColoredFunctions() {
+    stack.reserve(10);
+    index_set.reserve(10);
+  }
+
+  size_t size() const {
+    return stack.size();
+  }
+
+  const std::vector<FunctionPtr> &as_vector() const {
+    return stack;
+  }
+
+  const std::vector<function_palette::color_t> &get_colors_chain() const {
+    return colors_chain;
+  }
+
+  function_palette::colors_mask_t get_colors_mask() const {
+    return colors_mask;
+  }
+
+  void push_back(const FunctionPtr &el) {
+    stack.push_back(el);
+    index_set.insert(el);
+    for (const auto &sep_color : el->colors) {
+      colors_chain.push_back(sep_color);
+    }
+    recalc_mask();
+  }
+
+  void pop_back() {
+    FunctionPtr pop = stack.back();
+    index_set.erase(pop);
+    stack.pop_back();
+    for (const auto &sep_color __attribute__((unused)) : pop->colors) {
+      colors_chain.pop_back();
+    }
+    recalc_mask();
+  }
+
+  bool contains(const FunctionPtr &el) const {
+    return index_set.find(el) != index_set.end();
+  }
+};
+
+// here we check all palette rules like "api has-curl" or "messages-module messages-internals"
+// start from the root, make dfs expanding next_with_colors and check all rules for each dfs chain
+// these chains are left-to-right, e.g. colored f1->f2->f3, we find and check f1, then f1->f2, then f1->f2->f3
+class CheckFunctionsColors {
+  static constexpr int max_shown_errors_count = 10;
+
+  const FuncCallGraph &call_graph;
+  const function_palette::Palette &palette;
+  std::unordered_set<std::string> shown_errors;   // the easiest way to avoid duplicated errors
+
+public:
+  explicit CheckFunctionsColors(const FuncCallGraph &call_graph)
+    : call_graph(call_graph)
+    , palette(G->get_function_palette()) {}
+
+  void check() {
+    CallstackOfColoredFunctions callstack;
+    check_func_dfs(callstack, G->get_main_file()->main_function);
+  }
+
+  void check_func_dfs(CallstackOfColoredFunctions &callstack, const FunctionPtr &func) {
+    callstack.push_back(func);
+    bool was_any_error = false;
+
+    for (const auto &ruleset : palette.get_rulesets()) {
+      for (auto it = ruleset.rbegin(); it != ruleset.rend(); ++it) {  // reverse is important
+        const function_palette::PaletteRule &rule = *it;
+        if (!match_rule(callstack, rule)) {
+          continue;
+        }
+
+        if (rule.is_error()) {
+          show_error_on_rule_broken(callstack, rule);
+          was_any_error = true;
+        }
+        break;
+      }
+    }
+
+    if (!was_any_error && func->next_with_colors != nullptr) {
+      for (FunctionPtr next : *func->next_with_colors) {
+        if (callstack.size() < 50 && !callstack.contains(next)) {
+          check_func_dfs(callstack, next);
+        }
+      }
+    }
+    callstack.pop_back();
+  }
+
+  static bool match_rule(const CallstackOfColoredFunctions &callstack, const function_palette::PaletteRule &rule) {
+    const auto match_mask = callstack.get_colors_mask();
+    if (match_mask == 0 || !rule.contains_in(match_mask)) {
+      return false;
+    }
+
+    return match_two_vectors(rule.colors, callstack.get_colors_chain());
+  }
+
+  static bool match_two_vectors(const std::vector<function_palette::colors_mask_t> &rule_chain, const std::vector<function_palette::color_t> &actual_chain) {
+    auto rule_it = rule_chain.end() - 1;
+    auto actual_it = actual_chain.end() - 1;
+
+    while (true) {
+      bool rightmost_matched = *rule_it == *actual_it;
+
+      if (rightmost_matched) {
+        if (rule_it == rule_chain.begin()) {
+          return true;
+        }
+        if (actual_it == actual_chain.begin()) {
+          return false;
+        }
+        --rule_it;
+        --actual_it;
+      } else {
+        if (actual_it == actual_chain.begin()) {
+          return false;
+        }
+        --actual_it;
+      }
+    }
+  }
+
+  // on error (colored chain breaks some rule), we want to find an actual chain of calling
+  // this is launched only on error, that's why we don't care about performance and just use bfs
+  // todo think about using such approach for fork chains, throws chains, etc (and drop fork_prev, wait_prev, throws_reason from FunctionData)
+  std::vector<FunctionPtr> find_callstack_between_two_functions_bfs(FunctionPtr from, FunctionPtr target, const std::unordered_set<FunctionPtr> &shouldnt_appear) {
+    std::unordered_map<FunctionPtr, int> visited_level;
+    std::queue<FunctionPtr> bfs_queue;
+
+    bfs_queue.push(from);
+    visited_level[from] = 0;
+
+    while (!bfs_queue.empty()) {
+      FunctionPtr cur = bfs_queue.front();
+      bfs_queue.pop();
+      int next_level = visited_level[cur] + 1;
+
+      if (cur == target) {
+        break;
+      }
+
+      for (FunctionPtr called : call_graph.graph[cur]) {
+        if (shouldnt_appear.find(called) == shouldnt_appear.end() && visited_level.emplace(called, next_level).second) {
+          bfs_queue.push(called);
+        }
+      }
+    }
+
+    if (visited_level.find(target) == visited_level.end()) {    // couldn't find, just return [from, target]
+      return {from, target};
+    }
+
+    std::vector<FunctionPtr> callstack;
+    callstack.emplace_back(target);
+    for (FunctionPtr cur = target; cur != from;) {
+      int prev_level = visited_level[cur] - 1;
+      for (FunctionPtr callee : call_graph.rev_graph[cur]) {
+        auto found = visited_level.find(callee);
+        if (found != visited_level.end() && found->second == prev_level) {
+          callstack.push_back(callee);
+          cur = callee;
+          break;
+        }
+      }
+      kphp_assert(visited_level.find(cur)->second == prev_level);
+    }
+
+    std::reverse(callstack.begin(), callstack.end());
+    return callstack;
+  }
+
+  void show_error_on_rule_broken(const CallstackOfColoredFunctions &color_callstack, const function_palette::PaletteRule &rule) {
+    kphp_assert(rule.is_error());
+    if (shown_errors.size() > max_shown_errors_count) {
+      return;
+    }
+
+    auto vector = color_callstack.as_vector();    // f1, f2, f3 — all of them are colored, and their chain breaks the rule
+    std::vector<FunctionPtr> full_callstack;      // will be: src_main -> ... -> f1 -> ... -> f2 -> ... -> f3
+    for (int i = 0; i < vector.size() - 1; ++i) {
+      FunctionPtr cur = vector[i], next = vector[i+1];
+      std::unordered_set<FunctionPtr> shouldnt_appear;
+      kphp_assert(cur->next_with_colors);
+      for (FunctionPtr exclude : *cur->next_with_colors) {
+        if (exclude != next && exclude != cur) {
+          shouldnt_appear.insert(exclude);
+        }
+      }
+      auto next_callstack_part = find_callstack_between_two_functions_bfs(cur, next, shouldnt_appear);
+      full_callstack.insert(full_callstack.end(), next_callstack_part.begin(), next_callstack_part.end() - 1);
+    }
+    full_callstack.emplace_back(vector.back());
+
+    // having full callstack like "src_main -> main -> init -> apiFn@api -> .... -> curlFn@curl"
+    // we want to show a slice only containing a subchain that breaks the rule
+    auto first_item_to_show = full_callstack.begin();
+    while (!(*first_item_to_show)->colors.contains(rule.colors.front())) {
+      ++first_item_to_show;
+    }
+    auto last_item_to_show = full_callstack.end() - 1;
+    while (!(*last_item_to_show)->colors.contains(rule.colors.back())) {
+      --last_item_to_show;
+    }
+    if (first_item_to_show == last_item_to_show) {
+      first_item_to_show = full_callstack.begin();
+    }
+
+    std::vector<FunctionPtr> call_chain_to_show(first_item_to_show, last_item_to_show + 1);
+    std::string callstack_str = vk::join(call_chain_to_show, " -> ", [&](FunctionPtr f) {
+      return f->get_human_readable_name() + TermStringFormat::paint(f->colors.to_string(palette, rule.mask), TermStringFormat::cyan);
+    });
+
+    stage::set_location((*first_item_to_show)->root->location);
+    kphp_error(!shown_errors.insert(callstack_str).second,
+               fmt_format("{} => {}\n  This color rule is broken, call chain:\n{}",
+                          TermStringFormat::paint(rule.as_human_readable(palette), TermStringFormat::cyan),
+                          TermStringFormat::paint_red(rule.error),
+                          callstack_str));
+  }
+};
+
 class CalcBadVars {
 private:
-  class MergeBadVarsCallback : public MergeReachalbeCallback<FunctionPtr> {
+  // we use the same call graph to fill f->bad_vars and f->next_with_colors, approaches are very similar
+  // using the same call graph reduces memory footprint and allows to find connectivity components only once
+  class MergeBadVarsAndColorsCallback : public MergeReachalbeCallback<FunctionPtr> {
     IdMap<vector<VarPtr>> modified_global_vars;
   public:
-    explicit MergeBadVarsCallback(IdMap<vector<VarPtr>> &&modified_global_vars) :
+    explicit MergeBadVarsAndColorsCallback(IdMap<vector<VarPtr>> &&modified_global_vars) :
       modified_global_vars(std::move(modified_global_vars)) {}
 
     // here we calculate "bad vars" for a function — they will be used in check-ub.cpp
@@ -130,6 +373,46 @@ private:
     // this works in a single thread and uses some heuristic for speedup, but generally it means
     // "for f in component { for e in edge { f.bad_vars += e.bad_vars } }"
     void for_component(const vector<FunctionPtr> &component, const vector<FunctionPtr> &edges) override {
+      // 1) fill f->next_with_colors
+      // (this can be optimized if many functions are marked with colors, for now left simple to me more understandable)
+      std::unordered_set<FunctionPtr> next_colored_uniq;
+
+      // if an edge is colored, append this edge
+      // if not, append next_with_colors from this edge
+      for (FunctionPtr f: edges) {
+        if (!f->colors.empty()) {
+          next_colored_uniq.insert(f);
+        } else if (f->next_with_colors != nullptr) {
+          next_colored_uniq.insert(f->next_with_colors->begin(), f->next_with_colors->end());
+        }
+      }
+
+      // for a recursive bunch of functions (e.g. f1 -> f2 -> f1)
+      // assume that "every functions is reachable from any of them" — so, append all colored functions from a recurse
+      // this is not true in all cases, but enough for practical usage
+      // also, to reduce a number of permutations for next colored path searching, choose only one representative of each color
+      bool has_colors_in_component = std::any_of(component.begin(), component.end(), [](FunctionPtr f) { return !f->colors.empty(); });
+      if (has_colors_in_component && component.size() > 1) {
+        function_palette::colors_mask_t added{0};
+        for (FunctionPtr f : component) {
+          for (function_palette::color_t c : f->colors) {
+            if (!(added & c)) {
+              added |= c;
+              next_colored_uniq.insert(f);
+            }
+          }
+        }
+      }
+
+      if (!next_colored_uniq.empty()) {
+        auto *next_with_colors = new std::vector<FunctionPtr>(next_colored_uniq.begin(), next_colored_uniq.end());
+        for (FunctionPtr f : component) {
+          f->next_with_colors = next_with_colors;
+        }
+      }
+
+      // 2) fill f->bad_vars
+
       // optimization 1: lots of functions don't modify globals at all
       // then we leave f->bad_vars nullptr
       bool empty = vk::all_of(component, [&](FunctionPtr f) { return modified_global_vars[f].empty(); })
@@ -193,7 +476,7 @@ private:
       modified_global_vars[func] = std::move(dep_datas[i].modified_global_vars);
     }
 
-    MergeBadVarsCallback callback(std::move(modified_global_vars));
+    MergeBadVarsAndColorsCallback callback(std::move(modified_global_vars));
     MergeReachalbe<FunctionPtr> merge_bad_vars;
     merge_bad_vars.run(call_graph.graph, call_graph.rev_graph, call_graph.functions, &callback);
   }
@@ -265,7 +548,7 @@ private:
     }
   }
 
-  void save_func_dep(FuncCallGraph &call_graph) {
+  void save_func_dep(const FuncCallGraph &call_graph) {
     for (int i = 0; i < call_graph.n; i++) {
       FunctionPtr function = call_graph.functions[i];
       function->dep = std::move(call_graph.graph[function]);
@@ -313,7 +596,7 @@ private:
     }
   };
 
-  void generate_ref_vars(vector<DepData> &dep_datas) {
+  void generate_ref_vars(const std::vector<DepData> &dep_datas) {
     vector<VarPtr> vars;
     for (const auto &data : dep_datas) {
       vars.insert(vars.end(), data.ref_param_vars.begin(), data.ref_param_vars.end());
@@ -353,6 +636,7 @@ public:
       FuncCallGraph call_graph(std::move(functions), dep_datas);
       calc_resumable(call_graph, dep_datas);
       generate_bad_vars(call_graph, dep_datas);
+      CheckFunctionsColors(call_graph).check();
       save_func_dep(call_graph);
     }
 

--- a/compiler/pipes/parse-and-apply-phpdoc.cpp
+++ b/compiler/pipes/parse-and-apply-phpdoc.cpp
@@ -300,6 +300,18 @@ private:
         break;
       }
 
+      case php_doc_tag::kphp_color: {
+        std::istringstream is(tag.value);
+        std::string color_name;
+        is >> color_name;
+
+        kphp_error_return(!color_name.empty(), "An empty tag value");
+        kphp_error_return(G->get_function_palette().color_exists(color_name), "Color missing in palette (either a misprint or a new color that needs to be added)");
+
+        f_->colors.add(G->get_function_palette().get_color_by_name(color_name));
+        break;
+      }
+
       default:
         break;
     }

--- a/compiler/pipes/register-kphp-configuration.cpp
+++ b/compiler/pipes/register-kphp-configuration.cpp
@@ -11,13 +11,21 @@
 #include "compiler/data/function-data.h"
 #include "compiler/gentree.h"
 
-bool RegisterKphpConfiguration::check_function(FunctionPtr function) const {
-  return function->type == FunctionData::func_class_holder &&
-         function->class_id->name == configuration_class_name_;
+void RegisterKphpConfiguration::execute(FunctionPtr function, DataStream<FunctionPtr> &unused_os __attribute__ ((unused))) {
+  if (function->type == FunctionData::func_class_holder && function->class_id->name == configuration_class_name_) {
+    stage::set_name("Register KphpConfiguration");
+    handle_KphpConfiguration_class(function->class_id);
+  }
+  tmp_stream << function;
 }
 
-void RegisterKphpConfiguration::on_start() {
-  const auto klass = current_function->class_id;
+void RegisterKphpConfiguration::on_finish(DataStream<FunctionPtr> &os) {
+  stage::die_if_global_errors();
+  Base::on_finish(os);
+}
+
+
+void RegisterKphpConfiguration::handle_KphpConfiguration_class(ClassPtr klass) {
   kphp_error(
     !klass->members.has_any_instance_method() &&
     !klass->members.has_any_instance_var() &&
@@ -31,41 +39,108 @@ void RegisterKphpConfiguration::on_start() {
       return;
     }
 
-    // TODO: make it beautiful
-    kphp_error_return(c.local_name() == runtime_options_name_,
-                      fmt_format("Got unexpected {} constant '{}'",
-                                 configuration_class_name_, c.local_name()));
-
-    auto arr = c.value.try_as<op_array>();
-    kphp_error_return(arr, fmt_format("{}::{} must be a constexpr array",
-                                      configuration_class_name_, runtime_options_name_));
-    for (const auto &opt : arr->args()) {
-      auto opt_pair = opt.try_as<op_double_arrow>();
-      kphp_error_return(opt_pair, fmt_format("{}::{} must be an associative map",
-                                             configuration_class_name_, runtime_options_name_));
-      const auto *opt_key = GenTree::get_constexpr_string(opt_pair->key());
-      kphp_error_return(opt_key, fmt_format("{}::{} map keys must be constexpr strings",
-                                            configuration_class_name_, runtime_options_name_));
-      if (*opt_key == confdata_blacklist_key_) {
-        register_confdata_blacklist(opt_pair->value());
-      } else if (*opt_key == confdata_predefined_wildcard_key_) {
-        register_confdata_predefined_wildcard(opt_pair->value());
-      } else if (*opt_key == mysql_db_name_key_) {
-        register_mysql_db_name(opt_pair->value());
-      } else if (*opt_key == net_dc_mask_key_) {
-        register_net_dc_mask(opt_pair->value());
-      }  else if (*opt_key == warmup_workers_part_key_) {
-        register_warmup_workers_part(opt_pair->value());
-      }  else if (*opt_key == warmup_instance_cache_elements_part_key_) {
-        register_warmup_instance_cache_elements_part(opt_pair->value());
-      }  else if (*opt_key == warmup_timeout_sec_key_) {
-        register_warmup_timeout_sec(opt_pair->value());
-      } else {
-        kphp_error(0, fmt_format("Got unexpected option {}::{}['{}']",
-                                 configuration_class_name_, runtime_options_name_, *opt_key));
-      }
+    if (c.local_name() == function_color_palette_name_) {
+      handle_constant_function_palette(c);
+    } else if (c.local_name() == runtime_options_name_) {
+      handle_constant_runtime_options(c);
+    } else {
+      kphp_error_return(0, fmt_format("Got unexpected {} constant '{}'",
+                                      configuration_class_name_, c.local_name()));
     }
   });
+}
+
+void RegisterKphpConfiguration::handle_constant_function_palette(const ClassMemberConstant &c) {
+  function_palette::Palette palette;
+  parse_palette(c.value, palette);
+  G->set_function_palette(std::move(palette));
+}
+
+void RegisterKphpConfiguration::parse_palette(VertexPtr const_val, function_palette::Palette &palette) {
+  auto arr = const_val.try_as<op_array>();
+  kphp_error_return(arr, fmt_format("{}::{} must be a constexpr array",
+                                    configuration_class_name_, function_color_palette_name_));
+
+  for (const auto &opt : arr->args()) {
+    const auto ruleset_arr = opt.try_as<op_array>();
+    kphp_error_act(ruleset_arr, fmt_format("{}::{} must contain constexpr arrays (rulesets)",
+                                           configuration_class_name_, function_color_palette_name_), continue);
+
+    parse_palette_ruleset(ruleset_arr, palette);
+  }
+}
+
+void RegisterKphpConfiguration::parse_palette_ruleset(VertexAdaptor<op_array> arr, function_palette::Palette &palette) {
+  function_palette::PaletteRuleset ruleset;
+
+  for (const auto &rule_node : arr->args()) {
+    auto pair = rule_node.try_as<op_double_arrow>();
+    kphp_error_act(pair, fmt_format("{}::{} rule must be an associative map",
+                                    configuration_class_name_, function_color_palette_name_), continue);
+
+    parse_palette_rule(pair, palette, ruleset);
+  }
+
+  palette.add_ruleset(std::move(ruleset));
+}
+
+void RegisterKphpConfiguration::parse_palette_rule(VertexAdaptor<op_double_arrow> pair, function_palette::Palette &palette, function_palette::PaletteRuleset &add_to) {
+  auto parse_rule_key_colors = [this, &palette](VertexPtr key) -> std::vector<function_palette::color_t> {
+    const auto *rule_string = GenTree::get_constexpr_string(key);
+    auto color_names_strings = split(rule_string != nullptr ? *rule_string : "", ' ');
+    kphp_error(!color_names_strings.empty(), fmt_format("{}::{} map keys must be non-empty constexpr strings",
+                                                        configuration_class_name_, function_color_palette_name_));
+    auto mapper = vk::make_transform_iterator_range([&palette](auto color_name) {
+      return palette.register_color_name(color_name);
+    }, color_names_strings.begin(), color_names_strings.end());
+    return {mapper.begin(), mapper.end()};
+  };
+
+  auto parse_rule_value_error = [this](VertexPtr value) -> std::string {
+    const std::string *errtext_val = GenTree::get_constexpr_string(value);
+    const auto ok_val = value.try_as<op_int_const>();
+    kphp_error(errtext_val || (ok_val && ok_val->get_string() == "1"), fmt_format("{}::{} map values must be constexpr strings or number 1",
+                                                                                  configuration_class_name_, function_color_palette_name_));
+    return errtext_val != nullptr ? *errtext_val : "";
+  };
+
+  auto colors = parse_rule_key_colors(pair->key());
+  auto error = parse_rule_value_error(pair->value());
+  add_to.emplace_back(function_palette::PaletteRule{std::move(colors), std::move(error)});
+}
+
+// --------------------------------------------
+
+void RegisterKphpConfiguration::handle_constant_runtime_options(const ClassMemberConstant &c) {
+  auto arr = c.value.try_as<op_array>();
+  kphp_error_return(arr, fmt_format("{}::{} must be a constexpr array",
+                                    configuration_class_name_, runtime_options_name_));
+  for (const auto &opt : arr->args()) {
+    auto opt_pair = opt.try_as<op_double_arrow>();
+    kphp_error_return(opt_pair, fmt_format("{}::{} must be an associative map",
+                                           configuration_class_name_, runtime_options_name_));
+    const auto *opt_key = GenTree::get_constexpr_string(opt_pair->key());
+    kphp_error_return(opt_key, fmt_format("{}::{} map keys must be constexpr strings",
+                                          configuration_class_name_, runtime_options_name_));
+    if (*opt_key == confdata_blacklist_key_) {
+      register_confdata_blacklist(opt_pair->value());
+    } else if (*opt_key == confdata_predefined_wildcard_key_) {
+      register_confdata_predefined_wildcard(opt_pair->value());
+    } else if (*opt_key == mysql_db_name_key_) {
+      register_mysql_db_name(opt_pair->value());
+    } else if (*opt_key == net_dc_mask_key_) {
+      register_net_dc_mask(opt_pair->value());
+    }  else if (*opt_key == warmup_workers_part_key_) {
+      register_warmup_workers_part(opt_pair->value());
+    }  else if (*opt_key == warmup_instance_cache_elements_part_key_) {
+      register_warmup_instance_cache_elements_part(opt_pair->value());
+    }  else if (*opt_key == warmup_timeout_sec_key_) {
+      register_warmup_timeout_sec(opt_pair->value());
+    } else {
+      kphp_error(0, fmt_format("Got unexpected option {}::{}['{}']",
+                               configuration_class_name_, runtime_options_name_, *opt_key));
+    }
+  }
 }
 
 void RegisterKphpConfiguration::generic_register_simple_option(VertexPtr value, vk::string_view opt_key) const noexcept {

--- a/tests/phpt/colors/000_highload.php
+++ b/tests/phpt/colors/000_highload.php
@@ -1,0 +1,28 @@
+@kphp_should_fail
+/Calling no\-highload function from highload function/
+/someHighload@highload -> someNoHighload@no-highload/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "highload no-highload" => "Calling no-highload function from highload function",
+    ],
+  ];
+}
+
+/**
+ * @kphp-color highload
+ */
+function someHighload() {
+    someNoHighload();
+}
+
+/**
+ * @kphp-color no-highload
+ */
+function someNoHighload() {
+    echo 1;
+}
+
+someHighload();

--- a/tests/phpt/colors/001_allowed.php
+++ b/tests/phpt/colors/001_allowed.php
@@ -1,0 +1,107 @@
+@ok
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ */
+function someSsr() {
+    hasDbAccess();
+}
+
+/**
+ * @kphp-color ssr-allow-db
+ * @kphp-color has-db-access
+ */
+function hasDbAccess() {
+    echo 1;
+}
+
+someSsr();
+
+
+/**
+ * @kphp-color api
+ */
+function api() {
+    hasCurl();
+}
+
+/**
+ * @kphp-color api-allow-curl
+ * @kphp-color has-curl
+ */
+function hasCurl() {
+    echo 1;
+}
+
+api();
+
+
+/**
+ * @kphp-color api
+ */
+function apiCallApiCallback() {
+    apiCallback();
+}
+
+/**
+ * @kphp-color api-callback
+ */
+function apiCallback() {
+    hasCurl();
+}
+
+apiCallApiCallback();
+
+
+/**
+ * @kphp-color api
+ * @kphp-color api-callback
+ */
+function apiWithApiCallback() {
+    hasCurl();
+}
+
+apiWithApiCallback();
+
+
+/**
+ * @kphp-color message-internals
+ */
+function messageInternals() {
+    echo 1;
+}
+
+/**
+ * @kphp-color message-module
+ */
+function messageModule() {
+    messageInternals();
+}
+
+messageModule();

--- a/tests/phpt/colors/002_not_allowed.php
+++ b/tests/phpt/colors/002_not_allowed.php
@@ -1,0 +1,65 @@
+@kphp_should_fail
+/Calling function working with the database in the server side rendering function/
+/someSsr@ssr -> hasDbAccess@has-db-access/
+/Calling curl function from API functions/
+/api@api -> hasCurl@has-curl/
+<?php
+
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ */
+function someSsr() {
+    hasDbAccess();
+}
+
+/**
+ * @kphp-color has-db-access
+ */
+function hasDbAccess() {
+    echo 1;
+}
+
+someSsr();
+
+
+/**
+ * @kphp-color api
+ */
+function api() {
+    hasCurl();
+}
+
+/**
+ * @kphp-color has-curl
+ */
+function hasCurl() {
+    echo 1;
+}
+
+api();

--- a/tests/phpt/colors/003_not_allowed_message_internals.php
+++ b/tests/phpt/colors/003_not_allowed_message_internals.php
@@ -1,0 +1,26 @@
+@kphp_should_fail
+/Calling function marked as internal outside of functions with the color message-module/
+/ -> someFunction -> messageInternals@message-internals/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "message-internals"              => "Calling function marked as internal outside of functions with the color message-module",
+        "message-module message-internals" => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color message-internals
+ */
+function messageInternals() {
+    echo 1;
+}
+
+function someFunction() {
+    messageInternals();
+}
+
+someFunction();

--- a/tests/phpt/colors/004_not_allowed_api_curl.php
+++ b/tests/phpt/colors/004_not_allowed_api_curl.php
@@ -1,0 +1,30 @@
+@kphp_should_fail
+/Calling curl function from API functions/
+/api@api -> hasCurl@has-curl/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "api has-curl"                => "Calling curl function from API functions",
+        "api api-callback has-curl"   => 1,
+        "api api-allow-curl has-curl" => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color api
+ */
+function api() {
+    hasCurl();
+}
+
+/**
+ * @kphp-color has-curl
+ */
+function hasCurl() {
+    echo 1;
+}
+
+api();

--- a/tests/phpt/colors/005_not_allowed_ssr_db.php
+++ b/tests/phpt/colors/005_not_allowed_ssr_db.php
@@ -1,0 +1,29 @@
+@kphp_should_fail
+/Calling function working with the database in the server side rendering function/
+/someSsr@ssr -> hasDbAccess@has-db-access/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "ssr has-db-access"              => "Calling function working with the database in the server side rendering function",
+        "ssr ssr-allow-db has-db-access" => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ */
+function someSsr() {
+    hasDbAccess();
+}
+
+/**
+ * @kphp-color has-db-access
+ */
+function hasDbAccess() {
+    echo 1;
+}
+
+someSsr();

--- a/tests/phpt/colors/006_complex_ok.php
+++ b/tests/phpt/colors/006_complex_ok.php
@@ -1,0 +1,65 @@
+@ok
+<?php
+
+class E1 {
+    const E1_TXT = "Calling no-highload function from highload function";
+    const E2_TXT = self::E1_TXT;
+}
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => E1::E2_TXT,
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ * @kphp-color message-module
+ */
+function functionWithSsrAndMessageModule() {
+    functionWithMessageModule();
+}
+
+/**
+ * @kphp-color message-module
+ */
+function functionWithMessageModule() {
+    functionWithAllowDbAccessAndMessageInternals(); // ok, has allow color
+}
+
+/**
+ * @kphp-color ssr-allow-db
+ * @kphp-color has-db-access
+ * @kphp-color message-internals
+ */
+function functionWithAllowDbAccessAndMessageInternals() {
+    functionWithMessageInternals();
+}
+
+/**
+ * @kphp-color message-internals
+ */
+function functionWithMessageInternals() {
+    echo 1;
+}
+
+functionWithSsrAndMessageModule();

--- a/tests/phpt/colors/007_complex_fail.php
+++ b/tests/phpt/colors/007_complex_fail.php
@@ -1,0 +1,97 @@
+@kphp_should_fail
+/Calling function marked as internal outside of functions with the color message-module/
+/ -> dangerZoneCallingMessageInternals -> messageInternals@message-internals/
+/Calling no-highload function from highload function/
+/functionWithSsrAndMessageModuleAndHighload@highload -> functionWithMessageModule -> functionWithAllowDbAccessAndNoHighload@no-highload/
+/Calling function working with the database in the server side rendering function/
+/functionWithSsrAndMessageModuleAndHighload@ssr -> functionWithMessageModule -> functionWithAllowDbAccessAndNoHighload@has-db-access/
+/functionWithSsrAndMessageModuleAndHighload@ssr -> functionWithMessageModule -> functionWithDbAccessWithoutAllow@has-db-access/
+<?php
+
+define('DEFINED_ERR_TXT', "Calling function working with the database in the server side rendering function");
+
+class E1 {
+    const E1_TXT = "Calling no-highload function from highload function";
+    const E2_TXT = self::E1_TXT;
+}
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => E1::E2_TXT,
+    ],
+    [
+      "ssr has-db-access"                 => DEFINED_ERR_TXT,
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ * @kphp-color message-module
+ * @kphp-color highload
+ */
+function functionWithSsrAndMessageModuleAndHighload() {
+    functionWithMessageModule();
+}
+
+/**
+ * @kphp-color message-module
+ */
+function functionWithMessageModule() {
+    functionWithAllowDbAccessAndNoHighload(); // error, call no-highload in highload
+    functionWithDbAccessWithoutAllow(); // error, db is not allowed
+}
+
+/**
+ * @kphp-color has-db-access
+ * @kphp-color ssr-allow-db
+ * @kphp-color no-highload
+ */
+function functionWithAllowDbAccessAndNoHighload() {
+    echo 1;
+}
+
+/**
+ * @kphp-color has-db-access
+ */
+function functionWithDbAccessWithoutAllow() {
+    echo 1;
+}
+
+
+/**
+ * @kphp-color danger-zone
+ */
+function dangerZoneCallingMessageInternals() {
+    messageInternals();
+}
+
+/**
+ * @kphp-color message-internals
+ */
+function messageInternals() {
+    echo 1;
+}
+
+
+function main() {
+    dangerZoneCallingMessageInternals();
+    functionWithSsrAndMessageModuleAndHighload();
+}
+
+main();

--- a/tests/phpt/colors/008_cross_cals.php
+++ b/tests/phpt/colors/008_cross_cals.php
@@ -1,0 +1,49 @@
+@kphp_should_fail
+/Calling no-highload function from highload function/
+/f1@highload -> f2 -> f4 -> f5@no-highload/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color highload
+ */
+function f1() { f2(); }
+function f2() { f3(); f4(); f6(); }
+function f3() { echo 1; }
+function f4() { f5(); }
+
+/**
+ * @kphp-color no-highload
+ */
+function f5() { echo 1; }
+
+/**
+ * @kphp-color highload
+ */
+function f6() { echo 1; }
+
+f1();

--- a/tests/phpt/colors/009_two_error_in_subtree.php
+++ b/tests/phpt/colors/009_two_error_in_subtree.php
@@ -1,0 +1,48 @@
+@kphp_should_fail
+/Calling no-highload function from highload function/
+/f1@highload -> f2@no-highload/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color highload
+ */
+function f1() { f2(); /* error 1 */ }
+/**
+ * @kphp-color no-highload
+ */
+function f2() { f3(); }
+/**
+ * @kphp-color highload
+ */
+function f3() { f4(); /* error 2 (not displayed until error 1 is fixed) */ }
+/**
+ * @kphp-color no-highload
+ */
+function f4() { echo 1; }
+
+f1();

--- a/tests/phpt/colors/010_allowed_in_cross_calls.php
+++ b/tests/phpt/colors/010_allowed_in_cross_calls.php
@@ -1,0 +1,54 @@
+@ok
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ */
+function f1() { f2(); }
+/**
+ * @kphp-color ssr-allow-db
+ */
+function f2() { f3(); }
+/**
+ * @kphp-color has-db-access
+ */
+function f3() { f4(); }
+
+function f4() { echo 1; }
+function f5() { echo 1; }
+
+/**
+ * @kphp-color ssr
+ */
+function f6() { f7(); }
+/**
+ * @kphp-color has-db-access
+ */
+function f7() { echo 1; /* not an error, since above in the f2() function there was a color allowing this */ }
+
+f1();

--- a/tests/phpt/colors/011_error_with_different_caller.php
+++ b/tests/phpt/colors/011_error_with_different_caller.php
@@ -1,0 +1,57 @@
+@kphp_should_fail
+/Calling no-highload function from highload function/
+/f6@highload -> f7@no-highload/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"              => "Calling no-highload function from highload function",
+    ],
+    [
+      "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
+      "ssr ssr-allow-db has-db-access"    => 1,
+    ],
+    [
+      "api has-curl"                      => "Calling curl function from API functions",
+      "api api-callback has-curl"         => 1,
+      "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+      "message-internals"                 => "Calling function marked as internal outside of functions with the color message-module",
+      "message-module message-internals"  => 1,
+    ],
+    [
+      "danger-zone *"                     => "Calling function without color danger-zone in a function with color danger-zone",
+      "danger-zone danger-zone"           => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color ssr
+ */
+function f1() { f2(); }
+/**
+ * @kphp-color ssr-allow-db
+ */
+function f2() { f6(); /* error */ }
+/**
+ * @kphp-color has-db-access
+ */
+function f3() { f4(); }
+
+function f4() { f5(); }
+function f5() { f6(); /* error */ }
+
+/**
+ * @kphp-color highload
+ */
+function f6() { f7(); }
+/**
+ * @kphp-color no-highload
+ */
+function f7() { echo 1; /* error that should not be displayed because the exact same error has already been displayed */ }
+
+f1();
+f3();

--- a/tests/phpt/colors/012_recursive_call.php
+++ b/tests/phpt/colors/012_recursive_call.php
@@ -1,0 +1,46 @@
+@ok
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "highload no-highload" => "Calling no-highload function from highload function",
+    ],
+  ];
+}
+
+function withoutColor(int $a) {
+    if ($a) {
+        withoutColorToo($a);
+    }
+}
+
+function withoutColorToo(int $a) {
+    if ($a) {
+        withoutColor($a);
+    }
+}
+
+withoutColor((int)$_POST["id"]);
+
+/**
+ * @kphp-color highload
+ */
+function highload(int $a) {
+    if ($a) {
+        highloadToo($a);
+    }
+
+    echo 1;
+}
+
+/**
+ * @kphp-color highload
+ */
+function highloadToo(int $a) {
+    if ($a) {
+        highload($a);
+    }
+}
+
+highload((int)$_POST["id"]);

--- a/tests/phpt/colors/013_almost_same_rules.php
+++ b/tests/phpt/colors/013_almost_same_rules.php
@@ -1,0 +1,46 @@
+@kphp_should_fail
+/Calling curl function from API functions/
+/api@api -> hasCurl@has-curl/
+/api@api -> api2 -> hasCurl@has-curl/
+/Calling curl function from API2 functions/
+/api2@api2 -> hasCurl@has-curl/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "api has-curl"                      => "Calling curl function from API functions",
+        "api api-callback has-curl"         => 1,
+        "api api-allow-curl has-curl"       => 1,
+    ],
+    [
+        "api2 has-curl"                      => "Calling curl function from API2 functions",
+        "api2 api-callback has-curl"         => 1,
+        "api2 has-curl api-allow-curl"       => 1,
+    ],
+  ];
+}
+
+/**
+ * @kphp-color api
+ */
+function api() {
+    api2();
+    hasCurl();
+}
+
+/**
+ * @kphp-color api2
+ */
+function api2() {
+    hasCurl();
+}
+
+/**
+ * @kphp-color has-curl
+ */
+function hasCurl() {
+    echo 1;
+}
+
+api();

--- a/tests/phpt/colors/014_not_allowed_more.php
+++ b/tests/phpt/colors/014_not_allowed_more.php
@@ -1,0 +1,42 @@
+@kphp_should_fail
+/dont allow rgb nesting/
+/r@red -> r2 -> g@green -> g2 -> ssr1 -> ssr2 -> b@blue/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "ssr"    => 1,
+      "api"    => 1,
+    ],
+    [
+        'red green blue' => 'dont allow rgb nesting',
+    ]
+  ];
+}
+
+function init() { r(); }
+init();
+
+/**
+ * @kphp-color red
+ * @kphp-color api
+ */
+function r() { r2(); }
+/** @kphp-color ssr */
+function r2() { g(); b(); }
+
+/** @kphp-color green */
+function g() { g2(); }
+function g2() { ssr1(); }
+
+/**
+  * @kphp-color blue
+  */
+function b() { b2(); }
+function b2() { [1]; }
+
+/** @kphp-color ssr */
+function ssr1() { [1]; ssr2(); }
+/** @kphp-color ssr */
+function ssr2() { [1]; b(); }

--- a/tests/phpt/colors/015_colored_resumable.php
+++ b/tests/phpt/colors/015_colored_resumable.php
@@ -1,0 +1,48 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "api has-curl"    => "curl from api",
+    ],
+  ];
+}
+
+function init() {
+    $ii = fork(api());
+    wait($ii);
+}
+
+/** @kphp-color api */
+function api() {
+    sched_yield();
+    $i = fork(resum());
+    wait($i);
+    return null;
+}
+
+function resum() {
+    sched_yield();
+    // resum2();
+    return null;
+}
+
+function init2() {
+    $i = fork(resum2());
+    wait($i);
+}
+
+function resum2() {
+    sched_yield();
+    callurl();
+    return null;
+}
+
+/** @kphp-color has-curl */
+function callurl() { sched_yield(); 1; }
+
+
+init();
+init2();

--- a/tests/phpt/colors/016_colored_resumable_2.php
+++ b/tests/phpt/colors/016_colored_resumable_2.php
@@ -1,0 +1,49 @@
+@kphp_should_fail
+/curl from api/
+/api@api -> resum -> resum2 -> callurl@has-curl/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "api has-curl"    => "curl from api",
+    ],
+  ];
+}
+
+function init() {
+    $ii = fork(api());
+    wait($ii);
+}
+
+/** @kphp-color api */
+function api() {
+    sched_yield();
+    $i = fork(resum());
+    wait($i);
+    return null;
+}
+
+function resum() {
+    sched_yield();
+    resum2();
+    return null;
+}
+
+function init2() {
+    $i = fork(resum2());
+    wait($i);
+}
+
+function resum2() {
+    sched_yield();
+    callurl();
+    return null;
+}
+
+/** @kphp-color has-curl */
+function callurl() { sched_yield(); 1; }
+
+
+init();
+init2();

--- a/tests/phpt/colors/017_colored_recursive.php
+++ b/tests/phpt/colors/017_colored_recursive.php
@@ -1,0 +1,29 @@
+@kphp_should_fail
+/dont call curl from api/
+/f3@api -> f10 -> f11 -> f12 -> f1 -> f2@has-curl/
+<?php
+
+class KphpConfiguration {
+    const FUNCTION_PALETTE = [
+        [
+            'api has-curl' => 'dont call curl from api',
+            'api has-curl please' => 1,
+        ]
+    ];
+}
+
+function f1() { f2(); f3(); }
+/**
+ * @kphp-color has-curl
+ */
+function f2() { f10(); }
+/** @kphp-color api */
+function f3() { f10(); }
+function f10() { f11(); f100(); }
+function f11() { [1]; f12(); f13(); }
+function f12() { [2]; f1(); }
+function f13() { [3]; }
+function f100() { [100]; f101(); }
+function f101() { [101]; f102(); }
+function f102() { [101]; f101(); }
+f1();

--- a/tests/phpt/colors/018_colored_recursive_2.php
+++ b/tests/phpt/colors/018_colored_recursive_2.php
@@ -1,0 +1,28 @@
+@ok
+<?php
+
+class KphpConfiguration {
+    const FUNCTION_PALETTE = [
+        [
+            'api has-curl' => 'dont call curl from api',
+            'api has-curl please' => 1,
+        ]
+    ];
+}
+
+function f1() { if(0) f2(); if(0) f3(); }
+/**
+ * @kphp-color has-curl
+ * @kphp-color please
+ */
+function f2() { f10(); }
+/** @kphp-color api */
+function f3() { f10(); }
+function f10() { f11(); f100(); }
+function f11() { [1]; f12(); f13(); }
+function f12() { [2]; f1(); }
+function f13() { [3]; }
+function f100() { [100]; f101(); }
+function f101() { [101]; f102(); }
+function f102() { [101]; f101(); }
+f1();

--- a/tests/phpt/colors/019_emulate_cuf.php
+++ b/tests/phpt/colors/019_emulate_cuf.php
@@ -1,0 +1,51 @@
+@kphp_should_fail
+/dont call curl from api/
+/@api -> /
+/ -> f4@has-curl/
+<?php
+// a strange error pattern is because it's not unique and can vary from launch to launch
+
+class KphpConfiguration {
+    const FUNCTION_PALETTE = [
+        [
+            'api has-curl' => 'dont call curl from api',
+            'api has-curl please' => 1,
+        ]
+    ];
+}
+
+
+function cuf($name) {
+    if(0) api_1();
+    if(0) api_2();
+    api_3(); api_4(); api_5(); api_6();
+    f1(); f2(); f3(); f4(); f5(); f6();
+}
+
+/** @kphp-color api */
+function api_1() { f1(); f2(); f3(); api_2(); }
+function f1() { cuf('api_1'); }
+
+/** @kphp-color api */
+function api_2() { f2(); f1(); }
+function f2() { cuf('api_2'); }
+
+/** @kphp-color api */
+function api_3() { f3(); f4(); f1();  }
+function f3() { cuf('api_3'); }
+
+/** @kphp-color api */
+function api_4() { f4();  }
+/** @kphp-color has-curl */
+function f4() { cuf('api_3'); }
+
+/** @kphp-color api */
+function api_5() { f5();  }
+function f5() { cuf('api_3'); }
+
+/** @kphp-color api */
+function api_6() { f6();  }
+function f6() { cuf('api_3'); }
+
+cuf('api_1');
+

--- a/tests/phpt/colors/020_different_paths.php
+++ b/tests/phpt/colors/020_different_paths.php
@@ -1,0 +1,31 @@
+@kphp_should_fail
+/Calling curl function from API functions/
+/api2@api -> common -> callurl@has-curl/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "api has-curl"                      => "Calling curl function from API functions",
+        "api api-callback has-curl"         => 1,
+        "api api-allow-curl has-curl"       => 1,
+    ],
+  ];
+}
+
+/** @kphp-color api */
+function api1() { allow1(); }
+/** @kphp-color api-allow-curl */
+function allow1() { common(); }
+
+/** @kphp-color api-allow-curl */
+function allow2() { api2(); }
+/** @kphp-color api */
+function api2() { common(); }
+
+function common() { callurl(); }
+/** @kphp-color has-curl */
+function callurl() { [1]; }
+
+allow2();
+api1();

--- a/tests/phpt/colors/021_different_paths_ok.php
+++ b/tests/phpt/colors/021_different_paths_ok.php
@@ -1,0 +1,30 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+        "api has-curl"                      => "Calling curl function from API functions",
+        "api api-callback has-curl"         => 1,
+        "api api-allow-curl has-curl"       => 1,
+    ],
+  ];
+}
+
+/** @kphp-color api */
+function api1() { allow1(); }
+/** @kphp-color api-allow-curl */
+function allow1() { common(); }
+
+/** @kphp-color api-allow-curl */
+function allow2() { common(); }
+/** @kphp-color api */
+function api2() { allow2(); }
+
+function common() { callurl(); }
+/** @kphp-color has-curl */
+function callurl() { [1]; }
+
+api2();
+api1();

--- a/tests/phpt/colors/022_long_path.php
+++ b/tests/phpt/colors/022_long_path.php
@@ -1,0 +1,40 @@
+@kphp_should_fail
+/function fHigh\(\)/
+/fHigh@highload -> longDisallowedPath -> l1 -> l2 -> l3 -> l4 -> fLow@no-highload/
+<?php
+
+class KphpConfiguration {
+  const FUNCTION_PALETTE = [
+    [
+      "highload no-highload"          => 'Calling no-highload function from highload function',
+      'highload allow-hh no-highload' => 1,
+    ],
+];
+}
+
+/** @kphp-color highload */
+function fHigh() {
+     shortAllowedPath();
+     longDisallowedPath();
+}
+fHigh();
+
+/** @kphp-color no-highload */
+function fLow() { [1]; }
+
+function shortAllowedPath() {
+    s1();
+}
+
+/** @kphp-color allow-hh */
+function s1() { fLow(); }
+
+function longDisallowedPath() {
+    l1();
+}
+
+function l1() { l2(); }
+function l2() { l3(); }
+function l3() { l4(); }
+function l4() { fLow(); }
+


### PR DESCRIPTION
# Function colors

The concept of function colors consists of two parts: colors and their mixing palette. 
The colors define the properties of the functions, and the palette determines the order 
in which the colors of the functions can be mixed.

Function colors allow us to control function calls, disallowing some of them if they 
contradict some logic or rules.

A mixing palette is usually represented as a set of rule groups. Each group consists of
a set of rules, where the first rule describes an error, that is, a certain set of colors that 
cannot be mixed, and the rest are exceptions when it is allowed to do so.

For example:

```php
[
    "red green"        => "error",  // you can not do it this way
    "red yellow green" => "ok"      // but if there is also a yellow color, then you can
]
```

It is forbidden to mix `red` with `green`, but if `yellow` is mixed between them, then it is allowed.

Color mixing means chaining of function calls, where the chaining can be of length `>= 1`.

That is, we can say that if a function is `red`, then a `green` function cannot be called from it. 
But if the function has both `red` and `yellow` colors, we can call the function with `green` color. 
We can also say that if a function has a `red` color, we can call a function with `yellow` and `green`
 color from it.

To set the color for the function, added the annotation `@kphp-color`, which takes one argument.
To set multiple colors, you need to add several annotations (order is important).

```php
/**
 * @kphp-color red
 */
function f1() {}

/**
 * @kphp-color red
 * @kphp-color yellow
 */
function f2() {}
```

To define the mixing rules, used the `FUNCTION_PALETTE` constant in the `KphpConfiguration.php` file.

For example:

```php
const FUNCTION_PALETTE = [
  [
    "highload no-highload"              => "Calling no-highload function from highload function",
  ],
  [
    "ssr has-db-access"                 => "Calling function working with the database in the server side rendering function",
    "ssr ssr-allow-db has-db-access"    => 1,
  ],
]
```

A constant is a two-dimensional array or an array of rule groups. Each group consists of a set 
of rules. A rule is a key-value pair, where a string containing a set of colors separated by a space 
is written in the key, and a string describing the error or the number 1 (the fact that the rule does 
not result in an error) is written in the value.

In each group, the rule with an error must be the first rule. All further rules should not lead to an 
error (that is, they should have 1 in the value). All rules after the first are called exception rules, 
that is, they must contain the colors from the first rule and add new ones to them, thereby clarifying.