### PR TITLE
add value-based function call rewrites for some builtin funcs

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -348,6 +348,11 @@ function strtotime ($time ::: string, $timestamp ::: int = INT_MIN) ::: int | fa
 function time() ::: int;
 function hrtime (bool $as_number = false): mixed; // array|int
 
+// microtime(false) specialization
+function microtime_string () : string;
+// microtime(true) specialization
+function microtime_float () : float;
+
 function debug_backtrace() ::: string[][];
 function posix_getpid() ::: int;
 function posix_getuid() ::: int;
@@ -391,6 +396,12 @@ function preg_replace_callback ($regex ::: regexp, callable(string[] $x):string 
 function preg_quote ($str ::: string, $delimiter ::: string = '') ::: string;
 function preg_last_error() ::: int;
 function preg_split ($pattern ::: regexp, $subject ::: string, $limit ::: int = -1, $flags ::: int = 0) ::: mixed[] | false;
+
+// A preg_match() form that returns string-typed array result through a tuple.
+function preg_match_strings ($regex ::: regexp, $subject ::: string, $offset ::: int = 0) ::: tuple(int|false, string[]);
+
+// A preg_match_all() form that returns string-typed array result through a tuple.
+function preg_match_all_strings ($regex ::: regexp, $subject ::: string) ::: tuple(int|false, string[][]);
 
 define('SORT_REGULAR', 0);
 define('SORT_NUMERIC', 1);

--- a/runtime/datetime.cpp
+++ b/runtime/datetime.cpp
@@ -512,6 +512,9 @@ mixed f$microtime(bool get_as_float) {
   }
 }
 
+double f$microtime_float() { return microtime(); }
+string f$microtime_string() { return microtime_string(); }
+
 int64_t f$mktime(int64_t h, int64_t m, int64_t s, int64_t month, int64_t day, int64_t year) {
   tm t;
   time_t timestamp_t = time(nullptr);

--- a/runtime/datetime.h
+++ b/runtime/datetime.h
@@ -32,6 +32,8 @@ double microtime_monotonic();
 double microtime();
 
 mixed f$microtime(bool get_as_float = false);
+string f$microtime_string();
+double f$microtime_float();
 
 int64_t f$mktime(int64_t h = std::numeric_limits<int64_t>::min(),
                  int64_t m = std::numeric_limits<int64_t>::min(),

--- a/tests/phpt/datetime/microtime_float.php
+++ b/tests/phpt/datetime/microtime_float.php
@@ -1,0 +1,14 @@
+@ok
+<?php
+
+/** @param float $x */
+function ensure_float($x) {}
+
+function test() {
+  ensure_float(microtime(true));
+
+  $t = microtime(true);
+  ensure_float($t);
+}
+
+test();

--- a/tests/phpt/datetime/microtime_mixed_error.php
+++ b/tests/phpt/datetime/microtime_mixed_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_string/
+<?php
+
+/** @param string $x */
+function ensure_string($x) {}
+
+function test() {
+  $as_float = true;
+  ensure_string(microtime($as_float));
+}
+
+test();

--- a/tests/phpt/datetime/microtime_string.php
+++ b/tests/phpt/datetime/microtime_string.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+/** @param string $x */
+function ensure_string($x) {}
+
+function test() {
+  ensure_string(microtime());
+  ensure_string(microtime(false));
+
+  $t = microtime(false);
+  ensure_string($t);
+}
+
+test();

--- a/tests/phpt/regexp/008_preg_match_strings_direct.php
+++ b/tests/phpt/regexp/008_preg_match_strings_direct.php
@@ -1,0 +1,80 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+#ifndef KPHP
+function preg_match_strings(string $re, string $s, int $offset = 0) {
+  $m = [];
+  $n = preg_match($re, $s, $m, 0, $offset);
+  return tuple($n, $m);
+}
+#endif
+
+// There are 3 main ways to call preg_match_strings:
+//
+//   (regexp, string)
+//   (string, string)
+//   (mixed, string)
+//
+// The second argument can also be a of a non-string type, but it can
+// be implicitly converted to string without a problem.
+// We have an extra test for mixed->string test, just in case.
+
+/** @return mixed */
+function string_to_mixed(string $s) { return $s; }
+
+function test_regexp(string $s, int $offset) {
+  [$n, $m] = preg_match_strings('/\d/', $s, $offset);
+  var_dump($n, $m);
+
+  $tuple = preg_match_strings('/\d/', $s, $offset);
+  var_dump($tuple[0], $tuple[1]);
+
+  /** @var mixed */
+  $mixed_subject = string_to_mixed($s);
+  $tuple = preg_match_strings('/\d/', $mixed_subject, $offset);
+  var_dump($tuple[0], $tuple[1]);
+}
+
+function test_string(string $pat, string $s, int $offset) {
+  [$n, $m] = preg_match_strings($pat, $s, $offset);
+  var_dump($n, $m);
+
+  $tuple = preg_match_strings($pat, $s, $offset);
+  var_dump($tuple[0], $tuple[1]);
+
+  /** @var mixed */
+  $mixed_subject = string_to_mixed($s);
+  $tuple = preg_match_strings($pat, $mixed_subject, $offset);
+  var_dump($tuple[0], $tuple[1]);
+}
+
+/** @param mixed $pat */
+function test_mixed($pat, string $s, int $offset) {
+  [$n, $m] = preg_match_strings($pat, $s, $offset);
+  var_dump($n, $m);
+
+  $tuple = preg_match_strings($pat, $s, $offset);
+  var_dump($tuple[0], $tuple[1]);
+
+  /** @var mixed */
+  $mixed_subject = string_to_mixed($s);
+  $tuple = preg_match_strings($pat, $mixed_subject, $offset);
+  var_dump($tuple[0], $tuple[1]);
+}
+
+$regexps = ['/\d+/', '/no matches/', '/^foo/', '/.*/', '/#?/'];
+$inputs = ['430 43 1', '1', 'example', 'foo', '-40', 'hello world', 'longer string with numbers (43) and # symbol'];
+$offsets = [0, 1, 3, 10, 30, 100, -1, -3, -100];
+
+foreach ($regexps as $re) {
+  foreach ($inputs as $s) {
+    foreach ($offsets as $offset) {
+      test_regexp($s, $offset);
+      test_string($re, $s, $offset);
+      test_mixed($re, $s, $offset);
+    }
+  }
+}
+

--- a/tests/phpt/regexp/009_preg_match_strings.php
+++ b/tests/phpt/regexp/009_preg_match_strings.php
@@ -1,0 +1,78 @@
+@ok
+<?php
+
+/** @param string[] $x */
+function ensure_strings($x) {}
+
+function test_without_flags_and_offset(string $re, string $s) {
+  var_dump(preg_match($re, $s, $m1));
+  var_dump(preg_last_error());
+  var_dump($m1);
+  ensure_strings($m1);
+
+  $m2 = [];
+  var_dump(preg_match($re, $s, $m2));
+  var_dump(preg_last_error());
+  var_dump($m2);
+  ensure_strings($m2);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match($re, $s, $m3));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+function test_with_flags_and_offset(string $re, string $s, int $offset) {
+  var_dump(preg_match($re, $s, $m1, 0, $offset));
+  var_dump(preg_last_error());
+  var_dump($m1);
+  ensure_strings($m1);
+
+  $m2 = [];
+  var_dump(preg_match($re, $s, $m2, 0, $offset));
+  var_dump(preg_last_error());
+  var_dump($m2);
+  ensure_strings($m2);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match($re, $s, $m3, 0, $offset));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+function test_const_regexp_without_offset(string $s) {
+  var_dump(preg_match('/\d/', $s, $m));
+  var_dump($m);
+
+  /** @var mixed $m2 */
+  $m2 = [];
+  var_dump(preg_match('/\d/', $s, $m2));
+  var_dump($m2);
+}
+
+function test_const_regexp_with_flags_and_offset(string $s, int $offset) {
+  var_dump(preg_match('/\d/', $s, $m, 0, $offset));
+  var_dump($m);
+
+  /** @var mixed $m2 */
+  $m2 = [];
+  var_dump(preg_match('/\d/', $s, $m2, 0, $offset));
+  var_dump($m2);
+}
+
+$regexps = ['/\d+/', '/no matches/', '/^foo/', '/.*/', '/#?/'];
+$inputs = ['430 43 1', '1', 'example', 'foo', '-40', 'hello world', 'longer string with numbers (43) and # symbol'];
+$offsets = [0, 1, 3, 10, 30, 100, -1, -3, -100];
+
+foreach ($regexps as $re) {
+  foreach ($inputs as $s) {
+    foreach ($offsets as $offset) {
+      test_without_flags_and_offset($re, $s);
+      test_with_flags_and_offset($re, $s, $offset);
+      test_const_regexp_without_offset($s);
+      test_const_regexp_with_flags_and_offset($s, $offset);
+    }
+  }
+}

--- a/tests/phpt/regexp/010_preg_match.php
+++ b/tests/phpt/regexp/010_preg_match.php
@@ -1,0 +1,51 @@
+@ok
+<?php
+
+// Make sure that we don't replace the non-zero flag forms
+
+function test_without_flags_and_offset(string $re, string $s) {
+  var_dump(preg_match($re, $s, $m1, PREG_OFFSET_CAPTURE));
+  var_dump(preg_last_error());
+  var_dump($m1);
+
+  $m2 = [];
+  var_dump(preg_match($re, $s, $m2, PREG_OFFSET_CAPTURE));
+  var_dump(preg_last_error());
+  var_dump($m2);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match($re, $s, $m3, PREG_OFFSET_CAPTURE));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+function test_with_flags_and_offset(string $re, string $s, int $offset) {
+  var_dump(preg_match($re, $s, $m1, PREG_OFFSET_CAPTURE, $offset));
+  var_dump(preg_last_error());
+  var_dump($m1);
+
+  $m2 = [];
+  var_dump(preg_match($re, $s, $m2, PREG_OFFSET_CAPTURE, $offset));
+  var_dump(preg_last_error());
+  var_dump($m2);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match($re, $s, $m3, PREG_OFFSET_CAPTURE, $offset));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+$regexps = ['/\d+/', '/no matches/', '/^foo/', '/.*/', '/#?/'];
+$inputs = ['430 43 1', '1', 'example', 'foo', '-40', 'hello world', 'longer string with numbers (43) and # symbol'];
+$offsets = [0, 1, 3, 10, 30, 100, -1, -3, -100];
+
+foreach ($regexps as $re) {
+  foreach ($inputs as $s) {
+    foreach ($offsets as $offset) {
+      test_without_flags_and_offset($re, $s);
+      test_with_flags_and_offset($re, $s, $offset);
+    }
+  }
+}

--- a/tests/phpt/regexp/011_preg_match_strings_error.php
+++ b/tests/phpt/regexp/011_preg_match_strings_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_strings/
+<?php
+
+/** @param string[] $x */
+function ensure_strings($x) {}
+
+function test() {
+  preg_match('/x/', 'y', $m, PREG_OFFSET_CAPTURE, 10);
+  ensure_strings($m);
+}
+
+test();

--- a/tests/phpt/regexp/012_preg_match_strings_error2.php
+++ b/tests/phpt/regexp/012_preg_match_strings_error2.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_strings/
+<?php
+
+/** @param string[] $x */
+function ensure_strings($x) {}
+
+function test() {
+  $pat = '/x/';
+  preg_match($pat, 'y', $m, PREG_OFFSET_CAPTURE);
+  ensure_strings($m);
+}
+
+test();

--- a/tests/phpt/regexp/013_preg_match_strings_error3.php
+++ b/tests/phpt/regexp/013_preg_match_strings_error3.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/isset, !==, ===, is_array or similar function result may differ from PHP/
+<?php
+
+function test() {
+  $s = '';
+  if (preg_match('/x(\d+)/', 'hello x50', $m)) {
+    $s = $m[1];
+  }
+  if ($s !== '') {
+    var_dump($s);
+  }
+}
+
+test();

--- a/tests/phpt/regexp/014_preg_match_strings_error4.php
+++ b/tests/phpt/regexp/014_preg_match_strings_error4.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/isset, !==, ===, is_array or similar function result may differ from PHP/
+<?php
+
+function test() {
+  $s = false;
+  if (preg_match('/x(\d+)/', 'hello x50', $m)) {
+    $s = $m[1];
+  }
+  if ($s !== '') {
+    var_dump($s);
+  }
+}
+
+test();

--- a/tests/phpt/regexp/015_preg_match_strings_compare.php
+++ b/tests/phpt/regexp/015_preg_match_strings_compare.php
@@ -1,0 +1,37 @@
+@ok
+<?php
+
+function test1($re, $subject) {
+  $s = '';
+  if (preg_match($re, $subject, $m)) {
+    $s = $m[1];
+  }
+  var_dump([!empty($s)]);
+}
+
+function test2($re, $subject) {
+  $s = false;
+  if (preg_match($re, $subject, $m)) {
+    $s = $m[1];
+  }
+  var_dump([!empty($s)]);
+}
+
+$inputs = [
+  ['/x(\d+)/', 'hello x40'],
+  ['/x(\d+)/', 'hello'],
+  ['/x\d+/', 'hello x40'],
+  ['/x\d+/', 'hello'],
+  ['/x()y/', 'hello xy'],
+  ['/x()y/', 'hello x'],
+  ['/x(.*)y/', 'hello xy'],
+  ['/x(.*)y/', 'hello x0y'],
+  ['/x(.*)y/', 'hello x'],
+];
+
+foreach ($inputs as $input) {
+  list ($pattern, $subject) = $input;
+  echo "pattern=$pattern subject=$subject\n";
+  test1($pattern, $subject);
+  test2($pattern, $subject);
+}

--- a/tests/phpt/regexp/016_preg_match_strings2.php
+++ b/tests/phpt/regexp/016_preg_match_strings2.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+class Utils {
+  public static function validateNum(string $s): ?string {
+    if (preg_match('/^([0-9]+)$/', $s, $matches)) {
+      return $s;
+    }
+    return null;
+  }
+}
+
+var_dump(Utils::validateNum(''));
+var_dump(Utils::validateNum('0'));
+var_dump(Utils::validateNum('4394'));
+var_dump(Utils::validateNum('foo'));
+var_dump(Utils::validateNum('foo20'));

--- a/tests/phpt/regexp/017_preg_match_strings3.php
+++ b/tests/phpt/regexp/017_preg_match_strings3.php
@@ -1,0 +1,23 @@
+@ok
+<?php
+
+class Example {
+  public static function test(string $types, string $s) {
+    $matches = [];
+    if (!preg_match('/(\w+)(' . $types . ')$/i', $s, $matches)) {
+      var_dump(["no matches" => $matches]);
+      return;
+    }
+    var_dump($matches);
+  }
+}
+
+Example::test('', '');
+Example::test('x', '32x');
+Example::test('32x', 'x');
+Example::test('a|b', '');
+Example::test('a|b', '10a');
+Example::test('a|b', '10b');
+Example::test('a|b', '10');
+Example::test('a|b', 'a');
+Example::test('a|b', 'b');

--- a/tests/phpt/regexp/018_preg_match_all_strings.php
+++ b/tests/phpt/regexp/018_preg_match_all_strings.php
@@ -1,0 +1,69 @@
+@ok
+<?php
+
+/** @param string $x */
+function ensure_string($x) {}
+
+/** @param string[] $x */
+function ensure_string_array($x) {}
+
+function test_without_flags_and_offset(string $re, string $s) {
+  var_dump(preg_match_all($re, $s, $m1));
+  var_dump(preg_last_error());
+  var_dump($m1);
+  ensure_string_array($m1[0]);
+  ensure_string($m1[0][0]);
+
+  $m2 = [];
+  var_dump(preg_match_all($re, $s, $m2));
+  var_dump(preg_last_error());
+  var_dump($m2);
+  ensure_string_array($m2[0]);
+  ensure_string($m2[0][0]);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match_all($re, $s, $m3));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+function test_const_regexp_without_flags_and_offset(string $re, string $s) {
+  var_dump(preg_match_all('/\d/', $s, $m1));
+  var_dump(preg_last_error());
+  var_dump($m1);
+  ensure_string_array($m1[0]);
+  ensure_string($m1[0][0]);
+
+  $m2 = [];
+  var_dump(preg_match_all('/\d/', $s, $m2));
+  var_dump(preg_last_error());
+  var_dump($m2);
+  ensure_string_array($m2[0]);
+  ensure_string($m2[0][0]);
+
+  /** @var mixed $m3 */
+  $m3 = [];
+  var_dump(preg_match_all('/\d/', $s, $m3));
+  var_dump(preg_last_error());
+  var_dump($m3);
+}
+
+$regexps = ['/\d+/', '/no matches/', '/^foo/', '/.*/', '/#?/'];
+$inputs = [
+  '430 43 1 ',
+  '1',
+  'example',
+  ' foo ',
+  'foo _foo_',
+  '-40',
+  'hello world',
+  'longer string with numbers (43) and # symbol',
+];
+
+foreach ($regexps as $re) {
+  foreach ($inputs as $s) {
+    test_without_flags_and_offset($re, $s);
+    test_const_regexp_without_flags_and_offset($re, $s);
+  }
+}

--- a/tests/phpt/regexp/019_preg_match_all_strings_error.php
+++ b/tests/phpt/regexp/019_preg_match_all_strings_error.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_strings/
+<?php
+
+/** @param string[][] $x */
+function ensure_strings($x) {}
+
+function test() {
+  preg_match_all('/x/', 'y', $m, PREG_OFFSET_CAPTURE);
+  ensure_strings($m);
+}
+
+test();

--- a/tests/phpt/regexp/020_preg_match_all_strings_error2.php
+++ b/tests/phpt/regexp/020_preg_match_all_strings_error2.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_strings/
+<?php
+
+/** @param string[][] $x */
+function ensure_strings($x) {}
+
+function test() {
+  $pat = '/x/';
+  preg_match_all($pat, 'y', $m, PREG_OFFSET_CAPTURE);
+  ensure_strings($m);
+}
+
+test();

--- a/tests/phpt/regexp/021_preg_match_all_strings_error3.php
+++ b/tests/phpt/regexp/021_preg_match_all_strings_error3.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/isset, !==, ===, is_array or similar function result may differ from PHP/
+<?php
+
+function test() {
+  $s = '';
+  if (preg_match_all('/x(\d+)/', 'x hello x50', $m)) {
+    $s = $m[0][0];
+  }
+  if ($s !== '') {
+    var_dump($s);
+  }
+}
+
+test();

--- a/tests/phpt/regexp/022_preg_match_all_strings_error4.php
+++ b/tests/phpt/regexp/022_preg_match_all_strings_error4.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/isset, !==, ===, is_array or similar function result may differ from PHP/
+<?php
+
+function test() {
+  $x = [''];
+  if (preg_match_all('/x(\d+)/', 'x hello x50', $m)) {
+    $x = $m[0];
+  }
+  if (is_array($x)) {
+    var_dump($x);
+  }
+}
+
+test();

--- a/tests/phpt/regexp/023_preg_match_all_strings_error5.php
+++ b/tests/phpt/regexp/023_preg_match_all_strings_error5.php
@@ -1,0 +1,15 @@
+@kphp_should_fail
+/isset, !==, ===, is_array or similar function result may differ from PHP/
+<?php
+
+function test() {
+  $x = false;
+  if (preg_match_all('/x(\d+)/', 'x hello x50', $m)) {
+    $x = $m[0];
+  }
+  if (is_array($x)) {
+    var_dump($x);
+  }
+}
+
+test();

--- a/tests/phpt/regexp/024_preg_match_all_strings_compare.php
+++ b/tests/phpt/regexp/024_preg_match_all_strings_compare.php
@@ -1,0 +1,46 @@
+@ok
+<?php
+
+function test1($re, $subject) {
+  /** @var string[] */
+  $s = [];
+  if (preg_match_all($re, $subject, $m)) {
+    $s = $m[1];
+  }
+  var_dump([!empty($s)]);
+}
+
+function test2($re, $subject) {
+  $s = false;
+  if (preg_match_all($re, $subject, $m)) {
+    $s = $m[1];
+  }
+  var_dump([!empty($s)]);
+}
+
+function test3($re, $subject) {
+  preg_match_all($re, $subject, $m);
+  var_dump([!empty($m), !empty($m[0])]);
+}
+
+$inputs = [
+  ['/x(\d+)/', 'hello x40'],
+  ['/x(\d+)/', 'hello'],
+  ['/x\d+/', 'hello x40'],
+  ['/x\d+/', 'hello'],
+  ['/x()y/', 'hello xy'],
+  ['/x()y/', 'hello x'],
+  ['/x(.*)y/', 'hello xy'],
+  ['/x(.*)y/', 'hello x0y'],
+  ['/x(.*)y/', 'hello x'],
+  ['/a/', 'aaa'],
+  ['/aa/', 'aaaaa'],
+];
+
+foreach ($inputs as $input) {
+  list ($pattern, $subject) = $input;
+  echo "pattern=$pattern subject=$subject\n";
+  test1($pattern, $subject);
+  test2($pattern, $subject);
+  test3($pattern, $subject);
+}

--- a/tests/phpt/warnings/6_ub_seq_rvalue.php
+++ b/tests/phpt/warnings/6_ub_seq_rvalue.php
@@ -1,0 +1,18 @@
+@kphp_should_warn
+/Dangerous undefined behaviour string build, \[var = \$s1\]/
+/Dangerous undefined behaviour string build, \[var = \$s2\]/
+<?php
+
+// We generate a seq_rvalue for the specialized preg_match calls.
+// UB should be detected inside the seq_rvalue block.
+
+function test1() {
+  preg_match((($s1 = '') . $s1 . '/\d/'), '', $m);
+}
+
+function test2() {
+  preg_match('/\d/', (($s2 = '') . $s2 . '13'), $m);
+}
+
+test1();
+test2();


### PR DESCRIPTION
Rewrite patterns:

	microtime() -> microtime_string()
	microtime(false) -> microtime_string()
	microtime(true) -> microtime_float()

	preg_match($pat, $s, $m) -> ({ $tmp = preg_match_strings($pat, $s); $m = $tmp[1]; $tmp[0]; })
	preg_match($pat, $s, $m, 0, $offset) -> ({ $tmp = preg_match_strings($pat, $s, $offset); $m = $tmp[1]; $tmp[0] })
	preg_match_all($pat, $a, $m) -> ({ $tmp = preg_match_all_strings($pat, $s); $m = $tmp[1]; $tmp[0]; })

New functions:

	microtime_float        - microtime(true)
	microtime_string       - microtime(false)
	preg_match_strings     - like preg_match, but returns matches as string[]
	preg_match_all_strings - like preg_match_all, but returns matches as string[][]

TODO:
- [ ] Add numerical prefixes to all tests