### PR TITLE
remove a redundant error from parsing lambdas

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1457,6 +1457,7 @@ VertexAdaptor<op_function> GenTree::get_function(TokenType tok, vk::string_view 
 
   std::string func_name;
   bool is_lambda = uses_of_lambda != nullptr;
+  auto cnt_errors_before = stage::get_stage_info_ptr()->cnt_errors;
 
   // a function name is a token that immediately follow a 'function' token (full$$name inside a class)
   if (is_lambda) {
@@ -1555,7 +1556,7 @@ VertexAdaptor<op_function> GenTree::get_function(TokenType tok, vk::string_view 
     }
 
     require_lambdas();
-  } else if (!stage::has_error()) {
+  } else if (stage::get_stage_info_ptr()->cnt_errors == cnt_errors_before) {
     return cur_function->root;
   }
 

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -162,16 +162,16 @@ stage::StageInfo *stage::get_stage_info_ptr() {
 
 void stage::set_name(std::string &&name) {
   get_stage_info_ptr()->name = std::move(name);
-  get_stage_info_ptr()->error_flag = false;
+  get_stage_info_ptr()->cnt_errors = 0;
 }
 
 void stage::error() {
   get_stage_info_ptr()->global_error_flag = true;
-  get_stage_info_ptr()->error_flag = true;
+  get_stage_info_ptr()->cnt_errors++;
 }
 
 bool stage::has_error() {
-  return get_stage_info_ptr()->error_flag;
+  return get_stage_info_ptr()->cnt_errors > 0;
 }
 
 bool stage::has_global_error() {

--- a/compiler/stage.h
+++ b/compiler/stage.h
@@ -22,7 +22,7 @@ struct StageInfo {
   std::string name;
   Location location;
   bool global_error_flag{false};
-  bool error_flag{false};
+  uint32_t cnt_errors{0};
 };
 
 StageInfo *get_stage_info_ptr();

--- a/tests/phpt/parse_errors/fail_without_error_from_lambda.php
+++ b/tests/phpt/parse_errors/fail_without_error_from_lambda.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/Duplicate 'use' at the top of the file/
+!/Failed to parse second argument in/
+<?php
+
+use A\Foo;
+use A\Foo;
+
+$fn = function($x) {
+  echo $x;
+};
+
+$fn('hello');


### PR DESCRIPTION
Lambda parser returns `null function` if any error occurs. But it doesn't count previous errors.
In the PR counter of errors is added to distinguish new errors from old ones.
On top of that, negative regular expressions have been added to `kphp_tester.py` to check that extra errors do not arise. 