### PR TITLE
fixed win_to_utf8 for new emoji and symbols

### DIFF
--- a/runtime/vkext.cpp
+++ b/runtime/vkext.cpp
@@ -348,7 +348,7 @@ void write_char_utf8(int c) {
     return;
   }
   // 2 bytes(11): 110x xxxx 10xx xxxx
-  if (c <= 0x800) {
+  if (c < 0x800) {
     write_buff_char_2((char)(0xC0 + (c >> 6)), (char)(0x80 + (c & 63)));
     return;
   }

--- a/tests/phpt/string_functions/004_vk_win_to_utf.php
+++ b/tests/phpt/string_functions/004_vk_win_to_utf.php
@@ -9,5 +9,11 @@ function test_utf_to_win_to_utf(string $utf_str) {
     assert_str_eq3($result, $utf_str);
 }
 
+// corner cases
+test_utf_to_win_to_utf("");    // 129
+test_utf_to_win_to_utf("ࠀ󠁴󠁿");    // 0x800
+test_utf_to_win_to_utf("𐀀󠁴󠁿");    // 0x10000
+
+// emoji
 test_utf_to_win_to_utf("🏴󠁧󠁢󠁳󠁣󠁴󠁿");
 test_utf_to_win_to_utf("💩");

--- a/vkext/vkext.cpp
+++ b/vkext/vkext.cpp
@@ -456,7 +456,7 @@ void write_char_utf8(int c) {
     return;
   }
   // 2 bytes(11): 110x xxxx 10xx xxxx
-  if (c <= 0x800) {
+  if (c < 0x800) {
     write_buff_char_2((char)(0xC0 + (c >> 6)), (char)(0x80 + (c & 63)));
     return;
   }


### PR DESCRIPTION
How to reproduce:
```
function test_vk_win_to_utf8(string $utf_str) {
  $win_str = (string)vk_utf8_to_win($utf_str);
  echo vk_win_to_utf8($win_str);
}

test_vk_win_to_utf8("🏴󠁧󠁢󠁳󠁣󠁴󠁿");
```

expected: 🏴󠁧󠁢󠁳󠁣󠁴󠁿
actual: 🏴$#917607;$#917602;$#917619;$#917603;$#917620;$#917631;