### PR TITLE
Fix negative keys bug

### DIFF
--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -612,6 +612,11 @@ void array<T>::array_inner::unset_map_value(const string &string_key, int64_t pr
 }
 
 template<class T>
+bool array<T>::array_inner::is_vector_internal_or_last_index(int64_t key) const noexcept {
+  return key >= 0 && key <= int_size;
+}
+
+template<class T>
 size_t array<T>::array_inner::estimate_memory_usage() const {
   int64_t int_elements = int_size;
   int64_t string_elements = 0;
@@ -1070,7 +1075,7 @@ void array<T>::clear() {
 template<class T>
 T &array<T>::operator[](int64_t int_key) {
   if (is_vector()) {
-    if (int_key >= 0 && int_key <= p->int_size) {
+    if (p->is_vector_internal_or_last_index(int_key)) {
       if (int_key == p->int_size) {
         mutate_if_vector_needed_int();
         return p->emplace_back_vector_value();
@@ -1151,7 +1156,7 @@ T &array<T>::operator[](const const_iterator &it) noexcept {
     bool is_string_entry = it.self_->is_string_hash_entry(entry);
 
     if (is_vector()) {
-      if (!is_string_entry && entry->int_key <= p->int_size) {
+      if (!is_string_entry && p->is_vector_internal_or_last_index(entry->int_key)) {
         if (entry->int_key == p->int_size) {
           mutate_if_vector_needed_int();
           return p->emplace_back_vector_value();
@@ -1187,7 +1192,7 @@ template<class T>
 template<class ...Args>
 void array<T>::emplace_value(int64_t int_key, Args &&... args) noexcept {
   if (is_vector()) {
-    if (int_key >= 0 && int_key <= p->int_size) {
+    if (p->is_vector_internal_or_last_index(int_key)) {
       if (int_key == p->int_size) {
         mutate_if_vector_needed_int();
         p->emplace_back_vector_value(std::forward<Args>(args)...);
@@ -1342,7 +1347,7 @@ void array<T>::set_value(const const_iterator &it) noexcept {
     bool is_string_entry = it.self_->is_string_hash_entry(entry);
 
     if (is_vector()) {
-      if (!is_string_entry && entry->int_key <= p->int_size) {
+      if (!is_string_entry && p->is_vector_internal_or_last_index(entry->int_key)) {
         if (entry->int_key == p->int_size) {
           mutate_if_vector_needed_int();
           p->push_back_vector_value(entry->value);

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -116,13 +116,13 @@ bool array<T>::is_int_key(const typename array<T>::key_type &key) {
 
 template<>
 inline typename array<Unknown>::array_inner *array<Unknown>::array_inner::empty_array() {
-  static array_inner empty_array{
-    ExtraRefCnt::for_global_const, -1,
+  static array_inner_control empty_array{
+    0, ExtraRefCnt::for_global_const, -1,
     {0, 0},
     0, 2,
     0, std::numeric_limits<uint32_t>::max()
   };
-  return &empty_array;
+  return static_cast<array<Unknown>::array_inner *>(&empty_array);
 }
 
 template<class T>
@@ -166,7 +166,7 @@ typename array<T>::entry_pointer_type array<T>::array_inner::get_pointer(list_ha
 
 template<class T>
 const typename array<T>::string_hash_entry *array<T>::array_inner::begin() const {
-  return (const string_hash_entry *)get_entry(end_.next);
+  return (const string_hash_entry *)get_entry(last.next);
 }
 
 template<class T>
@@ -201,7 +201,7 @@ typename array<T>::string_hash_entry *array<T>::array_inner::prev(string_hash_en
 
 template<class T>
 typename array<T>::string_hash_entry *array<T>::array_inner::end() {
-  return (string_hash_entry * ) &end_;
+  return (string_hash_entry * ) &last;
 }
 
 template<class T>

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -433,7 +433,9 @@ private:
   template<class Arg, class...Args>
   void push_back_values(Arg &&arg, Args &&... args);
 
-private:
+  template<class T1>
+  void push_back_iterator(const array_iterator<T1> &it) noexcept;
+
   array_inner *p;
 
   template<class T1>

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -268,8 +268,8 @@ public:
   T &operator[](const string &s);
   T &operator[](const mixed &v);
   T &operator[](double double_key);
-  T &operator[](const const_iterator &it);
-  T &operator[](const iterator &it);
+  T &operator[](const const_iterator &it) noexcept;
+  T &operator[](const iterator &it) noexcept;
 
   template<class ...Args>
   void emplace_value(int64_t int_key, Args &&... args) noexcept;
@@ -301,8 +301,8 @@ public:
   template<class OptionalT>
   void set_value(const Optional<OptionalT> &key, const T &value) noexcept;
 
-  void set_value(const const_iterator &it);
-  void set_value(const iterator &it);
+  void set_value(const const_iterator &it) noexcept;
+  void set_value(const iterator &it) noexcept;
 
   // assign binary array_inner representation
   // can be used only on empty arrays to receive logically const array
@@ -334,8 +334,8 @@ public:
   void push_back(T &&v) noexcept;
   void push_back(const T &v) noexcept;
 
-  void push_back(const const_iterator &it);
-  void push_back(const iterator &it);
+  void push_back(const const_iterator &it) noexcept;
+  void push_back(const iterator &it) noexcept;
 
   const T push_back_return(const T &v);
   const T push_back_return(T &&v);

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -45,25 +45,39 @@ enum class overwrite_element {
   NO
 };
 
+using list_entry_pointer_type = uint32_t;
+
+struct array_list_hash_entry {
+  list_entry_pointer_type next;
+  list_entry_pointer_type prev;
+};
+
+struct array_inner_control {
+  // This stub field is needed to ensure the alignment during the const arrays generation
+  // TODO: figure out something smarter
+  int stub;
+  int ref_cnt;
+  int64_t max_key;
+  array_list_hash_entry last;
+  uint32_t int_size;
+  uint32_t int_buf_size;
+  uint32_t string_size;
+  uint32_t string_buf_size;
+};
+
 template<class T>
 class array {
-
 public:
+  // TODO why we need 2 value types?
   using ValueType = T;
-
-  typedef mixed key_type;
-  typedef T value_type;
+  using value_type = T;
+  using key_type = mixed;
 
   inline static bool is_int_key(const key_type &key);
 
 private:
-
-  using entry_pointer_type = uint32_t;
-
-  struct list_hash_entry {
-    entry_pointer_type next;
-    entry_pointer_type prev;
-  };
+  using entry_pointer_type = list_entry_pointer_type;
+  using list_hash_entry = array_list_hash_entry;
 
   struct int_hash_entry : list_hash_entry {
     T value;
@@ -90,7 +104,7 @@ private:
     uint64_t modulo_helper_string_buf_size{0};
   };
 
-  struct array_inner {
+  struct array_inner : array_inner_control {
     //if key is number, int_key contains this number, there is no string_key.
     //if key is string, int_key contains hash of this string, string_key contains this string.
     //empty hash_entry identified by (next == EMPTY_POINTER)
@@ -100,16 +114,6 @@ private:
 
     static constexpr entry_pointer_type EMPTY_POINTER = 0;
 
-    // This stub field is needed to ensure the alignment during the const arrays generation
-    // TODO: figure out something smarter
-    int stub{0};
-    int ref_cnt;
-    int64_t max_key;
-    list_hash_entry end_;
-    uint32_t int_size;
-    uint32_t int_buf_size;
-    uint32_t string_size;
-    uint32_t string_buf_size;
     int_hash_entry int_entries[KPHP_ARRAY_TAIL_SIZE];
 
     inline bool is_vector() const __attribute__ ((always_inline));
@@ -188,14 +192,8 @@ private:
 
     size_t estimate_memory_usage() const;
 
-    inline array_inner(int ref_cnt, int64_t max_key, list_hash_entry end_, uint32_t int_size, uint32_t int_buf_size, uint32_t string_size, uint32_t string_buf_size) :
-      ref_cnt(ref_cnt),
-      max_key(max_key),
-      end_(end_),
-      int_size(int_size),
-      int_buf_size(int_buf_size),
-      string_size(string_size),
-      string_buf_size(string_buf_size) {
+    constexpr array_inner(int ref_cnt, int64_t max_key, list_hash_entry end, uint32_t int_size, uint32_t int_buf_size, uint32_t string_size, uint32_t string_buf_size) noexcept :
+      array_inner_control{0, ref_cnt, max_key, end, int_size, int_buf_size, string_size, string_buf_size} {
     }
 
     inline array_inner(const array_inner &other) = delete;

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -184,6 +184,8 @@ private:
     inline T &get_vector_value(int64_t int_key);//unsafe
     inline void unset_map_value(const string &string_key, int64_t precomuted_hash);
 
+    bool is_vector_internal_or_last_index(int64_t key) const noexcept;
+
     size_t estimate_memory_usage() const;
 
     inline array_inner(int ref_cnt, int64_t max_key, list_hash_entry end_, uint32_t int_size, uint32_t int_buf_size, uint32_t string_size, uint32_t string_buf_size) :

--- a/runtime/instance-copy-processor.cpp
+++ b/runtime/instance-copy-processor.cpp
@@ -51,3 +51,15 @@ bool InstanceDeepDestroyVisitor::process(string &str) noexcept {
   }
   return true;
 }
+
+template<class T>
+bool InstanceDeepCopyVisitor::PrimitiveArrayProcessor<T>::process(InstanceDeepCopyVisitor &self, array<T> &arr) noexcept {
+  return self.process_array_impl(arr);
+}
+
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<int64_t>;
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<double>;
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<bool>;
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<Optional<int64_t>>;
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<Optional<double>>;
+template struct InstanceDeepCopyVisitor::PrimitiveArrayProcessor<Optional<bool>>;

--- a/tests/phpt/array/015_array_replace_neg_keys.php
+++ b/tests/phpt/array/015_array_replace_neg_keys.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+
+class A {
+  public $x = "A";
+}
+
+/**
+ * @param $a A[]
+ * @param $b A[]
+ */
+function test(array $a, array $b) {
+  $a = array_replace($a, $b);
+  foreach ($a as $k => $v) {
+    echo "$k => ", $v->x, "\n";
+  }
+}
+
+test([], [-2 => new A, -1 => new A, 0 => new A, 1 => new A]);
+test([-2 => new A, -1 => new A, 0 => new A, 1 => new A], []);
+test([-2 => new A, -1 => new A, 0 => new A, 1 => new A], [-1 => new A, 0 => new A, 1 => new A, 2 => new A]);


### PR DESCRIPTION
This patch fixes a bug when negative keys lead a crash from runtime.
Also I've done some refactoring.

Here I've also moved shared memory copying process for primitive types into runtime lib, it compiles with -O3 optimization level, so it works faster now!