### PR TITLE
mark long2ip argument type as int

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -619,7 +619,7 @@ function wordwrap ($str ::: string, $width ::: int = 75, $break ::: string = '\n
 
 function ip2long ($ip ::: string) ::: int | false;
 function ip2ulong ($ip ::: string) ::: string | false;
-function long2ip ($ip) ::: string;
+function long2ip ($ip ::: int) ::: string;
 
 function get_magic_quotes_gpc() ::: bool;
 function php_sapi_name() ::: string;

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -64,9 +64,6 @@ Optional<string> f$ip2ulong(const string &ip);
 
 string f$long2ip(int64_t num);
 
-template<class T>
-inline string f$long2ip(const T &v);//shut up warning on converting to int
-
 Optional<array<string>> f$gethostbynamel(const string &name);
 
 Optional<string> f$inet_pton(const string &address);
@@ -173,11 +170,6 @@ void free_runtime_environment();
  *     IMPLEMENTATION
  *
  */
-
-template<class T>
-string f$long2ip(const T &v) {
-  return f$long2ip(f$intval(v));
-}
 
 // for degug use only
 void f$raise_sigsegv();

--- a/tests/phpt/declare/03_strict_types_error.php
+++ b/tests/phpt/declare/03_strict_types_error.php
@@ -1,5 +1,8 @@
 @kphp_should_fail
+KPHP_SHOW_ALL_TYPE_ERRORS=1
 /pass int to argument \$str1 of strcmp/
 /but it's declared as @param string/
+/pass string\[\] to argument \$ip of long2ip/
+/but it's declared as @param int/
 <?php
 require_once __FILE__ . '.inc';

--- a/tests/phpt/declare/03_strict_types_error.php.inc
+++ b/tests/phpt/declare/03_strict_types_error.php.inc
@@ -2,4 +2,19 @@
 /** @kphp-strict-types-enable */
 declare(strict_types=1);
 
+require_once 'kphp_tester_include.php';
+
 var_dump(strcmp(54, 10));
+
+function test_long2ip() {
+  $i = 10;
+  $s = '150';
+  var_dump(long2ip(13)); // OK
+  var_dump(long2ip($i)); // OK
+  var_dump(long2ip((int)$s)); // OK
+
+  $a = ['foo'];
+  var_dump(long2ip($a)); // error
+}
+
+test_long2ip();


### PR DESCRIPTION
This will make this function usage safer when `strict_types=1` is used.
Right now it allows any argument and will fail at the run time if it
can't be converted to int.

Removed the template version as implicit cast param should insert `intval()`
calls where appropriate.