### PR TITLE
fixed tests for toString

### DIFF
--- a/tests/phpt/cl/182_toString_magic_method_call_function.php
+++ b/tests/phpt/cl/182_toString_magic_method_call_function.php
@@ -1,7 +1,7 @@
 @ok
 <?php
 class Foo {
-    private string $field = "";
+    private $field = "";
 
     public function __construct(string $a) {
         $this->field = $a;

--- a/tests/phpt/phc/parsing/instring_simple_error.php
+++ b/tests/phpt/phc/parsing/instring_simple_error.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Cannot convert type \[class_instance<C\$Y>\] to string/
+/Converting to a string of a class Y that does not contain a __toString\(\) method/
 <?php
 
 class X {


### PR DESCRIPTION
- Removed typehint for a class property, as it
  is not supported until PHP 7.4;

- Fixed error message in the test when using a
  class without `__toString()` when converting to
  a string.