### PR TITLE
allowed `catch` without variable

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -263,7 +263,15 @@ void compile_try(VertexAdaptor<op_try> root, CodeGenerator &W) {
         if (!is_first_catch) {
           W << "else " << BEGIN << NL;
         }
-        move_exception(caught_class, catch_op->var());
+
+        // if 'catch' is used without a variable, then
+        // the current exception can simply be destroyed
+        if (catch_op->without_variable) {
+          W << "CurException.destroy();" << NL;
+        } else {
+          move_exception(caught_class, catch_op->var());
+        }
+
         W << catch_op->cmd() << NL;
         if (!is_first_catch) {
           W << END << NL;
@@ -277,7 +285,15 @@ void compile_try(VertexAdaptor<op_try> root, CodeGenerator &W) {
         }
         std::string e = gen_unique_name("e");
         W << BEGIN;
-        move_exception(caught_class, catch_op->var());
+
+        // if 'catch' is used without a variable, then
+        // the current exception can simply be destroyed
+        if (catch_op->without_variable) {
+          W << "CurException.destroy();" << NL;
+        } else {
+          move_exception(caught_class, catch_op->var());
+        }
+
         W << catch_op->cmd() << NL << END << NL;
       }
 

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1999,7 +1999,14 @@ VertexAdaptor<op_catch> GenTree::get_catch() {
   auto exception_class = cur->str_val;
   CE (expect(tok_func_name, "type that implements Throwable"));
   auto exception_var_name = get_expression();
-  CE (!kphp_error(exception_var_name, "Cannot parse catch"));
+  auto without_variable = false;
+
+  // if 'catch' without variable
+  if (!exception_var_name) {
+    exception_var_name = create_superlocal_var("catch_");
+    without_variable = true;
+  }
+
   CE (!kphp_error(exception_var_name->type() == op_var, "Expected variable name in 'catch'"));
 
   CE (expect(tok_clpar, "')'"));
@@ -2008,6 +2015,7 @@ VertexAdaptor<op_catch> GenTree::get_catch() {
 
   auto catch_op = VertexAdaptor<op_catch>::create(exception_var_name.as<op_var>(), embrace(catch_body));
   catch_op->type_declaration = resolve_uses(cur_function, static_cast<std::string>(exception_class), '\\');
+  catch_op->without_variable = without_variable;
 
   return catch_op;
 }

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -1659,6 +1659,9 @@
       },
       "exception_class": {
         "type": "ClassPtr"
+      },
+      "without_variable": {
+        "type": "bool"
       }
     },
     "props": {

--- a/tests/phpt/exceptions/18_catch_without_variable.php
+++ b/tests/phpt/exceptions/18_catch_without_variable.php
@@ -1,0 +1,16 @@
+@ok php8
+<?php
+
+try {
+  throw new Exception();
+} catch (Exception) {
+  echo "Exception\n";
+}
+
+try {
+  throw new Exception();
+} catch (Exception) {
+  echo "Exception\n";
+} catch (Error) {
+  echo "FAIL\n";
+}


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/non-capturing_catches

A `catch` without a variable is a catch with the `without_variable`
flag set and with a variable with an autogenerated name. This variable
is further used as a placeholder.

At the stage of code generation, if the `without_variable` flag is set,
then we simply destroy the current exception, thereby handling it.

#290
