### PR TITLE
Job workers improvements

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -576,6 +576,7 @@ void ClassDeclaration::compile_accept_visitor_methods(CodeGenerator &W, ClassPtr
 
   if (klass->need_instance_cache_visitors) {
     W << NL;
+    compile_accept_visitor(W, klass, "InstanceUniqueIndexVisitor");
     compile_accept_visitor(W, klass, "InstanceDeepCopyVisitor");
     compile_accept_visitor(W, klass, "InstanceDeepDestroyVisitor");
   }

--- a/runtime/class_instance_decl.inl
+++ b/runtime/class_instance_decl.inl
@@ -77,7 +77,7 @@ public:
   inline class_instance<T> alloc(Args &&... args) __attribute__((always_inline));
   inline class_instance<T> empty_alloc() __attribute__((always_inline));
   inline void destroy() { o.reset(); }
-  int64_t get_reference_counter() const { return o->get_refcnt(); }
+  int64_t get_reference_counter() const { return o ? o->get_refcnt() : 0; }
 
   void set_reference_counter_to(ExtraRefCnt ref_cnt_value) noexcept;
   bool is_reference_counter(ExtraRefCnt ref_cnt_value) const noexcept;

--- a/runtime/class_instance_decl.inl
+++ b/runtime/class_instance_decl.inl
@@ -19,6 +19,8 @@
 //
 // Their instances are wrapped into the class_instance<T>.
 
+class abstract_refcountable_php_interface;
+
 template<class T>
 class class_instance {
   vk::intrusive_ptr<T> o;
@@ -106,6 +108,36 @@ public:
       res.o = vk::intrusive_ptr<T>{o->virtual_builtin_clone()};
       res.o->set_refcnt(1);
     }
+    return res;
+  }
+
+  template<class S = T>
+  std::enable_if_t<!std::is_polymorphic<S>{}, void *> get_base_raw_ptr() const noexcept {
+    return get();
+  }
+
+  template<class S = T>
+  std::enable_if_t<std::is_polymorphic<S>{}, void *> get_base_raw_ptr() const noexcept {
+    // all polymorphic instances inherit abstract_refcountable_php_interface
+    // don't inline, we need an explicit conversion to abstract_refcountable_php_interface
+    abstract_refcountable_php_interface *interface = get();
+    return interface;
+  }
+
+  template<class S = T>
+  static std::enable_if_t<!std::is_polymorphic<S>{}, class_instance> create_from_base_raw_ptr(void *raw_ptr) noexcept {
+    class_instance res;
+    res.o = vk::intrusive_ptr<T>{static_cast<T *>(raw_ptr)};
+    return res;
+  }
+
+  template<class S = T>
+  static std::enable_if_t<std::is_polymorphic<S>{}, class_instance> create_from_base_raw_ptr(void *raw_ptr) noexcept {
+    class_instance res;
+    auto *interface = static_cast<abstract_refcountable_php_interface *>(raw_ptr);
+    auto *object = dynamic_cast<T *>(interface);
+    php_assert(object);
+    res.o = vk::intrusive_ptr<T>{object};
     return res;
   }
 

--- a/runtime/instance-cache.cpp
+++ b/runtime/instance-cache.cpp
@@ -638,9 +638,6 @@ private:
   }
 
   void fire_warning(const InstanceDeepCopyVisitor &detach_processor, const char *class_name) noexcept {
-    if (detach_processor.is_depth_limit_exceeded()) {
-      php_warning("Depth limit exceeded on cloning instance of class '%s' into cache", class_name);
-    }
     if (detach_processor.is_memory_limit_exceeded()) {
       php_warning("Memory limit exceeded on saving instance of class '%s' into cache", class_name);
       context_->memory_swap_required = true;

--- a/runtime/instance-copy-processor.h
+++ b/runtime/instance-copy-processor.h
@@ -110,7 +110,6 @@ public:
   friend class impl_::InstanceDeepBasicVisitor<InstanceUniqueIndexVisitor>;
 
   using Basic = impl_::InstanceDeepBasicVisitor<InstanceUniqueIndexVisitor>;
-  using Basic::process;
   using Basic::operator();
 
   using Handler = bool (*)(uint32_t &);
@@ -127,8 +126,8 @@ public:
 
 private:
   template<typename T>
-  std::enable_if_t<!is_class_instance_inside<T>{}, bool> process(T &) noexcept {
-    return true;
+  bool process(T &t) noexcept {
+    return is_class_instance_inside<T>{} ? Basic::process(t) : true;
   }
 
   template<typename T>

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -12,6 +12,8 @@
 #include "runtime/kphp_core.h"
 #include "runtime/refcountable_php_classes.h"
 
+class InstanceUniqueIndexVisitor;
+
 class InstanceDeepCopyVisitor;
 
 class InstanceDeepDestroyVisitor;
@@ -33,6 +35,7 @@ struct SendingInstanceBase : virtual abstract_refcountable_php_interface {
   virtual const char *get_class() const noexcept = 0;
   virtual int get_hash() const noexcept = 0;
 
+  virtual void accept(InstanceUniqueIndexVisitor &) noexcept = 0;
   virtual void accept(InstanceDeepCopyVisitor &) noexcept = 0;
   virtual void accept(InstanceDeepDestroyVisitor &) noexcept = 0;
 
@@ -83,6 +86,10 @@ struct C$KphpJobWorkerResponseError: public refcountable_polymorphic_php_classes
   void generic_accept(Visitor &&visitor) noexcept {
     visitor("error", error);
     visitor("error_code", error_code);
+  }
+
+  void accept(InstanceUniqueIndexVisitor &visitor) noexcept {
+    return generic_accept(visitor);
   }
 
   void accept(InstanceDeepCopyVisitor &visitor) noexcept {

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -29,7 +29,7 @@ enum {
   server_nothing_replied_error = -2001
 };
 
-struct SendingInstanceBase : abstract_refcountable_php_interface {
+struct SendingInstanceBase : virtual abstract_refcountable_php_interface {
   virtual const char *get_class() const noexcept = 0;
   virtual int get_hash() const noexcept = 0;
 

--- a/runtime/job-workers/processing-jobs.cpp
+++ b/runtime/job-workers/processing-jobs.cpp
@@ -15,7 +15,7 @@ namespace job_workers {
 FinishedJob *copy_finished_job_to_script_memory(JobSharedMessage *job_message) noexcept {
   auto response = job_message->instance.cast_to<C$KphpJobWorkerResponse>();
   php_assert(!response.is_null());
-  response = copy_instance_into_script_memory(response);
+  response = copy_instance_into_other_memory(response, dl::get_default_script_allocator());
   if (!response.is_null()) {
     if (void *mem = dl::allocate(sizeof(FinishedJob))) {
       return new(mem) FinishedJob{std::move(response)};

--- a/runtime/kphp_type_traits.h
+++ b/runtime/kphp_type_traits.h
@@ -9,6 +9,8 @@
 #include "common/type_traits/list_of_types.h"
 
 #include "runtime/declarations.h"
+#include "runtime/optional.h"
+#include "runtime/shape.h"
 
 template<typename>
 struct is_array : std::false_type {
@@ -61,6 +63,11 @@ struct is_class_instance_inside<std::tuple<U, Ts...>> :
   std::integral_constant<bool,
     is_class_instance_inside<U>::value ||
     is_class_instance_inside<std::tuple<Ts...>>::value> {
+};
+
+template<size_t ...Is, typename ...Ts>
+struct is_class_instance_inside<shape<std::index_sequence<Is...>, Ts...>> :
+  is_class_instance_inside<std::tuple<Ts...>> {
 };
 
 template<class T, class U>

--- a/runtime/refcountable_php_classes.h
+++ b/runtime/refcountable_php_classes.h
@@ -17,36 +17,43 @@ public:
   virtual void release() noexcept = 0;
   virtual uint32_t get_refcnt() noexcept = 0;
   virtual void set_refcnt(uint32_t new_refcnt) noexcept = 0;
+
+  virtual uint32_t &get_unique_index_ref() noexcept = 0;
 };
 
 template<class ...Bases>
 class refcountable_polymorphic_php_classes : public Bases... {
 public:
   void add_ref() noexcept final {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      ++refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      ++refcnt_;
     }
   }
 
   uint32_t get_refcnt() noexcept final {
-    return refcnt;
+    return refcnt_;
   }
 
   void release() noexcept final __attribute__((always_inline)) {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      --refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      --refcnt_;
     }
-    if (refcnt == 0) {
+    if (refcnt_ == 0) {
       delete this;
     }
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept final {
-    refcnt = new_refcnt;
+    refcnt_ = new_refcnt;
+  }
+
+  uint32_t &get_unique_index_ref() noexcept final {
+    return unique_index_;
   }
 
 private:
-  uint32_t refcnt{0};
+  uint32_t refcnt_{0};
+  uint32_t unique_index_{0};
 };
 
 template<class ...Interfaces>
@@ -61,51 +68,56 @@ public:
   refcountable_polymorphic_php_classes_virt() __attribute__((always_inline)) = default;
 
   void add_ref() noexcept final {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      ++refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      ++refcnt_;
     }
   }
 
   uint32_t get_refcnt() noexcept final {
-    return refcnt;
+    return refcnt_;
   }
 
   void release() noexcept final __attribute__((always_inline)) {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      --refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      --refcnt_;
     }
-    if (refcnt == 0) {
+    if (refcnt_ == 0) {
       delete this;
     }
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept final {
-    refcnt = new_refcnt;
+    refcnt_ = new_refcnt;
+  }
+
+  uint32_t &get_unique_index_ref() noexcept final {
+    return unique_index_;
   }
 
 private:
-  uint32_t refcnt{0};
+  uint32_t refcnt_{0};
+  uint32_t unique_index_{0};
 };
 
 template<class Derived>
 class refcountable_php_classes  : public ManagedThroughDlAllocator {
 public:
   void add_ref() noexcept {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      ++refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      ++refcnt_;
     }
   }
 
   uint32_t get_refcnt() noexcept {
-    return refcnt;
+    return refcnt_;
   }
 
   void release() noexcept __attribute__((always_inline)) {
-    if (refcnt < ExtraRefCnt::for_global_const) {
-      --refcnt;
+    if (refcnt_ < ExtraRefCnt::for_global_const) {
+      --refcnt_;
     }
 
-    if (refcnt == 0) {
+    if (refcnt_ == 0) {
       static_assert(!std::is_polymorphic<Derived>{}, "Derived may not be polymorphic");
       /**
        * because of inheritance from ManagedThroughDlAllocator, which override operators new/delete
@@ -117,11 +129,16 @@ public:
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept {
-    refcnt = new_refcnt;
+    refcnt_ = new_refcnt;
+  }
+
+  uint32_t &get_unique_index_ref() noexcept {
+    return unique_index_;
   }
 
 private:
-  uint32_t refcnt{0};
+  uint32_t refcnt_{0};
+  uint32_t unique_index_{0};
 };
 
 class refcountable_empty_php_classes {

--- a/runtime/refcountable_php_classes.h
+++ b/runtime/refcountable_php_classes.h
@@ -60,12 +60,22 @@ template<class ...Interfaces>
 class refcountable_polymorphic_php_classes_virt : public virtual abstract_refcountable_php_interface, public Interfaces... {
 public:
   refcountable_polymorphic_php_classes_virt() __attribute__((always_inline)) = default;
+  // remove this after removing jessie support
+  refcountable_polymorphic_php_classes_virt(const refcountable_polymorphic_php_classes_virt &) __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt(refcountable_polymorphic_php_classes_virt &&) noexcept __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt &operator=(const refcountable_polymorphic_php_classes_virt &) __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt &operator=(refcountable_polymorphic_php_classes_virt &&) noexcept __attribute__((always_inline)) = default;
 };
 
 template<>
 class refcountable_polymorphic_php_classes_virt<> : public virtual abstract_refcountable_php_interface {
 public:
   refcountable_polymorphic_php_classes_virt() __attribute__((always_inline)) = default;
+  // remove this after removing jessie support
+  refcountable_polymorphic_php_classes_virt(const refcountable_polymorphic_php_classes_virt &) __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt(refcountable_polymorphic_php_classes_virt &&) noexcept __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt &operator=(const refcountable_polymorphic_php_classes_virt &) __attribute__((always_inline)) = default;
+  refcountable_polymorphic_php_classes_virt &operator=(refcountable_polymorphic_php_classes_virt &&) noexcept __attribute__((always_inline)) = default;
 
   void add_ref() noexcept final {
     if (refcnt_ < ExtraRefCnt::for_global_const) {

--- a/runtime/shape.h
+++ b/runtime/shape.h
@@ -9,6 +9,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "common/algorithms/find.h"
+
 template<size_t tag, typename T>
 class shape_node {
 public:

--- a/tests/cpp/runtime/kphp-type-traits-test.cpp
+++ b/tests/cpp/runtime/kphp-type-traits-test.cpp
@@ -1,0 +1,66 @@
+#include <gtest/gtest.h>
+
+
+#include "runtime/kphp_core.h"
+#include "runtime/kphp_type_traits.h"
+#include "runtime/refcountable_php_classes.h"
+
+struct Stub : refcountable_php_classes<Stub> {
+};
+
+TEST(kphp_type_traits_test, test_is_class_instance_inside) {
+  static_assert(!is_class_instance_inside<int64_t>{}, "except false");
+  static_assert(!is_class_instance_inside<mixed>{}, "except false");
+  static_assert(!is_class_instance_inside<string>{}, "except false");
+  static_assert(!is_class_instance_inside<array<bool>>{}, "except false");
+  static_assert(!is_class_instance_inside<array<array<mixed>>>{}, "except false");
+  static_assert(!is_class_instance_inside<Optional<int64_t>>{}, "except false");
+  static_assert(!is_class_instance_inside<std::tuple<int64_t, string>>{}, "except false");
+  static_assert(!is_class_instance_inside<std::tuple<int64_t, string, Optional<array<mixed>>>>{}, "except false");
+  static_assert(!is_class_instance_inside<std::tuple<shape<std::index_sequence<1, 2>, string, mixed>, string, Optional<array<mixed>>>>{}, "except false");
+
+  static_assert(is_class_instance_inside<class_instance<Stub>>{}, "except true");
+  static_assert(is_class_instance_inside<array<class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<Optional<array<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<Optional<array<Optional<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<array<array<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<array<Optional<array<class_instance<Stub>>>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<Optional<class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<Optional<Optional<class_instance<Stub>>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<std::tuple<class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<string, class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<mixed, class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<class_instance<Stub>, class_instance<Stub>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<std::tuple<Optional<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<Optional<std::tuple<class_instance<Stub>>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<std::tuple<array<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<array<std::tuple<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<array<Optional<std::tuple<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<array<string>, class_instance<Stub>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<std::tuple<std::tuple<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<std::tuple<std::tuple<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<array<std::tuple<std::tuple<class_instance<Stub>>>>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1, 2>, string, class_instance<Stub>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, array<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, Optional<array<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, std::tuple<class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, array<std::tuple<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<shape<std::index_sequence<1>, shape<std::index_sequence<1>, class_instance<Stub>>>>{}, "except true");
+
+  static_assert(is_class_instance_inside<std::tuple<shape<std::index_sequence<1>, class_instance<Stub>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<Optional<shape<std::index_sequence<1>, class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<array<shape<std::index_sequence<1>, class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<std::tuple<shape<std::index_sequence<1>, std::tuple<class_instance<Stub>>>>>{}, "except true");
+  static_assert(is_class_instance_inside<
+    std::tuple<string,
+      shape<std::index_sequence<1>,
+        Optional<std::tuple<
+          array<shape<std::index_sequence<1>, class_instance<Stub>>>>>>>>{}, "except true");
+}

--- a/tests/cpp/runtime/runtime-tests.cmake
+++ b/tests/cpp/runtime/runtime-tests.cmake
@@ -9,6 +9,7 @@ prepend(RUNTIME_TESTS_SOURCES ${BASE_DIR}/tests/cpp/runtime/
         flex-test.cpp
         inter-process-mutex-test.cpp
         inter-process-resource-test.cpp
+        kphp-type-traits-test.cpp
         memory_resource/details/memory_chunk_list-test.cpp
         memory_resource/details/memory_chunk_tree-test.cpp
         memory_resource/details/memory_ordered_chunk_list-test.cpp

--- a/tests/phpt/instance_cache/1_instance_cache.php
+++ b/tests/phpt/instance_cache/1_instance_cache.php
@@ -198,14 +198,14 @@ function test_loop_in_tree() {
 
   $result = instance_cache_store("tree_root_loop", $root);
 #ifndef KPHP
-  var_dump(false);
+  var_dump(true);
   if (false)
 #endif
   var_dump($result);
 
   $cached_root1 = instance_cache_fetch(TreeX::class, "tree_root_loop");
 #ifndef KPHP
-  var_dump(true);
+  var_dump(false);
   if (false)
 #endif
   var_dump(!$cached_root1);

--- a/tests/phpt/job_workers/1_interface_compilation.php
+++ b/tests/phpt/job_workers/1_interface_compilation.php
@@ -51,4 +51,27 @@ function test_compilation($x) {
   kphp_job_worker_store_response($m4);
 }
 
+function test_multiple_inheritance($x) {
+  if (!$x) {
+    return;
+  }
+
+  interface ReqInterface {}
+  abstract class ReqBaseClass implements \KphpJobWorkerRequest {}
+  final class Request1 extends ReqBaseClass implements ReqInterface {}
+
+  interface RespInterface {}
+  abstract class RespBaseClass implements \KphpJobWorkerResponse {}
+  final class Response1 extends RespBaseClass implements RespInterface {}
+
+  kphp_job_worker_start(new Request1, -1);
+
+  $x = kphp_job_worker_fetch_request();
+  if ($x instanceof Response1) {
+    var_dump(get_class($x));
+  }
+  kphp_job_worker_store_response(new Response1);
+}
+
 test_compilation(false);
+test_multiple_inheritance(false);

--- a/tests/phpt/memory_usage/2_classes.php
+++ b/tests/phpt/memory_usage/2_classes.php
@@ -22,7 +22,7 @@ function test_empty_class() {
 
 function test_class_with_simple_fields() {
   class MyClass1 {
-    // counter 4 // aligned to 8
+    // counter 4 + unique index 4
     public $x = 1; // 8
     public $y = 1.0; // 8
     public $z = true; // 1 // aligned to 8
@@ -54,7 +54,7 @@ function test_class_with_dynamic_array() {
       $this->x = range(0, $size);
     }
 
-    // counter 4 // aligned => 8
+    // counter 4 + unique index 4
     public $x = []; // 8
   } // total size = 16
 

--- a/tests/phpt/memory_usage/3_lambdas.php
+++ b/tests/phpt/memory_usage/3_lambdas.php
@@ -14,7 +14,7 @@ function test_empty_lambda() {
 }
 
 function test_lambda_with_use() {
-  // counter 4 aligned 8
+  // counter 4 + unique index 4
   $a = 10; // 8
   $b = 0.2; // 8;
   $c = false; // 1 aligned 8

--- a/tests/phpt/memory_usage/4_interfaces.php
+++ b/tests/phpt/memory_usage/4_interfaces.php
@@ -6,7 +6,7 @@ interface IMyClass {
 
 class MyClassEmpty implements IMyClass {
   // vtable 8
-  // counter 4 // aligned 8
+  // counter 4 + unique index 4 // aligned 8
 
   // total size = 16
   public function __construct() {}
@@ -14,15 +14,15 @@ class MyClassEmpty implements IMyClass {
 
 class MyClass1 implements IMyClass {
   // vtable 8
-  // counter 4
-  public $x = true; // 1 // cnt + $x aligned 8
+  // counter 4 + unique index 4
+  public $x = 123; // 8
 
-  // total size = 16
+  // total size = 24
 }
 
 class MyClass2 implements IMyClass {
   // vtable 8
-  // counter 4 // aligned 8
+  // counter 4 + unique index 4
   public $x = "hello"; // 8
   public $y = false; // 1 aligned 8
   public $z = 5; // 8
@@ -40,13 +40,13 @@ function test_empty_class() {
 
 function test_interfaces() {
 #ifndef KPHP
-  var_dump(16);
+  var_dump(24);
   var_dump(40);
   var_dump(16);
-  var_dump(16);
+  var_dump(24);
   var_dump(40);
   var_dump(0);
-  var_dump(16 + 16 + 40 + 8 + 80);
+  var_dump(16 + 16 + 40 + 8 + 8 + 80);
   return;
 #endif
   var_dump(estimate_memory_usage(new MyClass1()));

--- a/tests/phpt/memory_usage/5_polymorphic_classes.php
+++ b/tests/phpt/memory_usage/5_polymorphic_classes.php
@@ -3,21 +3,21 @@
 
 class A {
   // vtable 8
-  // counter 4 aligned 8
+  // counter 4 + unique index 4
   // total size = 16
   function __construct() {}
 }
 
 class B1 extends A {
   // vtable 8
-  // counter 4 aligned 8
+  // counter 4 + unique index 4
   // total size = 16
   function __construct() {}
 }
 
 class B2 extends A {
   // vtable 8
-  // counter 4 aligned 8
+  // counter 4 + unique index 4
   public $x = "hello"; // 8
   public $y = false; // 1 aligned 8
   // total size = 32
@@ -26,9 +26,9 @@ class B2 extends A {
 
 class C1 extends B1 {
   // vtable 8
-  // counter 4
-  public $x = true; // 1 // counter + $x aligned 8
-  // total size = 16
+  // counter + unique index 4
+  public $x = 123; // 8
+  // total size = 24
   function __construct() {}
 }
 
@@ -44,7 +44,7 @@ function test_polymorphic_classes() {
   var_dump(16);
   var_dump(16);
   var_dump(32);
-  var_dump(16);
+  var_dump(24);
   var_dump(32);
   return;
 #endif
@@ -60,10 +60,10 @@ function test_polymorphic_classes_in_array() {
   var_dump(16);
   var_dump(16);
   var_dump(32);
-  var_dump(16);
+  var_dump(24);
   var_dump(32);
   var_dump(0);
-  var_dump(16 + 16 + 32 + 16 + 32 + 8 + 96);
+  var_dump(16 + 16 + 32 + 24 + 32 + 8 + 96);
   return;
 #endif
   $ix = [new A(), new B1(), new B2(), new C1(), new C2(), null];

--- a/tests/python/tests/instance_cache/php/index.php
+++ b/tests/python/tests/instance_cache/php/index.php
@@ -1,0 +1,148 @@
+<?php
+
+function main() {
+  switch ($_SERVER["PHP_SELF"]) {
+    case "/store": {
+      test_store();
+      return;
+    }
+    case "/fetch_and_verify": {
+      test_fetch_and_verify();
+      return;
+    }
+    case "/delete": {
+      test_delete();
+      return;
+    }
+  }
+
+  critical_error("unknown test " . $_SERVER["PHP_SELF"]);
+}
+
+
+/** @kphp-immutable-class */
+class TestClassA {
+  function __construct(TestClassA $a1 = null, TestClassA $a2 = null,
+                       TestClassB $b1 = null, TestClassB $b2 = null,
+                       TestClassC $c1 = null, TestClassC $c2 = null) {
+    if ($a1 === null) {
+      for ($i = 0; $i != 3000; ++$i) {
+        $this->huge_arr["key $i"] = "value $i";
+      }
+      return;
+    }
+    $this->a = [$a1, $a2, $a2, $this, $a1, $this, $a1];
+    for ($i = 0; $i != 10; ++$i) {
+      array_push($this->a, $a1);
+      array_push($this->a, $a2);
+      array_push($this->a, $this);
+    }
+    $this->b = tuple([$b1, $b2, $b1, $b1, $b2], 100);
+    $this->ab = shape([
+      'b' => tuple(10, $b2),
+      'c' => shape([
+        'arr' => [$c1, $c1, $c2, $c2, $c2, $c2]
+      ])
+    ]);
+  }
+
+  /** @var TestClassA[] */
+  public $a = [];
+
+  /** @var tuple(TestClassB[]|null, int) */
+  public $b;
+
+  /** @var shape(b:tuple(int, TestClassB), c:shape(arr:TestClassC[]|false)) */
+  public $ab;
+
+  /** @var string[] */
+  public $huge_arr = [];
+}
+
+/** @kphp-immutable-class */
+class TestClassB {
+  function __construct(int $size, TestClassA $a = null) {
+    while (--$size > 0) {
+      $this->arr["A key $size"] = "A value $size";
+    }
+    if ($a) {
+      $this->a = tuple(TestClassA::class, $a);
+    }
+  }
+
+  /** @var string[] */
+  public $arr = [];
+
+  /** @var tuple(string, TestClassA)|null */
+  public $a = null;
+}
+
+/** @kphp-immutable-class */
+class TestClassC {
+  function __construct(int $size, TestClassB $b = null) {
+    while (--$size > 0) {
+      $this->arr["B key $size"] = "B value $size";
+    }
+
+    if ($b) {
+      $this->b = shape([
+        'key' => TestClassB::class,
+        'value' => tuple(0.1, [$b, $b, $b, $b])
+      ]);
+    }
+  }
+
+  /** @var string[] */
+  public $arr = [];
+
+  /** @var shape(key:string, value:tuple(double, TestClassB[]|null)|false)|null */
+  public $b = null;
+}
+
+/** @kphp-immutable-class */
+class TestClassABC {
+  function __construct() {
+    $a1 = new TestClassA();
+    $b1 = new TestClassB(10, $a1);
+    $c1 = new TestClassC(11, $b1);
+
+    $a2 = new TestClassA(
+      $a1, new TestClassA(),
+      $b1, new TestClassB(12),
+      $c1, new TestClassC(13));
+
+    $this->a = [$a1, $a2, new TestClassA($a1, $a2)];
+    $this->b = [$b1, new TestClassB(14, $a2)];
+    $this->c = [$c1, new TestClassC(15, $this->b[1])];
+  }
+
+  /** @var TestClassA[] */
+  public $a = [];
+  /** @var TestClassB[] */
+  public $b = [];
+  /** @var TestClassC[] */
+  public $c = [];
+}
+
+function test_store() {
+  $data = json_decode(file_get_contents('php://input'));
+  echo json_encode(["result" => instance_cache_store($data["key"], new TestClassABC, 5)]);
+}
+
+function test_fetch_and_verify() {
+  $data = json_decode(file_get_contents('php://input'));
+  /** @var TestClassABC $instance */
+  $instance = instance_cache_fetch(TestClassABC::class, $data["key"]);
+  echo json_encode([
+    "a" => $instance->a[0] === $instance->a[2]->a[0],
+    "b" => $instance->b[0] === $instance->b[1]->a[1]->b[0][0],
+    "c" => $instance->c[0] === $instance->a[2]->a[1]->ab["c"]["arr"][1],
+  ]);
+}
+
+function test_delete() {
+  $data = json_decode(file_get_contents('php://input'));
+  instance_cache_delete($data["key"]);
+}
+
+main();

--- a/tests/python/tests/instance_cache/test_store_fetch_delete.py
+++ b/tests/python/tests/instance_cache/test_store_fetch_delete.py
@@ -1,0 +1,45 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestStoreFetchDelete(KphpServerAutoTestCase):
+    def test_store_fetch_delete(self):
+        elements = 600
+
+        stats_before = self.kphp_server.get_stats(prefix="kphp_server.instance_cache_")
+        for i in range(elements):
+            resp = self.kphp_server.http_post(
+                uri="/store",
+                json={"key": "key{}".format(i)})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"result": True})
+
+            resp = self.kphp_server.http_post(
+                uri="/fetch_and_verify",
+                json={"key": "key{}".format(i)})
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"a": True, "b": True, "c": True})
+            
+            resp = self.kphp_server.http_post(
+                uri="/delete",
+                json={"key": "key{}".format(i)})
+            self.assertEqual(resp.status_code, 200)
+
+            stored_elements = i + 1
+            if stored_elements % 300 == 0:
+                self.kphp_server.assert_stats(
+                    initial_stats=stats_before,
+                    timeout=120,
+                    prefix="kphp_server.instance_cache_",
+                    expected_added_stats={
+                        "elements_stored": stored_elements,
+                        "elements_destroyed": stored_elements
+                    })
+
+        self.kphp_server.assert_stats(
+            initial_stats=stats_before,
+            prefix="kphp_server.instance_cache_",
+            expected_added_stats={
+                "memory_used": 0,
+                "elements_stored": elements,
+                "elements_destroyed": elements
+            })

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
@@ -24,7 +24,7 @@ abstract class ReferenceInvariantData {
     ];
     $this->b = [
       $this->ab,
-      $this->ab->b_arr[0],
+      $this->ab->b_arr["key 42"],
       $this->ab->b[0][1],
       $this->ab->b[0][2],
       new TestClassB(11),
@@ -48,7 +48,7 @@ abstract class ReferenceInvariantData {
     $assert($this->a[3] === $this->ab->a[0], "case a 2");
     $assert($this->a[5] === $this->ab->ab['a'][1], "case a 3");
 
-    $assert($this->b[1] === $this->ab->b_arr[0], "case b 1");
+    $assert($this->b[1] === $this->ab->b_arr["key 1"], "case b 1");
     $assert($this->b[3] === $this->ab->b[0][2], "case b 2");
     $assert($this->b[5] === $this->ab->ab['b']['arr'][1], "case b 3");
 
@@ -61,5 +61,25 @@ abstract class ReferenceInvariantData {
     $b = instance_cast($this->b[0], TestClassAB::class);
     $assert($b !== null, "common case 3");
     $assert($b->huge_arr["key 94"] === "value 94", "common case 4");
+  }
+
+  function verify_ref_cnt() {
+    $assert_ref_cnt = function (int $got, int $expected, string $msg) {
+      if ($got !== $expected) {
+        critical_error("$msg failed: expected $expected, got $got");
+      }
+    };
+    $assert_ref_cnt(get_reference_counter($this->ab), 218, "ab case 1");
+
+    $assert_ref_cnt(get_reference_counter($this->a[0]), 219, "a case 1");
+    $assert_ref_cnt(get_reference_counter($this->a[1]), 2, "a case 2");
+    $assert_ref_cnt(get_reference_counter($this->a[2]), 219, "a case 3");
+    $assert_ref_cnt(get_reference_counter($this->a[5]), 105, "a case 4");
+
+    $assert_ref_cnt(get_reference_counter($this->b[0]), 219, "b case 1");
+    $assert_ref_cnt(get_reference_counter($this->b[1]), 132, "b case 2");
+    $assert_ref_cnt(get_reference_counter($this->b[2]), 132, "b case 3");
+    $assert_ref_cnt(get_reference_counter($this->b[4]), 2, "b case 4");
+    $assert_ref_cnt(get_reference_counter($this->b[5]), 219, "b case 5");
   }
 }

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace ReferenceInvariant;
+
+abstract class ReferenceInvariantData {
+  /** @var TestClassAB|null */
+  public $ab = null;
+
+  /** @var TestInterfaceA[] */
+  public $a = [];
+
+  /** @var TestInterfaceB[] */
+  public $b = [];
+
+  function init_data() {
+    $this->ab = new TestClassAB();
+    $this->a = [
+      $this->ab,
+      new TestClassA(10),
+      $this->ab,
+      $this->ab->a[0],
+      $this->ab->a[2],
+      $this->ab->ab['a'][1],
+    ];
+    $this->b = [
+      $this->ab,
+      $this->ab->b_arr[0],
+      $this->ab->b[0][1],
+      $this->ab->b[0][2],
+      new TestClassB(11),
+      $this->ab->ab['b']['arr'][1],
+    ];
+  }
+
+  function verify_data() {
+    $assert = function (bool $ok, string $msg) {
+      if (!$ok) {
+        critical_error("$msg failed");
+      }
+    };
+
+    $assert($this->ab === $this->a[0], "case ab 1");
+    $assert($this->ab === $this->b[0], "case ab 2");
+    $assert($this->ab->b_arr["key 74"] === $this->ab->b_arr["key 10"], "case ab 3");
+    $assert($this->ab->b_arr["key 100"] === $this->ab->ab['b']['arr'][2], "case ab 4");
+
+    $assert($this->a[0] === $this->a[2], "case a 1");
+    $assert($this->a[3] === $this->ab->a[0], "case a 2");
+    $assert($this->a[5] === $this->ab->ab['a'][1], "case a 3");
+
+    $assert($this->b[1] === $this->ab->b_arr[0], "case b 1");
+    $assert($this->b[3] === $this->ab->b[0][2], "case b 2");
+    $assert($this->b[5] === $this->ab->ab['b']['arr'][1], "case b 3");
+
+    /** @var TestClassAB $a */
+    $a = instance_cast($this->a[0], TestClassAB::class);
+    $assert($a !== null, "common case 1");
+    $assert($a->huge_arr["key 17"] === "value 17", "common case 2");
+
+    /** @var TestClassAB $b */
+    $b = instance_cast($this->b[0], TestClassAB::class);
+    $assert($b !== null, "common case 3");
+    $assert($b->huge_arr["key 94"] === "value 94", "common case 4");
+  }
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantData.php
@@ -82,4 +82,26 @@ abstract class ReferenceInvariantData {
     $assert_ref_cnt(get_reference_counter($this->b[4]), 2, "b case 4");
     $assert_ref_cnt(get_reference_counter($this->b[5]), 219, "b case 5");
   }
+
+  function verify_job_ref_cnt() {
+    $assert_job_ref_cnt = function (int $got, string $msg) {
+      // 0x7ffffff3 is a value of extra_ref_cnt_value::for_job_worker_communication in the runtime
+      $expected = 0x7ffffff3;
+      if ($got !== $expected) {
+        critical_error("$msg failed: expected $expected, got $got");
+      }
+    };
+    $assert_job_ref_cnt(get_reference_counter($this->ab), "ab case 1");
+
+    $assert_job_ref_cnt(get_reference_counter($this->a[0]), "a case 1");
+    $assert_job_ref_cnt(get_reference_counter($this->a[1]), "a case 2");
+    $assert_job_ref_cnt(get_reference_counter($this->a[2]), "a case 3");
+    $assert_job_ref_cnt(get_reference_counter($this->a[5]), "a case 4");
+
+    $assert_job_ref_cnt(get_reference_counter($this->b[0]), "b case 1");
+    $assert_job_ref_cnt(get_reference_counter($this->b[1]), "b case 2");
+    $assert_job_ref_cnt(get_reference_counter($this->b[2]), "b case 3");
+    $assert_job_ref_cnt(get_reference_counter($this->b[4]), "b case 4");
+    $assert_job_ref_cnt(get_reference_counter($this->b[5]), "b case 5");
+  }
 }

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantRequest.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantRequest.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ReferenceInvariant;
+
+class ReferenceInvariantRequest extends ReferenceInvariantData implements \KphpJobWorkerRequest {
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantResponse.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/ReferenceInvariantResponse.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ReferenceInvariant;
+
+class ReferenceInvariantResponse extends ReferenceInvariantData implements \KphpJobWorkerResponse {
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestAbstractClassA.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestAbstractClassA.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace ReferenceInvariant;
+
+abstract class TestAbstractClassA implements TestInterfaceA {
+  function __construct(TestInterfaceA $a1, TestInterfaceA $a2, TestInterfaceB $b1, TestInterfaceB $b2) {
+    $this->a = [$a1, $a2, $a1, $a1, $a2, $this, $this];
+    for ($i = 0; $i != 100; ++$i) {
+      array_push($this->a, $a1);
+      array_push($this->a, $a2);
+      array_push($this->a, $this);
+    }
+    $this->b = tuple([$b1, $b2, $b1, $b1, $b2], 100);
+    $this->ab = shape([
+      'a' => tuple(10, $a2),
+      'b' => shape([
+        'arr' => [$b1, $b1, $b2, $b2, $b2, $b2]
+      ])
+    ]);
+    for ($i = 0; $i != 100; ++$i) {
+      $this->huge_arr["key $i"] = "value $i";
+    }
+  }
+
+  /** @var TestInterfaceA[] */
+  public $a = [];
+
+  /** @var tuple(TestInterfaceB[]|null, int) */
+  public $b;
+
+  /** @var shape(a:tuple(int, TestInterfaceA), b:shape(arr:TestInterfaceB[]|false)) */
+  public $ab;
+
+  /** @var string[] */
+  public $huge_arr = [];
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassA.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassA.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ReferenceInvariant;
+
+class TestClassA implements TestInterfaceA {
+  function __construct(int $size) {
+    while (--$size > 0) {
+      $this->a["A key $size"] = "A value $size";
+    }
+  }
+
+  /** @var string[] */
+  public $a = [];
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassAB.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassAB.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace ReferenceInvariant;
+
+class TestClassAB extends TestAbstractClassA implements TestInterfaceB {
+  function __construct() {
+    $b = new TestClassB(200);
+    parent::__construct($this, new TestClassA(100), $this, $b);
+
+    for ($i = 0; $i != 123; ++$i) {
+      $this->b_arr["key $i"] = $b;
+    }
+  }
+
+  /** @var TestInterfaceB[] */
+  public $b_arr = [];
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassB.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestClassB.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace ReferenceInvariant;
+
+class TestClassB implements TestInterfaceB {
+  function __construct(int $size) {
+    while (--$size > 0) {
+      $this->b["B key $size"] = "B value $size";
+    }
+  }
+
+  /** @var string[] */
+  public $b = [];
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestInterfaceA.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestInterfaceA.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ReferenceInvariant;
+
+interface TestInterfaceA {
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/TestInterfaceB.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/TestInterfaceB.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ReferenceInvariant;
+
+interface TestInterfaceB {
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/http_worker.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/http_worker.php
@@ -18,4 +18,5 @@ function test_reference_invariant() {
     critical_error("got empty job response");
   }
   $result_stats->verify_data();
+  $result_stats->verify_ref_cnt();
 }

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/http_worker.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/http_worker.php
@@ -1,0 +1,21 @@
+<?php
+
+use ReferenceInvariant\ReferenceInvariantRequest;
+use ReferenceInvariant\ReferenceInvariantResponse;
+
+function test_reference_invariant() {
+  $req = new ReferenceInvariantRequest();
+  $req->init_data();
+
+  $job_id = kphp_job_worker_start($req, -1);
+  if (!$job_id) {
+    critical_error("Can't send job");
+  }
+
+  $result = wait($job_id);
+  $result_stats = instance_cast($result, ReferenceInvariantResponse::class);
+  if ($result_stats === null) {
+    critical_error("got empty job response");
+  }
+  $result_stats->verify_data();
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/job_worker.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/job_worker.php
@@ -1,0 +1,12 @@
+<?php
+
+use ReferenceInvariant\ReferenceInvariantRequest;
+use ReferenceInvariant\ReferenceInvariantResponse;
+
+function run_job_reference_invariant(ReferenceInvariantRequest $request) {
+  $request->verify_data();
+
+  $resp = new ReferenceInvariantResponse();
+  $resp->init_data();
+  kphp_job_worker_store_response($resp);
+}

--- a/tests/python/tests/job_workers/php/ReferenceInvariant/job_worker.php
+++ b/tests/python/tests/job_workers/php/ReferenceInvariant/job_worker.php
@@ -5,6 +5,7 @@ use ReferenceInvariant\ReferenceInvariantResponse;
 
 function run_job_reference_invariant(ReferenceInvariantRequest $request) {
   $request->verify_data();
+  $request->verify_job_ref_cnt();
 
   $resp = new ReferenceInvariantResponse();
   $resp->init_data();

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -70,6 +70,11 @@ function do_http_worker() {
       test_send_job_no_reply();
       return;
     }
+    case "/test_reference_invariant": {
+      require_once "ReferenceInvariant/http_worker.php";
+      test_reference_invariant();
+      return;
+    }
   }
 
   critical_error("unknown test " . $_SERVER["PHP_SELF"]);

--- a/tests/python/tests/job_workers/php/job_worker.php
+++ b/tests/python/tests/job_workers/php/job_worker.php
@@ -1,6 +1,7 @@
 <?php
 
 use ComplexScenario\CollectStatsJobRequest;
+use ReferenceInvariant\ReferenceInvariantRequest;
 
 require_once 'SharedImmutableMessageScenario/job_worker.php';
 require_once 'utils.php';
@@ -35,6 +36,9 @@ function do_job_worker() {
   } else if ($req instanceof CollectStatsJobRequest) {
     require_once "ComplexScenario/_job_scenario.php";
     run_job_complex_scenario($req);
+  } else if ($req instanceof ReferenceInvariantRequest) {
+    require_once "ReferenceInvariant/job_worker.php";
+    run_job_reference_invariant($req);
   } else {
     run_job_shared_immutable_message_scenario($req);
   }

--- a/tests/python/tests/job_workers/test_messages_references.py
+++ b/tests/python/tests/job_workers/test_messages_references.py
@@ -1,0 +1,38 @@
+from multiprocessing.dummy import Pool as ThreadPool
+
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestMessagesReferences(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 18,
+            "--job-workers-ratio": 0.16,
+            "--verbosity-job-workers=2": True,
+        })
+
+    def do_test(self, it):
+        resp = self.kphp_server.http_get("/test_reference_invariant")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_reference_invariant(self):
+        requests_count = 1000
+        with ThreadPool(5) as pool:
+            for _ in pool.imap_unordered(self.do_test, range(requests_count)):
+                pass
+
+        self.kphp_server.assert_stats(
+            prefix="kphp_server.workers_job_",
+            expected_added_stats={
+                "memory_messages_shared_messages_buffers_acquired": requests_count * 2,
+                "memory_messages_shared_messages_buffers_released": requests_count * 2,
+                "jobs_queue_size": 0,
+                "jobs_sent": requests_count,
+                "jobs_replied": requests_count,
+                "pipe_errors_server_write": 0,
+                "pipe_errors_server_read": 0,
+                "pipe_errors_client_write": 0,
+                "pipe_errors_client_read": 0,
+            })
+        self.assertKphpNoTerminatedRequests()


### PR DESCRIPTION
This patch
1) Saves references when copying instances to the instance cache and between workers.
2) Fixes a bug, which spoiled multiple inheritance for job workers requests/responses classes.