### PR TITLE
Prevent job workers from waking up on new job while another one is running

### DIFF
--- a/net/net-reactor.cpp
+++ b/net/net-reactor.cpp
@@ -245,6 +245,9 @@ static int epoll_conv_flags(int flags) {
   if (!(flags & EVT_LEVEL)) {
     r |= EPOLLET;
   }
+  if (flags & EPOLLONESHOT) {
+    r |= EPOLLONESHOT;
+  }
   return r;
 }
 
@@ -323,7 +326,7 @@ int net_reactor_insert(net_reactor_ctx_t *ctx, int fd, int flags) {
     return 0;
   }
 
-  flags &= EVT_NEW | EVT_NOHUP | EVT_LEVEL | EVT_RWX;
+  flags &= EVT_NEW | EVT_NOHUP | EVT_LEVEL | EVT_RWX | EPOLLONESHOT;
   ev->ready = 0; // !!! this bugfix led to some AIO-related bugs, now fixed with the aid of C_REPARSE flag
   if ((ev->state & (EVT_LEVEL | EVT_RWX | EVT_IN_EPOLL)) == flags + EVT_IN_EPOLL) {
     return 0;

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -110,7 +110,7 @@ conn_type_t php_jobs_server = [] {
 
 } // namespace
 
-int JobWorkerServer::job_parse_execute(connection *c) {
+int JobWorkerServer::job_parse_execute(connection *c) noexcept {
   assert(c == read_job_connection);
 
   if (sigterm_on) {
@@ -183,7 +183,7 @@ int JobWorkerServer::job_parse_execute(connection *c) {
   return 0;
 }
 
-void JobWorkerServer::init() {
+void JobWorkerServer::init() noexcept {
   const auto &job_workers_ctx = vk::singleton<JobWorkersContext>::get();
 
   assert(job_workers_ctx.pipes_inited);
@@ -199,7 +199,7 @@ void JobWorkerServer::init() {
   job_reader = PipeJobReader{read_job_fd};
 }
 
-void JobWorkerServer::rearm_read_job_fd() {
+void JobWorkerServer::rearm_read_job_fd() noexcept {
   // We need to rearm fd because we use EPOLLONESHOT
   epoll_insert(read_job_fd, EPOLL_FLAGS);
 }
@@ -233,7 +233,7 @@ const char *JobWorkerServer::send_job_reply(JobSharedMessage *job_response) noex
   return nullptr;
 }
 
-void JobWorkerServer::store_job_response_error(const char *error_msg, int error_code) {
+void JobWorkerServer::store_job_response_error(const char *error_msg, int error_code) noexcept {
   php_assert(running_job);
 
   auto &memory_manager = vk::singleton<job_workers::SharedMemoryManager>::get();

--- a/server/job-workers/job-worker-server.cpp
+++ b/server/job-workers/job-worker-server.cpp
@@ -9,15 +9,13 @@
 #include "common/kprintf.h"
 #include "common/pipe-utils.h"
 
-#include "net/net-events.h"
 #include "net/net-connections.h"
+#include "net/net-events.h"
 
 #include "server/job-workers/job-message.h"
 #include "server/job-workers/job-worker-server.h"
 #include "server/job-workers/job-workers-context.h"
-#include "server/job-workers/job-stats.h"
 #include "server/job-workers/shared-memory-manager.h"
-#include "server/php-master-restart.h"
 #include "server/php-worker.h"
 #include "server/server-log.h"
 #include "server/server-stats.h"
@@ -62,11 +60,11 @@ void jobs_server_at_query_end(connection *c) {
   job_worker_server.reset_running_job();
   job_worker_server.rearm_read_job_fd();
 
-  assert (c->status != conn_wait_net);
+  assert(c->status != conn_wait_net);
 }
 
 int jobs_server_php_wakeup(connection *c) {
-  assert (c->status == conn_expect_query || c->status == conn_wait_net);
+  assert(c->status == conn_expect_query || c->status == conn_wait_net);
   c->status = conn_expect_query;
 
   auto *worker = reinterpret_cast<JobCustomData *>(c->custom_data)->worker;
@@ -75,13 +73,12 @@ int jobs_server_php_wakeup(connection *c) {
   if (timeout == 0) {
     jobs_server_at_query_end(c);
   } else {
-    assert (c->pending_queries >= 0 && c->status == conn_wait_net);
-    assert (timeout > 0);
+    assert(c->pending_queries >= 0 && c->status == conn_wait_net);
+    assert(timeout > 0);
     set_connection_timeout(c, timeout);
   }
   return 0;
 }
-
 
 conn_type_t php_jobs_server = [] {
   auto res = conn_type_t();
@@ -102,7 +99,7 @@ conn_type_t php_jobs_server = [] {
   res.init_outbound = server_failed;
   res.connected = server_failed;
   res.free_buffers = server_failed;
-  res.close = server_noop;    // can be on master termination, when fd is closed before SIGKILL is received
+  res.close = server_noop; // can be on master termination, when fd is closed before SIGKILL is received
 
   // The following handlers will be set to default ones:
   //    flush
@@ -186,7 +183,6 @@ int JobWorkerServer::job_parse_execute(connection *c) {
   return 0;
 }
 
-
 void JobWorkerServer::init() {
   const auto &job_workers_ctx = vk::singleton<JobWorkersContext>::get();
 
@@ -202,7 +198,6 @@ void JobWorkerServer::init() {
 
   job_reader = PipeJobReader{read_job_fd};
 }
-
 
 void JobWorkerServer::rearm_read_job_fd() {
   // We need to rearm fd because we use EPOLLONESHOT

--- a/server/job-workers/job-worker-server.h
+++ b/server/job-workers/job-worker-server.h
@@ -34,15 +34,15 @@ public:
 
   JobRequestStat job_stat;
 
-  void init();
+  void init() noexcept;
 
-  void rearm_read_job_fd();
+  void rearm_read_job_fd() noexcept;
 
-  int job_parse_execute(connection *c);
+  int job_parse_execute(connection *c) noexcept;
 
   void reset_running_job() noexcept;
 
-  void store_job_response_error(const char *error_msg, int error_code);
+  void store_job_response_error(const char *error_msg, int error_code) noexcept;
 
   void flush_job_stat() noexcept;
 

--- a/server/job-workers/job-worker-server.h
+++ b/server/job-workers/job-worker-server.h
@@ -36,6 +36,8 @@ public:
 
   void init();
 
+  void rearm_read_job_fd();
+
   int job_parse_execute(connection *c);
 
   void reset_running_job() noexcept;
@@ -47,6 +49,8 @@ public:
   bool reply_is_expected() const noexcept;
 
 private:
+  static const int EPOLL_FLAGS;
+
   const char *send_job_reply(JobSharedMessage *response) noexcept;
 
   JobSharedMessage *running_job{nullptr};

--- a/server/job-workers/job-worker-server.h
+++ b/server/job-workers/job-worker-server.h
@@ -49,8 +49,6 @@ public:
   bool reply_is_expected() const noexcept;
 
 private:
-  static const int EPOLL_FLAGS;
-
   const char *send_job_reply(JobSharedMessage *response) noexcept;
 
   JobSharedMessage *running_job{nullptr};


### PR DESCRIPTION
The main idea is to enable `EPOLLONESHOT` flag for fd we read new jobs from and rearm it only when job is already served.

relates to `KPHP-1353`