### PR TITLE
make it possible to split functions.txt into separate files

### DIFF
--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -189,7 +189,7 @@ std::string CompilerCore::search_required_file(const std::string &file_name) con
   return full_file_name;
 }
 
-SrcFilePtr CompilerCore::register_file(const string &file_name, LibPtr owner_lib) {
+SrcFilePtr CompilerCore::register_file(const string &file_name, LibPtr owner_lib, bool builtin) {
   if (file_name.empty()) {
     return SrcFilePtr();
   }
@@ -223,6 +223,7 @@ SrcFilePtr CompilerCore::register_file(const string &file_name, LibPtr owner_lib
       SrcFilePtr new_file = SrcFilePtr(new SrcFile(full_file_name, short_file_name, owner_lib));
       std::string func_name = "src_" + new_file->short_file_name + fmt_format("{:x}", vk::std_hash(full_file_name));
       new_file->main_func_name = replace_non_alphanum(std::move(func_name));
+      new_file->is_from_functions_file = builtin;
       vk::string_view unified_file_name{new_file->file_name};
       if (unified_file_name.starts_with(settings().base_dir.get())) {
         unified_file_name.remove_prefix(settings().base_dir.get().size());
@@ -313,8 +314,8 @@ void CompilerCore::register_main_file(const string &file_name, DataStream<SrcFil
   }
 }
 
-SrcFilePtr CompilerCore::require_file(const string &file_name, LibPtr owner_lib, DataStream<SrcFilePtr> &os, bool error_if_not_exists /* = true */) {
-  SrcFilePtr file = register_file(file_name, owner_lib);
+SrcFilePtr CompilerCore::require_file(const string &file_name, LibPtr owner_lib, DataStream<SrcFilePtr> &os, bool error_if_not_exists /* = true */, bool builtin) {
+  SrcFilePtr file = register_file(file_name, owner_lib, builtin);
   kphp_error (file || !error_if_not_exists, fmt_format("Cannot load file [{}]", file_name));
   if (file && try_require_file(file)) {
     os << file;

--- a/compiler/compiler-core.h
+++ b/compiler/compiler-core.h
@@ -56,10 +56,10 @@ public:
 
   std::string search_required_file(const std::string &file_name) const;
   std::string search_file_in_include_dirs(const std::string &file_name, size_t *dir_index = nullptr) const;
-  SrcFilePtr register_file(const string &file_name, LibPtr owner_lib);
+  SrcFilePtr register_file(const string &file_name, LibPtr owner_lib, bool builtin = false);
 
   void register_main_file(const string &file_name, DataStream<SrcFilePtr> &os);
-  SrcFilePtr require_file(const string &file_name, LibPtr owner_lib, DataStream<SrcFilePtr> &os, bool error_if_not_exists = true);
+  SrcFilePtr require_file(const string &file_name, LibPtr owner_lib, DataStream<SrcFilePtr> &os, bool error_if_not_exists = true, bool builtin = false);
 
   void require_function(const string &name, DataStream<FunctionPtr> &os);
   void require_function(FunctionPtr function, DataStream<FunctionPtr> &os);

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -204,7 +204,9 @@ bool compiler_execute(CompilerSettings *settings) {
   G->register_main_file(settings->main_file.get(), src_file_stream);
 
   if (!G->settings().functions_file.get().empty()) {
-    G->require_file(G->settings().functions_file.get(), LibPtr{}, src_file_stream);
+    bool builtin = true;
+    bool error_if_not_exists = true;
+    G->require_file(G->settings().functions_file.get(), LibPtr{}, src_file_stream, error_if_not_exists, builtin);
   }
 
   static lockf_wrapper unique_file_lock;

--- a/compiler/data/src-file.cpp
+++ b/compiler/data/src-file.cpp
@@ -61,7 +61,7 @@ vk::string_view SrcFile::get_line(int id) {
 }
 
 bool SrcFile::is_builtin() const {
-  if (file_name == G->settings().functions_file.get()) {
+  if (is_from_functions_file) {
     return true;
   }
 

--- a/compiler/data/src-file.h
+++ b/compiler/data/src-file.h
@@ -23,6 +23,7 @@ public:
   bool loaded{false};
   bool is_required{false};
   bool is_strict_types{false}; // whether declare(strict_types=1) is set
+  bool is_from_functions_file{false}; // functions.txt + all files required from it
 
   std::string main_func_name;
   FunctionPtr main_function;

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -216,6 +216,7 @@ VertexAdaptor<op_require> GenTree::get_require(bool once) {
   const bool is_opened = open_parent();
   auto require = VertexAdaptor<op_require>::create(GenTree::get_expression());
   require->once = once;
+  require->builtin = processing_file->is_from_functions_file;
   if (is_opened) {
     CE(expect(tok_clpar, "')'"));
   }

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -36,8 +36,8 @@ private:
   DataStream<SrcFilePtr> &file_stream;
   DataStream<FunctionPtr> &function_stream;
 
-  SrcFilePtr require_file(const string &file_name, bool error_if_not_exists) {
-    return G->require_file(file_name, current_function->file_id->owner_lib, file_stream, error_if_not_exists);
+  SrcFilePtr require_file(const string &file_name, bool error_if_not_exists, bool builtin = false) {
+    return G->require_file(file_name, current_function->file_id->owner_lib, file_stream, error_if_not_exists, builtin);
   }
 
   void require_function(const string &name) {
@@ -140,8 +140,8 @@ private:
     // we assume that if it returns an instance, it'll reference the required class in one way or another
   }
 
-  VertexPtr make_require_call(VertexPtr root, const std::string &name, bool once) {
-    auto file = require_file(name, true);
+  VertexPtr make_require_call(VertexPtr root, const std::string &name, bool once, bool builtin = false) {
+    auto file = require_file(name, true, builtin);
     kphp_error_act (file, fmt_format("Cannot require [{}]\n", name), return root);
     VertexPtr call = VertexAdaptor<op_func_call>::create();
     call->set_string(file->main_func_name);
@@ -236,7 +236,7 @@ public:
       if (is_composer_autoload(name)) {
         return require_composer_autoload(root);
       }
-      return make_require_call(root, name, require->once);
+      return make_require_call(root, name, require->once, require->builtin);
     }
 
     return root;

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -122,6 +122,10 @@
       "once": {
         "type": "bool",
         "default": "false"
+      },
+      "builtin": {
+        "type": "bool",
+        "default": "false"
       }
     }
   },

--- a/functions.txt
+++ b/functions.txt
@@ -8,6 +8,9 @@ if (0) {
   define('PHP_SAPI', php_sapi_name());//"Defined in source code"
 }
 
+require_once __DIR__ . '/functions_uberh3.txt';
+require_once __DIR__ . '/functions_spl.txt';
+
 interface Throwable {
     public function getMessage () ::: string;
     public function getCode () ::: int;
@@ -54,31 +57,6 @@ class Error implements Throwable {
 
     final private function __clone() ::: void;
 }
-
-class ArithmeticError extends Error {}
-class DivisionByZeroError extends ArithmeticError {}
-class AssertionError extends Error {}
-class CompileError extends Error {}
-class ParseError extends CompileError {}
-class TypeError extends Error {}
-class ArgumentCountError extends TypeError {}
-class ValueError extends Error {}
-class UnhandledMatchError extends Error {}
-
-class LogicException extends Exception {}
-class BadFunctionCallException extends LogicException {}
-class BadMethodCallException extends BadFunctionCallException {}
-class DomainException extends LogicException {}
-class InvalidArgumentException extends LogicException {}
-class LengthException extends LogicException {}
-class OutOfRangeException extends LogicException {}
-
-class RuntimeException extends Exception {}
-class OutOfBoundsException extends RuntimeException {}
-class OverflowException extends RuntimeException {}
-class RangeException extends RuntimeException {}
-class UnderflowException extends RuntimeException {}
-class UnexpectedValueException extends RuntimeException {}
 
 interface Memcache {
     public function get (string|string[] $key) ::: mixed;
@@ -1297,50 +1275,6 @@ function confdata_get_values_by_predefined_wildcard($wildcard ::: string) ::: mi
 function profiler_set_log_suffix($suffix ::: string) ::: void;
 function profiler_set_function_label($label ::: string) ::: void;
 function profiler_is_enabled() ::: bool;
-
-// uber h3 bindings https://h3geo.org/docs
-final class UberH3 {
-  // Indexing functions: https://h3geo.org/docs/api/indexing
-  static public function geoToH3(float $latitude, float $longitude, int $resolution) ::: int;
-  static public function h3ToGeo(int $h3_index) ::: tuple(float, float);
-  static public function h3ToGeoBoundary(int $h3_index) ::: tuple(float, float)[];
-
-  // Index inspection functions: https://h3geo.org/docs/api/inspection
-  static public function h3GetResolution(int $h3_index) ::: int;
-  static public function h3GetBaseCell(int $h3_index) ::: int;
-  static public function stringToH3(string $h3_index_str) ::: int;
-  static public function h3ToString(int $h3_index) ::: string;
-  static public function h3IsValid(int $h3_index) ::: bool;
-  static public function h3IsResClassIII(int $h3_index) ::: bool;
-  static public function h3IsPentagon(int $h3_index) ::: bool;
-  static public function h3GetFaces(int $h3_index) ::: int[];
-  static public function maxFaceCount(int $h3_index) ::: int;
-
-  // Grid traversal functions: https://h3geo.org/docs/api/traversal
-  static public function kRing(int $h3_index_origin, int $k) ::: int[] | false;
-  static public function maxKringSize(int $k) ::: int;
-  static public function kRingDistances(int $h3_index_origin, int $k) ::: tuple(int, int)[] | false;
-  static public function hexRange(int $h3_index_origin, int $k) ::: int[] | false;
-  static public function hexRangeDistances(int $h3_index_origin, int $k) ::: tuple(int, int)[] | false;
-  static public function hexRanges(int[] $h3_indexes, int $k) ::: int[] | false;
-  static public function hexRing(int $h3_index_origin, int $k) ::: int[] | false;
-  static public function h3Line(int $h3_index_start, int $h3_index_end) ::: int[] | false;
-  static public function h3LineSize(int $h3_index_start, int $h3_index_end) ::: int;
-  static public function h3Distance(int $h3_index_start, int $h3_index_end) ::: int;
-
-  // Hierarchical grid functions: https://h3geo.org/docs/api/hierarchy
-  static public function h3ToParent(int $h3_index, int $parent_resolution) ::: int;
-  static public function h3ToChildren(int $h3_index, int $children_resolution) ::: int[] | false;
-  static public function maxH3ToChildrenSize(int $h3_index, int $children_resolution) ::: int;
-  static public function h3ToCenterChild(int $h3_index, int $children_resolution) ::: int;
-  static public function compact(int[] $h3_indexes) ::: int[] | false;
-  static public function uncompact(int[] $h3_indexes, int $resolution) ::: int[] | false;
-  static public function maxUncompactSize(int[] $h3_indexes, int $resolution) ::: int;
-
-  // Region functions: https://h3geo.org/docs/api/regions
-  static public function polyfill(tuple(float, float)[] $polygon_boundary, tuple(float, float)[][] $holes, int $resolution) ::: int[] | false;
-  static public function maxPolyfillSize(tuple(float, float)[] $polygon_boundary, tuple(float, float)[][] $holes, int $resolution) ::: int;
-}
 
 /** Job workers interface **/
 

--- a/functions_spl.txt
+++ b/functions_spl.txt
@@ -1,0 +1,26 @@
+<?php
+
+class ArithmeticError extends Error {}
+class DivisionByZeroError extends ArithmeticError {}
+class AssertionError extends Error {}
+class CompileError extends Error {}
+class ParseError extends CompileError {}
+class TypeError extends Error {}
+class ArgumentCountError extends TypeError {}
+class ValueError extends Error {}
+class UnhandledMatchError extends Error {}
+
+class LogicException extends Exception {}
+class BadFunctionCallException extends LogicException {}
+class BadMethodCallException extends BadFunctionCallException {}
+class DomainException extends LogicException {}
+class InvalidArgumentException extends LogicException {}
+class LengthException extends LogicException {}
+class OutOfRangeException extends LogicException {}
+
+class RuntimeException extends Exception {}
+class OutOfBoundsException extends RuntimeException {}
+class OverflowException extends RuntimeException {}
+class RangeException extends RuntimeException {}
+class UnderflowException extends RuntimeException {}
+class UnexpectedValueException extends RuntimeException {}

--- a/functions_uberh3.txt
+++ b/functions_uberh3.txt
@@ -1,0 +1,45 @@
+<?php
+
+// uber h3 bindings https://h3geo.org/docs
+final class UberH3 {
+  // Indexing functions: https://h3geo.org/docs/api/indexing
+  static public function geoToH3(float $latitude, float $longitude, int $resolution) ::: int;
+  static public function h3ToGeo(int $h3_index) ::: tuple(float, float);
+  static public function h3ToGeoBoundary(int $h3_index) ::: tuple(float, float)[];
+
+  // Index inspection functions: https://h3geo.org/docs/api/inspection
+  static public function h3GetResolution(int $h3_index) ::: int;
+  static public function h3GetBaseCell(int $h3_index) ::: int;
+  static public function stringToH3(string $h3_index_str) ::: int;
+  static public function h3ToString(int $h3_index) ::: string;
+  static public function h3IsValid(int $h3_index) ::: bool;
+  static public function h3IsResClassIII(int $h3_index) ::: bool;
+  static public function h3IsPentagon(int $h3_index) ::: bool;
+  static public function h3GetFaces(int $h3_index) ::: int[];
+  static public function maxFaceCount(int $h3_index) ::: int;
+
+  // Grid traversal functions: https://h3geo.org/docs/api/traversal
+  static public function kRing(int $h3_index_origin, int $k) ::: int[] | false;
+  static public function maxKringSize(int $k) ::: int;
+  static public function kRingDistances(int $h3_index_origin, int $k) ::: tuple(int, int)[] | false;
+  static public function hexRange(int $h3_index_origin, int $k) ::: int[] | false;
+  static public function hexRangeDistances(int $h3_index_origin, int $k) ::: tuple(int, int)[] | false;
+  static public function hexRanges(int[] $h3_indexes, int $k) ::: int[] | false;
+  static public function hexRing(int $h3_index_origin, int $k) ::: int[] | false;
+  static public function h3Line(int $h3_index_start, int $h3_index_end) ::: int[] | false;
+  static public function h3LineSize(int $h3_index_start, int $h3_index_end) ::: int;
+  static public function h3Distance(int $h3_index_start, int $h3_index_end) ::: int;
+
+  // Hierarchical grid functions: https://h3geo.org/docs/api/hierarchy
+  static public function h3ToParent(int $h3_index, int $parent_resolution) ::: int;
+  static public function h3ToChildren(int $h3_index, int $children_resolution) ::: int[] | false;
+  static public function maxH3ToChildrenSize(int $h3_index, int $children_resolution) ::: int;
+  static public function h3ToCenterChild(int $h3_index, int $children_resolution) ::: int;
+  static public function compact(int[] $h3_indexes) ::: int[] | false;
+  static public function uncompact(int[] $h3_indexes, int $resolution) ::: int[] | false;
+  static public function maxUncompactSize(int[] $h3_indexes, int $resolution) ::: int;
+
+  // Region functions: https://h3geo.org/docs/api/regions
+  static public function polyfill(tuple(float, float)[] $polygon_boundary, tuple(float, float)[][] $holes, int $resolution) ::: int[] | false;
+  static public function maxPolyfillSize(tuple(float, float)[] $polygon_boundary, tuple(float, float)[][] $holes, int $resolution) ::: int;
+}


### PR DESCRIPTION
Just as before, we specify a path to a **root** `functions.txt` file.
That file can make a `require_once()` call to another file that
will be processed as a part of builtin declarations.

We achieve this behavior by marking the root functions file with
a flag `is_from_functions_file`. Then, every file required from
it will inherit that flag. `file->is_builtin()` will respect that flag.

This change is motivated not only by a need to logically separate the
definitions, but also to make it possible to move some declarations
to another namespace. For example, FFI-related `CData` class should
be declared in `FFI` namespace (`\FFI\CData`).
This is required to make our implementation (#295) closer to the PHP implementation.

I only did a minimal separation for now as a proof of concept.
We can re-arrange them later.