### PR TITLE
fixed a bug with bin and hex literals

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -367,10 +367,12 @@ bool TokenLexerNum::parse(LexerData *lexer_data) const {
     binary,
   } state = before_dot;
 
-  if (s[0] == '0' && s[1] == 'x') {
+  const auto hex_symbol = vk::any_of_equal(s[1], 'x', 'X');
+  const auto bin_symbol = vk::any_of_equal(s[1], 'b', 'B');
+  if (s[0] == '0' && hex_symbol) {
     t += 2;
     state = hex;
-  } else if (s[0] == '0' && s[1] == 'b') {
+  } else if (s[0] == '0' && bin_symbol) {
     t += 2;
     state = binary;
   }
@@ -508,7 +510,7 @@ bool TokenLexerNum::parse(LexerData *lexer_data) const {
   }
 
   if (!is_float) {
-    if (s[0] == '0' && s[1] != 'x' && s[1] != 'b') {
+    if (s[0] == '0' && !hex_symbol && !bin_symbol) {
       for (int i = 0; i < t - s; i++) {
         if (s[i] < '0' || s[i] > '7') {
           return TokenLexerError("Bad octal number").parse(lexer_data);

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -11,6 +11,9 @@ TEST(lexer_test, test_php_tokens) {
     std::vector<std::string> expected;
   };
   std::vector<testCase> tests = {
+    {"0x10, 0X10", {"tok_int_const(0x10)", "tok_comma(,)", "tok_int_const(0X10)"}},
+    {"0b10, 0B10", {"tok_int_const(0b10)", "tok_comma(,)", "tok_int_const(0B10)"}},
+
     {"exit", {"tok_func_name(exit)"}},
     {"exit()", {"tok_func_name(exit)", "tok_oppar(()", "tok_clpar())"}},
     {"die", {"tok_func_name(die)"}},

--- a/tests/phpt/number_literals/001_hex.php
+++ b/tests/phpt/number_literals/001_hex.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+
+var_dump(0x10);
+var_dump(0X10);

--- a/tests/phpt/number_literals/002_bin.php
+++ b/tests/phpt/number_literals/002_bin.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+
+var_dump(0b10);
+var_dump(0B10);


### PR DESCRIPTION
Previously, using uppercase letters in binary and hexadecimal (`0B10` or `0XAA`) literals resulted in a parsing error.