### PR TITLE
fixed `parse_str` behavior with empty or `null` string

### DIFF
--- a/runtime/url.cpp
+++ b/runtime/url.cpp
@@ -201,6 +201,10 @@ void parse_str_set_value(mixed &arr, const string &key, const string &value) {
 }
 
 void f$parse_str(const string &str, mixed &arr) {
+  if (str.empty()) {
+    return;
+  }
+
   arr = array<mixed>();
 
   array<string> par = explode('&', str, INT_MAX);

--- a/tests/phpt/dl/481_parse_str_with_empty_string.php
+++ b/tests/phpt/dl/481_parse_str_with_empty_string.php
@@ -1,0 +1,10 @@
+@ok
+<?php
+
+$params = [];
+parse_str("", $params);
+var_dump($params);
+
+$params = [];
+parse_str(null, $params);
+var_dump($params);


### PR DESCRIPTION
Before:
```
array(1) {
  [""]=>
  string(0) ""
}
```
After:
```
array(0) {
}
```