### PR TITLE
[tl-compiler] allow use constructor as argument type before constructor declaration

### DIFF
--- a/common/tl/compiler/tl-parser-new.cpp
+++ b/common/tl/compiler/tl-parser-new.cpp
@@ -944,11 +944,11 @@ std::pair<bool, std::string> convert_type_to_bare_constructor(std::string id) {
       break;
     }
   }
-  if ('a' <= id[pos] && id[pos] <= 'z') {
+  if (std::islower(static_cast<unsigned char>(id[pos]))) {
     return {false, std::move(id)};
   } else {
-    assert('A' <= id[pos] && id[pos] <= 'Z');
-    id[pos] += 'a' - 'A';
+    assert(std::isupper(static_cast<unsigned char>(id[pos])));
+    id[pos] = std::tolower(static_cast<unsigned char>(id[pos]));
     return {true, std::move(id)};
   }
 }
@@ -964,11 +964,11 @@ std::pair<bool, std::string> convert_bare_constructor_to_type(std::string id) {
       break;
     }
   }
-  if ('A' <= id[pos] && id[pos] <= 'Z') {
+  if (std::isupper(static_cast<unsigned char>(id[pos]))) {
     return {false, std::move(id)};
   } else {
-    assert('a' <= id[pos] && id[pos] <= 'z');
-    id[pos] += 'A' - 'a';
+    assert(std::islower(static_cast<unsigned char>(id[pos])));
+    id[pos] = std::toupper(static_cast<unsigned char>(id[pos]));
     return {true, std::move(id)};
   }
 }

--- a/common/tl/compiler/tl-parser-new.cpp
+++ b/common/tl/compiler/tl-parser-new.cpp
@@ -1756,7 +1756,7 @@ struct tl_combinator_tree *tl_parse_ident(struct tree *T, int s) {
   L = alloc_ctree_node();
   if (is_constructor) {
     L->flags |= 5;
-    t->flags |= 8;
+    t->flags |= 1;
   } else if (s) {
     L->flags |= 1;
     t->flags |= 8;


### PR DESCRIPTION
If type of the argument is undeclared constructor, then its type can not be polymorphic.
If type can not be polymorphic, then constructor name and type name are differ in register of first letter.

This commit allows to concatenate tl-scheme files really in any order.

For example, now you can use primitive type int before its declaration:

```
....
@readwrite friends.deleteUser uid:int = Bool;
...
int#a8509bda ? = Int;
```