### PR TITLE
Forbid reumable calls in foreach by reference from non local vars

### DIFF
--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -99,6 +99,7 @@ public:
   bool cpp_template_call = false;
   bool cpp_variadic_call = false;
   bool is_resumable = false;
+  bool can_be_implicitly_interrupted_by_other_resumable = false;
   bool is_virtual_method = false;
   bool is_overridden_method = false;
   bool is_no_return = false;

--- a/compiler/pipes/calc-bad-vars.cpp
+++ b/compiler/pipes/calc-bad-vars.cpp
@@ -549,6 +549,7 @@ class CalcBadVars {
       }
     }
     for (const auto &func : call_graph.functions) {
+      func->can_be_implicitly_interrupted_by_other_resumable = into_resumable[func];
       if (from_resumable[func] && into_resumable[func]) {
         func->is_resumable = true;
         func->fork_prev = from_parents[func];

--- a/compiler/pipes/check-nested-foreach.h
+++ b/compiler/pipes/check-nested-foreach.h
@@ -1,5 +1,5 @@
 // Compiler for PHP (aka KPHP)
-// Copyright (c) 2020 LLC «V Kontakte»
+// Copyright (c) 2021 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #pragma once
@@ -7,23 +7,21 @@
 #include "compiler/function-pass.h"
 
 class CheckNestedForeachPass final : public FunctionPassBase {
-  vector<VarPtr> foreach_vars{};
-  vector<VarPtr> foreach_ref_vars{};
-  vector<VarPtr> foreach_key_vars{};
-  vector<VarPtr> errored_vars{};
 public:
-
-  string get_description() override {
+  std::string get_description() final {
     return "Try to detect common errors: nested foreach";
   }
 
-  bool check_function(FunctionPtr function) const override {
+  bool check_function(FunctionPtr function) const final {
     return !function->is_extern();
   }
 
+  VertexPtr on_enter_vertex(VertexPtr vertex) final;
+  VertexPtr on_exit_vertex(VertexPtr vertex) final;
 
-  VertexPtr on_enter_vertex(VertexPtr vertex) override;
-
-
-  VertexPtr on_exit_vertex(VertexPtr vertex) override;
+private:
+  std::vector<VarPtr> foreach_vars_;
+  std::vector<VarPtr> foreach_ref_vars_;
+  std::vector<VarPtr> foreach_key_vars_;
+  std::vector<VarPtr> errored_vars_;
 };

--- a/compiler/pipes/check-nested-foreach.h
+++ b/compiler/pipes/check-nested-foreach.h
@@ -20,6 +20,7 @@ public:
   VertexPtr on_exit_vertex(VertexPtr vertex) final;
 
 private:
+  std::vector<VarPtr> foreach_iterable_non_local_vars_;
   std::vector<VarPtr> foreach_vars_;
   std::vector<VarPtr> foreach_ref_vars_;
   std::vector<VarPtr> foreach_key_vars_;

--- a/tests/phpt/fork/025_foreach_by_global_var_ref_error.php
+++ b/tests/phpt/fork/025_foreach_by_global_var_ref_error.php
@@ -1,0 +1,34 @@
+@kphp_should_fail
+/It is forbidden to call resumable functions inside foreach with reference by var \$global_var_x with non local scope visibility/
+<?php
+
+$global_var_x = [["x"], "y"];
+
+function wait_once($i) {
+  static $flag = true;
+  if ($flag) {
+    wait($i);
+    $flag = false;
+  }
+}
+
+function foo() {
+  global $global_var_x;
+  sched_yield();
+  $global_var_x = 1;
+  return null;
+}
+
+function demo() {
+  global $global_var_x;
+
+  $i = fork(foo());
+  foreach ($global_var_x as &$value) {
+    wait_once($i);
+    $value = [1];
+  }
+
+  var_dump($global_var_x);
+}
+
+demo();

--- a/tests/phpt/fork/026_foreach_by_class_static_var_ref_error.php
+++ b/tests/phpt/fork/026_foreach_by_class_static_var_ref_error.php
@@ -1,0 +1,33 @@
+@kphp_should_fail
+/It is forbidden to call resumable functions inside foreach with reference by var A::\$static_var_x with non local scope visibility/
+<?php
+
+class A {
+  static $static_var_x = [["x"], "y"];
+}
+
+function wait_once($i) {
+  static $flag = true;
+  if ($flag) {
+    wait($i);
+    $flag = false;
+  }
+}
+
+function foo() {
+  sched_yield();
+  A::$static_var_x = 1;
+  return null;
+}
+
+function demo() {
+  $i = fork(foo());
+  foreach (A::$static_var_x as &$value) {
+    wait_once($i);
+    $value = [1];
+  }
+
+  var_dump(A::$static_var_x);
+}
+
+demo();

--- a/tests/phpt/fork/027_foreach_by_static_var_ref_error.php
+++ b/tests/phpt/fork/027_foreach_by_static_var_ref_error.php
@@ -1,0 +1,36 @@
+@kphp_should_fail
+/It is forbidden to call resumable functions inside foreach with reference by var \$static_var_x with non local scope visibility/
+<?php
+
+function wait_once($i) {
+  static $flag = true;
+  if ($flag) {
+    wait($i);
+    $flag = false;
+  }
+}
+
+function foo() {
+  sched_yield();
+  demo(false);
+  return null;
+}
+
+function demo($x = true) {
+  static $static_var_x = [["x"], "y"];
+
+  if (!$x) {
+    $static_var_x = 1;
+    return;
+  }
+
+  $i = fork(foo());
+  foreach ($static_var_x as &$value) {
+    wait_once($i);
+    $value = [1];
+  }
+
+  var_dump($static_var_x);
+}
+
+demo();

--- a/tests/phpt/fork/028_foreach_by_instance_field_ref_error.php
+++ b/tests/phpt/fork/028_foreach_by_instance_field_ref_error.php
@@ -1,0 +1,36 @@
+@kphp_should_fail
+/It is forbidden to call resumable functions inside foreach with reference by var A::\$x with non local scope visibility/
+<?php
+
+class A {
+  /** @var mixed */
+  public $x = [["x"], "y"];
+}
+
+function wait_once($i) {
+  static $flag = true;
+  if ($flag) {
+    wait($i);
+    $flag = false;
+  }
+}
+
+function foo(A $a) {
+  sched_yield();
+  $a->x = 1;
+  return null;
+}
+
+function demo() {
+  $a = new A;
+
+  $i = fork(foo($a));
+  foreach ($a->x as &$value) {
+    wait_once($i);
+    $value = [1];
+  }
+
+  var_dump($a->x);
+}
+
+demo();


### PR DESCRIPTION
Consider the following example 
```php
<?php

$global_var_x = [["x"], "y"];

function wait_once($i) {
  static $flag = true;
  if ($flag) {
    wait($i);
    $flag = false;
  }
}

function foo() {
  global $global_var_x;
  sched_yield();
  $global_var_x = 1;
  return null;
}

function demo() {
  global $global_var_x;

  $i = fork(foo());
  foreach ($global_var_x as &$value) {
    wait_once($i);
    $value = [1];
  }

  var_dump($global_var_x);
}

demo();
```

kphp2cpp compiles it, but if you try to run it, you'll get SIGSEGV or other runtime error. The problem is going form the foreach reference.

This patch forbids such kind of constructions: calling resumable function from foreach body which iterates by reference with non local scope viability variable: global vars, static vars, class static vars,and instance fields.