### PR TITLE
Try to fix SIGSEGV in job workers

### DIFF
--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -295,6 +295,16 @@ void rollback_malloc_replacement() noexcept {
   MallocHooksSwitcher::get().switch_hooks(true);
 }
 
+MemoryReplacementGuard::MemoryReplacementGuard(memory_resource::unsynchronized_pool_resource &memory_resource, bool force_enable_disable) : force_enable_disable_(force_enable_disable) {
+  dl::enter_critical_section();
+  dl::set_current_script_allocator(memory_resource, force_enable_disable_);
+}
+
+MemoryReplacementGuard::~MemoryReplacementGuard() {
+  dl::restore_default_script_allocator(force_enable_disable_);
+  dl::leave_critical_section();
+}
+
 } // namespace dl
 
 // replace global operators new and delete for linked C++ code

--- a/runtime/allocator.h
+++ b/runtime/allocator.h
@@ -50,6 +50,13 @@ bool is_malloc_replaced() noexcept;
 void replace_malloc_with_script_allocator() noexcept;
 void rollback_malloc_replacement() noexcept;
 
+class MemoryReplacementGuard {
+  bool force_enable_disable_;
+public:
+  explicit MemoryReplacementGuard(memory_resource::unsynchronized_pool_resource &memory_resource, bool force_enable_disable = false);
+  ~MemoryReplacementGuard();
+};
+
 } // namespace dl
 
 // replace malloc so it starts to use a script memory

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -245,7 +245,7 @@ size_t array<T>::array_inner::estimate_size(int64_t &new_int_size, int64_t &new_
   new_string_size = std::max(new_string_size, int64_t{0});
 
   if (new_int_size + new_string_size > MAX_HASHTABLE_SIZE) {
-    php_critical_error ("max array size exceeded");
+    php_critical_error ("max array size exceeded: int_size = %" PRIi64 ", string_size = %" PRIi64, new_int_size, new_string_size);
   }
 
   if (is_vector) {
@@ -708,7 +708,7 @@ void array<T>::mutate_to_size(int64_t int_size) {
     return;
   }
   if (unlikely(int_size > array_inner::MAX_HASHTABLE_SIZE)) {
-    php_critical_error ("max array size exceeded");
+    php_critical_error ("max array size exceeded: int_size = %" PRIi64, int_size);
   }
   const auto new_int_buff_size = static_cast<uint32_t>(int_size);
   p = static_cast<array_inner *>(dl::reallocate(p, p->sizeof_vector(new_int_buff_size), p->sizeof_vector(p->int_buf_size)));

--- a/runtime/instance-copy-processor.h
+++ b/runtime/instance-copy-processor.h
@@ -9,6 +9,7 @@
 
 #include "common/mixin/not_copyable.h"
 
+#include "runtime/allocator.h"
 #include "runtime/kphp_core.h"
 #include "runtime/memory_resource/unsynchronized_pool_resource.h"
 
@@ -411,7 +412,7 @@ class_instance<T> copy_instance_into_other_memory(const class_instance<T> &insta
                                                   memory_resource::unsynchronized_pool_resource &memory_pool,
                                                   ExtraRefCnt memory_ref_cnt = ExtraRefCnt{ExtraRefCnt::extra_ref_cnt_value(0)},
                                                   ResourceCallbackOOM oom_callback = nullptr) noexcept {
-  dl::set_current_script_allocator(memory_pool, false);
+  dl::MemoryReplacementGuard shared_memory_guard{memory_pool};
 
   class_instance<T> copied_instance = instance;
   InstanceDeepCopyVisitor copyVisitor{memory_pool, memory_ref_cnt, oom_callback};
@@ -420,6 +421,5 @@ class_instance<T> copy_instance_into_other_memory(const class_instance<T> &insta
     copied_instance = class_instance<T>{};
   }
 
-  dl::restore_default_script_allocator(false);
   return copied_instance;
 }

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -223,7 +223,7 @@ void JobWorkerServer::store_job_response_error(const char *error_msg, int error_
   auto &memory_manager = vk::singleton<job_workers::SharedMemoryManager>::get();
   auto *response_memory = memory_manager.acquire_shared_message<job_workers::JobSharedMessage>();
   if (!response_memory) {
-    log_server_error("Can't store job response error: not enough shared memory");
+    log_server_error("Can't store job response error: not enough shared memory.\nUnstored error details: error_code = %d, error_msg = %s", error_code, error_msg);
     return;
   }
 


### PR DESCRIPTION
Most likely, SIGSEGV happened because some signal interrupted execution at the moment, when allocator was replaced to a shared memory resourse

relates to `KPHP-1349`