### PR TITLE
WIP: added support for property promotion

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -593,7 +593,7 @@ VertexPtr GenTree::get_expr_top(bool was_arrow) {
         func_call->set_string("McMemcache");
       }
 
-      res = gen_constructor_call_with_args(func_call->str_val, func_call->get_next()).set_location(func_call);
+      res = gen_constructor_call_with_args(func_call->str_val, func_call->as_vector()).set_location(func_call);
       CE(res);
       break;
     }
@@ -872,8 +872,26 @@ VertexPtr GenTree::get_def_value() {
   return val;
 }
 
+AccessModifiers GenTree::try_get_visibility_modifiers() {
+  if (test_expect(tok_public)) {
+    return AccessModifiers::public_;
+  } else if (test_expect(tok_private)) {
+    return AccessModifiers::private_;
+  } else if (test_expect(tok_protected)) {
+    return AccessModifiers::protected_;
+  }
+  return AccessModifiers::not_modifier_;
+}
+
 VertexAdaptor<op_func_param> GenTree::get_func_param() {
   auto location = auto_location();
+
+  // if is promoted property
+  const auto access_modifier = try_get_visibility_modifiers();
+  // if there is a modifier
+  if (access_modifier != AccessModifiers::not_modifier_) {
+    next_cur();
+  }
 
   const TypeHint *type_hint = get_typehint();
   bool is_varg = false;
@@ -920,6 +938,7 @@ VertexAdaptor<op_func_param> GenTree::get_func_param() {
     v->type_hint = type_hint;
   }
   v->is_cast_param = is_cast_param;
+  v->access_modifier = access_modifier;
 
   return v;
 }
@@ -1052,7 +1071,7 @@ void GenTree::func_force_return(VertexAdaptor<op_function> func, VertexPtr val) 
     return_node = VertexAdaptor<op_return>::create();
   }
 
-  vector<VertexPtr> next = cmd->get_next();
+  vector<VertexPtr> next = cmd->as_vector();
   next.push_back(return_node);
   func->cmd_ref() = VertexAdaptor<op_seq>::create(next);
 }
@@ -1507,7 +1526,14 @@ VertexAdaptor<op_func_param_list> GenTree::parse_cur_function_param_list() {
   CE(expect(tok_clpar, "')'"));
 
   for (size_t i = 1; i < params_next.size(); ++i) {
-    if (!params_next[i]->has_default_value()) {
+    const auto &param = params_next[i];
+
+    // if promoted property outside constructor
+    if (cur_function->local_name() != ClassData::NAME_OF_CONSTRUCT && param->access_modifier != AccessModifiers::not_modifier_) {
+      kphp_error(0, "Cannot declare promoted property outside a constructor");
+    }
+
+    if (!param->has_default_value()) {
       kphp_error(!params_next[i - 1]->has_default_value(), "Optional parameter is provided before required");
     }
   }
@@ -1610,6 +1636,21 @@ VertexAdaptor<op_function> GenTree::get_function(TokenType tok, vk::string_view 
     } else if (modifiers.is_static()) {
       kphp_assert(cur_class);
       cur_class->members.add_static_method(cur_function);
+    }
+
+    // add all the promoted properties in constructor to the class
+    if (cur_function->is_constructor()) {
+      for (const auto &p : cur_function->get_params()) {
+        const auto &param = p.as<op_func_param>();
+
+        if (param->access_modifier != AccessModifiers::not_modifier_) {
+          const auto field_modifiers = FieldModifiers{param->access_modifier};
+          auto var = VertexAdaptor<op_var>::create().set_location(auto_location());
+          var->str_val = param->var()->str_val;
+
+          cur_class->members.add_instance_field(var, {}, field_modifiers, "", param->type_hint);
+        }
+      }
     }
 
     // the function is ready, register it;

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -128,6 +128,7 @@ public:
   VertexAdaptor<op_func_call> get_anonymous_function(TokenType tok = tok_function, bool is_static = false);
   VertexAdaptor<op_function> get_function(TokenType tok, vk::string_view phpdoc_str, FunctionModifiers modifiers, std::vector<VertexAdaptor<op_func_param>> *uses_of_lambda = nullptr);
 
+  AccessModifiers try_get_visibility_modifiers();
   ClassMemberModifiers parse_class_member_modifier_mask();
   VertexPtr get_class_member(vk::string_view phpdoc_str);
 

--- a/compiler/pipes/gen-tree-postprocess.cpp
+++ b/compiler/pipes/gen-tree-postprocess.cpp
@@ -256,7 +256,58 @@ VertexPtr GenTreePostprocessPass::on_exit_vertex(VertexPtr root) {
     return convert_array_with_spread_operators(array);
   }
 
+  if (auto fun = root.try_as<op_function>()) {
+    process_property_promotion(fun);
+  }
+
   return root;
+}
+
+void GenTreePostprocessPass::process_property_promotion(VertexAdaptor<op_function> &fun) const {
+  if (!fun->func_id->is_constructor()) {
+    return;
+  }
+
+  auto promoted_params = std::vector<VertexAdaptor<op_func_param>>();
+
+  // TODO: add flag 'with_property_promotion' instead of iterating over parameters here
+  const auto param_list = fun->param_list();
+  for (const auto &p : param_list->params()) {
+    const auto &param = p.try_as<op_func_param>();
+
+    if (param->access_modifier != AccessModifiers::not_modifier_) {
+      promoted_params.push_back(param);
+    }
+  }
+
+  if (promoted_params.empty()) {
+    return;
+  }
+
+  auto func_stmts = fun->cmd()->as_vector();
+
+  // create an expression like "$this-><name> = <name>" for each promoted property
+  // all such expressions are placed at the very beginning of the expression list
+  // inside the constructor to avoid collisions with existing expressions
+  for (const auto &param : promoted_params) {
+    const auto &param_name = param->var()->str_val;
+    const auto *field = current_function->class_id->get_instance_field(param_name);
+    if (!field) {
+      continue;
+    }
+
+    const auto prop_var = field->var;
+    const auto this_vertex = ClassData::gen_vertex_this(fun->location);
+
+    auto prop_fetch = VertexAdaptor<op_instance_prop>::create(this_vertex).set_location(fun->location);
+    prop_fetch->set_string(param_name);
+    prop_fetch->var_id = prop_var;
+
+    const auto set_vertex = VertexAdaptor<op_set>::create(prop_fetch, param->var().clone());
+    func_stmts.insert(func_stmts.begin(), set_vertex);
+  }
+
+  fun->cmd_ref() = VertexAdaptor<op_seq>::create(func_stmts);;
 }
 
 VertexAdaptor<op_array> array_vertex_from_slice(const VertexRange &args, size_t start, size_t end) {

--- a/compiler/pipes/gen-tree-postprocess.h
+++ b/compiler/pipes/gen-tree-postprocess.h
@@ -23,4 +23,5 @@ public:
 
   // converts the spread operator (...$a) to a call to the array_merge_spread function
   static VertexPtr convert_array_with_spread_operators(VertexAdaptor<op_array> array_vertex);
+  void process_property_promotion(VertexAdaptor<op_function> &fun) const;
 };

--- a/compiler/pipes/preprocess-function.cpp
+++ b/compiler/pipes/preprocess-function.cpp
@@ -260,7 +260,7 @@ private:
     // just as ordinary positional argument:
     //   $this->fun(1, 2, 3) -> fun($this, 1, [2, 3])
 
-    const std::vector<VertexPtr> &cur_call_args = call->get_next();
+    const std::vector<VertexPtr> &cur_call_args = call->as_vector();
     auto positional_args_start = cur_call_args.begin();
 
     int min_args = func_args_n - 1; // variadic param may accept 0 args, so subtract 1

--- a/compiler/pipes/register-variables.h
+++ b/compiler/pipes/register-variables.h
@@ -10,7 +10,7 @@
 #include "compiler/function-pass.h"
 
 /**
- * 1. Function parametres (with default values)
+ * 1. Function parameters (with default values)
  * 2. Global variables
  * 3. Static local variables (with default values)
  * 4. Local variables

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -63,7 +63,7 @@ VertexPtr ResolveSelfStaticParentPass::on_enter_vertex(VertexPtr v) {
           this_vertex = VertexAdaptor<op_instance_prop>::create(this_vertex).set_location(v);
           this_vertex->set_string(LambdaClassData::get_parent_this_name());
         }
-        v = VertexAdaptor<op_func_call>::create(this_vertex, v->get_next()).set_location(v);
+        v = VertexAdaptor<op_func_call>::create(this_vertex, v->as_vector()).set_location(v);
         v->extra_type = op_ex_func_call_arrow;
         v->set_string(std::string{method->local_name()});
         v.as<op_func_call>()->func_id = method;

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -447,6 +447,10 @@
       "is_callable": {
         "type": "bool",
         "default": "false"
+      },
+      "access_modifier": {
+        "type": "AccessModifiers",
+        "default": "AccessModifiers::not_modifier_"
       }
     }
   },

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -7,6 +7,7 @@
 #include "common/wrappers/iterator_range.h"
 
 #include "compiler/common.h"
+#include "compiler/data/class-member-modifiers.h"
 #include "compiler/data/data_ptr.h"
 #include "compiler/data/vertex-adaptor.h"
 #include "compiler/inferring/expr-node.h"
@@ -166,7 +167,14 @@ public:
 
   VertexPtr &back() { return ith(size() - 1); }
 
-  std::vector<VertexPtr> get_next() { return std::vector<VertexPtr>(begin(), end()); }
+  /**
+   * as_vector returns a vector which is a set of VertexPtr that
+   * should be interpreted depending on the type of the vertex.
+   *
+   * For example, for 'op_seq' this will be equivalent to a list
+   * of vertices in the sequence.
+   */
+  std::vector<VertexPtr> as_vector() { return {begin(), end()}; }
 
   bool empty() { return size() == 0; }
 


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/constructor_promotion

Declaring class properties in constructor parameters can be called syntactic sugar, so it matches very well with the code that we are compiling now.
In fact, the following conversion process is currently taking place:

From:
```php
class Test {
    public function __construct(public Type $prop = DEFAULT) {}
}
```

To:
```php
class Test {
    public Type $prop;
 
    public function __construct(Type $prop = DEFAULT) {
        $this->prop = $prop;
    }
}
```

And also in its process the restrictions set by the language are checked.