### PR TITLE
fix loosing methods visibility when `instanceof` is used

### DIFF
--- a/tests/phpt/interfaces/037_smart_instanceof_and_multiple_inheritance.php
+++ b/tests/phpt/interfaces/037_smart_instanceof_and_multiple_inheritance.php
@@ -1,0 +1,26 @@
+@ok
+<?php
+
+interface A { public function fn_a(); }
+interface B { public function fn_b(); }
+
+class C implements A, B {
+  public function fn_a() { echo 'a'; }
+  public function fn_b() { echo 'b'; }
+  public function fn_c() { echo 'c'; }
+}
+
+function bar(B $b) {
+    $b->fn_b();
+}
+
+function foo(A $a) {
+  if ($a instanceof B) {
+    $a->fn_a();
+    bar($a);
+    // It must fail a compilation process, but it doesn't. Hope to fix it in the future
+    $a->fn_c();
+  }
+}
+
+foo(new C());

--- a/tests/phpt/interfaces/134_instanceof_incompatible_types.php
+++ b/tests/phpt/interfaces/134_instanceof_incompatible_types.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/A and B are not compatible/
+<?php
+
+class A {}
+class B {}
+
+function foo(A $a) {
+    if ($a instanceof B) {
+    }
+}
+
+foo(new A());


### PR DESCRIPTION
In the PR fix of losing extra information about variables is present. When a variable is checked with `instanceof` about brother class, KPHP forgets about the original type, so now we find a first child of both classes and cast the variable to it.