### PR TITLE
drop wait() edges from a call graph of calculating bad vars

### DIFF
--- a/compiler/pipes/calc-bad-vars.cpp
+++ b/compiler/pipes/calc-bad-vars.cpp
@@ -141,24 +141,11 @@ private:
   };
 
   void generate_bad_vars(FuncCallGraph &call_graph, vector<DepData> &dep_datas) {
-    FunctionPtr wait_func = G->get_function("wait");
-    if (!wait_func) { // when functions.txt is empty or disabled for dev
-      return;
-    }
-
     IdMap<std::vector<VarPtr>> tmp_vars(call_graph.n);
 
     for (int i = 0; i < call_graph.n; i++) {
       FunctionPtr func = call_graph.functions[i];
       tmp_vars[func] = std::move(dep_datas[i].used_global_vars);
-
-      if (func->is_resumable) {
-        call_graph.graph[wait_func].push_back(func);
-        call_graph.rev_graph[func].push_back(wait_func);
-
-        call_graph.graph[func].push_back(wait_func);
-        call_graph.rev_graph[wait_func].push_back(func);
-      }
     }
 
     MergeBadVarsCallback callback(std::move(tmp_vars));


### PR DESCRIPTION
Now, `wait()` is an implicit edge when building a call graph for calculating bad vars for all resumable functions. The reason is probably an assumption that "If I am resumable, some other function can modify globals if I am interrupted". 

That makes sense, but in fact, there is only 1 diff on vkcom when removing this condition.

Why do I want to remove this? The main reason is that I want to use the same call graph to implement function coloring. And of course, colors do not become reachable from any resumable function. Also, this change speeds up CalcBadVarsF for about 2 seconds even without other optimizations — because call graph connectivity becomes smaller.