### PR TITLE
improve stacktrace on type mismatch when variable reassigning occurs

### DIFF
--- a/compiler/inferring/restriction-stacktrace-finder.cpp
+++ b/compiler/inferring/restriction-stacktrace-finder.cpp
@@ -128,7 +128,7 @@ bool RestrictionStacktraceFinder::find_call_trace_with_error(tinf::Node *cur_nod
     tinf::Node *to = e->to;
     kphp_assert(e->from == cur_node && e->to != cur_node);
 
-    if (vk::contains(node_path, to)) {
+    if (vk::contains(node_path, to) && dynamic_cast<tinf::VarNode *>(to) == nullptr) {
       continue;
     }
     if (node_path.size() == max_cnt_nodes_in_path) {

--- a/tests/phpt/stacktrace/10_stacktrace.php
+++ b/tests/phpt/stacktrace/10_stacktrace.php
@@ -1,0 +1,24 @@
+@kphp_should_fail
+/return string\|false\|null from getHtml/
+/\$result is string\|false\|null/
+/str_replace returns string\|false\|null/
+/\$html is string\|false\|null/
+/preg_replace returns string\|false\|null/
+/\$html is string\|false\|null/
+/"1" is string/
+<?php
+
+/**
+ * @return string
+ */
+function getHtml() {
+  $html = '1';
+  if (1) {
+    $html = preg_replace('~>\s+<~', '><', $html);
+  }
+
+  $result = str_replace('<span></span>', '<div></div>', $html);
+  return $result;
+}
+
+getHtml();

--- a/tests/phpt/stacktrace/11_stacktrace.php
+++ b/tests/phpt/stacktrace/11_stacktrace.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/pass mixed to argument \$s of takeS/
+/\$value_old is mixed/
+/ternary operator is mixed/
+/1 is int/
+<?php
+
+function takeS(string $s) { 1; }
+function getM(any $v) : mixed { return null; }
+
+function demo() {
+    $value_old = 1 ? 1 : '1';
+    if(1)
+        $value_old = strlen($value_old) ? getM($value_old) . 'asdf' : $value_old;
+    takeS($value_old);
+}
+
+demo();


### PR DESCRIPTION
fixes KPHP-1275
Two new tests were added, that didn't pass before