### PR TITLE
support '@kphp-color remover' for manual splitting recursively-joined call graph components

### DIFF
--- a/compiler/function-colors.cpp
+++ b/compiler/function-colors.cpp
@@ -23,17 +23,22 @@ std::string PaletteRule::as_human_readable(const Palette &palette) const {
 
 // --------------------------------------------
 
+Palette::Palette() {
+  color_names_mapping["transparent"] = special_color_transparent;
+  color_names_mapping["remover"] = special_color_remover;
+}
+
 color_t Palette::register_color_name(const std::string &color_name) {
   auto found = color_names_mapping.find(color_name);
   if (found != color_names_mapping.end()) {
     return found->second;
   }
 
-  int bit_shift = 1 + color_names_mapping.size();
+  int bit_shift = color_names_mapping.size() - 1;   // user-defined colors are 1<<1, 1<<2, and so on
   color_t color = 1ULL << bit_shift;
 
   color_names_mapping[color_name] = color;
-  kphp_error(color_names_mapping.size() != 62, "Reached limit of colors in palette — more than 62 colors");
+  kphp_error(color_names_mapping.size() != 64, "Reached limit of colors in palette — more than 64 colors");
   return color;
 }
 
@@ -55,6 +60,9 @@ std::string Palette::get_name_by_color(color_t color) const {
 // --------------------------------------------
 
 void ColorContainer::add(color_t color) {
+  if (color == special_color_transparent) {
+    return;
+  }
   // append color to the end of forward list
   // a bit inconvenient, but we use forward_list intentionally to consume only 8 bytes on emptiness (the most common case)
   auto before_end = std::next(sep_colors.before_begin(), std::distance(sep_colors.begin(), sep_colors.end()));

--- a/compiler/function-colors.h
+++ b/compiler/function-colors.h
@@ -15,6 +15,9 @@ namespace function_palette {
 using color_t = uint64_t;
 using colors_mask_t = uint64_t;
 
+constexpr color_t special_color_transparent = 0;        // all functions without any colors are transparent: C + transparent = C
+constexpr color_t special_color_remover = 1ULL << 63;   // @kphp-color remover works so: C + remover = transparent
+
 class Palette;
 
 // rules are representation of human-written "api has-curl" => "error text" or "api allow-curl has-curl" => 1
@@ -49,6 +52,8 @@ class Palette {
   std::map<std::string, color_t> color_names_mapping;
 
 public:
+  Palette();
+
   color_t register_color_name(const std::string &color_name);
 
   void add_ruleset(PaletteRuleset &&ruleset) {

--- a/tests/phpt/colors/023_color_remover.php
+++ b/tests/phpt/colors/023_color_remover.php
@@ -1,0 +1,37 @@
+@ok
+<?php
+
+class KphpConfiguration {
+    const FUNCTION_PALETTE = [
+        [
+            'highload no-highload' => 'error text',
+        ]
+    ];
+}
+
+/** @kphp-color remover */
+function callAct() {
+    if(0) f1();
+    if(0) f2();
+    if(0) f3();
+    if(0) f4();
+}
+
+
+/** @kphp-color highload */
+function f1() { g1(); }
+function g1() { callAct(); }
+
+/** @kphp-color highload */
+function f2() { g2(); }
+function g2() { callAct(); }
+
+function f3() { g3(); }
+/** @kphp-color no-highload */
+function g3() { callAct(); }
+
+function f4() { g4(); }
+/** @kphp-color no-highload */
+function g4() { callAct(); }
+
+callAct();


### PR DESCRIPTION
Functions marked with this special color are dropped off the call graph, like they don't exist at all.

We'll use this in real code for routing points like callAct or for exit points like fatalExit.
Marked functions will allow us to deal with highly-connected indirectly-recursive call graph components, where every function is accessible from every other.
Using this special color for functions like callAct can split such components into smaller ones, which influences all palette rules at once.