### PR TITLE
Job workers: graceful termination

### DIFF
--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -108,6 +108,11 @@ conn_type_t php_jobs_server = [] {
 int JobWorkerServer::job_parse_execute(connection *c) {
   assert(c == read_job_connection);
 
+  if (sigterm_on) {
+    tvkprintf(job_workers, 1, "Get new job after SIGTERM. Ignore it\n");
+    return 0;
+  }
+
   if (running_job) {
     tvkprintf(job_workers, 3, "Get new job while another job is running. Goes back to event loop now\n");
     has_delayed_jobs = true;

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -43,6 +43,10 @@ function do_http_worker() {
       test_client_wait_false();
       return;
     }
+    case "/test_job_graceful_shutdown": {
+      test_job_graceful_shutdown();
+      return;
+    }
   }
 
   critical_error("unknown test");
@@ -182,4 +186,10 @@ function test_client_wait_false() {
   }
   $result = kphp_job_worker_wait($id);
   echo json_encode(["jobs-result" => $result === null ? "null" : "not null"]);
+}
+
+function test_job_graceful_shutdown() {
+  $context = json_decode(file_get_contents('php://input'));
+  $ids = send_jobs($context);
+  echo json_encode(["jobs-result" => gather_jobs($ids)]);
 }

--- a/tests/python/tests/job_workers/test_job_graceful_termination.py
+++ b/tests/python/tests/job_workers/test_job_graceful_termination.py
@@ -1,0 +1,41 @@
+import signal
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJobGracefulTermination(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--job-workers-num": 2,
+            "--verbosity-job-workers=2": True,
+        })
+
+    def _test_job_graceful_termination_impl(self, termination_type):
+        resp = self.kphp_server.http_post(
+            uri="/test_job_graceful_shutdown",
+            json={
+                "data": [[1, 2, 3, 4], [7, 9, 12]],
+                "tag": "x2_with_work_after_response",
+                "job-sleep-time-sec": 5
+            })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "jobs-result": [
+                {"data": [1 * 1, 2 * 2, 3 * 3, 4 * 4], "stats": []},
+                {"data": [7 * 7, 9 * 9, 12 * 12], "stats": []},
+            ]})
+        if termination_type == 'shutdown':
+            self.kphp_server.send_signal(signal.SIGTERM)
+            self.kphp_server.wait_termination(10)
+            self.kphp_server.start()
+        elif termination_type == 'restart':
+            self.kphp_server.start()
+        else:
+            assert False
+        self.kphp_server.assert_log(["start work after response", "finish work after response"], "Work after response wasn't completed")
+
+    def test_job_graceful_shutdown(self):
+        self._test_job_graceful_termination_impl(termination_type='shutdown')
+
+    def test_job_graceful_restart(self):
+        self._test_job_graceful_termination_impl(termination_type='restart')


### PR DESCRIPTION
Here is graceful termination logic for job workers. Now master process waits for termination of all job workers as well as all HTTP workers on graceful shutdown / restart.
Note: job workers are always terminated strictly after all HTTP workers.