### PR TITLE
Rework tracking references to the same instances on copying 

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -576,7 +576,7 @@ void ClassDeclaration::compile_accept_visitor_methods(CodeGenerator &W, ClassPtr
 
   if (klass->need_instance_cache_visitors) {
     W << NL;
-    compile_accept_visitor(W, klass, "InstanceUniqueIndexVisitor");
+    compile_accept_visitor(W, klass, "InstanceReferencesCountingVisitor");
     compile_accept_visitor(W, klass, "InstanceDeepCopyVisitor");
     compile_accept_visitor(W, klass, "InstanceDeepDestroyVisitor");
   }

--- a/runtime/job-workers/job-interface.h
+++ b/runtime/job-workers/job-interface.h
@@ -12,7 +12,7 @@
 #include "runtime/kphp_core.h"
 #include "runtime/refcountable_php_classes.h"
 
-class InstanceUniqueIndexVisitor;
+class InstanceReferencesCountingVisitor;
 
 class InstanceDeepCopyVisitor;
 
@@ -35,7 +35,7 @@ struct SendingInstanceBase : virtual abstract_refcountable_php_interface {
   virtual const char *get_class() const noexcept = 0;
   virtual int get_hash() const noexcept = 0;
 
-  virtual void accept(InstanceUniqueIndexVisitor &) noexcept = 0;
+  virtual void accept(InstanceReferencesCountingVisitor &) noexcept = 0;
   virtual void accept(InstanceDeepCopyVisitor &) noexcept = 0;
   virtual void accept(InstanceDeepDestroyVisitor &) noexcept = 0;
 
@@ -88,7 +88,7 @@ struct C$KphpJobWorkerResponseError: public refcountable_polymorphic_php_classes
     visitor("error_code", error_code);
   }
 
-  void accept(InstanceUniqueIndexVisitor &visitor) noexcept {
+  void accept(InstanceReferencesCountingVisitor &visitor) noexcept {
     return generic_accept(visitor);
   }
 

--- a/runtime/refcountable_php_classes.h
+++ b/runtime/refcountable_php_classes.h
@@ -18,42 +18,41 @@ public:
   virtual uint32_t get_refcnt() noexcept = 0;
   virtual void set_refcnt(uint32_t new_refcnt) noexcept = 0;
 
-  virtual uint32_t &get_unique_index_ref() noexcept = 0;
+  virtual void *get_instance_data_raw_ptr() noexcept = 0;
 };
 
 template<class ...Bases>
 class refcountable_polymorphic_php_classes : public Bases... {
 public:
   void add_ref() noexcept final {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      ++refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      ++refcnt;
     }
   }
 
   uint32_t get_refcnt() noexcept final {
-    return refcnt_;
+    return refcnt;
   }
 
   void release() noexcept final __attribute__((always_inline)) {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      --refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      --refcnt;
     }
-    if (refcnt_ == 0) {
+    if (refcnt == 0) {
       delete this;
     }
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept final {
-    refcnt_ = new_refcnt;
+    refcnt = new_refcnt;
   }
 
-  uint32_t &get_unique_index_ref() noexcept final {
-    return unique_index_;
+  void *get_instance_data_raw_ptr() noexcept final {
+    return this;
   }
 
 private:
-  uint32_t refcnt_{0};
-  uint32_t unique_index_{0};
+  uint32_t refcnt{0};
 };
 
 template<class ...Interfaces>
@@ -68,56 +67,55 @@ public:
   refcountable_polymorphic_php_classes_virt() __attribute__((always_inline)) = default;
 
   void add_ref() noexcept final {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      ++refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      ++refcnt;
     }
   }
 
   uint32_t get_refcnt() noexcept final {
-    return refcnt_;
+    return refcnt;
   }
 
   void release() noexcept final __attribute__((always_inline)) {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      --refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      --refcnt;
     }
-    if (refcnt_ == 0) {
+    if (refcnt == 0) {
       delete this;
     }
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept final {
-    refcnt_ = new_refcnt;
+    refcnt = new_refcnt;
   }
 
-  uint32_t &get_unique_index_ref() noexcept final {
-    return unique_index_;
+  void *get_instance_data_raw_ptr() noexcept final {
+    return this;
   }
 
 private:
-  uint32_t refcnt_{0};
-  uint32_t unique_index_{0};
+  uint32_t refcnt{0};
 };
 
 template<class Derived>
 class refcountable_php_classes  : public ManagedThroughDlAllocator {
 public:
   void add_ref() noexcept {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      ++refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      ++refcnt;
     }
   }
 
   uint32_t get_refcnt() noexcept {
-    return refcnt_;
+    return refcnt;
   }
 
   void release() noexcept __attribute__((always_inline)) {
-    if (refcnt_ < ExtraRefCnt::for_global_const) {
-      --refcnt_;
+    if (refcnt < ExtraRefCnt::for_global_const) {
+      --refcnt;
     }
 
-    if (refcnt_ == 0) {
+    if (refcnt == 0) {
       static_assert(!std::is_polymorphic<Derived>{}, "Derived may not be polymorphic");
       /**
        * because of inheritance from ManagedThroughDlAllocator, which override operators new/delete
@@ -129,16 +127,14 @@ public:
   }
 
   void set_refcnt(uint32_t new_refcnt) noexcept {
-    refcnt_ = new_refcnt;
+    refcnt = new_refcnt;
   }
 
-  uint32_t &get_unique_index_ref() noexcept {
-    return unique_index_;
+  void *get_instance_data_raw_ptr() noexcept {
+    return this;
   }
-
 private:
-  uint32_t refcnt_{0};
-  uint32_t unique_index_{0};
+  uint32_t refcnt{0};
 };
 
 class refcountable_empty_php_classes {

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/JobRequest.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/JobRequest.php
@@ -1,0 +1,30 @@
+<?php
+
+
+namespace SharedMemoryPieceCopying;
+
+
+class JobRequest implements \KphpJobWorkerRequest {
+  /**
+   * @var SharedMemoryContext
+   */
+  public $shared_memory_context = null;
+  public $id = 0;
+  public $label = "";
+
+  /**
+   * JobRequest constructor.
+   * @param SharedMemoryContext|null $shared_memory_context
+   * @param int $id
+   * @param string $label
+   */
+  public function __construct(?SharedMemoryContext $shared_memory_context, int $id, string $label)
+  {
+    $this->shared_memory_context = $shared_memory_context;
+    $this->id = $id;
+    $this->label = $label;
+  }
+
+
+}
+

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/JobResponse.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/JobResponse.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace SharedMemoryPieceCopying;
+
+
+class JobResponse implements \KphpJobWorkerResponse
+{
+  public int $ans = 0;
+
+  /**
+   * @var SomeContext
+   */
+  public $instance_from_shared_mem = null;
+
+  /**
+   * @var int[]
+   */
+  public $array_from_shared_mem = [];
+
+  /**
+   * @var mixed
+   */
+  public $mixed_from_shared_mem = null;
+  public $string_from_shared_mem = "";
+}

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/SharedMemoryContext.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/SharedMemoryContext.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace SharedMemoryPieceCopying;
+
+/**
+ * @kphp-immutable-class
+ */
+class SharedMemoryContext implements \KphpJobWorkerSharedMemoryPiece {
+  /**
+   * @var SomeContext
+   */
+  public $instance = null;
+
+  /**
+   * @var int[]
+   */
+  public $array = [];
+
+  /**
+   * @var mixed
+   */
+  public $mixed = null;
+  public $string = "";
+
+  /**
+   * SharedMemoryContext constructor.
+   * @param SomeContext|null $instance
+   * @param int[] $array
+   * @param mixed|null $mixed
+   * @param string $string
+   */
+  public function __construct(?SomeContext $instance, array $array, $mixed, string $string)
+  {
+    $this->instance = $instance;
+    $this->array = $array;
+    $this->mixed = $mixed;
+    $this->string = $string;
+  }
+}

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/SomeContext.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/SomeContext.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace SharedMemoryPieceCopying;
+
+/**
+ * @kphp-immutable-class
+ */
+class SomeContext {
+  /**
+   * @var int[]
+   */
+  public $some_data = [];
+
+  /**
+   * SomeContext constructor.
+   * @param int[] $arr
+   */
+  public function __construct(array $arr)
+  {
+    $this->some_data = $arr;
+  }
+
+
+}

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/http_worker.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/http_worker.php
@@ -1,0 +1,73 @@
+<?php
+
+use SharedMemoryPieceCopying\JobRequest;
+use SharedMemoryPieceCopying\JobResponse;
+use SharedMemoryPieceCopying\SharedMemoryContext;
+use SharedMemoryPieceCopying\SomeContext;
+
+function test_shared_memory_piece_copying() {
+  $data = json_decode(file_get_contents('php://input'));
+  $label = (string)$data['label'];
+
+  $some_data = [];
+  $string = "";
+  for ($i = 0; $i < 100; $i++) {
+    $some_data[] = $i;
+    $string = $string . "X";
+  }
+  $context = new SomeContext($some_data);
+
+  $array = $some_data;
+  $array[] = 101;
+
+  $mixed = $string . "X";
+
+  $shared_mem_context = new SharedMemoryContext($context, $array, $mixed, $string);
+  $reqs = [];
+  $jobs_num = get_job_workers_number();
+  if ($label === "job_request:instance") {
+    $jobs_num /= 2;
+  }
+  for ($i = 0; $i < $jobs_num; $i++) {
+    $reqs[] = new JobRequest($shared_mem_context, $i, $label);
+  }
+
+  $job_ids = kphp_job_worker_start_multi($reqs, -1);
+
+  $resumable_ids = [];
+  foreach ($job_ids as $id) {
+    if ($id) {
+      $resumable_ids[] = $id;
+    } else {
+      raise_error("Some job id is false after start");
+      return;
+    }
+  }
+
+  $responses = wait_multi($resumable_ids);
+
+  if ($label === "instance_cache:instance") {
+    for ($i = 0; $i < $jobs_num; $i++) {
+      /**
+       * @var $instance SomeContext
+       */
+      $instance = instance_cache_fetch(SomeContext::class, "test_$i");
+      for ($i = 0; $i < 100; $i++) {
+        if ($instance->some_data[$i] !== $some_data[$i]) {
+          raise_error("Data was changed in instance cache");
+        }
+      }
+    }
+  }
+
+  $result = ['jobs-result' => []];
+  foreach ($responses as $resp) {
+    if ($resp instanceof JobResponse) {
+      $result['jobs-result'][] = $resp->ans;
+    } else {
+      $result['jobs-result'][] = instance_to_array($resp);
+    }
+  }
+
+  echo json_encode($result);
+}

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/job_worker.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/job_worker.php
@@ -1,0 +1,43 @@
+<?php
+
+use SharedMemoryPieceCopying\JobRequest;
+use SharedMemoryPieceCopying\JobResponse;
+
+function run_shared_memory_piece_copying_job(JobRequest $req) {
+  $resp = new JobResponse();
+
+  $resp->ans = 42;
+
+  switch ($req->label) {
+    case "job_response:instance": {
+      $resp->instance_from_shared_mem = $req->shared_memory_context->instance;
+      break;
+    }
+    case "job_response:array": {
+      $resp->array_from_shared_mem = $req->shared_memory_context->array;
+      break;
+    }
+    case "job_response:mixed": {
+      $resp->mixed_from_shared_mem = $req->shared_memory_context->mixed;
+      break;
+    }
+    case "job_response:string": {
+      $resp->string_from_shared_mem = $req->shared_memory_context->string;
+      break;
+    }
+    case "job_request:instance": {
+      $req->label = "";
+      $inner_req_id = kphp_job_worker_start($req, -1);
+      if ($inner_req_id) {
+         $inner_resp = wait($inner_req_id);
+      }
+      break;
+    }
+    case "instance_cache:instance": {
+      instance_cache_store("test_" . $req->id, $req->shared_memory_context->instance);
+      break;
+    }
+  }
+
+  kphp_job_worker_store_response($resp);
+}

--- a/tests/python/tests/job_workers/php/http_worker.php
+++ b/tests/python/tests/job_workers/php/http_worker.php
@@ -75,6 +75,11 @@ function do_http_worker() {
       test_reference_invariant();
       return;
     }
+    case "/test_shared_memory_piece_in_response": {
+      require_once "SharedMemoryPieceCopying/http_worker.php";
+      test_shared_memory_piece_copying();
+      return;
+    }
   }
 
   critical_error("unknown test " . $_SERVER["PHP_SELF"]);

--- a/tests/python/tests/job_workers/php/job_worker.php
+++ b/tests/python/tests/job_workers/php/job_worker.php
@@ -39,6 +39,9 @@ function do_job_worker() {
   } else if ($req instanceof ReferenceInvariantRequest) {
     require_once "ReferenceInvariant/job_worker.php";
     run_job_reference_invariant($req);
+  } else if ($req instanceof \SharedMemoryPieceCopying\JobRequest) {
+    require_once "SharedMemoryPieceCopying/job_worker.php";
+    run_shared_memory_piece_copying_job($req);
   } else {
     run_job_shared_immutable_message_scenario($req);
   }

--- a/tests/python/tests/job_workers/test_job_shared_immutable_message.py
+++ b/tests/python/tests/job_workers/test_job_shared_immutable_message.py
@@ -92,3 +92,32 @@ class TestJobSharedImmutableMessage(KphpServerAutoTestCase):
                 "kphp_server.workers_job_memory_messages_extra_buffers_64mb_buffers_acquired": 0,
                 "kphp_server.workers_job_memory_messages_extra_buffers_64mb_buffer_acquire_fails": 0,
             })
+
+    def _test_shared_memory_piece_copying_impl(self, label):
+        for i in range(50):
+            resp = self.kphp_server.http_post(uri="/test_shared_memory_piece_in_response", json={
+                "label": label,
+            })
+            self.assertEqual(resp.status_code, 200)
+            for ans in resp.json()['jobs-result']:
+                self.assertEqual(ans, 42)
+
+    def test_copy_instance_from_shared_memory_piece_to_response(self):
+        self._test_shared_memory_piece_copying_impl("job_response:instance")
+
+    def test_copy_array_from_shared_memory_piece_to_job_response(self):
+        self._test_shared_memory_piece_copying_impl("job_response:array")
+
+    def test_copy_string_from_shared_memory_piece_to_job_response(self):
+        self._test_shared_memory_piece_copying_impl("job_response:string")
+
+    def test_copy_mixed_from_shared_memory_piece_to_job_response(self):
+        self._test_shared_memory_piece_copying_impl("job_response:mixed")
+
+    def test_copy_instance_from_shared_memory_piece_to_instance_cache(self):
+        self._test_shared_memory_piece_copying_impl("instance_cache:instance")
+
+    def test_copy_instance_from_shared_memory_piece_to_job_request(self):
+        self._test_shared_memory_piece_copying_impl("job_request:instance")
+
+


### PR DESCRIPTION
Now we use `std::unordered_map` instead of updating additional `unique_index_` member to track such references. It prevents data races when copying of shared memory is performed simultaneously from several processes.

relates to `KPHP-1399`