### PR TITLE
Enable smartcasts for opset inside condition

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -701,7 +701,7 @@ VertexAdaptor<op_ternary> GenTree::create_ternary_op_vertex(VertexPtr condition,
     return VertexAdaptor<op_ternary>::create(condition, true_expr, false_expr);
   }
 
-  auto cond_var = create_superlocal_var("shorthand_ternary_cond");
+  auto cond_var = create_superlocal_var("shorthand_ternary_cond").set_location(condition);
 
   auto cond = conv_to<tp_bool>(VertexAdaptor<op_set>::create(cond_var, condition));
 

--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -369,6 +369,11 @@ void CFG::create_condition_cfg(VertexPtr tree_node, Node *res_start, Node *res_t
           add_type_check_usage(*res_true, ifi_any_type & ~ifi_is_null, var);
           add_type_check_usage(*res_false, ifi_is_null, var);
         }
+      } else if (tree_node->type() == op_set) {
+        // support for cases like: if ($x = $some_value) {...}
+        if (auto var = tree_node.try_as<meta_op_binary>()->lhs().try_as<op_var>()) {
+          add_type_check_usage(*res_true, ifi_any_type & ~(ifi_is_false | ifi_is_null), var);
+        }
       } else if (auto var = tree_node.try_as<op_var>()) {
         add_type_check_usage(*res_true, ifi_any_type & ~(ifi_is_false | ifi_is_null), var);
       } else if (tree_node->type() == op_eq3) {

--- a/tests/phpt/dl/1030_ternary_fails.php
+++ b/tests/phpt/dl/1030_ternary_fails.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/Variable \$lhs has Unknown type/
+<?php
+
+function test_ternary_fails($lhs, $rhs) {
+  var_dump($lhs ? $lhs : $rhs);
+}
+
+test_ternary_fails(false, 42);

--- a/tests/phpt/dl/1031_shorthand_ternary_fails.php
+++ b/tests/phpt/dl/1031_shorthand_ternary_fails.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/Variable \$shorthand_ternary_cond.* has Unknown type/
+<?php
+
+function test_shorthand_ternary_fails($lhs, $rhs) {
+  var_dump($lhs ?: $rhs);
+}
+
+test_shorthand_ternary_fails(false, 42);

--- a/tests/phpt/optional/004_operations.php
+++ b/tests/phpt/optional/004_operations.php
@@ -78,8 +78,6 @@ function test_binary_operations_optional_int($lhs, $rhs) {
   echo "=== "; var_dump($lhs === $rhs);
   echo "!== "; var_dump($lhs !== $rhs);
 
-  echo "?: "; var_dump($lhs ?: $rhs);
-
   echo ". "; var_dump($lhs . $rhs);
 }
 
@@ -115,8 +113,6 @@ function test_binary_operations_null_false($lhs, $rhs) {
 
   echo "=== "; var_dump($lhs === $rhs);
   echo "!== "; var_dump($lhs !== $rhs);
-
-  echo "?: "; var_dump($lhs ?: $rhs);
 
   echo ". "; var_dump($lhs . $rhs);
 }

--- a/tests/phpt/smart_casts/08_auto_drop_optional_inside_condition.php
+++ b/tests/phpt/smart_casts/08_auto_drop_optional_inside_condition.php
@@ -1,0 +1,26 @@
+@ok
+<?php
+
+function foo(int $i) {
+  var_dump($i);
+}
+
+function test_shorthand_ternary($a) {
+  if (0) {
+    $a = false;
+  }
+  $b = $a ?: 321;
+  foo($b);
+}
+
+function test_opset_inside_condition($a) {
+  if (0) {
+    $a = false;
+  }
+  if ($b = $a) {
+    foo($b);
+  }
+}
+
+test_shorthand_ternary(123);
+test_opset_inside_condition(123);


### PR DESCRIPTION
Enable smartcasts for opset inside condition; this also involves smartcasts in shorthand ternary operator.