### PR TITLE
Job workers: improve interface

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -1349,9 +1349,9 @@ class KphpJobWorkerResponseError implements KphpJobWorkerResponse {
   public function getErrorCode() ::: int;
 }
 
-function kphp_job_worker_start(KphpJobWorkerRequest $request, float $timeout = -1.0) ::: int;
+function kphp_job_worker_start(KphpJobWorkerRequest $request, float $timeout = -1.0) ::: future<KphpJobWorkerResponse> | false;
 /** @kphp-extern-func-info resumable */
-function kphp_job_worker_wait(int $job_id, float $timeout = -1.0) ::: KphpJobWorkerResponse;
+function kphp_job_worker_wait(future<KphpJobWorkerResponse> $job_id, float $timeout = -1.0) ::: KphpJobWorkerResponse;
 
 function kphp_job_worker_fetch_request() ::: KphpJobWorkerRequest;
 function kphp_job_worker_store_response(KphpJobWorkerResponse $response) ::: void;

--- a/runtime/job-workers/client-functions.h
+++ b/runtime/job-workers/client-functions.h
@@ -9,5 +9,5 @@
 
 void free_job_client_interface_lib() noexcept;
 
-int64_t f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRequest> &request, double timeout = -1.0) noexcept;
+Optional<int64_t> f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRequest> &request, double timeout = -1.0) noexcept;
 class_instance<C$KphpJobWorkerResponse> f$kphp_job_worker_wait(int64_t job_resumable_id, double timeout = -1.0) noexcept;

--- a/tests/python/tests/job_workers/php/ComplexScenario/_http_scenario.php
+++ b/tests/python/tests/job_workers/php/ComplexScenario/_http_scenario.php
@@ -10,6 +10,9 @@ require_once "_stats_processor.php";
 
 function collect_stats_with_job(StatTraits $traits, int $master_port) {
   $job_id = kphp_job_worker_start(new CollectStatsJobRequest($master_port, $traits));
+  if (!$job_id) {
+    critical_error("Can't send job");
+  }
   $result = kphp_job_worker_wait($job_id);
   $result_stats = instance_cast($result, CollectStatsJobResponse::class);
   if ($result_stats === null) {


### PR DESCRIPTION
Job now is represented as `future<KphpJobWorkerResponse>` instead of `int64_t`