### PR TITLE
suggest reset()/end() funcs alternative in error messages

### DIFF
--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -567,6 +567,17 @@ private:
         return;
       }
     }
+
+    // people try to use some of these and struggle to find an alternative
+    if (unexisting_func_name == "reset") {
+      kphp_error(0, fmt_format("KPHP does not support reset(), maybe array_first_value() is what you are looking for?\n"));
+      return;
+    }
+    if (unexisting_func_name == "end") {
+      kphp_error(0, fmt_format("KPHP does not support end(), maybe array_last_value() is what you are looking for?\n"));
+      return;
+    }
+
     kphp_error(0, fmt_format("Unknown function {}()\n", unexisting_func_name));
   }
 };

--- a/tests/phpt/errors/008_reset_func.php
+++ b/tests/phpt/errors/008_reset_func.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/KPHP does not support reset\(\), maybe array_first_value\(\) is what you are looking for\?/
+<?php
+
+$arr = [];
+reset($arr);

--- a/tests/phpt/errors/009_end_func.php
+++ b/tests/phpt/errors/009_end_func.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/KPHP does not support end\(\), maybe array_last_value\(\) is what you are looking for\?/
+<?php
+
+$arr = [];
+end($arr);


### PR DESCRIPTION
KPHP doesn't have `reset()` and `end()` functions, but
many times people want `array_first_value()` or `array_last_value()` instead.
Giving a better error message here is the least we can do.