### PR TITLE
fix passing lambdas through variables

### DIFF
--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -426,8 +426,8 @@ private:
         if (!func->is_template && !func->is_instantiation_of_template_function()) {
           if (auto arg_assum = infer_class_of_expr(current_function, call_arg).try_as_class()) {
             ClassPtr lambda_interface_klass = infer_class_of_expr(func, param->var()).try_as_class();
-            auto is_correct_lambda = arg_assum->is_lambda() && lambda_interface_klass && lambda_interface_klass->is_parent_of(arg_assum);
-            kphp_error_act(is_correct_lambda, fmt_format("Can't infer lambda from expression passed as argument: {}", param->var()->str_val), return call);
+            kphp_error_act(lambda_interface_klass && lambda_interface_klass->is_parent_of(arg_assum),
+                           fmt_format("Can't infer lambda from expression passed as argument: {}", param->var()->str_val), return call);
           } else {
             kphp_error_act(false, fmt_format("You must passed lambda as argument: {}", param->var()->str_val), return call);
           }

--- a/tests/phpt/lambdas/047_typed_lambda_through_var.php
+++ b/tests/phpt/lambdas/047_typed_lambda_through_var.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+/**@param callable(int):string $run*/
+function foo($run) {
+    var_dump($run(10));
+}
+
+function bar() {
+    /**@var $run callable(int):string*/
+    $run = function($x) { return "here - $x"; };
+    foo($run);
+}
+
+bar();


### PR DESCRIPTION
Fix compilation when a typed lambda is passed through a temporary variable to function