### PR TITLE
wait_queue_size function

### DIFF
--- a/docs/kphp-language/best-practices/async-programming-forks.md
+++ b/docs/kphp-language/best-practices/async-programming-forks.md
@@ -344,6 +344,10 @@ Adds a fork to an existing queue; if *T2!=T*, leads to re-inferring *T=lca(T,T2)
 
 Returns if this queue is empty (no forks to wait).
 
+<aside>wait_queue_size( future_queue&lt;any&gt; ): int</aside>
+
+Returns queue size.
+
 <aside>wait_queue_next( future_queue&lt;T&gt; ): future&lt;T&gt;|false (resumable)</aside>
 
 Stops the current fork until any result of the queue is ready and lets other forks to run.

--- a/functions.txt
+++ b/functions.txt
@@ -911,6 +911,7 @@ function wait_concurrently ($id ::: future<any>) ::: bool;
 function wait_queue_create (array< future<any> | false > $request_ids = []) ::: future_queue<^1[*][*]>;
 function wait_queue_push (future_queue<any> &$queue_id, future<any> | false $request_ids) ::: void;
 function wait_queue_empty (future_queue<any> $queue_id) ::: bool;
+function wait_queue_size (future_queue<any> $queue_id) ::: int;
 /** @kphp-extern-func-info resumable */
 function wait_queue_next (future_queue<any> $queue_id, $timeout ::: float = -1.0) ::: future<^1[*]> | false;
 function wait_queue_next_synchronously (future_queue<any> $queue_id) ::: future<^1[*]> | false;

--- a/runtime/resumable.cpp
+++ b/runtime/resumable.cpp
@@ -1017,6 +1017,19 @@ bool f$wait_queue_empty(int64_t queue_id) {
   return q->left_functions == 0 && q->first_finished_function == -2;
 }
 
+int64_t f$wait_queue_size(int64_t queue_id) {
+  if (!is_wait_queue_id(queue_id)) {
+    if (queue_id != -1) {
+      php_warning("Wrong queue_id %" PRIi64 " in function wait_queue_size", queue_id);
+    }
+    return 0;
+  }
+
+  wait_queue *q = get_wait_queue(queue_id);
+  wait_queue_skip_gotten(q);
+  return q->left_functions;
+}
+
 static void wait_queue_next(int64_t queue_id, double timeout) {
   php_assert(timeout > get_precise_now()); // TODO remove asserts
   php_assert(in_main_thread()); // TODO remove asserts

--- a/runtime/resumable.h
+++ b/runtime/resumable.h
@@ -106,6 +106,7 @@ int64_t f$wait_queue_create();
 int64_t f$wait_queue_create(const mixed &resumable_ids);
 int64_t f$wait_queue_push(int64_t queue_id, const mixed &resumable_ids);
 bool f$wait_queue_empty(int64_t queue_id);
+int64_t f$wait_queue_size(int64_t queue_id);
 Optional<int64_t> f$wait_queue_next(int64_t queue_id, double timeout = -1.0);
 Optional<int64_t> f$wait_queue_next_synchronously(int64_t queue_id);
 

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -178,6 +178,10 @@ function test_jobs_in_wait_queue() {
   $ids = send_jobs($context);
 
   $wait_queue = wait_queue_create($ids);
+  if (wait_queue_size($wait_queue) !== 2) {
+    raise_error("Wrong queue size");
+    return;
+  }
 
   $id = wait_queue_next($wait_queue, 0.2);
   if ($id !== false) {
@@ -195,6 +199,12 @@ function test_jobs_in_wait_queue() {
     }
     $result[$ready_id] = gather_jobs([$ready_id])[0];
   }
+
+  if (wait_queue_size($wait_queue) !== 0) {
+    raise_error("Wrong queue size");
+    return;
+  }
+
   ksort($result);
 
   echo json_encode(["jobs-result" => array_values($result)]);


### PR DESCRIPTION
This function could be useful for job buffering

For example
```php
<?php

function foo(): int {
    sched_yield_sleep(0.001);

    return mt_rand(1, 10);
}

$queue = wait_queue_create([]);

function process(): void {
    global $queue;

    $ready_fork_id = wait_queue_next($queue);
    $result = wait($ready_fork_id);

    echo $result, PHP_EOL;
}

for ($i = 0; $i < 100; $i++) {
    $fork_id = fork(foo());
    wait_queue_push($queue, $fork_id);

    while (wait_queue_size($queue) >= 10) {
        process();
    }
}

while (!wait_queue_empty($queue)) {
    process();
}
```