### PR TITLE
Job workers: enhancements

### DIFF
--- a/common/pipe-utils.cpp
+++ b/common/pipe-utils.cpp
@@ -14,7 +14,7 @@
 #include "common/crc32c.h"
 #include "common/server/limits.h"
 
-struct connection *epoll_insert_pipe(enum pipe_type type, int pipe_fd, conn_type_t *conn_type, void *extra) {
+struct connection *epoll_insert_pipe(enum pipe_type type, int pipe_fd, conn_type_t *conn_type, void *extra, int extra_flags) {
   if (check_conn_functions(conn_type) < 0) {
     return NULL;
   }
@@ -61,7 +61,7 @@ struct connection *epoll_insert_pipe(enum pipe_type type, int pipe_fd, conn_type
   }
 
   epoll_sethandler(pipe_fd, 0, server_read_write_gateway, c);
-  epoll_insert(pipe_fd, (c->flags & C_WANTRD ? EVT_READ : 0) | (c->flags & C_WANTWR ? EVT_WRITE : 0) | EVT_SPEC);
+  epoll_insert(pipe_fd, (c->flags & C_WANTRD ? EVT_READ : 0) | (c->flags & C_WANTWR ? EVT_WRITE : 0) | extra_flags);
   return c;
 }
 

--- a/common/pipe-utils.h
+++ b/common/pipe-utils.h
@@ -14,5 +14,5 @@ enum pipe_type {
   pipe_for_read,
   pipe_for_write
 };
-struct connection *epoll_insert_pipe(enum pipe_type type, int pipe_fd, conn_type_t *conn_type, void *extra);
+struct connection *epoll_insert_pipe(enum pipe_type type, int pipe_fd, conn_type_t *conn_type, void *extra, int extra_flags = EVT_SPEC);
 

--- a/functions.txt
+++ b/functions.txt
@@ -1338,7 +1338,7 @@ function kphp_job_worker_store_response(KphpJobWorkerResponse $response) ::: voi
 
 function is_kphp_job_workers_enabled() ::: bool;
 
-function kphp_job_workers_count() ::: int;
+function get_job_workers_number() ::: int;
 
 // zstd api
 function zstd_compress(string $data, int $level = 3) ::: string | false;

--- a/functions.txt
+++ b/functions.txt
@@ -1338,6 +1338,8 @@ function kphp_job_worker_store_response(KphpJobWorkerResponse $response) ::: voi
 
 function is_kphp_job_workers_enabled() ::: bool;
 
+function kphp_job_workers_count() ::: int;
+
 // zstd api
 function zstd_compress(string $data, int $level = 3) ::: string | false;
 function zstd_uncompress(string $data) ::: string | false;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2198,7 +2198,6 @@ static void free_runtime_libs() {
 
   free_job_client_interface_lib();
   free_job_server_interface_lib();
-  free_job_workers_interface_lib();
 
   free_confdata_functions_lib();
   free_instance_cache_lib();

--- a/runtime/job-workers/client-functions.cpp
+++ b/runtime/job-workers/client-functions.cpp
@@ -113,7 +113,9 @@ Optional<int64_t> f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRe
   }
 
   const auto now = std::chrono::system_clock::now();
-  memory_request->job_deadline_time = std::chrono::duration<double>{now.time_since_epoch()}.count() + timeout;
+  memory_request->job_start_time = std::chrono::duration<double>{now.time_since_epoch()}.count();
+  memory_request->job_timeout = timeout;
+
   int job_id = 0;
   {
     dl::CriticalSectionSmartGuard critical_section;

--- a/runtime/job-workers/client-functions.cpp
+++ b/runtime/job-workers/client-functions.cpp
@@ -92,9 +92,9 @@ Optional<int64_t> f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRe
   }
   if (timeout < 0) {
     timeout = DEFAULT_SCRIPT_TIMEOUT;
-  } else if (timeout < 1 || timeout > MAX_SCRIPT_TIMEOUT) {
-    timeout = vk::clamp(timeout, 1.0, MAX_SCRIPT_TIMEOUT * 1.0);
-    php_warning("timeout value was clamped to [%d; %d]", 1, MAX_SCRIPT_TIMEOUT);
+  } else if (timeout < 0.05 || timeout > MAX_SCRIPT_TIMEOUT) {
+    timeout = vk::clamp(timeout, 0.05, MAX_SCRIPT_TIMEOUT * 1.0);
+    php_warning("timeout value was clamped to [%f; %d]", 0.05, MAX_SCRIPT_TIMEOUT);
   }
 
   auto &memory_manager = vk::singleton<job_workers::SharedMemoryManager>::get();

--- a/runtime/job-workers/job-interface.cpp
+++ b/runtime/job-workers/job-interface.cpp
@@ -43,7 +43,7 @@ void global_init_job_workers_lib() noexcept {
   }
 }
 
-void free_job_workers_interface_lib() noexcept {
+void clear_shared_job_messages() noexcept {
   if (f$is_kphp_job_workers_enabled()) {
     vk::singleton<job_workers::SharedMemoryManager>::get().forcibly_release_all_attached_messages();
   }

--- a/runtime/job-workers/job-interface.cpp
+++ b/runtime/job-workers/job-interface.cpp
@@ -31,6 +31,11 @@ bool f$is_kphp_job_workers_enabled() noexcept {
   return vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0;
 }
 
+int64_t f$kphp_job_workers_count() noexcept {
+  return vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker);
+}
+
+
 void global_init_job_workers_lib() noexcept {
   if (f$is_kphp_job_workers_enabled()) {
     vk::singleton<job_workers::SharedMemoryManager>::get().init();

--- a/runtime/job-workers/job-interface.cpp
+++ b/runtime/job-workers/job-interface.cpp
@@ -28,10 +28,10 @@ int get_job_timeout_wakeup_id() {
 }
 
 bool f$is_kphp_job_workers_enabled() noexcept {
-  return vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0;
+  return f$get_job_workers_number() > 0;
 }
 
-int64_t f$kphp_job_workers_count() noexcept {
+int64_t f$get_job_workers_number() noexcept {
   return vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker);
 }
 

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -106,7 +106,7 @@ bool f$is_kphp_job_workers_enabled() noexcept;
 int64_t f$kphp_job_workers_count() noexcept;
 
 void global_init_job_workers_lib() noexcept;
-void free_job_workers_interface_lib() noexcept;
+void clear_shared_job_messages() noexcept;
 
 int get_job_timeout_wakeup_id();
 

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -103,7 +103,7 @@ class_instance<C$KphpJobWorkerResponseError> create_error_on_other_memory(int32_
 
 bool f$is_kphp_job_workers_enabled() noexcept;
 
-int64_t f$kphp_job_workers_count() noexcept;
+int64_t f$get_job_workers_number() noexcept;
 
 void global_init_job_workers_lib() noexcept;
 void clear_shared_job_messages() noexcept;

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -103,6 +103,8 @@ class_instance<C$KphpJobWorkerResponseError> create_error_on_other_memory(int32_
 
 bool f$is_kphp_job_workers_enabled() noexcept;
 
+int64_t f$kphp_job_workers_count() noexcept;
+
 void global_init_job_workers_lib() noexcept;
 void free_job_workers_interface_lib() noexcept;
 

--- a/server/job-workers/job-message.h
+++ b/server/job-workers/job-message.h
@@ -34,7 +34,12 @@ public:
 
   int32_t job_id{0};
   int32_t job_result_fd_idx{-1};
-  double job_deadline_time{-1.0};
+  double job_start_time{-1.0};
+  double job_timeout{-1.0};
+
+  double job_deadline_time() const noexcept {
+    return job_start_time + job_timeout;
+  }
 
 protected:
   JobSharedMessageMetadata() = default;

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -175,7 +175,7 @@ void JobWorkerServer::init() {
     clear_event(result_pipe[0]);
   }
 
-  read_job_connection = epoll_insert_pipe(pipe_for_read, read_job_fd, &php_jobs_server, nullptr);
+  read_job_connection = epoll_insert_pipe(pipe_for_read, read_job_fd, &php_jobs_server, nullptr, EVT_LEVEL);
   assert(read_job_connection);
   memset(read_job_connection->custom_data, 0, sizeof(read_job_connection->custom_data));
 

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -150,6 +150,9 @@ int JobWorkerServer::job_parse_execute(connection *c) {
   auto now = std::chrono::system_clock::now();
   double timeout_sec = job->job_deadline_time - std::chrono::duration<double>{now.time_since_epoch()}.count();
 
+  tvkprintf(job_workers, 2, "got new job: <job_result_fd_idx, job_id> = <%d, %d> , job_memory_ptr = %p, left_job_time = %f\n",
+            job->job_result_fd_idx, job->job_id, job, timeout_sec);
+
   job_query_data *job_data = job_query_data_create(job, [](JobSharedMessage *job_response) {
     return vk::singleton<JobWorkerServer>::get().send_job_reply(job_response);
   });

--- a/server/job-workers/job-worker-server.h
+++ b/server/job-workers/job-worker-server.h
@@ -30,8 +30,6 @@ public:
 
   int job_parse_execute(connection *c);
 
-  void try_complete_delayed_jobs();
-
   void reset_running_job() noexcept;
 
   void try_store_job_response_error(const char *error_msg, int error_code);
@@ -46,7 +44,6 @@ private:
   JobSharedMessage *running_job{nullptr};
   PipeJobWriter job_writer;
   PipeJobReader job_reader;
-  bool has_delayed_jobs{false};
   int read_job_fd{-1};
   connection *read_job_connection{nullptr};
   bool reply_was_sent{false};

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -37,7 +37,7 @@ extern int master_flag;
 
 enum class RunMode {
   master,
-  http_worker,
+  general_worker,
   job_worker,
 };
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1558,7 +1558,7 @@ static void generic_event_loop(RunMode mode) {
       }
     }
     // fall through
-    case RunMode::http_worker: {
+    case RunMode::general_worker: {
       if (http_port > 0 && http_sfd < 0) {
         dl_assert (!master_flag, "failed to get http_fd\n");
         if (master_flag) {
@@ -1664,7 +1664,7 @@ static void generic_event_loop(RunMode mode) {
       cron();
     }
 
-    if (vk::any_of_equal(mode, RunMode::http_worker, RunMode::master)) {
+    if (vk::any_of_equal(mode, RunMode::general_worker, RunMode::master)) {
       lease_cron();
       if (sigterm_on && !rpc_stopped) {
         rpcc_stop();
@@ -1678,7 +1678,7 @@ static void generic_event_loop(RunMode mode) {
       main_thread_reactor.pre_event();
     }
 
-    if (vk::any_of_equal(mode, RunMode::http_worker, RunMode::master)) {
+    if (vk::any_of_equal(mode, RunMode::general_worker, RunMode::master)) {
       if (sigterm_on && precise_now > sigterm_time && !php_worker_run_flag && pending_http_queue.first_query == (conn_query *)&pending_http_queue) {
         vkprintf(1, "Quitting because of sigterm\n");
         break;
@@ -1695,7 +1695,7 @@ static void generic_event_loop(RunMode mode) {
     vkprintf (1, "Quitting because of pending signals = %llx\n", pending_signals);
   }
 
-  if (mode == RunMode::http_worker && http_sfd >= 0) {
+  if (mode == RunMode::general_worker && http_sfd >= 0) {
     epoll_close(http_sfd);
     assert (close(http_sfd) >= 0);
   }

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1629,9 +1629,7 @@ static void generic_event_loop(RunMode mode) {
       vkprintf (1, "epoll_work(): %d out of %d connections, network buffers: %d used, %d out of %d allocated\n",
                 active_connections, maxconn, NB_used, NB_alloc, NB_max);
     }
-    if (mode == RunMode::job_worker) {
-      job_worker_server.try_complete_delayed_jobs();
-    }
+
     epoll_work(57);
 
     if (precise_now > next_create_outbound) {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -427,7 +427,7 @@ void delete_worker(worker_info_t *w) {
     dead_utime += w->my_info.utime;
     dead_stime += w->my_info.stime;
   }
-  dead_worker_stats.add_worker_stats_from(w->stats->worker_stats);
+  dead_worker_stats.add_worker_stats_from(w->stats->worker_stats, w->type);
   // ignore dead workers memory and percentiles stats
   dead_worker_stats.reset_memory_and_percentiles_stats();
   worker_free(w);
@@ -1167,7 +1167,7 @@ std::string php_master_prepare_stats(bool full_flag, int worker_pid) {
       }
 
       if (full_flag) {
-        worker_stats.add_worker_stats_from(w->stats->worker_stats);
+        worker_stats.add_worker_stats_from(w->stats->worker_stats, w->type);
       }
 
       if (worker_pid == -1 || w->pid == worker_pid) {
@@ -1739,7 +1739,7 @@ static void cron() {
     w->stats->update(cpu_timestamp);
     running_general_workers += w->stats->istats.is_running && (w->type == WorkerType::general_worker);
     running_job_workers += w->stats->istats.is_running && (w->type == WorkerType::job_worker);
-    server_stats.worker_stats.add_worker_stats_from(w->stats->worker_stats);
+    server_stats.worker_stats.add_worker_stats_from(w->stats->worker_stats, w->type);
   }
   server_stats.update_misc_stat_for_general_workers(MiscStatTimestamp{my_now, running_general_workers});
   server_stats.update_misc_stat_for_job_workers(MiscStatTimestamp{my_now, running_job_workers});

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -734,7 +734,7 @@ int run_worker(WorkerType worker_type) {
   if (new_pid == 0) {
     switch (worker_type) {
       case WorkerType::general_worker:
-        run_mode = RunMode::http_worker;
+        run_mode = RunMode::general_worker;
         break;
       case WorkerType::job_worker:
         run_mode = RunMode::job_worker;

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -658,8 +658,6 @@ long long php_script_memory_get_total_usage(void *ptr) {
 }
 
 void php_script_set_timeout(double t) {
-  assert (t >= 0.1);
-
   static itimerval timer;
   timer.it_interval.tv_sec = 0;
   timer.it_interval.tv_usec = 0;

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -161,7 +161,7 @@ void php_worker_try_start(php_worker *worker) {
 void php_worker_init_script(php_worker *worker) {
   double timeout = worker->finish_time - precise_now - 0.01;
   if (worker->terminate_flag) {
-    worker->state = phpq_finish; // TODO: fix job memory leak here: forcibly_release_all_attached_messages() is called only at `phpq_free_script` state
+    worker->state = phpq_finish;
     return;
   }
 
@@ -650,6 +650,7 @@ void php_worker_free_script(php_worker *worker) {
 
 void php_worker_finish(php_worker *worker) {
   vkprintf (2, "free php script [req_id = %016llx]\n", worker->req_id);
+  clear_shared_job_messages(); // it's here because `phpq_free_script` state is skipped when worker->terminate_flag == true
   lease_on_worker_finish(worker);
   php_worker_free(worker);
 }

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -160,8 +160,8 @@ void php_worker_try_start(php_worker *worker) {
 
 void php_worker_init_script(php_worker *worker) {
   double timeout = worker->finish_time - precise_now - 0.01;
-  if (worker->terminate_flag || timeout < 0.2) {
-    worker->state = phpq_finish;
+  if (worker->terminate_flag) {
+    worker->state = phpq_finish; // TODO: fix job memory leak here: forcibly_release_all_attached_messages() is called only at `phpq_free_script` state
     return;
   }
 

--- a/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
+++ b/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
@@ -30,7 +30,8 @@ void check_new_message(JobSharedMessage *message) {
   ASSERT_EQ(message->owners_counter, 1);
   ASSERT_EQ(message->job_id, 0);
   ASSERT_EQ(message->job_result_fd_idx, -1);
-  ASSERT_EQ(message->job_deadline_time, -1.0);
+  ASSERT_EQ(message->job_start_time, -1.0);
+  ASSERT_EQ(message->job_timeout, -1.0);
 }
 
 struct AcquiredReleased {

--- a/tests/python/tests/job_workers/php/SyncJobCommand.php
+++ b/tests/python/tests/job_workers/php/SyncJobCommand.php
@@ -1,0 +1,10 @@
+<?php
+
+/** @kphp-immutable-class */
+class SyncJobCommand {
+  public $command = '';
+
+  function __construct(string $command) {
+    $this->command = $command;
+  }
+}

--- a/tests/python/tests/job_workers/php/job_worker.php
+++ b/tests/python/tests/job_workers/php/job_worker.php
@@ -14,6 +14,8 @@ function do_job_worker() {
         return x2_with_error($req);
       case "x2_with_work_after_response":
         return x2_with_work_after_response($req);
+      case "sync_job":
+        return sync_job($req);
     }
     if ($req->tag !== "") {
       critical_error("Unknown tag " + $req->tag);
@@ -115,4 +117,14 @@ function x2_with_work_after_response(X2Request $x2_req) {
   fprintf(STDERR, "start work after response\n");
   safe_sleep($x2_req->sleep_time_sec);
   fprintf(STDERR, "finish work after response\n");
+}
+
+function sync_job(X2Request $req) {
+  $id = $req->arr_request[0];
+  instance_cache_store("sync_job_started_$id", new SyncJobCommand('started'));
+
+  while (instance_cache_fetch(SyncJobCommand::class, "finish_sync_job_$id") === null) {
+  }
+
+  kphp_job_worker_store_response(new X2Response);
 }

--- a/tests/python/tests/job_workers/test_job_worker_wakeup.py
+++ b/tests/python/tests/job_workers/test_job_worker_wakeup.py
@@ -1,0 +1,26 @@
+import signal
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJobWorkerWakeup(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 8,
+            "--job-workers-ratio": 0.25,
+            "--verbosity-job-workers=2": True,
+        })
+
+    def test_job_worker_wakeup_on_merged_events(self):
+        resp = self.kphp_server.http_post(
+            uri="/test_job_worker_wakeup_on_merged_events",
+            json={
+                "data": [[1, 2, 3, 4], [7, 9, 12], [13, 14, 15]],
+            })
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "jobs-result": [
+                {"data": [1 * 1, 2 * 2, 3 * 3, 4 * 4], "stats": []},
+                {"data": [7 * 7, 9 * 9, 12 * 12], "stats": []},
+                {"data": [13 * 13, 14 * 14, 15 * 15], "stats": []},
+            ]})


### PR DESCRIPTION
Here are the following enhancements for job workers:
1. Configuring epoll to wake up only one worker on event, instead of all
2. Fix job shared memory leak, when worker terminates before script is inited
3. Implement `kphp_job_workers_count()` function
4. Other minor improvements