### PR TITLE
fix long_opeq.php test

### DIFF
--- a/tests/phpt/phc/codegen/long_opeq.php
+++ b/tests/phpt/phc/codegen/long_opeq.php
@@ -10,22 +10,7 @@
 		return 1;
 	}
 
-#ifndef KPHP
-  $_6 = f("six");
-  $_3 = f("three");
-  $_1 = f("one");
-  $x[$_1][2][$_3][4][5][$_6] += 1;
+  $x[f("one")][2][f("three")][4][5][f("six")] += 1;
 
-  if (false) {
-#endif
-  if (strpos(get_engine_version(), "Clang") !== false) {
-  	$x[f("six")][2][f("three")][4][5][f("one")] += 1;
-  } else {
-    $x[f("one")][2][f("three")][4][5][f("six")] += 1;
-  }
-
-#ifndef KPHP
-  }
-#endif
 	var_dump($x);
 ?>


### PR DESCRIPTION
After migrating to c++17 standard this test start failing. The reason is that prior c++17 evaluation order is unspecified, so compiler may call any functions. Thus fixating such order in test was a mistake.
But in c++17 [evaluation order](https://en.cppreference.com/w/cpp/language/eval_order) became more strict, and particularly in case of long_opeq.php test this order is determined.