### PR TITLE
namespace name is interpreted as a single token

### DIFF
--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -341,7 +341,9 @@ bool TokenLexerName::parse(LexerData *lexer_data) const {
     t++; // consume '}'
   }
 
-  if (type == tok_func_name) {
+  // If the previous token is namespace, then we don't need to convert the
+  // value to keyword, since in PHP 8 their use as namespace name is allowed.
+  if (type == tok_func_name && !lexer_data->are_last_tokens(tok_namespace)) {
     const KeywordType *tp = KeywordsSet::get_type(name.begin(), name.size());
     if (tp != nullptr) {
       lexer_data->add_token((int)(t - st), tp->type, s, t);

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -113,6 +113,15 @@ TEST(lexer_test, test_php_tokens) {
 
     // combined tests
     {"echo \"{$x->y}\";", {"tok_echo(echo)", "tok_str_begin(\")", "tok_expr_begin({)", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end(})", "tok_str_end(\")", "tok_semicolon(;)"}},
+
+    // namespaces
+    {"namespace Foo\\Boo", {"tok_namespace(namespace)", "tok_func_name(Foo\\Boo)"}},
+    {"namespace \\Foo\\Boo", {"tok_namespace(namespace)", "tok_func_name(\\Foo\\Boo)"}},
+    {"namespace \\Foo", {"tok_namespace(namespace)", "tok_func_name(\\Foo)"}},
+    {"namespace iter\\fn", {"tok_namespace(namespace)", "tok_func_name(iter\\fn)"}},
+    {"namespace fn", {"tok_namespace(namespace)", "tok_func_name(fn)"}},
+    {"namespace try", {"tok_namespace(namespace)", "tok_func_name(try)"}},
+    {"namespace self", {"tok_namespace(namespace)", "tok_func_name(self)"}},
   };
 
   for (const auto &test : tests) {

--- a/tests/phpt/php8/namespaces/001_namespaces.php
+++ b/tests/phpt/php8/namespaces/001_namespaces.php
@@ -1,0 +1,14 @@
+@ok php8
+<?php
+
+require_once "src/fn/Foo.php";
+require_once "src/iter/fn/Foo.php";
+require_once "src/self/fn/Foo.php";
+
+use fn\Foo as Foo1;
+use iter\fn\Foo as Foo2;
+use self\Foo as Foo3;
+
+Foo1::run();
+Foo2::run();
+Foo2::run();

--- a/tests/phpt/php8/namespaces/002_namespace_with_spaces.php
+++ b/tests/phpt/php8/namespaces/002_namespace_with_spaces.php
@@ -1,0 +1,5 @@
+@kphp_should_fail php8
+/Bad function name/
+<?php
+
+namespace Foo \ Bar \ Baz;

--- a/tests/phpt/php8/namespaces/src/fn/Foo.php
+++ b/tests/phpt/php8/namespaces/src/fn/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace fn;
+
+class Foo {
+    public static function run() {
+        echo __METHOD__ . "\n";
+    }
+}

--- a/tests/phpt/php8/namespaces/src/iter/fn/Foo.php
+++ b/tests/phpt/php8/namespaces/src/iter/fn/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace iter\fn;
+
+class Foo {
+    public static function run() {
+        echo __METHOD__ . "\n";
+    }
+}

--- a/tests/phpt/php8/namespaces/src/self/fn/Foo.php
+++ b/tests/phpt/php8/namespaces/src/self/fn/Foo.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace self\fn;
+
+class Foo {
+    public static function run() {
+        echo __METHOD__ . "\n";
+    }
+}


### PR DESCRIPTION
RFC: https://wiki.php.net/rfc/namespaced_names_as_token

KPHP already interprets namespace names as a single token, like
PHP 8. The only change here is that now keywords after the
`namespace ` will not be converted to keyword tokens, thus it will
be possible to create a namespace with a name like a keyword,
as in PHP 8.

For example:

```php
namespace fn;
```

