### PR TITLE
Gracefully terminate on 'class not found' compile error

### DIFF
--- a/compiler/pipes/register-variables.cpp
+++ b/compiler/pipes/register-variables.cpp
@@ -107,8 +107,8 @@ void RegisterVariablesPass::register_var(VertexAdaptor<op_var> var_vertex) {
       string class_name = name.substr(0, pos$$);
       string var_name = name.substr(pos$$ + 2);
       ClassPtr klass = G->get_class(replace_characters(class_name, '$', '\\'));
+      kphp_error_return(klass, fmt_format("class {} not found", class_name));
       ClassPtr used_klass = klass;
-      kphp_assert(klass);
       while (klass && !klass->members.has_field(var_name)) {
         klass = klass->parent_class;
       }

--- a/tests/phpt/cl/192_access_to_undef_class.php
+++ b/tests/phpt/cl/192_access_to_undef_class.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/class Foo not found/
+<?php
+
+function test_access_to_undef_class() {
+  var_dump(Foo::$static_var_x);
+}
+
+test_access_to_undef_class();


### PR DESCRIPTION
This simple PR fix crash of compiler on such code with undefined class Foo:
```
<?php

var_dump(Foo::$static_var_x);
```