### PR TITLE
Don't sent pid on mc stats request.

### DIFF
--- a/server/server-stats.cpp
+++ b/server/server-stats.cpp
@@ -701,7 +701,7 @@ void ServerStats::write_stats_to(stats_t *stats) const noexcept {
                      aggregated_stats_->general_workers.vm_percentiles, aggregated_stats_->job_workers.vm_percentiles);
 }
 
-void ServerStats::write_stats_to(std::ostream &os) const noexcept {
+void ServerStats::write_stats_to(std::ostream &os, bool add_worker_pids) const noexcept {
   const auto &master_vm = aggregated_stats_->master_process.vm_stats;
   const auto &master_idle = aggregated_stats_->master_process.idle_stats;
 
@@ -739,8 +739,10 @@ void ServerStats::write_stats_to(std::ostream &os) const noexcept {
     const auto net_time = ns2double(workers_query.get_stat(QueriesStat::Key::net_time, w));
     const auto script_time = ns2double(workers_query.get_stat(QueriesStat::Key::script_time, w));
     const auto worker_pid = workers_misc.get_stat(MiscStat::Key::process_pid, w);
-    os << "pid " << worker_pid << "\t" << worker_pid << "\n"
-       << "active_special_connections " << worker_pid << "\t" << workers_misc.get_stat(MiscStat::Key::active_special_connections, w) << "\n"
+    if (add_worker_pids) {
+      os << "pid " << worker_pid << "\t" << worker_pid << "\n";
+    }
+    os << "active_special_connections " << worker_pid << "\t" << workers_misc.get_stat(MiscStat::Key::active_special_connections, w) << "\n"
        << "max_special_connections " << worker_pid << "\t" << workers_misc.get_stat(MiscStat::Key::max_special_connections, w) << "\n"
        << "VM " << worker_pid << "\t" << workers_vm.get_stat(VMStat::Key::vm_kb, w) << "Kb\n"
        << "VM_max " << worker_pid << "\t" << workers_vm.get_stat(VMStat::Key::vm_peak_kb, w) << "Kb\n"

--- a/server/server-stats.h
+++ b/server/server-stats.h
@@ -36,7 +36,7 @@ public:
   // these functions should be called only from the master process
   void aggregate_stats() noexcept;
   void write_stats_to(stats_t *stats) const noexcept;
-  void write_stats_to(std::ostream &os) const noexcept;
+  void write_stats_to(std::ostream &os, bool add_worker_pids) const noexcept;
 
   uint64_t get_worker_activity_counter(uint16_t worker_process_id) const noexcept;
 

--- a/tests/python/tests/stats/test_master_stats.py
+++ b/tests/python/tests/stats/test_master_stats.py
@@ -13,6 +13,7 @@ class TestMasterStats(KphpServerAutoTestCase):
             key, value = stat_line.split('\t', 1)
             stats_dict[key] = value
 
+        self.assertNotIn("pid", stats_dict)
         self.assertIn("uptime", stats_dict)
         self.assertIn("kphp_version", stats_dict)
         self.assertIn("tot_queries", stats_dict)
@@ -26,6 +27,7 @@ class TestMasterStats(KphpServerAutoTestCase):
         self.assertNotEqual(mc_stats.text, "")
 
         stats_dict = json.loads(mc_stats.text)
+        self.assertIn("pid", stats_dict)
         self.assertIn("uptime", stats_dict)
         self.assertIn("version", stats_dict)
         self.assertIn("kphp_version", stats_dict)


### PR DESCRIPTION
This patch disable sending pid via mc stats because it breaks some monitoring scripts.