### PR TITLE
added support of explicit octal numbers

### DIFF
--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -23,6 +23,8 @@ std::string debugTokenName(TokenType t) {
   constexpr auto name_pairs = vk::to_array<std::pair<TokenType, const char *>>({
     {tok_empty, "tok_empty"},
     {tok_int_const, "tok_int_const"},
+    {tok_int_octal_const, "tok_int_octal_const"},
+    {tok_int_octal_const_sep, "tok_int_octal_const_sep"},
     {tok_int_const_sep, "tok_int_const_sep"},
     {tok_float_const, "tok_float_const"},
     {tok_float_const_sep, "tok_float_const_sep"},

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -416,6 +416,21 @@ VertexPtr GenTree::get_op_num_const() {
     return get_vertex_with_str_val(VertexAdaptor<op_float_const>{}, val);
   }
 
+  if (cur->type() == tok_int_octal_const) {
+    std::string val = static_cast<string>(cur->str_val);
+    // hack, replace "o" with zero so that C++ treats the literal as valid
+    val[1] = '0';
+    return get_vertex_with_str_val(VertexAdaptor<op_int_const>{}, val);
+  }
+
+  if (cur->type() == tok_int_octal_const_sep) {
+    std::string val = static_cast<string>(cur->str_val);
+    // hack, replace "o" with zero so that C++ treats the literal as valid
+    val[1] = '0';
+    check_and_remove_num_separators(val);
+    return get_vertex_with_str_val(VertexAdaptor<op_int_const>{}, val);
+  }
+
   return VertexPtr{};
 }
 
@@ -492,6 +507,16 @@ VertexPtr GenTree::get_expr_top(bool was_arrow) {
       break;
     }
     case tok_int_const: {
+      res = get_op_num_const();
+      next_cur();
+      break;
+    }
+    case tok_int_octal_const: {
+      res = get_op_num_const();
+      next_cur();
+      break;
+    }
+    case tok_int_octal_const_sep: {
       res = get_op_num_const();
       next_cur();
       break;

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -367,10 +367,12 @@ bool TokenLexerNum::parse(LexerData *lexer_data) const {
     binary,
   } state = before_dot;
 
-  if (s[0] == '0' && s[1] == 'x') {
+  const auto hex_symbol = vk::any_of_equal(s[1], 'x', 'X');
+  const auto bin_symbol = vk::any_of_equal(s[1], 'b', 'B');
+  if (s[0] == '0' && hex_symbol) {
     t += 2;
     state = hex;
-  } else if (s[0] == '0' && s[1] == 'b') {
+  } else if (s[0] == '0' && bin_symbol) {
     t += 2;
     state = binary;
   }
@@ -508,7 +510,7 @@ bool TokenLexerNum::parse(LexerData *lexer_data) const {
   }
 
   if (!is_float) {
-    if (s[0] == '0' && s[1] != 'x' && s[1] != 'b') {
+    if (s[0] == '0' && !hex_symbol && !bin_symbol) {
       for (int i = 0; i < t - s; i++) {
         if (s[i] < '0' || s[i] > '7') {
           return TokenLexerError("Bad octal number").parse(lexer_data);

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -9,6 +9,8 @@
 enum TokenType {
   tok_empty,
   tok_int_const,
+  tok_int_octal_const,     // 0o123
+  tok_int_octal_const_sep, // 0o123_102
   tok_int_const_sep, // 1234_5678_9123
   tok_float_const,
   tok_float_const_sep, // 10_999.1000_9999

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -11,6 +11,9 @@ TEST(lexer_test, test_php_tokens) {
     std::vector<std::string> expected;
   };
   std::vector<testCase> tests = {
+    {"0x10, 0X10", {"tok_int_const(0x10)", "tok_comma(,)", "tok_int_const(0X10)"}},
+    {"0b10, 0B10", {"tok_int_const(0b10)", "tok_comma(,)", "tok_int_const(0B10)"}},
+
     {"exit", {"tok_func_name(exit)"}},
     {"exit()", {"tok_func_name(exit)", "tok_oppar(()", "tok_clpar())"}},
     {"die", {"tok_func_name(die)"}},

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -13,6 +13,8 @@ TEST(lexer_test, test_php_tokens) {
   std::vector<testCase> tests = {
     {"0x10, 0X10", {"tok_int_const(0x10)", "tok_comma(,)", "tok_int_const(0X10)"}},
     {"0b10, 0B10", {"tok_int_const(0b10)", "tok_comma(,)", "tok_int_const(0B10)"}},
+    {"0o10, 0O10", {"tok_int_octal_const(0o10)", "tok_comma(,)", "tok_int_octal_const(0O10)"}},
+    {"0o10_10",    {"tok_int_octal_const_sep(0o10_10)"}},
 
     {"exit", {"tok_func_name(exit)"}},
     {"exit()", {"tok_func_name(exit)", "tok_oppar(()", "tok_clpar())"}},

--- a/tests/phpt/number_literals/001_hex.php
+++ b/tests/phpt/number_literals/001_hex.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+
+var_dump(0x10);
+var_dump(0X10);

--- a/tests/phpt/number_literals/002_bin.php
+++ b/tests/phpt/number_literals/002_bin.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+
+var_dump(0b10);
+var_dump(0B10);

--- a/tests/phpt/number_literals/003_oct.php
+++ b/tests/phpt/number_literals/003_oct.php
@@ -1,0 +1,6 @@
+@ok
+<?php
+
+// Disabled until php8 on CI
+// var_dump(0o10);
+// var_dump(0O10);

--- a/tests/phpt/numeric_literal_separator/001_numeric_literal_ok.php
+++ b/tests/phpt/numeric_literal_separator/001_numeric_literal_ok.php
@@ -7,6 +7,13 @@ echo 0b100_100_100;
 echo 0b1_1_1_1;
 echo 0b11_11;
 
+// int 8
+// Disabled until php8 on CI
+// echo 0o100_100;
+// echo 0o100_777_100;
+// echo 0o1_2_4_5;
+// echo 0o11_22;
+
 // int 10
 echo 100_100;
 echo 100_999_100;


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/explicit_octal_notation

Example:
```php
0o10;
0O10;
```

#290 