### PR TITLE
implemented `FFI::string()` function

### DIFF
--- a/functions.txt
+++ b/functions.txt
@@ -1351,5 +1351,7 @@ final class FFI {
 
   public static function isNull(\FFI\CData $cdata): bool;
 
+  public static function string(FFI\CData $ptr, ?int $size = null): string;
+
   private function __construct();
 }

--- a/runtime/ffi.h
+++ b/runtime/ffi.h
@@ -169,6 +169,16 @@ class_instance<C$FFI$Scope> f$FFI$$load(const string &filename);
 class_instance<C$FFI$Scope> f$FFI$$scope(const string &scope_name);
 
 template<class T>
+string f$FFI$$string(const T &v) {
+  return string(reinterpret_cast<const char*>(ffi_c_value_ptr(v)));
+}
+
+template<class T>
+string f$FFI$$string(const T &v, int64_t size) {
+  return string(reinterpret_cast<const char*>(ffi_c_value_ptr(v)), size);
+}
+
+template<class T>
 int64_t f$FFI$$sizeof(CDataPtr<T> cdata __attribute__ ((unused))) {
   return sizeof(CDataPtr<T>);
 }

--- a/tests/phpt/ffi/typing/052_string_arg_error.php
+++ b/tests/phpt/ffi/typing/052_string_arg_error.php
@@ -1,0 +1,7 @@
+@kphp_should_fail
+KPHP_ENABLE_FFI=1
+/\$ptr argument is FFI\\CData_uint16\*, expected a C string compatible type/
+<?php
+
+$v = FFI::new('uint16_t');
+$s = FFI::string(FFI::addr($v));

--- a/tests/python/tests/ffi/php/util/string.php
+++ b/tests/python/tests/ffi/php/util/string.php
@@ -1,0 +1,51 @@
+<?php
+
+function test_with_len_uint8ptr() {
+  $v = FFI::new('uint32_t');
+  $v->cdata = 0x78787861;
+  $ptr = FFI::cast('uint8_t*', FFI::addr($v));
+  $s = FFI::string($ptr, 4);
+  var_dump($s);
+  var_dump($s === 'axxx');
+}
+
+function test_with_len_int16ptr() {
+  $v = FFI::new('int16_t');
+  $v->cdata = 0x6161;
+  $s = FFI::string(FFI::addr($v), 2);
+  var_dump($s);
+  var_dump($s === 'aa');
+}
+
+function test_with_len_structptr() {
+  $cdef = FFI::cdef('
+    struct Foo {
+      char c1;
+      char c2;
+      char c3;
+    };
+  ');
+  $foo = $cdef->new('struct Foo');
+  $foo->c1 = "f";
+  $foo->c2 = "o";
+  $foo->c3 = "o";
+  $s = FFI::string(FFI::addr($foo), 3);
+  var_dump($s);
+  var_dump($s === 'foo');
+}
+
+function test_without_len() {
+  $v = FFI::new('uint32_t');
+  $v->cdata = 0x00617861;
+  $ptr = FFI::cast('char*', FFI::addr($v));
+  $s = FFI::string($ptr);
+  var_dump($s);
+  var_dump($s == 'axa');
+
+  // TODO: add tests with `const char*` when #357 is resolved.
+}
+
+test_with_len_uint8ptr();
+test_with_len_int16ptr();
+test_with_len_structptr();
+test_without_len();

--- a/tests/python/tests/ffi/test_ffi.py
+++ b/tests/python/tests/ffi/test_ffi.py
@@ -245,6 +245,9 @@ class TestFFI(KphpCompilerAutoTestCase):
     def test_util_isnull(self):
         self.ffi_build_and_compare_with_php('php/util/isnull.php')
 
+    def test_util_string(self):
+        self.ffi_build_and_compare_with_php('php/util/string.php')
+
     # multi-file tests
 
     def test_multifile(self):


### PR DESCRIPTION
PHP has 2 forms of that call:

1. With explicit length
2. Without explicit length

For (2) it requires the CData ptr to be `char*` or `const char*` (checked).
It also expects it to be null-terminated (unchecked).
If passed CData would be something incompatible, it gives a run time error.

KPHP would give a compile-time error for (2) function form.

For (1) both PHP and KPHP won't perform any type checking.

Refs #343