### PR TITLE
fixed `parse_str` behavior

### DIFF
--- a/runtime/url.cpp
+++ b/runtime/url.cpp
@@ -201,7 +201,8 @@ void parse_str_set_value(mixed &arr, const string &key, const string &value) {
 }
 
 void f$parse_str(const string &str, mixed &arr) {
-  if (str.empty()) {
+  if (f$trim(str).empty()) {
+    arr = array<mixed>();
     return;
   }
 

--- a/tests/phpt/dl/481_parse_str_with_empty_string.php
+++ b/tests/phpt/dl/481_parse_str_with_empty_string.php
@@ -18,5 +18,5 @@ parse_str(' ', $params);
 var_dump($params);
 
 $params = null;
-parse_str(' \t\n', $params);
+parse_str('\t\n', $params);
 var_dump($params);

--- a/tests/phpt/dl/481_parse_str_with_empty_string.php
+++ b/tests/phpt/dl/481_parse_str_with_empty_string.php
@@ -8,3 +8,15 @@ var_dump($params);
 $params = [];
 parse_str(null, $params);
 var_dump($params);
+
+$params = [1,2,3];
+parse_str('', $params);
+var_dump($params);
+
+$params = null;
+parse_str(' ', $params);
+var_dump($params);
+
+$params = null;
+parse_str(' \t\n', $params);
+var_dump($params);


### PR DESCRIPTION
Function returns an empty array, not `null` if the string is empty, and also if it consists of whitespace characters,