### PR TITLE
enable instanceof smart casts for unions

### DIFF
--- a/tests/phpt/smart_casts/05_unions.php
+++ b/tests/phpt/smart_casts/05_unions.php
@@ -1,0 +1,123 @@
+@ok
+<?php
+
+class Expr {}
+
+class UnaryOp extends Expr {
+  public $arg = null;
+
+  public function __construct(Expr $arg) {
+    $this->arg = $arg;
+  }
+}
+class UnaryMinus extends UnaryOp {}
+class UnaryPlus extends UnaryOp {}
+
+class Literal extends Expr {}
+class StringLiteral extends Literal { public $string_value = 'foo'; }
+class IntLiteral extends Literal { public $int_value = 54; }
+
+/** @param StringLiteral|IntLiteral $x */
+function test1($x) {
+  if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  }
+}
+
+/** @param StringLiteral|IntLiteral|UnaryOp $x */
+function test2($x) {
+  if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  } else if ($x instanceof UnaryOp) {
+    var_dump(get_class($x->arg));
+  }
+}
+
+/** @param StringLiteral|UnaryOp|IntLiteral $x */
+function test3($x) {
+  if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  } else if ($x instanceof UnaryOp) {
+    var_dump(get_class($x->arg));
+  }
+}
+
+/** @param UnaryOp|Literal $x */
+function test4($x) {
+  if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  } else if ($x instanceof UnaryOp) {
+    var_dump(get_class($x->arg));
+  }
+}
+
+/** @param Literal|UnaryOp $x */
+function test5($x) {
+  if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  } else if ($x instanceof UnaryOp) {
+    var_dump(get_class($x->arg));
+  }
+}
+
+/** @param UnaryMinus|Literal|UnaryPlus $x */
+function test6($x) {
+  if ($x instanceof UnaryPlus) {
+    var_dump(['unary plus' => get_class($x->arg)]);
+  } else if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof IntLiteral) {
+    var_dump($x->int_value);
+  } else if ($x instanceof UnaryMinus) {
+    var_dump(['unary minus' => get_class($x->arg)]);
+  }
+}
+
+/** @param UnaryMinus|UnaryPlus|StringLiteral $x */
+function test7($x) {
+  if ($x instanceof UnaryPlus) {
+    var_dump(['unary plus' => get_class($x->arg)]);
+  } else if ($x instanceof StringLiteral) {
+    var_dump($x->string_value);
+  } else if ($x instanceof UnaryMinus) {
+    var_dump(['unary minus' => get_class($x->arg)]);
+  }
+}
+
+test1(new StringLiteral());
+test1(new IntLiteral());
+
+test2(new UnaryOp(new IntLiteral()));
+test2(new StringLiteral());
+test2(new IntLiteral());
+
+test3(new UnaryOp(new IntLiteral()));
+test3(new StringLiteral());
+test3(new IntLiteral());
+
+test4(new UnaryOp(new IntLiteral()));
+test4(new StringLiteral());
+test4(new IntLiteral());
+
+test5(new UnaryOp(new IntLiteral()));
+test5(new StringLiteral());
+test5(new IntLiteral());
+
+test6(new UnaryMinus(new IntLiteral()));
+test6(new UnaryPlus(new StringLiteral()));
+test6(new StringLiteral());
+test6(new IntLiteral());
+
+test6(new UnaryMinus(new IntLiteral()));
+test6(new UnaryPlus(new UnaryMinus(new IntLiteral())));
+test6(new StringLiteral());

--- a/tests/phpt/smart_casts/06_unions_with_interfaces.php
+++ b/tests/phpt/smart_casts/06_unions_with_interfaces.php
@@ -1,0 +1,80 @@
+@ok
+<?php
+
+interface Node {}
+
+interface CallableNode extends Node {}
+interface ConstexprNode extends Node {}
+
+class NodeImpl implements Node {}
+class CallableImpl implements CallableNode {}
+class IntLiteral implements ConstexprNode {}
+class StringLiteral implements ConstexprNode {}
+
+/** @param CallableNode|ConstexprNode $x */
+function test1($x) {
+  if ($x instanceof CallableImpl) {
+    var_dump(get_class($x));
+  } else if ($x instanceof IntLiteral) {
+    var_dump(get_class($x));
+  } else if ($x instanceof StringLiteral) {
+    var_dump(get_class($x));
+  }
+
+  if ($x instanceof NodeImpl) {
+    var_dump(get_class($x));
+  }
+}
+
+/** @param CallableNode|IntLiteral|StringLiteral $x */
+function test2($x) {
+  if ($x instanceof CallableImpl) {
+    var_dump(get_class($x));
+  } else if ($x instanceof IntLiteral) {
+    var_dump(get_class($x));
+  } else if ($x instanceof StringLiteral) {
+    var_dump(get_class($x));
+  }
+}
+
+/** @param IntLiteral|CallableNode|ConstexprNode $x */
+function test3($x) {
+  if ($x instanceof CallableImpl) {
+    var_dump(get_class($x));
+  } else if ($x instanceof IntLiteral) {
+    var_dump(get_class($x));
+  } else if ($x instanceof StringLiteral) {
+    var_dump(get_class($x));
+  }
+}
+
+/** @param IntLiteral|StringLiteral|CallableImpl $x */
+function test4($x) {
+  if ($x instanceof CallableImpl) {
+    var_dump(get_class($x));
+  } else if ($x instanceof IntLiteral) {
+    var_dump(get_class($x));
+  } else if ($x instanceof StringLiteral) {
+    var_dump(get_class($x));
+  }
+}
+
+test1(new NodeImpl());
+test1(new CallableImpl());
+test1(new IntLiteral());
+test1(new StringLiteral());
+
+test2(new NodeImpl());
+test2(new CallableImpl());
+test2(new IntLiteral());
+test2(new StringLiteral());
+
+test3(new NodeImpl());
+test3(new CallableImpl());
+test3(new IntLiteral());
+test3(new StringLiteral());
+
+test4(new NodeImpl());
+test4(new CallableImpl());
+test4(new IntLiteral());
+test4(new StringLiteral());

--- a/tests/phpt/smart_casts/07_nullable_class.php
+++ b/tests/phpt/smart_casts/07_nullable_class.php
@@ -1,0 +1,73 @@
+@ok
+<?php
+
+class A {
+  public $a = 1;
+}
+
+class A1 extends A {
+  public $a1 = 1;
+}
+
+class A2 extends A {
+  public $a2 = 1;
+}
+
+/** @param A1|A2|null $x */
+function test1($x) {
+  if ($x instanceof A1) {
+    var_dump($x->a1);
+    var_dump($x->a);
+  }
+  if ($x instanceof A2) {
+    var_dump($x->a2);
+    var_dump($x->a);
+  }
+}
+
+/** @param A1|null|A2 $x */
+function test2($x) {
+  if ($x instanceof A1) {
+    var_dump($x->a1);
+    var_dump($x->a);
+  }
+  if ($x instanceof A2) {
+    var_dump($x->a2);
+    var_dump($x->a);
+  }
+}
+
+/** @param A1|null $x */
+function test3($x) {
+  if ($x instanceof A1) {
+    var_dump($x->a1);
+    var_dump($x->a);
+  }
+}
+
+/** @param A|null $x */
+function test4($x) {
+  if ($x instanceof A1) {
+    var_dump($x->a1);
+    var_dump($x->a);
+  }
+  if ($x instanceof A2) {
+    var_dump($x->a2);
+    var_dump($x->a);
+  }
+}
+
+test1(new A1());
+test1(new A2());
+test1(null);
+
+test2(new A1());
+test2(new A2());
+test2(null);
+
+test3(new A1());
+test3(null);
+
+test4(new A1());
+test4(new A2());
+test4(null);


### PR DESCRIPTION
Teach extract_instance_from_type_hint() how to handle union types.
The algorithm used is close to the one that is used during the type inference.

We try to find a common base type for all union variants.
If there are multiple candidates, we'll give up.

This is good enough for most sane class hierarchies.

Fixes #217