### PR TITLE
allow empty escape_char in fgetcsv/fputcsv functions

### DIFF
--- a/tests/phpt/streams/csv_input.txt
+++ b/tests/phpt/streams/csv_input.txt
@@ -1,0 +1,3 @@
+"cell1","cell2\","cell3","cell4"
+"\\\line1
+line2\\\"

--- a/tests/phpt/streams/fgetcsv.php
+++ b/tests/phpt/streams/fgetcsv.php
@@ -1,0 +1,12 @@
+@ok php7_4
+<?php
+
+function test_empty_escape() {
+  $stream = fopen(__DIR__ . '/csv_input.txt', 'r');
+  while (($data = fgetcsv($stream, 0, ',', '"', '')) !== false) {
+      var_dump($data);
+  }
+  fclose($stream);
+}
+
+test_empty_escape();

--- a/tests/phpt/streams/fputcsv.php
+++ b/tests/phpt/streams/fputcsv.php
@@ -1,0 +1,15 @@
+@ok php7_4
+<?php
+
+function test_empty_escape() {
+  $stream = fopen('php://stdout', 'w');
+  $rows = [
+    ['\\'],
+    ['\\"']
+  ];
+  foreach ($rows as $row) {
+    fputcsv($stream, $row, ',', '"', '');
+  }
+}
+
+test_empty_escape();


### PR DESCRIPTION
This is how it works in PHP7.4.

See https://bugs.php.net/bug.php?id=51496