### PR TITLE
Introduce job workers ratio option

### DIFF
--- a/common/kprintf.cpp
+++ b/common/kprintf.cpp
@@ -260,7 +260,7 @@ static void verbosity_option_set(int *v) {
   }
 }
 
-int verbosity_options_parser(int c) {
+int verbosity_options_parser(int c, const char *) {
   if (VERBOSITY_OPTION_SHIFT <= c && c < VERBOSITY_OPTION_SHIFT + verbosity_types_num){
     verbosity_option_set(verbosity_types[c - VERBOSITY_OPTION_SHIFT].value);
     return 0;

--- a/common/options.cpp
+++ b/common/options.cpp
@@ -326,7 +326,7 @@ void usage_and_exit() {
   exit(2);
 }
 
-int parse_engine_options_long(int argc, char **argv, int (*execute)(int val)) {
+int parse_engine_options_long(int argc, char **argv, options_parser execute) {
   usage_progname = argv[0];
   std::string opt_string;
   std::vector<option> long_opts;
@@ -402,9 +402,9 @@ int parse_engine_options_long(int argc, char **argv, int (*execute)(int val)) {
     }
     int res;
     if (options[c].parser == nullptr) {
-      res = execute ? execute(c) : -1;
+      res = execute ? execute(c, options[c].name.c_str()) : -1;
     } else {
-      res = options[c].parser(c);
+      res = options[c].parser(c, options[c].name.c_str());
     }
     if (res < 0) {
       kprintf("Failed to parse option %s\n", options[c].name.c_str());
@@ -422,6 +422,6 @@ void always_enable_option(const char *name, char *arg) {
   char *old_optarg = optarg;
   optarg = arg;
   options[c].help += " [enabled by default]";
-  options[c].parser(c);
+  options[c].parser(c, options[c].name.c_str());
   optarg = old_optarg;
 }

--- a/common/options.h
+++ b/common/options.h
@@ -4,9 +4,14 @@
 
 #pragma once
 
-#include <assert.h>
+#include <array>
+#include <cassert>
+#include <cstddef>
 #include <getopt.h> // IWYU pragma: export
-#include <stddef.h>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+#include "common/wrappers/string_view.h"
 
 #define MAX_OPTION_ID 10000
 
@@ -94,17 +99,42 @@ static int OPTION_PARSER_FUNCTION_ ## suffix(int _unused __attribute__((unused))
     if (var ## _option_passed) free((char *)var);                       \
   }
 
-#define OPTION_PRINT_DEPRECATION_MESSAGE_(option_pattern, ...) \
-  kprintf ("warning: option '" option_pattern "' is deprecated and is going to be removed soon, don't use them!\n", __VA_ARGS__);
+class DeprecatedOptions : vk::not_copyable {
+public:
+  void add_warning(const char *msg) noexcept {
+    if (deprecation_warnings_count_ < deprecation_warnings_.size()) {
+      deprecation_warnings_[deprecation_warnings_count_++] = msg;
+    }
+  }
+
+  const auto &get_warnings() const noexcept {
+    return deprecation_warnings_;
+  }
+
+private:
+  friend class vk::singleton<DeprecatedOptions>;
+
+  DeprecatedOptions() = default;
+
+  std::array<vk::string_view, 16> deprecation_warnings_;
+  size_t deprecation_warnings_count_{0};
+};
+
+#define OPTION_PRINT_DEPRECATION_MESSAGE_(options) { \
+    const char *msg = "option '" options "' is deprecated and is going to be removed soon, don't use them!";  \
+    vk::singleton<DeprecatedOptions>::get().add_warning(msg);                                                 \
+  }
 
 #define DEPRECATED_OPTION(name, has_arg)              \
   OPTION_PARSER(OPT_DEPRECATED, name, has_arg, " ") { \
-    OPTION_PRINT_DEPRECATION_MESSAGE_("--%s", name);  \
+    OPTION_PRINT_DEPRECATION_MESSAGE_("--" name);  \
     return 0;                                         \
   }
 
-#define DEPRECATED_OPTION_SHORT(name, letter, has_arg)              \
-  OPTION_PARSER_SHORT(OPT_DEPRECATED, name, letter, has_arg, " ") { \
-    OPTION_PRINT_DEPRECATION_MESSAGE_("--%s/-%c", name, letter);    \
-    return 0;                                                       \
+#define DEPRECATED_OPTION_SHORT(name, letter, has_arg)                    \
+  OPTION_PARSER_SHORT(OPT_DEPRECATED, name, (letter)[0], has_arg, " ") {  \
+    static_assert(sizeof(letter) == 2, "1 char string is expected");      \
+    OPTION_PRINT_DEPRECATION_MESSAGE_("--" name "/-" letter);             \
+    return 0;                                                             \
   }
+

--- a/common/options.h
+++ b/common/options.h
@@ -120,21 +120,21 @@ private:
   size_t deprecation_warnings_count_{0};
 };
 
-#define OPTION_PRINT_DEPRECATION_MESSAGE_(options) { \
+#define OPTION_ADD_DEPRECATION_MESSAGE(options) { \
     const char *msg = "option '" options "' is deprecated and is going to be removed soon, don't use them!";  \
     vk::singleton<DeprecatedOptions>::get().add_warning(msg);                                                 \
   }
 
 #define DEPRECATED_OPTION(name, has_arg)              \
   OPTION_PARSER(OPT_DEPRECATED, name, has_arg, " ") { \
-    OPTION_PRINT_DEPRECATION_MESSAGE_("--" name);  \
+    OPTION_ADD_DEPRECATION_MESSAGE("--" name);  \
     return 0;                                         \
   }
 
 #define DEPRECATED_OPTION_SHORT(name, letter, has_arg)                    \
   OPTION_PARSER_SHORT(OPT_DEPRECATED, name, (letter)[0], has_arg, " ") {  \
     static_assert(sizeof(letter) == 2, "1 char string is expected");      \
-    OPTION_PRINT_DEPRECATION_MESSAGE_("--" name "/-" letter);             \
+    OPTION_ADD_DEPRECATION_MESSAGE("--" name "/-" letter);                \
     return 0;                                                             \
   }
 

--- a/common/options.h
+++ b/common/options.h
@@ -46,7 +46,7 @@ static inline const char *get_option_section_name(option_section_t section) {
   return NULL;
 }
 
-typedef int (*options_parser)(int);
+typedef int (*options_parser)(int, const char *);
 
 void parse_usage();
 void remove_all_options();
@@ -70,12 +70,12 @@ void usage_set_other_args_desc(const char *s);
 
 
 #define COMMON_OPTION_PARSER__(suffix, section, name, letter, has_arg, ...)                                     \
-static int OPTION_PARSER_FUNCTION_ ## suffix(int _unused);                                                      \
+static int OPTION_PARSER_FUNCTION_ ## suffix(int, const char *);                                                \
 __attribute__((constructor))                                                                                    \
 static void REGISTER_OPTION_PARSER_FUNCTION_ ## suffix() {                                                      \
   parse_common_option((section), OPTION_PARSER_FUNCTION_ ## suffix, (name), (has_arg), (letter), __VA_ARGS__);  \
 }                                                                                                               \
-static int OPTION_PARSER_FUNCTION_ ## suffix(int _unused __attribute__((unused)))
+static int OPTION_PARSER_FUNCTION_ ## suffix(int, const char *)
 
 #define COMMON_OPTION_PARSER_(...) COMMON_OPTION_PARSER__(__VA_ARGS__)
 #define OPTION_PARSER(section, name, has_arg, ...) COMMON_OPTION_PARSER_(__COUNTER__, section, name, -1, has_arg, __VA_ARGS__)

--- a/common/tl2php/tl2php.cpp
+++ b/common/tl2php/tl2php.cpp
@@ -74,7 +74,7 @@ static bool generate_tests = false;
 static bool generate_tl_internals = false;
 static std::string combined2_tl_file;
 
-int tl2php_parse_f(int i) {
+int tl2php_parse_f(int i, const char *) {
   switch (i) {
     case 'f': {
       forcibly_overwrite_dir = true;

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -77,7 +77,7 @@ public:
   }
 
   void process_args(int32_t argc, char **argv) {
-    parse_engine_options_long(argc, argv, [](int32_t option_id) {
+    parse_engine_options_long(argc, argv, [](int32_t option_id, const char *) {
       if (option_id == 'h') {
         usage_and_exit();
       }

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -52,6 +52,7 @@
 #include "server/php-engine-vars.h"
 #include "server/php-queries.h"
 #include "server/php-query-data.h"
+#include "server/workers-control.h"
 
 static enum {
   QUERY_TYPE_NONE,
@@ -1699,7 +1700,7 @@ string f$get_engine_version() {
 }
 
 int64_t f$get_engine_workers_number() {
-  return workers_n;
+  return vk::singleton<WorkersControl>::get().get_total_workers_count();
 }
 
 static char ini_vars_storage[sizeof(array<string>)];

--- a/runtime/job-workers/job-interface.cpp
+++ b/runtime/job-workers/job-interface.cpp
@@ -5,6 +5,7 @@
 #include "server/job-workers/job-stats.h"
 #include "server/job-workers/job-workers-context.h"
 #include "server/job-workers/shared-memory-manager.h"
+#include "server/workers-control.h"
 
 #include "runtime/job-workers/processing-jobs.h"
 #include "runtime/resumable.h"
@@ -27,7 +28,7 @@ int get_job_timeout_wakeup_id() {
 }
 
 bool f$is_kphp_job_workers_enabled() noexcept {
-  return vk::singleton<job_workers::JobWorkersContext>::get().job_workers_num > 0;
+  return vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0;
 }
 
 void global_init_job_workers_lib() noexcept {

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -143,7 +143,7 @@ public:
 
   void unsupported_operation(const char *operation_name, const char *key, int key_len) noexcept {
     ++event_counters_.unsupported_total_events;
-    log_server_warning("Confdata binlog reading error: got unsupported operation '%s' with key '%.*s'\n", operation_name, std::max(key_len, 0), key);
+    log_server_warning("Confdata binlog reading error: got unsupported operation '%s' with key '%.*s'", operation_name, std::max(key_len, 0), key);
   }
 
   void init(memory_resource::unsynchronized_pool_resource &memory_pool) noexcept {

--- a/server/job-workers/job-worker-client.cpp
+++ b/server/job-workers/job-worker-client.cpp
@@ -27,12 +27,12 @@ int JobWorkerClient::read_job_results(int fd, void *data __attribute__((unused))
   auto &job_worker_client = vk::singleton<JobWorkerClient>::get();
   assert(fd == job_worker_client.read_job_result_fd);
   if (ev->ready & EVT_SPEC) {
-    log_server_error("job worker client special event: fd = %d, flags = %d\n", fd, ev->ready);
+    log_server_error("job worker client special event: fd = %d, flags = %d", fd, ev->ready);
     // TODO:
     return 0;
   }
   if (!(ev->ready & EVT_READ)) {
-    log_server_error("Strange event in client: fd = %d, ev->ready = 0x%08x\n", fd, ev->ready);
+    log_server_error("Strange event in client: fd = %d, ev->ready = 0x%08x", fd, ev->ready);
     return 0;
   }
 

--- a/server/job-workers/job-workers-context.h
+++ b/server/job-workers/job-workers-context.h
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <queue>
 #include <unordered_set>
-#include <climits>
 
 #include "common/kprintf.h"
 #include "common/mixin/not_copyable.h"

--- a/server/job-workers/job-workers-context.h
+++ b/server/job-workers/job-workers-context.h
@@ -31,6 +31,7 @@ public:
   size_t running_job_workers{0};
   size_t dying_job_workers{0};
   size_t job_workers_num{0};
+  double job_workers_ratio{0};
 
   Pipe job_pipe{};
   std::vector<Pipe> result_pipes;

--- a/server/job-workers/job-workers-context.h
+++ b/server/job-workers/job-workers-context.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <queue>
 #include <unordered_set>
+#include <climits>
 
 #include "common/kprintf.h"
 #include "common/mixin/not_copyable.h"
@@ -27,11 +28,6 @@ public:
   using Pipe = std::array<int, 2>;
 
   static constexpr int MAX_HANGING_TIME_SEC = 20; // TODO: tune it
-
-  size_t running_job_workers{0};
-  size_t dying_job_workers{0};
-  size_t job_workers_num{0};
-  double job_workers_ratio{0};
 
   Pipe job_pipe{};
   std::vector<Pipe> result_pipes;

--- a/server/job-workers/pipe-io.cpp
+++ b/server/job-workers/pipe-io.cpp
@@ -18,15 +18,15 @@ bool PipeJobWriter::write_to_pipe(int write_fd, const char *description) {
 
   if (written == -1) {
     if (errno == EWOULDBLOCK) {
-      log_server_error("Fail on %s to pipe: pipe is full\n", description);
+      log_server_error("Fail on %s to pipe: pipe is full", description);
     } else {
-      log_server_error("Fail on %s to pipe: %s\n", description, strerror(errno));
+      log_server_error("Fail on %s to pipe: %s", description, strerror(errno));
     }
     return false;
   }
 
   if (written != bytes_to_write) {
-    log_server_error("Fail on %s to pipe: written bytes = %zd, but requested = %zd\n", description, written, bytes_to_write);
+    log_server_error("Fail on %s to pipe: written bytes = %zd, but requested = %zd", description, written, bytes_to_write);
     return false;
   }
 
@@ -70,11 +70,11 @@ PipeJobReader::ReadStatus PipeJobReader::read_from_pipe(size_t bytes_cnt, const 
     if (errno == EWOULDBLOCK) {
       return READ_BLOCK;
     }
-    log_server_error("Couldn't %s: %s\n", description, strerror(errno));
+    log_server_error("Couldn't %s: %s", description, strerror(errno));
     return READ_FAIL;
   }
   if (read_bytes != bytes_cnt) {
-    log_server_error("Couldn't %s. Got %zd bytes, but expected %zd. Probably some jobs are written not atomically\n", description, bytes_cnt, read_bytes);
+    log_server_error("Couldn't %s. Got %zd bytes, but expected %zd. Probably some jobs are written not atomically", description, bytes_cnt, read_bytes);
     return READ_FAIL;
   }
   return READ_OK;

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -27,7 +27,6 @@ int pid = -1;
 int no_sql = 0;
 
 int master_flag = 0; // 1 -- master, 0 -- single process, -1 -- child
-int workers_n = 0;
 
 RunMode run_mode;
 
@@ -44,7 +43,6 @@ int http_port = -1;
 int http_sfd = -1;
 
 /** rpc **/
-long long rpc_failed, rpc_sent, rpc_received, rpc_received_news_subscr, rpc_received_news_redirect;
 int rpc_port = -1;
 int rpc_sfd = -1;
 long long rpc_client_actor = -1;
@@ -65,7 +63,6 @@ int master_pipe_fast_write = -1;
   GLOBAL VARIABLES
  ***/
 int sql_target_id = -1;
-int in_ready = 0;
 int script_timeout = 0;
 int disable_access_log = 0;
 int force_clear_sql_connection = 0;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -34,7 +34,6 @@ extern int pid;
 extern int no_sql;
 
 extern int master_flag;
-extern int workers_n;
 
 enum class RunMode {
   master,
@@ -58,7 +57,6 @@ extern int http_port;
 extern int http_sfd;
 
 /** rpc **/
-extern long long rpc_failed, rpc_sent, rpc_received, rpc_received_news_subscr, rpc_received_news_redirect;
 extern int rpc_port;
 extern int rpc_sfd;
 extern long long rpc_client_actor;
@@ -96,7 +94,6 @@ struct php_immediate_stats_t {
   GLOBAL VARIABLES
  ***/
 extern int sql_target_id;
-extern int in_ready;
 extern int script_timeout;
 extern int disable_access_log;
 extern int force_clear_sql_connection;
@@ -123,8 +120,6 @@ extern long long memory_used_to_recreate_script;
 #define SIGPHPASSERT (SIGRTMIN + 1)
 #define SIGSTACKOVERFLOW (SIGRTMIN + 2)
 #endif
-
-#define MAX_WORKERS 999
 
 /***
   save of stdout/stderr fd

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2098,6 +2098,19 @@ int main_args_handler(int i, const char *long_option) {
     case 2018: {
       return read_option_to(long_option, 0.0, 10.0, vk::singleton<LeaseContext>::get().rpc_stop_ready_timeout);
     }
+    case 2019: {
+      // TODO REMOVE ME!
+      OPTION_ADD_DEPRECATION_MESSAGE("--job-workers-num");
+      return parse_numeric_option(long_option, 0, int{WorkersControl::max_workers_count} / 2, [](int job_workers_num) {
+        auto &control = vk::singleton<WorkersControl>::get();
+        const uint16_t total_workers = control.get_total_workers_count();
+        // expect that -f options is set in advance
+        assert(total_workers);
+        control.set_total_workers_count(total_workers + job_workers_num);
+        const double ratio = static_cast<double>(job_workers_num) / static_cast<double>(control.get_total_workers_count());
+        control.set_ratio(WorkerType::job_worker, ratio);
+      });
+    }
     default:
       return -1;
   }
@@ -2119,7 +2132,6 @@ void parse_main_args_till_option(int argc, char *argv[], const char *till_option
 }
 
 DEPRECATED_OPTION("use-unix", no_argument);
-DEPRECATED_OPTION("job-workers-num", required_argument);
 DEPRECATED_OPTION_SHORT("json-log", "j", no_argument);
 DEPRECATED_OPTION_SHORT("crc32c", "C", no_argument);
 DEPRECATED_OPTION_SHORT("tl-schema", "T", required_argument);
@@ -2169,6 +2181,7 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("job-workers-ratio", required_argument, 2016, "the jobs workers ratio of the overall workers number");
   parse_option("job-workers-shared-memory-size", required_argument, 2017, "total size of shared memory used for job workers related communication");
   parse_option("lease-stop-ready-timeout", required_argument, 2018, "timeout for RPC_STOP_READY acknowledgement waiting in seconds (default: 0)");
+  parse_option("job-workers-num", required_argument, 2019, "DEPRECATED");
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);
 }

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -76,6 +76,7 @@
 #include "server/php-sql-connections.h"
 #include "server/php-worker-stats.h"
 #include "server/php-worker.h"
+#include "server/server-log.h"
 
 using job_workers::JobWorkersContext;
 using job_workers::JobWorkerClient;
@@ -2137,9 +2138,9 @@ void parse_main_args_till_option(int argc, char *argv[], const char *till_option
 }
 
 DEPRECATED_OPTION("use-unix", no_argument);
-DEPRECATED_OPTION_SHORT("json-log", 'j', no_argument);
-DEPRECATED_OPTION_SHORT("crc32c", 'C', no_argument);
-DEPRECATED_OPTION_SHORT("tl-schema", 'T', required_argument);
+DEPRECATED_OPTION_SHORT("json-log", "j", no_argument);
+DEPRECATED_OPTION_SHORT("crc32c", "C", no_argument);
+DEPRECATED_OPTION_SHORT("tl-schema", "T", required_argument);
 
 void parse_main_args(int argc, char *argv[]) {
   usage_set_other_args_desc("");
@@ -2229,6 +2230,13 @@ void init_default() {
   if (logname) {
     reopen_logs();
     reopen_json_log();
+  }
+
+  for(auto deprecation_warning : vk::singleton<DeprecatedOptions>::get().get_warnings()) {
+    if (deprecation_warning.empty()) {
+      break;
+    }
+    log_server_warning(deprecation_warning);
   }
 }
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2103,11 +2103,13 @@ int main_args_handler(int i, const char *long_option) {
       OPTION_ADD_DEPRECATION_MESSAGE("--job-workers-num");
       return parse_numeric_option(long_option, 0, int{WorkersControl::max_workers_count} / 2, [](int job_workers_num) {
         auto &control = vk::singleton<WorkersControl>::get();
-        const uint16_t total_workers = control.get_total_workers_count();
+        uint16_t total_workers = control.get_total_workers_count();
         // expect that -f options is set in advance
         assert(total_workers);
-        control.set_total_workers_count(total_workers + job_workers_num);
-        const double ratio = static_cast<double>(job_workers_num) / static_cast<double>(control.get_total_workers_count());
+        total_workers += job_workers_num;
+        assert(total_workers <= WorkersControl::max_workers_count);
+        control.set_total_workers_count(total_workers);
+        const double ratio = static_cast<double>(job_workers_num) / static_cast<double>(total_workers);
         control.set_ratio(WorkerType::job_worker, ratio);
       });
     }

--- a/server/php-master-restart.cpp
+++ b/server/php-master-restart.cpp
@@ -23,10 +23,6 @@
 shared_data_t *shared_data;
 master_data_t *me, *other; // these are pointers to shared memory
 
-int me_all_workers_n;
-int me_running_http_workers_n;
-int me_dying_http_workers_n;
-
 void init_mutex(pthread_mutex_t *mutex) {
   pthread_mutexattr_t attr;
 

--- a/server/php-master-restart.h
+++ b/server/php-master-restart.h
@@ -63,10 +63,6 @@ static_assert(sizeof(shared_data_t) == SHARED_DATA_T_SIZEOF, "Layout of this str
 extern shared_data_t *shared_data;
 extern master_data_t *me, *other; // these are pointers to shared memory
 
-extern int me_all_workers_n; // http workers + job workers
-extern int me_running_http_workers_n;
-extern int me_dying_http_workers_n;
-
 inline bool in_new_master_on_restart() {
   return other->is_alive && me->rate > other->rate;
 }

--- a/server/server-log.cpp
+++ b/server/server-log.cpp
@@ -31,7 +31,11 @@ void write_log_server_impl(ServerLog type, const char *format, ...) noexcept {
   vsnprintf(buffer.data(), buffer.size(), format, ap);
   va_end (ap);
 
-  kprintf("%s:%s", level2str(type), buffer.data());
+  kprintf("%s: %s\n", level2str(type), buffer.data());
   vk::singleton<JsonLogger>::get().write_log_with_backtrace(buffer.data(), static_cast<int>(type));
 }
 
+void write_log_server_impl(ServerLog type, vk::string_view msg) noexcept {
+  kprintf("%s: %.*s\n", level2str(type), static_cast<int>(msg.size()), msg.data());
+  vk::singleton<JsonLogger>::get().write_log_with_backtrace(msg, static_cast<int>(type));
+}

--- a/server/server-log.h
+++ b/server/server-log.h
@@ -16,6 +16,7 @@ enum class ServerLog {
 
 // This api should be used only from the master process or from the worker processes net coroutine context
 void write_log_server_impl(ServerLog type, const char *format, ...) noexcept __attribute__ ((format (printf, 2, 3)));
+void write_log_server_impl(ServerLog type, vk::string_view msg) noexcept;
 
 #define log_server_critical(...) write_log_server_impl(ServerLog::Critical, __VA_ARGS__)
 #define log_server_error(...) write_log_server_impl(ServerLog::Error, __VA_ARGS__)

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -20,7 +20,8 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         php-worker.cpp
         php-worker-stats.cpp
         server-log.cpp
-        slot-ids-factory.cpp)
+        slot-ids-factory.cpp
+        workers-control.cpp)
 
 prepend(KPHP_JOB_WORKERS_SOURCES ${BASE_DIR}/server/job-workers/
         job-stats.cpp

--- a/server/workers-control.cpp
+++ b/server/workers-control.cpp
@@ -41,7 +41,7 @@ void WorkersControl::on_worker_terminating(WorkerType worker_type) noexcept {
   auto &meta = meta_[static_cast<size_t>(worker_type)];
   assert(meta.running);
   --meta.running;
-  meta.dying++;
+  ++meta.dying;
 }
 
 void WorkersControl::on_worker_removing(WorkerType worker_type, bool dying, uint16_t worker_unique_id) noexcept {

--- a/server/workers-control.cpp
+++ b/server/workers-control.cpp
@@ -1,0 +1,35 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include <cassert>
+#include <cmath>
+
+#include "server/workers-control.h"
+
+bool WorkersControl::init() noexcept {
+  static_assert(static_cast<size_t>(WorkerType::types_count) == 2, "check yourself");
+
+  auto &job_workers_meta = meta_[static_cast<size_t>(WorkerType::job_worker)];
+  if (job_workers_meta.ratio > 0) {
+    job_workers_meta.count = static_cast<uint16_t>(std::ceil(job_workers_meta.ratio * total_workers_count_));
+    if (job_workers_meta.count >= total_workers_count_) {
+      return false;
+    }
+  }
+  meta_[static_cast<size_t>(WorkerType::general_worker)].count = total_workers_count_ - job_workers_meta.count;
+  return true;
+}
+
+void WorkersControl::on_worker_terminating(WorkerType worker_type) noexcept {
+  auto &meta = meta_[static_cast<size_t>(worker_type)];
+  assert(meta.running);
+  --meta.running;
+  meta.dying++;
+}
+
+void WorkersControl::on_worker_removing(WorkerType worker_type, bool dying) noexcept {
+  auto &meta = meta_[static_cast<size_t>(worker_type)];
+  const auto before = dying ? meta.dying-- : meta.running--;
+  assert(before);
+}

--- a/server/workers-control.cpp
+++ b/server/workers-control.cpp
@@ -4,20 +4,36 @@
 
 #include <cassert>
 #include <cmath>
+#include <limits>
+#include <numeric>
 
 #include "server/workers-control.h"
+
+namespace {
+
+constexpr uint16_t EMPTY_ID = std::numeric_limits<uint16_t>::max();
+
+} // namespace
 
 bool WorkersControl::init() noexcept {
   static_assert(static_cast<size_t>(WorkerType::types_count) == 2, "check yourself");
 
-  auto &job_workers_meta = meta_[static_cast<size_t>(WorkerType::job_worker)];
-  if (job_workers_meta.ratio > 0) {
-    job_workers_meta.count = static_cast<uint16_t>(std::ceil(job_workers_meta.ratio * total_workers_count_));
-    if (job_workers_meta.count >= total_workers_count_) {
+  auto &job_workers = meta_[static_cast<size_t>(WorkerType::job_worker)];
+  if (job_workers.ratio > 0) {
+    job_workers.count = static_cast<uint16_t>(std::ceil(job_workers.ratio * total_workers_count_));
+    if (job_workers.count >= total_workers_count_) {
       return false;
     }
   }
-  meta_[static_cast<size_t>(WorkerType::general_worker)].count = total_workers_count_ - job_workers_meta.count;
+
+  auto &general_workers = meta_[static_cast<size_t>(WorkerType::general_worker)];
+  general_workers.count = total_workers_count_ - job_workers.count;
+
+  general_workers.unique_ids_.fill(EMPTY_ID);
+  std::iota(general_workers.unique_ids_.begin(), general_workers.unique_ids_.begin() + general_workers.count, uint16_t{0});
+
+  job_workers.unique_ids_.fill(EMPTY_ID);
+  std::iota(job_workers.unique_ids_.begin(), job_workers.unique_ids_.begin() + job_workers.count, general_workers.count);
   return true;
 }
 
@@ -28,8 +44,22 @@ void WorkersControl::on_worker_terminating(WorkerType worker_type) noexcept {
   meta.dying++;
 }
 
-void WorkersControl::on_worker_removing(WorkerType worker_type, bool dying) noexcept {
+void WorkersControl::on_worker_removing(WorkerType worker_type, bool dying, uint16_t worker_unique_id) noexcept {
   auto &meta = meta_[static_cast<size_t>(worker_type)];
   const auto before = dying ? meta.dying-- : meta.running--;
   assert(before);
+  const uint16_t alive = get_alive_count(worker_type);
+  assert(alive < meta.count);
+  const uint16_t next_unique_id = std::exchange(meta.unique_ids_[meta.count - alive - 1], worker_unique_id);
+  assert(next_unique_id == EMPTY_ID);
+}
+
+uint16_t WorkersControl::on_worker_creating(WorkerType worker_type) noexcept {
+  auto &meta = meta_[static_cast<size_t>(worker_type)];
+  const uint16_t alive = get_alive_count(worker_type);
+  assert(alive < meta.count);
+  const uint16_t next_unique_id = std::exchange(meta.unique_ids_[meta.count - alive - 1], EMPTY_ID);
+  assert(next_unique_id != EMPTY_ID);
+  ++meta.running;
+  return next_unique_id;
 }

--- a/server/workers-control.h
+++ b/server/workers-control.h
@@ -1,0 +1,85 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2021 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <array>
+#include <limits>
+#include <cinttypes>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+
+enum class WorkerType {
+  general_worker = 0, // for http, task, rpc stuff
+  job_worker = 1, // for parallel job stuff
+  types_count
+};
+
+class WorkersControl : vk::not_copyable {
+public:
+  static constexpr uint16_t max_workers_count{1000};
+
+  bool init() noexcept;
+
+  void set_total_workers_count(uint16_t workers_count) noexcept {
+    total_workers_count_ = workers_count;
+  }
+
+  uint16_t get_total_workers_count() const noexcept {
+    return total_workers_count_;
+  }
+
+  uint16_t get_count(WorkerType worker_type) const noexcept {
+    return meta_[static_cast<size_t>(worker_type)].count;
+  }
+
+  uint16_t get_running_count(WorkerType worker_type) const noexcept {
+    return meta_[static_cast<size_t>(worker_type)].running;
+  }
+
+  uint16_t get_dying_count(WorkerType worker_type) const noexcept {
+    return meta_[static_cast<size_t>(worker_type)].dying;
+  }
+
+  uint16_t get_alive_count(WorkerType worker_type) const noexcept {
+    const auto &meta = meta_[static_cast<size_t>(worker_type)];
+    return meta.running + meta.dying;
+  }
+
+  uint16_t get_all_alive() const noexcept {
+    uint16_t result = 0;
+    for (size_t type = 0; type != meta_.size(); ++type) {
+      result += get_alive_count(static_cast<WorkerType>(type));
+    }
+    return result;
+  }
+
+  void set_ratio(WorkerType worker_type, double ratio) noexcept {
+    meta_[static_cast<size_t>(worker_type)].ratio = ratio;
+  }
+
+  void on_worker_starting(WorkerType worker_type) noexcept {
+    ++meta_[static_cast<size_t>(worker_type)].running;
+  }
+
+  void on_worker_terminating(WorkerType worker_type) noexcept;
+  void on_worker_removing(WorkerType worker_type, bool dying) noexcept;
+
+private:
+  WorkersControl() = default;
+
+  friend class vk::singleton<WorkersControl>;
+
+  struct WorkerGroupMetadata : vk::not_copyable {
+    uint16_t count{0};
+
+    uint16_t running{0};
+    uint16_t dying{0};
+
+    double ratio{std::numeric_limits<double>::quiet_NaN()};
+  };
+  uint16_t total_workers_count_{0};
+  std::array<WorkerGroupMetadata, static_cast<size_t>(WorkerType::types_count)> meta_;
+};

--- a/server/workers-control.h
+++ b/server/workers-control.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <array>
-#include <limits>
 #include <cinttypes>
 
 #include "common/mixin/not_copyable.h"
@@ -60,12 +59,9 @@ public:
     meta_[static_cast<size_t>(worker_type)].ratio = ratio;
   }
 
-  void on_worker_starting(WorkerType worker_type) noexcept {
-    ++meta_[static_cast<size_t>(worker_type)].running;
-  }
-
+  uint16_t on_worker_creating(WorkerType worker_type) noexcept;
   void on_worker_terminating(WorkerType worker_type) noexcept;
-  void on_worker_removing(WorkerType worker_type, bool dying) noexcept;
+  void on_worker_removing(WorkerType worker_type, bool dying, uint16_t worker_unique_id) noexcept;
 
 private:
   WorkersControl() = default;
@@ -73,12 +69,14 @@ private:
   friend class vk::singleton<WorkersControl>;
 
   struct WorkerGroupMetadata : vk::not_copyable {
-    uint16_t count{0};
+    double ratio{0};
 
+    uint16_t count{0};
     uint16_t running{0};
+
     uint16_t dying{0};
 
-    double ratio{std::numeric_limits<double>::quiet_NaN()};
+    std::array<uint16_t, max_workers_count> unique_ids_{};
   };
   uint16_t total_workers_count_{0};
   std::array<WorkerGroupMetadata, static_cast<size_t>(WorkerType::types_count)> meta_;

--- a/tests/cpp/runtime/_runtime-tests-env.cpp
+++ b/tests/cpp/runtime/_runtime-tests-env.cpp
@@ -7,6 +7,7 @@
 #include "runtime/job-workers/job-interface.h"
 #include "runtime/tl/rpc_response.h"
 #include "server/php-engine-vars.h"
+#include "server/workers-control.h"
 
 // Используется в некоторых тестах, что бы обмануть clang и не дать ему выкинуть вызов std::malloc из кода
 void *alloc_no_inline(int x) {
@@ -20,7 +21,7 @@ public:
   static void reset_global_vars() {
     pid = 0;
     logname_id = 0;
-    workers_n = 1;
+    vk::singleton<WorkersControl>::get().set_total_workers_count(1);
   }
 
   void SetUp() final {

--- a/tests/cpp/runtime/inter-process-resource-test.cpp
+++ b/tests/cpp/runtime/inter-process-resource-test.cpp
@@ -4,10 +4,10 @@
 
 void set_pid_and_user_id(pid_t p) {
   // прибиваем гвоздями, используется в InterProcessResourceControl для определения кол-ва воркеров
-  workers_n = 10;
+  vk::singleton<WorkersControl>::get().set_total_workers_count(10);
   // pid используется как уникальный идентификатор в InterProcessResourceControl
   pid = p;
-  // logname_id используется как id процесса от 0 до workers_n
+  // logname_id используется как id процесса от 0 до workers_count
   logname_id = p;
 }
 

--- a/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
+++ b/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
@@ -11,6 +11,7 @@
 #include "server/job-workers/job-workers-context.h"
 #include "server/job-workers/shared-memory-manager.h"
 #include "server/php-engine-vars.h"
+#include "server/workers-control.h"
 
 using namespace job_workers;
 using SHMM = vk::singleton<SharedMemoryManager>;
@@ -112,8 +113,7 @@ void worker_function() {
 
 TEST(shared_memory_manager_test, test_manager) {
   SHMM::get().set_memory_limit(256 * 1024 * 1024);
-  workers_n = 5;
-  vk::singleton<JobWorkersContext>::get().job_workers_num = 2;
+  vk::singleton<WorkersControl>::get().set_total_workers_count(7);
   SHMM::get().init();
 
   const auto &stats = SHMM::get().get_stats();

--- a/tests/cpp/server/server-tests.cmake
+++ b/tests/cpp/server/server-tests.cmake
@@ -2,7 +2,8 @@ prepend(SERVER_TESTS_SOURCES ${BASE_DIR}/tests/cpp/server/
         job-workers/shared-memory-manager-test.cpp
         cluster-name-test.cpp
         confdata-binlog-events-test.cpp
-        php-engine-test.cpp)
+        php-engine-test.cpp
+        workers-control-test.cpp)
 
 if(COMPILER_GCC)
     set_source_files_properties(${BASE_DIR}/tests/cpp/server/confdata-binlog-events-test.cpp PROPERTIES COMPILE_FLAGS -Wno-stringop-overflow)

--- a/tests/cpp/server/workers-control-test.cpp
+++ b/tests/cpp/server/workers-control-test.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+
+#include "server/workers-control.h"
+
+#define ASSERT_WORKERS(t, running, dying, all_alive) {       \
+  ASSERT_EQ(control.get_all_alive(), all_alive);             \
+  ASSERT_EQ(control.get_running_count(t), running);          \
+  ASSERT_EQ(control.get_dying_count(t), dying);              \
+  ASSERT_EQ(control.get_alive_count(t), (running) + (dying));\
+}
+
+TEST(workers_control_test, test_small_workers_count) {
+  auto &control = vk::singleton<WorkersControl>::get();
+  control.set_total_workers_count(2);
+  ASSERT_EQ(control.get_total_workers_count(), 2);
+
+  control.set_ratio(WorkerType::job_worker, 0.9);
+  ASSERT_FALSE(control.init());
+}
+
+TEST(workers_control_test, test_workers_count) {
+  auto &control = vk::singleton<WorkersControl>::get();
+  control.set_total_workers_count(356);
+  ASSERT_EQ(control.get_total_workers_count(), 356);
+
+  control.set_ratio(WorkerType::job_worker, 0.3);
+  ASSERT_TRUE(control.init());
+
+  ASSERT_EQ(control.get_count(WorkerType::job_worker), 107);
+  ASSERT_EQ(control.get_count(WorkerType::general_worker), 249);
+
+  for (WorkerType type : {WorkerType::job_worker, WorkerType::general_worker}) {
+    ASSERT_WORKERS(type, 0, 0, 0);
+  }
+
+  ASSERT_EQ(control.on_worker_creating(WorkerType::general_worker), 248);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::general_worker), 247);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::job_worker), 355);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::job_worker), 354);
+
+  for (WorkerType type : {WorkerType::job_worker, WorkerType::general_worker}) {
+    ASSERT_WORKERS(type, 2, 0, 4);
+  }
+
+  for (int i = 246; i >= 0; --i) {
+    ASSERT_EQ(control.on_worker_creating(WorkerType::general_worker), i);
+  }
+  ASSERT_WORKERS(WorkerType::general_worker, 249, 0, 251);
+
+  for (int i = 353; i >= 249; --i) {
+    ASSERT_EQ(control.on_worker_creating(WorkerType::job_worker), i);
+  }
+  ASSERT_WORKERS(WorkerType::job_worker, 107, 0, 356);
+
+  control.on_worker_terminating(WorkerType::general_worker);
+  control.on_worker_terminating(WorkerType::general_worker);
+  control.on_worker_terminating(WorkerType::general_worker);
+  ASSERT_WORKERS(WorkerType::general_worker, 246, 3, 356);
+  ASSERT_WORKERS(WorkerType::job_worker, 107, 0, 356);
+
+  control.on_worker_terminating(WorkerType::job_worker);
+  control.on_worker_terminating(WorkerType::job_worker);
+  ASSERT_WORKERS(WorkerType::general_worker, 246, 3, 356);
+  ASSERT_WORKERS(WorkerType::job_worker, 105, 2, 356);
+
+  control.on_worker_removing(WorkerType::general_worker, true, 100);
+  control.on_worker_removing(WorkerType::general_worker, false, 105);
+  ASSERT_WORKERS(WorkerType::general_worker, 245, 2, 354);
+  ASSERT_WORKERS(WorkerType::job_worker, 105, 2, 354);
+
+  control.on_worker_removing(WorkerType::job_worker, true, 300);
+  control.on_worker_removing(WorkerType::job_worker, false, 350);
+  ASSERT_WORKERS(WorkerType::general_worker, 245, 2, 352);
+  ASSERT_WORKERS(WorkerType::job_worker, 104, 1, 352);
+
+  ASSERT_EQ(control.on_worker_creating(WorkerType::general_worker), 105);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::job_worker), 350);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::general_worker), 100);
+  ASSERT_EQ(control.on_worker_creating(WorkerType::job_worker), 300);
+  ASSERT_WORKERS(WorkerType::general_worker, 247, 2, 356);
+  ASSERT_WORKERS(WorkerType::job_worker, 106, 1, 356);
+}

--- a/tests/python/tests/job_workers/test_complex_scenario_job.py
+++ b/tests/python/tests/job_workers/test_complex_scenario_job.py
@@ -7,8 +7,8 @@ class TestComplexScenarioJob(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 3,
-            "--workers-num": 15
+            "--workers-num": 18,
+            "--job-workers-ratio": 0.16
         })
 
     def assert_stats_count(self, stats):

--- a/tests/python/tests/job_workers/test_cpu_job.py
+++ b/tests/python/tests/job_workers/test_cpu_job.py
@@ -5,7 +5,8 @@ class TestCpuJob(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5
         })
 
     def test_simple_cpu_job(self):

--- a/tests/python/tests/job_workers/test_job_errors.py
+++ b/tests/python/tests/job_workers/test_job_errors.py
@@ -12,7 +12,8 @@ class TestJobErrors(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5
         })
 
     def _assert_result(self, stats_before, resp, error_code, buffers=4):

--- a/tests/python/tests/job_workers/test_job_graceful_termination.py
+++ b/tests/python/tests/job_workers/test_job_graceful_termination.py
@@ -6,7 +6,8 @@ class TestJobGracefulTermination(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2,
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5,
             "--verbosity-job-workers=2": True,
         })
 

--- a/tests/python/tests/job_workers/test_job_resumable.py
+++ b/tests/python/tests/job_workers/test_job_resumable.py
@@ -5,7 +5,8 @@ class TestJobResumable(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5
         })
 
     def test_jobs_in_wait_queue(self):

--- a/tests/python/tests/job_workers/test_job_with_mc_requests.py
+++ b/tests/python/tests/job_workers/test_job_with_mc_requests.py
@@ -5,7 +5,8 @@ class TestJobWithRpcRequests(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5
         })
 
     def test_job_with_mc_query(self):

--- a/tests/python/tests/job_workers/test_job_with_rpc_requests.py
+++ b/tests/python/tests/job_workers/test_job_with_rpc_requests.py
@@ -5,7 +5,8 @@ class TestJobWithRpcRequests(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--job-workers-num": 2
+            "--workers-num": 4,
+            "--job-workers-ratio": 0.5
         })
 
     def test_job_with_rpc_query(self):


### PR DESCRIPTION
Hi there!

The main idea of this patch is introducing the job workers ratio option, however I did some refactoring.

0) Split workers into 2 groups: **_general_** for http/rpc/task and **_job_** for parallel jobs
1) Workers control logic refactoring
2) Write deprecation warnings into json logs
3) Some refactoring about option parsing
4) Drop QPSCalculator for stats, because it is not required anymore (gauge stats work fine without it)
5) Simple stats for job workers