### PR TITLE
Job workers: starting job from job workers 

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -1349,8 +1349,8 @@ class KphpJobWorkerResponseError implements KphpJobWorkerResponse {
   public function getErrorCode() ::: int;
 }
 
-function kphp_job_worker_start(KphpJobWorkerRequest $request, float $timeout = -1.0) ::: future<KphpJobWorkerResponse> | false;
-function kphp_job_worker_start_multi(KphpJobWorkerRequest[] $request, float $timeout = -1.0) ::: (future<KphpJobWorkerResponse> | false)[];
+function kphp_job_worker_start(KphpJobWorkerRequest $request, float $timeout) ::: future<KphpJobWorkerResponse> | false;
+function kphp_job_worker_start_multi(KphpJobWorkerRequest[] $request, float $timeout) ::: (future<KphpJobWorkerResponse> | false)[];
 
 function kphp_job_worker_fetch_request() ::: KphpJobWorkerRequest;
 function kphp_job_worker_store_response(KphpJobWorkerResponse $response) ::: void;

--- a/runtime/job-workers/client-functions.cpp
+++ b/runtime/job-workers/client-functions.cpp
@@ -100,11 +100,6 @@ bool job_workers_api_allowed() {
     php_warning("Can't send job: job workers disabled");
     return false;
   }
-  auto &client = vk::singleton<job_workers::JobWorkerClient>::get();
-  if (!client.is_inited()) {
-    php_warning("Can't send job: call from job worker");
-    return false;
-  }
   return true;
 }
 

--- a/runtime/job-workers/client-functions.h
+++ b/runtime/job-workers/client-functions.h
@@ -9,5 +9,5 @@
 
 void free_job_client_interface_lib() noexcept;
 
-Optional<int64_t> f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRequest> &request, double timeout = -1.0) noexcept;
-array<Optional<int64_t>> f$kphp_job_worker_start_multi(const array<class_instance<C$KphpJobWorkerRequest>> &requests, double timeout = -1.0) noexcept;
+Optional<int64_t> f$kphp_job_worker_start(const class_instance<C$KphpJobWorkerRequest> &request, double timeout) noexcept;
+array<Optional<int64_t>> f$kphp_job_worker_start_multi(const array<class_instance<C$KphpJobWorkerRequest>> &requests, double timeout) noexcept;

--- a/server/job-workers/job-worker-client.cpp
+++ b/server/job-workers/job-worker-client.cpp
@@ -63,8 +63,6 @@ void JobWorkerClient::init(int job_result_slot) {
   assert(job_workers_ctx.pipes_inited);
 
   write_job_fd = job_workers_ctx.job_pipe[1];
-  close(job_workers_ctx.job_pipe[0]); // this endpoint is for job worker to read job
-  clear_event(job_workers_ctx.job_pipe[0]);
 
   for (int i = 0; i < job_workers_ctx.result_pipes.size(); ++i) {
     auto &result_pipe = job_workers_ctx.result_pipes[i];
@@ -72,11 +70,9 @@ void JobWorkerClient::init(int job_result_slot) {
       read_job_result_fd = result_pipe[0];
       job_result_fd_idx = job_result_slot;
     } else {
-      close(result_pipe[0]); // this endpoint is for another HTTP worker to read job result
+      close(result_pipe[0]); // this endpoint is for another client worker to read job result
       clear_event(result_pipe[0]);
     }
-    close(result_pipe[1]); // this endpoint is for job worker to write job result
-    clear_event(result_pipe[1]);
   }
 
   if (read_job_result_fd >= 0) {

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -149,8 +149,8 @@ int JobWorkerServer::job_parse_execute(connection *c) {
   double job_wait_time = now_time - job->job_start_time;
   double left_job_time = job->job_deadline_time() - now_time;
 
-  tvkprintf(job_workers, 2, "got new job: <job_result_fd_idx, job_id> = <%d, %d> , job_memory_ptr = %p, left_job_time = %f, job_wait_time = %f\n",
-            job->job_result_fd_idx, job->job_id, job, left_job_time, job_wait_time);
+  tvkprintf(job_workers, 2, "got new job: <job_result_fd_idx, job_id> = <%d, %d>, left_job_time = %f, job_wait_time = %f, job_memory_ptr = %p\n",
+            job->job_result_fd_idx, job->job_id, left_job_time, job_wait_time, job);
 
   const auto &job_memory_stats = job->resource.get_memory_stats();
   vk::singleton<ServerStats>::get().add_job_stats(job_wait_time, job_memory_stats.max_real_memory_used, job_memory_stats.max_memory_used);
@@ -173,12 +173,6 @@ void JobWorkerServer::init() {
   assert(job_workers_ctx.pipes_inited);
 
   read_job_fd = job_workers_ctx.job_pipe[0];
-  close(job_workers_ctx.job_pipe[1]); // this endpoint is for HTTP worker to write job
-  clear_event(job_workers_ctx.job_pipe[1]);
-  for (auto &result_pipe : job_workers_ctx.result_pipes) {
-    close(result_pipe[0]); // this endpoint is for HTTP worker to read job result
-    clear_event(result_pipe[0]);
-  }
 
   read_job_connection = epoll_insert_pipe(pipe_for_read, read_job_fd, &php_jobs_server, nullptr, EVT_LEVEL);
   assert(read_job_connection);

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -174,7 +174,7 @@ void JobWorkerServer::init() {
 
   read_job_fd = job_workers_ctx.job_pipe[0];
 
-  read_job_connection = epoll_insert_pipe(pipe_for_read, read_job_fd, &php_jobs_server, nullptr, EVT_LEVEL);
+  read_job_connection = epoll_insert_pipe(pipe_for_read, read_job_fd, &php_jobs_server, nullptr, EVT_LEVEL | EVT_SPEC);
   assert(read_job_connection);
   memset(read_job_connection->custom_data, 0, sizeof(read_job_connection->custom_data));
 

--- a/server/job-workers/shared-memory-manager.h
+++ b/server/job-workers/shared-memory-manager.h
@@ -17,7 +17,7 @@
 
 namespace memory_resource {
 class unsynchronized_pool_resource;
-} // memory_resource
+} // namespace memory_resource
 
 namespace job_workers {
 
@@ -31,7 +31,9 @@ struct WorkerProcessMeta {
   //    immutable request data
   //    ok response
   //    error response (only for job workers)
-  std::array<JobMetadata *, 4> attached_messages{};
+  // + 2 messages: mutable request & immutable request, if job is invoked from running job
+  // so let's use 8 just in case
+  std::array<JobMetadata *, 8> attached_messages{};
 
   void attach(JobMetadata *message) noexcept {
     replace(nullptr, message);

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1490,9 +1490,6 @@ static void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_
         set_main_target(rpc_clients.front());
       }
 
-      if (vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0) {
-        vk::singleton<JobWorkerClient>::get().init(logname_id);
-      }
       break;
     }
     case WorkerType::job_worker: {
@@ -1502,6 +1499,10 @@ static void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_
     }
     default:
       assert(0);
+  }
+
+  if (vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0) {
+    vk::singleton<JobWorkerClient>::get().init(logname_id);
   }
 
   if (no_sql) {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1198,7 +1198,7 @@ void run_master_on() {
   }
 
   if (vk::singleton<WorkersControl>::get().get_count(WorkerType::job_worker) > 0) {
-    vk::singleton<JobWorkersContext>::get().master_init_pipes(vk::singleton<WorkersControl>::get().get_count(WorkerType::general_worker));
+    vk::singleton<JobWorkersContext>::get().master_init_pipes(vk::singleton<WorkersControl>::get().get_total_workers_count());
   }
 
   bool need_http_fd = http_fd != nullptr && *http_fd == -1;

--- a/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
+++ b/tests/cpp/server/job-workers/shared-memory-manager-test.cpp
@@ -119,7 +119,7 @@ TEST(shared_memory_manager_test, test_manager) {
 
   const auto &stats = SHMM::get().get_stats();
   ASSERT_EQ(stats.memory_limit, 256 * 1024 * 1024);
-  ASSERT_GT(stats.unused_memory, 1000000); // 1mb == 1 048 576
+  ASSERT_GT(stats.unused_memory, 980000); // 1mb == 1 048 576
   ASSERT_LT(stats.unused_memory, 1048576);
 
   std::array<pid_t, 5> children{};

--- a/tests/phpt/job_workers/1_interface_compilation.php
+++ b/tests/phpt/job_workers/1_interface_compilation.php
@@ -28,11 +28,11 @@ function test_compilation($x) {
 
   $m1 = new Req;
   $m1->$ai = new A1;
-  kphp_job_worker_start($m1);
+  kphp_job_worker_start($m1, -1);
 
   $m2 = new Req;
   $m2->$ai = new A2;
-  kphp_job_worker_start($m2);
+  kphp_job_worker_start($m2, -1);
 
   $x = kphp_job_worker_fetch_request();
   if ($x instanceof Req) {

--- a/tests/phpt/job_workers/2_shared_immutable_messages_basic_compilation.php
+++ b/tests/phpt/job_workers/2_shared_immutable_messages_basic_compilation.php
@@ -46,7 +46,7 @@ function test_compilation($x) {
   	$requests[] = new SimpleJobRequest($shared_data, $offset, $limit);
   }
 
-  kphp_job_worker_start_multi($requests);
+  kphp_job_worker_start_multi($requests, -1);
 }
 
 test_compilation(false);

--- a/tests/python/tests/job_workers/php/ComplexScenario/_http_scenario.php
+++ b/tests/python/tests/job_workers/php/ComplexScenario/_http_scenario.php
@@ -12,7 +12,7 @@ use ComplexScenario\StatsRPCSimple;
 require_once "_stats_processor.php";
 
 function collect_stats_with_job(StatsInterface $stat, int $master_port) {
-  $job_id = kphp_job_worker_start(new CollectStatsJobRequest($master_port, $stat));
+  $job_id = kphp_job_worker_start(new CollectStatsJobRequest($master_port, $stat), -1);
   if (!$job_id) {
     critical_error("Can't send job");
   }

--- a/tests/python/tests/job_workers/php/SharedImmutableMessageScenario/http_worker.php
+++ b/tests/python/tests/job_workers/php/SharedImmutableMessageScenario/http_worker.php
@@ -52,7 +52,7 @@ function test_job_worker_start_multi_impl(bool $use_shared_data) {
     $offset += $limit;
   }
 
-  $job_ids = kphp_job_worker_start_multi($requests);
+  $job_ids = kphp_job_worker_start_multi($requests, -1);
   foreach ($requests as $req) {
     if ($req instanceof SumJobRequestWithSharedData) {
       if ($req->shared_data !== $shared_data) {
@@ -102,7 +102,7 @@ function test_error_different_shared_memory_pieces() {
     $offset += $limit;
   }
 
-  $job_ids = kphp_job_worker_start_multi($requests);
+  $job_ids = kphp_job_worker_start_multi($requests, -1);
 
   echo json_encode(['job-ids' => $job_ids]);
 }

--- a/tests/python/tests/job_workers/php/X2Request.php
+++ b/tests/python/tests/job_workers/php/X2Request.php
@@ -3,6 +3,7 @@
 class X2Request implements KphpJobWorkerRequest {
   public $arr_request = [];
   public $tag = "";
+  public $redirect_chain_len = 0;
   public $master_port = 0;
   public $sleep_time_sec = 0;
   public $error_type = "";

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -152,7 +152,7 @@ function raise_error(string $err) {
 function test_client_too_big_request() {
   $req = new X2Request;
   $req->arr_request = make_big_fake_array();
-  echo json_encode(["job-id" => kphp_job_worker_start($req)]);
+  echo json_encode(["job-id" => kphp_job_worker_start($req, -1)]);
 }
 
 function test_jobs_in_wait_queue() {
@@ -185,7 +185,7 @@ function test_jobs_in_wait_queue() {
 function test_client_wait_false() {
   $id = false;
   if ($id) {
-    $id = kphp_job_worker_start(new X2Request);
+    $id = kphp_job_worker_start(new X2Request, -1);
   }
   $result = wait($id);
   echo json_encode(["jobs-result" => $result === null ? "null" : "not null"]);
@@ -205,7 +205,7 @@ function test_job_worker_wakeup_on_merged_events() {
     $req = new X2Request;
     $req->arr_request = [$waiting_worker_id];
     $req->tag = 'sync_job';
-    $sync_job_ids[] = kphp_job_worker_start($req);
+    $sync_job_ids[] = kphp_job_worker_start($req, -1);
     $waiting_workers[] = $waiting_worker_id;
     while (instance_cache_fetch(SyncJobCommand::class, "sync_job_started_$waiting_worker_id") === null) {}
   }

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -1,6 +1,7 @@
 <?php
 
 require_once 'SharedImmutableMessageScenario/http_worker.php';
+require_once 'utils.php';
 
 function do_http_worker() {
   switch($_SERVER["PHP_SELF"]) {
@@ -75,6 +76,7 @@ function send_jobs($context, float $timeout = -1.0): array {
   foreach ($context["data"] as $arr) {
     $req = new X2Request;
     $req->tag = (string)$context["tag"];
+    $req->redirect_chain_len = (int)$context["redirect-chain-len"];
     $req->master_port = (int)$context["master-port"];
     $req->arr_request = (array)$arr;
     $req->sleep_time_sec = (int)$context["job-sleep-time-sec"];
@@ -198,17 +200,7 @@ function test_job_graceful_shutdown() {
 }
 
 function test_job_worker_wakeup_on_merged_events() {
-  $waiting_workers = [];
-  $sync_job_ids = [];
-  for ($i = 0; $i < get_job_workers_number(); $i++) {
-    $waiting_worker_id = $i + 1;
-    $req = new X2Request;
-    $req->arr_request = [$waiting_worker_id];
-    $req->tag = 'sync_job';
-    $sync_job_ids[] = kphp_job_worker_start($req, -1);
-    $waiting_workers[] = $waiting_worker_id;
-    while (instance_cache_fetch(SyncJobCommand::class, "sync_job_started_$waiting_worker_id") === null) {}
-  }
+  [$waiting_workers, $sync_job_ids] = suspend_job_workers(get_job_workers_number());
 
   fwrite(STDERR, "Sync jobs started\n");
 
@@ -217,15 +209,7 @@ function test_job_worker_wakeup_on_merged_events() {
 
   fwrite(STDERR, "Simple jobs were sent\n");
 
-  foreach ($waiting_workers as $id) {
-    instance_cache_store("finish_sync_job_$id", new SyncJobCommand('finish'));
-  }
-
-  foreach (gather_jobs($sync_job_ids) as $res) {
-    if (!isset($res['data'])) {
-      raise_error('Error in sync job response');
-    }
-  }
+  resume_job_workers($waiting_workers, $sync_job_ids);
 
   echo json_encode(["jobs-result" => gather_jobs($ids)]);
 }

--- a/tests/python/tests/job_workers/php/utils.php
+++ b/tests/python/tests/job_workers/php/utils.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @param int $to_block
+ * @return \tuple(int[], (future<KphpJobWorkerResponse>|false)[])
+ */
+function suspend_job_workers(int $to_block) {
+  $waiting_workers = [];
+  $sync_job_ids = [];
+  for ($i = 0; $i < $to_block; $i++) {
+    $waiting_worker_id = rand() * rand();
+    $req = new X2Request;
+    $req->arr_request = [$waiting_worker_id];
+    $req->tag = 'sync_job';
+    $sync_job_ids[] = kphp_job_worker_start($req, -1);
+    $waiting_workers[] = $waiting_worker_id;
+    while (instance_cache_fetch(SyncJobCommand::class, "sync_job_started_$waiting_worker_id") === null) {}
+  }
+  return tuple($waiting_workers, $sync_job_ids);
+}
+
+function resume_job_workers(array $waiting_workers, array $sync_job_ids) {
+  foreach ($waiting_workers as $id) {
+    instance_cache_store("finish_sync_job_$id", new SyncJobCommand('finish'));
+  }
+
+  foreach (gather_jobs($sync_job_ids) as $res) {
+    if (!isset($res['data'])) {
+      critical_error('Error in sync job response');
+    }
+  }
+}
+
+function safe_sleep(float $sleep_time_sec) {
+  $s = microtime(true);
+  do {
+    sched_yield_sleep(0.01);
+  } while(microtime(true) - $s < $sleep_time_sec);
+}

--- a/tests/python/tests/job_workers/test_job_inside_job.py
+++ b/tests/python/tests/job_workers/test_job_inside_job.py
@@ -1,0 +1,69 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestJobInsideJob(KphpServerAutoTestCase):
+    WORKERS_NUM = 12
+    JOB_WORKERS_RATIO = 0.5
+    JOB_WORKERS_NUM = WORKERS_NUM * JOB_WORKERS_RATIO
+
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": cls.WORKERS_NUM,
+            "--job-workers-ratio": cls.JOB_WORKERS_RATIO,
+            "--verbosity-job-workers=2": True,
+        })
+
+    def _test_job_redirect_chain(self, *, data, redirect_chain_len, timeout_error=False):
+        stats_before = self.kphp_server.get_stats()
+        resp = self.kphp_server.http_post(
+            uri="/test_simple_cpu_job",
+            json={"data": data,
+                  "tag": "redirect_to_job_worker",
+                  "redirect-chain-len": redirect_chain_len,
+                  })
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "jobs-result": [
+                {"data": [x ** 2 for x in cur_data], "stats": []} if not timeout_error else
+                {"error": "Job client timeout", "error_code": -102}
+                for cur_data in data
+            ]})
+        messages_cnt = len(data) * 2 * (redirect_chain_len + 1)
+        if redirect_chain_len >= self.JOB_WORKERS_NUM:
+            messages_cnt -= 1
+        self.kphp_server.assert_stats(
+            initial_stats=stats_before,
+            timeout=10,
+            expected_added_stats={
+                "kphp_server.workers_job_memory_messages_shared_messages_buffers_acquired": messages_cnt,
+                "kphp_server.workers_job_memory_messages_shared_messages_buffers_released": messages_cnt,
+                "kphp_server.workers_job_memory_messages_shared_messages_buffer_acquire_fails": 0
+            })
+        return resp
+
+    def test_simple_job_redirect(self):
+        self._test_job_redirect_chain(data=[[1, 2, 3, 4], [7, 9, 12]], redirect_chain_len=1)
+
+    def test_job_redirect_max_chain(self):
+        self._test_job_redirect_chain(data=[[i for i in range(10)]], redirect_chain_len=self.JOB_WORKERS_NUM - 1)
+
+    def test_job_redirect_too_long_chain(self):
+        self._test_job_redirect_chain(data=[[i for i in range(10)]], redirect_chain_len=self.JOB_WORKERS_NUM,
+                                      timeout_error=True)
+
+    def test_job_worker_self_lock_freedom(self):
+        data = [[i for i in range(10)]]
+        resp = self.kphp_server.http_post(
+            uri="/test_simple_cpu_job",
+            json={"data": data,
+                  "tag": "self_lock_job",
+                  "master-port": self.kphp_server.master_port
+                  })
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json(), {
+            "jobs-result": [
+                {"data": [x ** 2 for x in cur_data], "stats": []} for cur_data in data
+            ]})


### PR DESCRIPTION
If we allow to run jobs from job workers, we face with the problem of self-locks.
It happens in the following cases:
1. If all job workers simultaneously send a job. So there're no free job workers to serve this new job, because all of them are waiting for job response. The core reason of this case is that all jobs are processed synchronously, e.g. worker can't serve new job while another one is running.
2. When epoll reactor "binds" a new job event to the sender job worker process and never wake up another free job workers on this event. As far as I can see, the core reason of this case is internal events delivery mechanism of epoll in `EPOLLEXCLUSIVE` mode.

To solve the problems I've done the following:
1. Made timeout parameter of `kphp_job_worker_start()` function required. It must force developers to choose timeout more carefully with taking into the account the case (1). Solving the core reason of case (1) is separate extremely difficult enormous task.
2. Disabled `EPOLLEXCLUSIVE` mode. Waking up all the job workers on every event seems much more reasonable now given that case (2) can happen.