### PR TITLE
Abstract in traits

### DIFF
--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -293,13 +293,9 @@ VertexRange FunctionData::get_params() const {
   return root->param_list()->params();
 }
 
-bool FunctionData::can_take_cnt_params(int expected_cnt_params, FunctionPtr called_func) {
-  if (!called_func) {
-    return false;
-  }
-
-  int min_cnt_params = called_func->get_min_argn() - called_func->has_implicit_this_arg();
-  int max_cnt_params = static_cast<int>(called_func->get_params().size()) - called_func->has_implicit_this_arg();
+bool FunctionData::can_take_cnt_params(int expected_cnt_params) {
+  int min_cnt_params = get_min_argn() - has_implicit_this_arg();
+  int max_cnt_params = static_cast<int>(get_params().size()) - has_implicit_this_arg();
   if (expected_cnt_params < min_cnt_params || max_cnt_params < expected_cnt_params) {
     kphp_error(false, fmt_format("Wrong arguments count: {} (expected {}..{})", expected_cnt_params, min_cnt_params, max_cnt_params));
     return false;

--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -293,7 +293,7 @@ VertexRange FunctionData::get_params() const {
   return root->param_list()->params();
 }
 
-bool FunctionData::check_cnt_params(int expected_cnt_params, FunctionPtr called_func) {
+bool FunctionData::can_take_cnt_params(int expected_cnt_params, FunctionPtr called_func) {
   if (!called_func) {
     return false;
   }

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -168,6 +168,7 @@ public:
   std::string get_name_of_self_method() const;
 
   int get_min_argn();
+  bool can_override_method(FunctionPtr interface_method);
 
   bool is_lambda() const {
     return static_cast<bool>(function_in_which_lambda_was_created);
@@ -187,7 +188,7 @@ public:
 
   VertexRange get_params() const;
 
-  bool can_take_cnt_params(int expected_cnt_params);
+  bool can_take_cnt_params(int expected_cnt_params, bool is_silent = false);
 
   vk::string_view local_name() const & { return get_local_name_from_global_$$(name); }
   vk::string_view local_name() const && = delete;

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -187,7 +187,7 @@ public:
 
   VertexRange get_params() const;
 
-  static bool check_cnt_params(int expected_cnt_params, FunctionPtr called_func);
+  static bool can_take_cnt_params(int expected_cnt_params, FunctionPtr called_func);
 
   vk::string_view local_name() const & { return get_local_name_from_global_$$(name); }
   vk::string_view local_name() const && = delete;

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -187,7 +187,7 @@ public:
 
   VertexRange get_params() const;
 
-  static bool can_take_cnt_params(int expected_cnt_params, FunctionPtr called_func);
+  bool can_take_cnt_params(int expected_cnt_params);
 
   vk::string_view local_name() const & { return get_local_name_from_global_$$(name); }
   vk::string_view local_name() const && = delete;

--- a/compiler/data/lambda-class-data.cpp
+++ b/compiler/data/lambda-class-data.cpp
@@ -131,7 +131,7 @@ std::string LambdaClassData::get_name_of_invoke_function_for_extern(VertexAdapto
 
   auto func_param_callback = callback_it->as<op_func_param>();
   const auto *type_hint_callable = func_param_callback->type_hint->try_as<TypeHintCallable>();
-  if (!FunctionData::check_cnt_params(type_hint_callable->arg_types.size(), *template_of_invoke_method)) {
+  if (!FunctionData::can_take_cnt_params(type_hint_callable->arg_types.size(), *template_of_invoke_method)) {
     return "";
   }
 

--- a/compiler/data/lambda-class-data.cpp
+++ b/compiler/data/lambda-class-data.cpp
@@ -113,7 +113,7 @@ void infer_type_of_callback_arg(const TypeHint *type_hint, VertexAdaptor<op_func
 std::string LambdaClassData::get_name_of_invoke_function_for_extern(VertexAdaptor<op_func_call> extern_function_call,
                                                                     FunctionPtr function_context,
                                                                     std::map<int, Assumption> *template_type_id_to_ClassPtr /*= nullptr*/,
-                                                                    FunctionPtr *template_of_invoke_method /*= nullptr*/) const {
+                                                                    FunctionPtr template_of_invoke_method /*= {}*/) const {
   std::string invoke_method_name = replace_backslashes(construct_function->class_id->name) + "$$" + NAME_OF_INVOKE_METHOD;
 
   VertexRange call_params = extern_function_call->args();
@@ -131,11 +131,11 @@ std::string LambdaClassData::get_name_of_invoke_function_for_extern(VertexAdapto
 
   auto func_param_callback = callback_it->as<op_func_param>();
   const auto *type_hint_callable = func_param_callback->type_hint->try_as<TypeHintCallable>();
-  if (!FunctionData::can_take_cnt_params(type_hint_callable->arg_types.size(), *template_of_invoke_method)) {
+  if (!template_of_invoke_method->can_take_cnt_params(type_hint_callable->arg_types.size())) {
     return "";
   }
 
-  auto template_invoke_params = (*template_of_invoke_method)->get_params();
+  auto template_invoke_params = template_of_invoke_method->get_params();
   for (int i = 0; i < type_hint_callable->arg_types.size(); ++i) {
     Assumption assumption;
     auto lambda_param = template_invoke_params[i + 1].as<op_func_param>();

--- a/compiler/data/lambda-class-data.h
+++ b/compiler/data/lambda-class-data.h
@@ -21,7 +21,7 @@ public:
   std::string get_name_of_invoke_function_for_extern(VertexAdaptor<op_func_call> extern_function_call,
                                                      FunctionPtr function_context,
                                                      std::map<int, Assumption> *template_type_id_to_ClassPtr = nullptr,
-                                                     FunctionPtr *template_of_invoke_method = nullptr) const;
+                                                     FunctionPtr template_of_invoke_method = {}) const;
 
   VertexAdaptor<op_func_call> gen_constructor_call_pass_fields_as_args() const;
   VertexAdaptor<op_func_call> gen_constructor_call_with_args(std::vector<VertexPtr> args) const;

--- a/compiler/data/lambda-interface-generator.cpp
+++ b/compiler/data/lambda-interface-generator.cpp
@@ -84,6 +84,7 @@ void LambdaInterfaceGenerator::add_type_hints(FunctionPtr invoke_method) noexcep
   auto params = invoke_method->get_params();
   for (int i = 1; i < params.size(); ++i) {
     params[i].as<op_func_param>()->type_hint = arg_types[i - 1];
+    params[i].as<op_func_param>()->type_as_part_of_signature = arg_types[i - 1];
   }
   invoke_method->return_typehint = return_type;
 }

--- a/compiler/data/virtual-method-generator.cpp
+++ b/compiler/data/virtual-method-generator.cpp
@@ -53,6 +53,7 @@ bool check_that_signatures_are_same(FunctionPtr interface_function, ClassPtr con
   kphp_assert(derived_method);
 
   if (!derived_method->can_override_method(interface_function)) {
+    stage::set_location(derived_method->root->location);
     kphp_error(false, fmt_format("Declaration of {} must be compatible with version in class {}",
                                  interface_function->get_human_readable_name(),
                                  context_class->name));

--- a/compiler/data/virtual-method-generator.cpp
+++ b/compiler/data/virtual-method-generator.cpp
@@ -52,27 +52,8 @@ bool check_that_signatures_are_same(FunctionPtr interface_function, ClassPtr con
   FunctionPtr derived_method = interface_method_in_derived->function;
   kphp_assert(derived_method);
 
-  /**
-   * Check that overridden method has count of parameters at least as in interface
-   * and has appropriate count of default parameters e.g.:
-   *
-   * interface I { public function foo($x, $y); }
-   * class A implements I { public function foo($x, $y = 10, $z = 20); }
-   *
-   * Interface I: i_argn = 2
-   * Class A    : min_argn = 1, max_argn = 3, default_argn = 2
-   * check that : i_argn <= max_argn && (default_argn >= max_argn - i_argn)
-   */
-  auto min_argn = derived_method->get_min_argn();
-  auto derived_params = derived_method->get_params();
-  auto max_argn = derived_params.size();
-  auto default_argn = max_argn - min_argn;
-
-  auto interface_params = interface_function->get_params();
-  auto i_argn = interface_params.size();
-
-  if (!(i_argn <= max_argn && (default_argn >= max_argn - i_argn))) {
-    kphp_error(false, fmt_format("Count of arguments are different in interface method: `{}` and in class: `{}`",
+  if (!derived_method->can_override_method(interface_function)) {
+    kphp_error(false, fmt_format("Declaration of {} must be compatible with version in class {}",
                                  interface_function->get_human_readable_name(),
                                  context_class->name));
 

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -849,6 +849,7 @@ VertexAdaptor<op_func_param> GenTree::get_func_param() {
       type_hint = TypeHintOptional::create(type_hint, true, false);
     }
     v->type_hint = type_hint;
+    v->type_as_part_of_signature = type_hint;
   }
   v->is_cast_param = is_cast_param;
 

--- a/compiler/pipes/check-function-calls.cpp
+++ b/compiler/pipes/check-function-calls.cpp
@@ -59,7 +59,7 @@ void CheckFunctionCallsPass::check_func_call(VertexPtr call) {
                                    func_param->var()->get_string(),
                                    OpInfo::str(call_params[i]->type())));
 
-      if (!FunctionData::can_take_cnt_params(func_param->type_hint->try_as<TypeHintCallable>()->arg_types.size(), call_param->func_id)) {
+      if (!call_param->func_id->can_take_cnt_params(func_param->type_hint->try_as<TypeHintCallable>()->arg_types.size())) {
         return;
       }
     }

--- a/compiler/pipes/check-function-calls.cpp
+++ b/compiler/pipes/check-function-calls.cpp
@@ -52,14 +52,17 @@ void CheckFunctionCallsPass::check_func_call(VertexPtr call) {
 
   for (int i = 0; i < call_params.size(); i++) {
     auto func_param = func_params[i].as<op_func_param>();
-    if (f->is_extern() && func_param->type_hint && func_param->type_hint->try_as<TypeHintCallable>()) {
+    if (!f->is_extern() || !func_param->type_hint) {
+      continue;
+    }
+    if (const auto *param_type_hint = func_param->type_hint->try_as<TypeHintCallable>()) {
       auto call_param = call_params[i].try_as<op_func_ptr>();
       kphp_error_return(call_param,
                         fmt_format("Argument '{}' should be function pointer, but {} found",
                                    func_param->var()->get_string(),
                                    OpInfo::str(call_params[i]->type())));
 
-      if (!call_param->func_id->can_take_cnt_params(func_param->type_hint->try_as<TypeHintCallable>()->arg_types.size())) {
+      if (!call_param->func_id->can_take_cnt_params(param_type_hint->arg_types.size())) {
         return;
       }
     }

--- a/compiler/pipes/check-function-calls.cpp
+++ b/compiler/pipes/check-function-calls.cpp
@@ -59,7 +59,7 @@ void CheckFunctionCallsPass::check_func_call(VertexPtr call) {
                                    func_param->var()->get_string(),
                                    OpInfo::str(call_params[i]->type())));
 
-      if (!FunctionData::check_cnt_params(func_param->type_hint->try_as<TypeHintCallable>()->arg_types.size(), call_param->func_id)) {
+      if (!FunctionData::can_take_cnt_params(func_param->type_hint->try_as<TypeHintCallable>()->arg_types.size(), call_param->func_id)) {
         return;
       }
     }

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -156,7 +156,7 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
     }
 
     auto expected_arguments_count = type_hint_callable->arg_types.size();
-    if (!FunctionData::check_cnt_params(expected_arguments_count, func_ptr_of_callable)) {
+    if (!FunctionData::can_take_cnt_params(expected_arguments_count, func_ptr_of_callable)) {
       continue;
     }
   }

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -156,7 +156,7 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
     }
 
     auto expected_arguments_count = type_hint_callable->arg_types.size();
-    if (!FunctionData::can_take_cnt_params(expected_arguments_count, func_ptr_of_callable)) {
+    if (!func_ptr_of_callable->can_take_cnt_params(expected_arguments_count)) {
       continue;
     }
   }

--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -166,7 +166,7 @@ private:
 
       if (auto template_of_invoke_method = lambda_class->get_template_of_invoke_function()) {
         std::map<int, Assumption> template_type_id_to_ClassPtr;
-        invoke_name = lambda_class->get_name_of_invoke_function_for_extern(call, current_function, &template_type_id_to_ClassPtr, &template_of_invoke_method);
+        invoke_name = lambda_class->get_name_of_invoke_function_for_extern(call, current_function, &template_type_id_to_ClassPtr, template_of_invoke_method);
 
         instance_of_template_invoke = generate_instance_template_function_by_name(template_type_id_to_ClassPtr, template_of_invoke_method, invoke_name);
         instance_of_template_invoke->instantiation_of_template_function_location = call_arg->get_location();

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -440,6 +440,10 @@
         "type": "bool",
         "default": "false"
       },
+      "type_as_part_of_signature": {
+        "type": "const TypeHint *",
+        "default": "nullptr"
+      },
       "is_callable": {
         "type": "bool",
         "default": "false"

--- a/tests/phpt/class_inheritance/102_same_variables_name.php
+++ b/tests/phpt/class_inheritance/102_same_variables_name.php
@@ -1,4 +1,5 @@
 @kphp_should_fail
+/You may not override field: `x`, in class: `D`/
 <?php
 
 class B {

--- a/tests/phpt/class_inheritance/107_wrong_arguments_count_in_static_abstract_method.php
+++ b/tests/phpt/class_inheritance/107_wrong_arguments_count_in_static_abstract_method.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Count of arguments/
+/Declaration of Base::foo must be compatible with version in class Derived/
 <?php
 
 abstract class Base {

--- a/tests/phpt/lambdas/130_typed_callables_auto_assum.php
+++ b/tests/phpt/lambdas/130_typed_callables_auto_assum.php
@@ -1,10 +1,7 @@
 @kphp_should_fail
 KPHP_SHOW_ALL_TYPE_ERRORS=1
-/pass B to argument \$arg0 of L\\Avoid::__invoke/
-/assign string to A::\$a/
-/but it's declared as @var int/
-/pass A to argument \$b of anonymous\(...\)/
-/but it's declared as @param B/
+/130_typed_callables_auto_assum.php:29/
+/Declaration of L\\Avoid::__invoke must be compatible with version in class/
 <?php
 
 

--- a/tests/phpt/traits/abstract_in_traits/000_abstract_and_non_abstract_methods.php
+++ b/tests/phpt/traits/abstract_in_traits/000_abstract_and_non_abstract_methods.php
@@ -1,0 +1,25 @@
+@ok
+<?php
+
+trait AT {
+  abstract protected function func(): void;
+}
+
+trait BT {
+  protected function func(): void {
+    var_dump('123');
+  }
+
+  public function func_dec(): void {
+    $this->func();
+  }
+}
+
+class CT {
+  use AT;
+  use BT;
+}
+
+
+$ct = new CT();
+$ct->func_dec();

--- a/tests/phpt/traits/abstract_in_traits/001_non_abstract_and_abstract_methods.php
+++ b/tests/phpt/traits/abstract_in_traits/001_non_abstract_and_abstract_methods.php
@@ -1,0 +1,18 @@
+@ok
+<?php
+
+trait AT {
+  public function run(int $x): void { var_dump('123'); }
+}
+
+trait BT {
+  abstract public function run(int $x): void;
+}
+
+class CT {
+  use AT;
+  use BT;
+}
+
+$ct = new CT();
+$ct->run(10);

--- a/tests/phpt/traits/abstract_in_traits/002_abstract_and_abstract.php
+++ b/tests/phpt/traits/abstract_in_traits/002_abstract_and_abstract.php
@@ -1,0 +1,31 @@
+@ok
+<?php
+
+trait AT {
+  abstract public function run(int $x): void;
+}
+
+trait BT {
+  abstract public function run(int $x): void;
+}
+
+abstract class CT {
+  use AT;
+  use BT;
+}
+
+class CT2 {
+    use AT;
+    use BT;
+    public function run(int $x): void { var_dump($x); }
+}
+
+class CT_D extends CT {
+    public function run(int $x): void { var_dump($x); }
+}
+
+$ct = new CT_D();
+$ct->run(10);
+
+$ct2 = new CT2();
+$ct2->run(10);

--- a/tests/phpt/traits/abstract_in_traits/003_abstract_and_class_impl.php
+++ b/tests/phpt/traits/abstract_in_traits/003_abstract_and_class_impl.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+trait A {
+    abstract public function run($x, $y);
+}
+
+class C {
+    use A;
+    public function run() {
+        var_dump("Ignore A::run");
+    }
+}
+
+$c = new C();
+$c->run();

--- a/tests/phpt/traits/abstract_in_traits/004_non_abstract_class_impl.php
+++ b/tests/phpt/traits/abstract_in_traits/004_non_abstract_class_impl.php
@@ -1,0 +1,18 @@
+@ok
+<?php
+
+trait A {
+    public function run(int $x) { var_dump($x); }
+}
+
+abstract class C {
+    use A;
+    abstract public function run();
+}
+
+class CD extends C {
+    public function run() { var_dump("CD"); }
+}
+
+$cd = new CD();
+$cd->run();

--- a/tests/phpt/traits/abstract_in_traits/005_double_override_abstract.php
+++ b/tests/phpt/traits/abstract_in_traits/005_double_override_abstract.php
@@ -1,0 +1,20 @@
+@ok
+<?php
+
+trait A {
+    abstract public function run(int $x);
+}
+
+trait B {
+    abstract public function run(int $x, float $y = 0, string $s = "");
+}
+
+trait C {
+    abstract public function run(int $x, float $y = 0);
+}
+
+abstract class D {
+    use A;
+    use C;
+    use B;
+}

--- a/tests/phpt/traits/abstract_in_traits/006_abstract_and_non_abstract_methods_reverse.php
+++ b/tests/phpt/traits/abstract_in_traits/006_abstract_and_non_abstract_methods_reverse.php
@@ -1,0 +1,25 @@
+@ok
+<?php
+
+trait AT {
+  abstract protected function func(): void;
+}
+
+trait BT {
+  protected function func(): void {
+    var_dump('123');
+  }
+
+  public function func_dec(): void {
+    $this->func();
+  }
+}
+
+class CT {
+  use BT;
+  use AT;
+}
+
+
+$ct = new CT();
+$ct->func_dec();

--- a/tests/phpt/traits/abstract_in_traits/006_diff_signatures_two_traits.php
+++ b/tests/phpt/traits/abstract_in_traits/006_diff_signatures_two_traits.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+trait A {
+    abstract public function foo(int $x);
+}
+
+trait B {
+    abstract public function foo(int $x, int $y = 0);
+}
+
+abstract class AB {
+    use A;
+    use B;
+}

--- a/tests/phpt/traits/abstract_in_traits/100_diff_signatures_two_traits.php
+++ b/tests/phpt/traits/abstract_in_traits/100_diff_signatures_two_traits.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+/Declaration of A::foo must be compatible with version in trait B/
+<?php
+
+trait A {
+    abstract public function foo(int $x);
+}
+
+trait B {
+    abstract public function foo(int $x, int $y = 0);
+}
+
+abstract class AB {
+    use B;
+    use A;
+}

--- a/tests/phpt/traits/abstract_in_traits/101_diff_typehints_traits.php
+++ b/tests/phpt/traits/abstract_in_traits/101_diff_typehints_traits.php
@@ -1,0 +1,12 @@
+@kphp_should_fail
+/Declaration of B::foo must be compatible with version in trait A/
+<?php
+
+trait A { abstract public function foo(int $x); }
+
+trait B { abstract public function foo(float $x); }
+
+abstract class AB {
+    use A;
+    use B;
+}

--- a/tests/phpt/traits/abstract_in_traits/102_double_override_abstract.php
+++ b/tests/phpt/traits/abstract_in_traits/102_double_override_abstract.php
@@ -1,0 +1,21 @@
+@kphp_should_fail
+/Declaration of C::run must be compatible with version in trait B/
+<?php
+
+trait A {
+    abstract public function run(int $x);
+}
+
+trait B {
+    abstract public function run(int $x, float $y = 0, string $s = "");
+}
+
+trait C {
+    abstract public function run(int $x, float $y = 0);
+}
+
+abstract class D {
+    use A;
+    use B;
+    use C;
+}


### PR DESCRIPTION
This PR allows `abstract` methods from traits to be overridden by instance methods from other traits.
On top of that, KPHP will check signatures and parameters more precisely.

There are some subtle issues with abstract methods in traits as PHP checks their signatures unpredictably and some errors can occur by changing the order of `uses` in a class. Look at tests e.g. 006 vs 100 and 005 vs 102 the difference is only in order.

Implementation in KPHP stays close as much as possible to PHP7.4. The website compiles well and tests are passed.