### PR TITLE
rewrite ClassData::get_instance_method()

### DIFF
--- a/compiler/data/class-data.h
+++ b/compiler/data/class-data.h
@@ -188,6 +188,8 @@ public:
 private:
   bool has_polymorphic_member_dfs(std::unordered_set<ClassPtr> &checked) const;
 
+  const ClassMemberInstanceMethod *find_instance_method_by_local_name(vk::string_view local_name) const;
+
   template<class MemberT>
   const MemberT *find_by_local_name(vk::string_view local_name) const {
     for (const auto &ancestor : get_all_ancestors()) {

--- a/tests/phpt/regress/issue215/test1.php
+++ b/tests/phpt/regress/issue215/test1.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+interface Iface {
+  function f();
+}
+
+abstract class AbstractBase {
+  public function f() {}
+}
+
+abstract class AbstractBase2 extends AbstractBase {}
+
+class Concrete extends AbstractBase2 implements Iface {}
+
+$c = new Concrete();

--- a/tests/phpt/regress/issue215/test2.php
+++ b/tests/phpt/regress/issue215/test2.php
@@ -1,0 +1,18 @@
+@ok
+<?php
+
+interface Iface {
+  function f();
+}
+
+abstract class AbstractBase {
+  public function f() {}
+}
+
+abstract class AbstractBase2 extends AbstractBase {}
+
+abstract class AbstractBase3 extends AbstractBase2 {}
+
+class Concrete extends AbstractBase3 implements Iface {}
+
+$c = new Concrete();

--- a/tests/phpt/regress/issue215/test3.php
+++ b/tests/phpt/regress/issue215/test3.php
@@ -1,0 +1,23 @@
+<?php
+
+interface Iface1 {}
+
+interface Iface2 {
+  public function f();
+}
+
+interface Iface extends Iface1, Iface2 {}
+
+abstract class BaseClass implements Iface {}
+
+abstract class F extends BaseClass {
+  public function g() {
+    $this->f();
+  }
+}
+
+class G extends F {
+  public function f() {}
+}
+
+$g = new G();


### PR DESCRIPTION
Previously, we used this approach:

* Collect all ancestors into `std::vector` (interfaces, base classes)
* Iterate over them, return the first member match

What we get wrong with this approach is that we could get an abstract method
instead of the implementation as the order of `get_all_ancestors()` doesn't
prefer classes to interfaces.

Consider this case:

```php
interface Iface { function f(); }

// Actually implements Iface, but doesn't state that
abstract class AbstractBase {
  public function f() {}
}

abstract class AbstractBase2 extends AbstractBase {}

// Implements Iface via AbstractBase, which is a base class of AbstractBase2
class Concrete extends AbstractBase2 implements Iface {}
```

With the old approach, we'll get a compile-time error.

The new approach prefers non-abstract methods; it'll traverse the classes and
try to find the first non-abstract method. If it's not possible, it will
return the first abstract method (like we did before). The code is slightly
more complicated than that just to avoid redundant work.

As we do more (useful) work now and sometimes need to check more classes,
I tried to write this method so it's not slower than before.

	old method:
	| Instance method lookup | 365669 | 3.478 sec | 6.370 sec | - | +6.3 MB |
	new method:
	| Instance method lookup | 365669 | 3.256 sec | 7.154 sec | - |       - |

Note: locking is applied in the same fashion as in find_by_local_name, per `.members` lookup.

Fixes #215