### PR TITLE
Drop extra TL header.

### DIFF
--- a/compiler/code-gen/files/tl2cpp/tl-module.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-module.cpp
@@ -15,7 +15,6 @@ std::set<std::string> modules_with_functions;
 void Module::compile_tl_h_file(CodeGenerator &W) const {
   W << OpenFile(name + ".h", "tl");
   W << "#pragma once" << NL;
-  W << ExternInclude("runtime/tl/tl_builtins.h");
   W << ExternInclude("tl/tl_const_vars.h");
   W << h_includes;
   W << NL;


### PR DESCRIPTION
This header is useless, because it is existed in precompiled header as well.