### PR TITLE
Precompute hashes for isset() and unset()

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1326,7 +1326,11 @@ void compile_xset(VertexAdaptor<meta_op_xset> root, CodeGenerator &W) {
       } else {
         kphp_assert (0);
       }
-      W << index->key() << ")";
+      W << index->key();
+      if (auto precomputed_hash = can_use_precomputed_hash_indexing_array(index->key())) {
+        W << ", " << precomputed_hash << "_i64";
+      }
+      W << ")";
       return;
     }
   }

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -308,14 +308,14 @@ public:
   // can be used only on empty arrays to receive logically const array
   void assign_raw(const char *s);
 
-  const T *find_value(int64_t int_key) const;
-  const T *find_value(int32_t key) const { return find_value(int64_t{key}); }
-  const T *find_value(const string &s) const;
-  const T *find_value(const string &s, int64_t precomuted_hash) const;
-  const T *find_value(const mixed &v) const;
-  const T *find_value(double double_key) const;
-  const T *find_value(const const_iterator &it) const;
-  const T *find_value(const iterator &it) const;
+  const T *find_value(int64_t int_key) const noexcept;
+  const T *find_value(int32_t key) const noexcept { return find_value(int64_t{key}); }
+  const T *find_value(const string &s) const noexcept;
+  const T *find_value(const string &s, int64_t precomuted_hash) const noexcept;
+  const T *find_value(const mixed &v) const noexcept;
+  const T *find_value(double double_key) const noexcept;
+  const T *find_value(const const_iterator &it) const noexcept;
+  const T *find_value(const iterator &it) const noexcept;
 
   // All non-const methods find_no_mutate() do not lead to a copy
   iterator find_no_mutate(int64_t int_key) noexcept;
@@ -351,11 +351,13 @@ public:
   bool has_key(const K &key) const;
 
   template<class K>
-  bool isset(const K &key) const;
+  bool isset(const K &key) const noexcept;
+  bool isset(const string &key, int64_t precomputed_hash) const noexcept;
 
   void unset(int64_t int_key);
   void unset(int32_t key) { unset(int64_t{key}); }
   void unset(const string &string_key);
+  void unset(const string &string_key, int64_t precomputed_hash);
   void unset(const mixed &var_key);
   void unset(double double_key);
 

--- a/runtime/mixed.inl
+++ b/runtime/mixed.inl
@@ -1370,7 +1370,8 @@ bool mixed::isset(int64_t int_key) const {
   return as_array().isset(int_key);
 }
 
-bool mixed::isset(const string &string_key) const {
+template <class ...MaybeHash>
+bool mixed::isset(const string &string_key, MaybeHash ...maybe_hash) const {
   if (unlikely (get_type() != type::ARRAY)) {
     int64_t int_key{std::numeric_limits<int64_t>::max()};
     if (get_type() == type::STRING) {
@@ -1383,7 +1384,7 @@ bool mixed::isset(const string &string_key) const {
     return isset(int_key);
   }
 
-  return as_array().isset(string_key);
+  return as_array().isset(string_key, maybe_hash...);
 }
 
 bool mixed::isset(const mixed &v) const {
@@ -1421,7 +1422,8 @@ void mixed::unset(int64_t int_key) {
   return as_array().unset(int_key);
 }
 
-void mixed::unset(const string &string_key) {
+template <class ...MaybeHash>
+void mixed::unset(const string &string_key, MaybeHash ...maybe_hash) {
   if (unlikely (get_type() != type::ARRAY)) {
     if (get_type() != type::NUL && (get_type() != type::BOOLEAN || as_bool())) {
       php_warning("Cannot use variable of type %s as array in unset", get_type_c_str());
@@ -1429,7 +1431,7 @@ void mixed::unset(const string &string_key) {
     return;
   }
 
-  return as_array().unset(string_key);
+  return as_array().unset(string_key, maybe_hash...);
 }
 
 void mixed::unset(const mixed &v) {

--- a/runtime/mixed_decl.inl
+++ b/runtime/mixed_decl.inl
@@ -111,13 +111,15 @@ public:
 
   inline bool isset(int64_t int_key) const;
   inline bool isset(int32_t key) const { return isset(int64_t{key}); }
-  inline bool isset(const string &string_key) const;
+  template <class ...MaybeHash>
+  inline bool isset(const string &string_key, MaybeHash ...maybe_hash) const;
   inline bool isset(const mixed &v) const;
   inline bool isset(double double_key) const;
 
   inline void unset(int64_t int_key);
   inline void unset(int32_t key) { unset(int64_t{key}); }
-  inline void unset(const string &string_key);
+  template <class ...MaybeHash>
+  inline void unset(const string &string_key, MaybeHash ...maybe_hash);
   inline void unset(const mixed &v);
   inline void unset(double double_key);
 


### PR DESCRIPTION
Currently, isset() and unset() functions of array calculate hash from compile time known strings at runtime. This patch modify such behavior and move calculation of hash at code generation phase.