### PR TITLE
use relative file names in hashes/codegen/exceptions

### DIFF
--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -3,6 +3,7 @@
   <component name="Encoding" addBOMForNewFiles="with NO BOM">
     <file url="file://$PROJECT_DIR$/common/string-processing.cpp" charset="windows-1251" />
     <file url="file://$PROJECT_DIR$/objs/generated/auto/flex/vk-flex-data.cpp" charset="windows-1251" />
+    <file url="file://$PROJECT_DIR$/tests/phpt/dl/964_try.php" charset="windows-1251" />
     <file url="PROJECT" charset="UTF-8" />
   </component>
 </project>

--- a/compiler/code-gen/code-generator.cpp
+++ b/compiler/code-gen/code-generator.cpp
@@ -67,7 +67,7 @@ void CodeGenerator::close_file_clear_writer() {
 
 void CodeGenerator::feed_hash_of_comments(SrcFilePtr file, int line_num) {
   vk::string_view line_contents = file->get_line(line_num);
-  hash_of_comments = hash_of_comments * 56235515617499ULL + string_hash(line_contents.data(), line_contents.size());
+  hash_of_comments = hash_of_comments * 56235415617457ULL + string_hash(line_contents.data(), line_contents.size());
 }
 
 void CodeGenerator::add_include(const std::string &s) {

--- a/compiler/code-gen/code-generator.h
+++ b/compiler/code-gen/code-generator.h
@@ -55,7 +55,7 @@ private:
   int lock_comments_cnt;
 
   void feed_hash(unsigned long long val) {
-    hash_of_cpp = hash_of_cpp * 56235515617499ULL + val;
+    hash_of_cpp = hash_of_cpp * 56235415617457ULL + val;
   }
 
   void feed_hash_of_comments(SrcFilePtr file, int line_num);

--- a/compiler/code-gen/files/vars-cpp.cpp
+++ b/compiler/code-gen/files/vars-cpp.cpp
@@ -29,7 +29,7 @@ struct InitVar {
       kphp_assert(location.function && location.file);
       W << VarName(var) << ".init (" << var->init_val << ", "
         << RawString(location.function->name) << ", "
-        << RawString(location.file->unified_file_name + ':' + std::to_string(location.line))
+        << RawString(location.file->relative_file_name + ':' + std::to_string(location.line))
         << ");" << NL;
     } else {
       W << VarName(var) << " = " << var->init_val << ";" << NL;

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1122,7 +1122,7 @@ bool compile_tracing_profiler(FunctionPtr func, CodeGenerator &W) {
   const auto &location = func->root->get_location();
   const char *is_root = func->profiler_state == FunctionData::profiler_status::enable_as_root ? "true" : "false";
   W << "struct TracingProfilerTraits " << BEGIN
-    << "static constexpr const char *file_name() noexcept { return " << RawString(location.file->unified_file_name) << "; }" << NL
+    << "static constexpr const char *file_name() noexcept { return " << RawString(location.file->relative_file_name) << "; }" << NL
     << "static constexpr const char *function_name() noexcept { return " << RawString(func->get_human_readable_name(false)) << "; }" << NL
     << "static constexpr size_t function_line() noexcept { return " << std::max(location.line, 0) << "; }" << NL
     << "static constexpr size_t profiler_level() noexcept { return " << G->settings().profiler_level.get() << "; }" << NL

--- a/compiler/code-gen/writer-data.cpp
+++ b/compiler/code-gen/writer-data.cpp
@@ -64,7 +64,7 @@ void WriterData::dump(std::string &dest_str, const std::vector<Line>::iterator &
 
   if (file) {
     dest_str += "//source = [";
-    dest_str += file->unified_file_name;
+    dest_str += file->relative_file_name;
     dest_str += "]\n";
   }
 

--- a/compiler/data/function-data.cpp
+++ b/compiler/data/function-data.cpp
@@ -271,7 +271,7 @@ string FunctionData::get_human_readable_name(bool add_details) const {
   }
 
   if (add_details && is_instantiation_of_template_function()) {
-    auto &file = instantiation_of_template_function_location.get_file()->unified_file_name;
+    auto &file = instantiation_of_template_function_location.get_file()->relative_file_name;
     auto line = std::to_string(instantiation_of_template_function_location.line);
     result_name += " (instantiated at " + file + ":" + line + ")";
   }

--- a/compiler/data/lambda-interface-generator.cpp
+++ b/compiler/data/lambda-interface-generator.cpp
@@ -36,7 +36,7 @@ InterfacePtr LambdaInterfaceGenerator::generate() noexcept {
   } else {
     // for stable generation of comments
     invoke_fun_v->func_id->file_id = SrcFilePtr(new SrcFile());
-    invoke_fun_v->func_id->file_id->unified_file_name = interface->name;
+    invoke_fun_v->func_id->file_id->relative_file_name = interface->name;
     G->register_function(invoke_fun_v->func_id);
   }
   return registered_interface;

--- a/compiler/data/src-file.h
+++ b/compiler/data/src-file.h
@@ -13,13 +13,13 @@
 #include "compiler/debug.h"
 
 class SrcFile {
-  DEBUG_STRING_METHOD { return unified_file_name; }
+  DEBUG_STRING_METHOD { return relative_file_name; }
   
 public:
   int id{0};
   std::string text, file_name, short_file_name;
-  std::string unified_file_name;
-  std::string unified_dir_name;
+  std::string relative_file_name;
+  std::string relative_dir_name;
   bool loaded{false};
   bool is_required{false};
   bool is_strict_types{false}; // whether declare(strict_types=1) is set

--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -150,6 +150,7 @@ std::string debugTokenName(TokenType t) {
     {tok_arrow, "tok_arrow"},
     {tok_class_c, "tok_class_c"},
     {tok_file_c, "tok_file_c"},
+    {tok_file_relative_c, "tok_file_relative_c"},
     {tok_func_c, "tok_func_c"},
     {tok_dir_c, "tok_dir_c"},
     {tok_line_c, "tok_line_c"},

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -445,6 +445,11 @@ VertexPtr GenTree::get_expr_top(bool was_arrow) {
       next_cur();
       break;
     }
+    case tok_file_relative_c: {
+      res = get_vertex_with_str_val(VertexAdaptor<op_string>{}, processing_file->relative_file_name);
+      next_cur();
+      break;
+    }
     case tok_class_c: {
       res = get_vertex_with_str_val(VertexAdaptor<op_string>{}, cur_class ? cur_class->name : "");
       next_cur();

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1876,12 +1876,12 @@ void GenTree::parse_namespace_and_uses_at_top_of_file() {
   next_cur();
   kphp_error (test_expect(tok_func_name), "Namespace name expected");
   processing_file->namespace_name = static_cast<string>(cur->str_val);
-  std::string real_unified_dir = processing_file->unified_dir_name;
+  std::string real_relative_dir = processing_file->relative_dir_name;
   if (processing_file->owner_lib) {
-    vk::string_view current_file_unified_dir = real_unified_dir;
+    vk::string_view current_file_relative_dir = real_relative_dir;
     vk::string_view lib_unified_dir = processing_file->owner_lib->unified_lib_dir();
-    kphp_assert_msg(current_file_unified_dir.starts_with(lib_unified_dir), "lib processing file should be in lib dir");
-    real_unified_dir.erase(0, lib_unified_dir.size() + 1);
+    kphp_assert_msg(current_file_relative_dir.starts_with(lib_unified_dir), "lib processing file should be in lib dir");
+    real_relative_dir.erase(0, lib_unified_dir.size() + 1);
   }
   // to properly handle the vendor/ folder, assert from below is commented-out
   //string expected_namespace_name = replace_characters(real_unified_dir, '/', '\\');

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -228,11 +228,12 @@ void LexerData::hack_last_tokens() {
     tokens.back().type_ = tok_func_name;
   }
 
+  // "err" is a specific vkcom function, something like "new Exception"; it's ugly and should be removed somewhen
   if (are_last_tokens(except_token_tag<tok_function>{}, tok_func_name, tok_oppar, any_token_tag{})) {
     if (tokens[tokens.size() - 3].str_val == "err") {
       Token t = tokens.back();
       tokens.pop_back();
-      tokens.emplace_back(tok_file_c);
+      tokens.emplace_back(tok_file_relative_c);
       tokens.emplace_back(tok_comma);
       tokens.emplace_back(tok_line_c);
       if (t.type() != tok_clpar) {

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -595,7 +595,7 @@ void PerformanceIssuesReport::add_issues_and_require_flush(FunctionPtr function,
     return;
   }
   FunctionPerformanceIssues function_issues{
-    function->file_id->unified_file_name,
+    function->file_id->relative_file_name,
     prepare_for_json(function->get_human_readable_name(false)),
     std::move(issues)
   };

--- a/compiler/pipes/gen-tree-postprocess.cpp
+++ b/compiler/pipes/gen-tree-postprocess.cpp
@@ -113,7 +113,7 @@ VertexPtr process_require_lib(VertexAdaptor<op_func_call> require_lib_call) {
   if (txt_file_index <= php_file_index) {
     const std::string &txt_file = functions_txt_full.empty() ? functions_txt : functions_txt_full;
     if (SrcFilePtr header_file = G->register_file(txt_file, registered_lib)) {
-      lib->update_lib_main_file(header_file->file_name, header_file->unified_dir_name);
+      lib->update_lib_main_file(header_file->file_name, header_file->relative_dir_name);
       auto req_header_txt = make_require_once_call(header_file, require_lib_call);
       auto lib_run_global_call = VertexAdaptor<op_func_call>::create();
       lib_run_global_call->set_string(lib->run_global_function_name());
@@ -123,7 +123,7 @@ VertexPtr process_require_lib(VertexAdaptor<op_func_call> require_lib_call) {
   if (!new_vertex) {
     const std::string &php_file = index_php_full.empty() ? index_php : index_php_full;
     if (SrcFilePtr lib_index_file = G->register_file(php_file, registered_lib)) {
-      lib->update_lib_main_file(lib_index_file->file_name, lib_index_file->unified_dir_name);
+      lib->update_lib_main_file(lib_index_file->file_name, lib_index_file->relative_dir_name);
       new_vertex = make_require_once_call(lib_index_file, require_lib_call);
     }
   }

--- a/compiler/pipes/preprocess-exceptions.cpp
+++ b/compiler/pipes/preprocess-exceptions.cpp
@@ -39,8 +39,12 @@ VertexPtr PreprocessExceptions::on_exit_vertex(VertexPtr root) {
     return root;
   }
 
+  // file and line are passed to "new Exception" construction
+  // but we are using relative file name (relative to base dir) for two purposes:
+  // 1) file names on compilation servers have often /some/strange/absolute paths, strip them off
+  // 2) the result of codegeneration doesn't depend on username / project location
   auto file_arg = VertexAdaptor<op_string>::create().set_location(root->location);
-  file_arg->set_string(root->location.get_file()->file_name);
+  file_arg->set_string(root->location.get_file()->relative_file_name);
   auto line_arg = GenTree::create_int_const(root->location.get_line());
   return VertexAdaptor<op_exception_constructor_call>::create(call, file_arg, line_arg).set_location(root->location);
 }

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -120,6 +120,6 @@ inline void ResolveSelfStaticParentPass::check_access_to_class_from_this_file(Cl
   if (ref_class && !ref_class->can_be_php_autoloaded) {
     kphp_error(ref_class->file_id == current_function->file_id,
                fmt_format("Class {} can be accessed only from file {}, as it is not autoloadable",
-                          ref_class->name, ref_class->file_id->unified_file_name));
+                          ref_class->name, ref_class->file_id->relative_file_name));
   }
 }

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -105,7 +105,7 @@ Location::Location(const SrcFilePtr &file, const FunctionPtr &function, int line
 std::string Location::as_human_readable() const {
   std::string out;
 
-  out += file ? file->unified_file_name : "unknown file";
+  out += file ? file->relative_file_name : "unknown file";
   out += ":";
   out += std::to_string(line);
 
@@ -113,7 +113,7 @@ std::string Location::as_human_readable() const {
   if (function && function->type == FunctionData::func_local) {
     std::string function_name = function->get_human_readable_name();
     std::string psr4_file_name = replace_characters(function_name.substr(0, function_name.find(':')), '\\', '/') + ".php";
-    if (file && file->unified_file_name == psr4_file_name) {
+    if (file && file->relative_file_name == psr4_file_name) {
       function_name = function_name.substr(function_name.rfind('\\', psr4_file_name.size()) + 1);
     }
     out += "  in " + function_name;

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -140,6 +140,7 @@ enum TokenType {
 
   tok_class_c,
   tok_file_c,
+  tok_file_relative_c,
   tok_func_c,
   tok_dir_c,
   tok_line_c,

--- a/tests/phpt/cl/162_mix_class_and_null.php
+++ b/tests/phpt/cl/162_mix_class_and_null.php
@@ -131,7 +131,7 @@ echo $a ? $a->x : " ", "\n";
 
 $e = new Exception();
 if(0) $e = null;
-echo $e ? $e->getFile() : "", "\n";
+echo $e ? basename($e->getFile()) : "", "\n";
 if(1) $e = null;
-echo $e ? $e->getFile() : "", "\n";
+echo $e ? basename($e->getFile()) : "", "\n";
 

--- a/tests/phpt/dl/964_try.php
+++ b/tests/phpt/dl/964_try.php
@@ -11,7 +11,7 @@ function getException($desc) {
 function processException (Exception $e) {
   echo 'message: ',  $e->getMessage(), "\n";
   echo "code = ", $e->getCode(), "\n";
-  echo "file = ", $e->getFile(), "\n";
+  echo "file = ", basename($e->getFile()), "\n";
   echo "line = ", $e->getLine(), "\n"; 
 //  var_dump (count ($e->getTrace()));
   var_dump (@count ($e->getTraceAsString()));
@@ -40,7 +40,7 @@ try {
 } catch (Exception $e) {
     echo 'Выброшено исключение: ',  $e->getMessage(), "\n";
     echo "code = ", $e->getCode(), "\n";
-    echo "file = ", $e->getFile(), "\n";
+    echo "file = ", basename($e->getFile()), "\n";
     echo "line = ", $e->getLine(), "\n";
 //    var_dump (count ($e->getTrace()));
     var_dump (@count ($e->getTraceAsString()));

--- a/tests/phpt/exceptions/07_error_methods.php
+++ b/tests/phpt/exceptions/07_error_methods.php
@@ -8,7 +8,7 @@ function test() {
     var_dump([
       $e->getMessage(),
       $e->getCode(),
-      $e->getFile(),
+      basename($e->getFile()),
       $e->getLine(),
       count($e->getTrace()) !== 0,
       strlen($e->getTraceAsString()) !== 0,

--- a/tests/phpt/exceptions/08_exception_methods.php
+++ b/tests/phpt/exceptions/08_exception_methods.php
@@ -8,7 +8,7 @@ function test() {
     var_dump([
       $e->getMessage(),
       $e->getCode(),
-      $e->getFile(),
+      basename($e->getFile()),
       $e->getLine(),
       count($e->getTrace()) !== 0,
       strlen($e->getTraceAsString()) !== 0,

--- a/tests/phpt/exceptions/12_throwable_methods.php
+++ b/tests/phpt/exceptions/12_throwable_methods.php
@@ -8,7 +8,7 @@ function test() {
     var_dump([
       $e->getMessage(),
       $e->getCode(),
-      $e->getFile(),
+      basename($e->getFile()),
       $e->getLine(),
       count($e->getTrace()) !== 0,
       strlen($e->getTraceAsString()) !== 0,
@@ -22,7 +22,7 @@ function test() {
     var_dump([
       $e2->getMessage(),
       $e2->getCode(),
-      $e2->getFile(),
+      basename($e2->getFile()),
       $e2->getLine(),
       count($e2->getTrace()) !== 0,
       strlen($e2->getTraceAsString()) !== 0,

--- a/tests/phpt/exceptions/inheritance/02_access_inherited_props.php
+++ b/tests/phpt/exceptions/inheritance/02_access_inherited_props.php
@@ -9,7 +9,7 @@
 
 class MyException extends Exception {
   public function getLocation(): string {
-    return $this->file . ':' . $this->line;
+    return basename($this->file) . ':' . $this->line;
   }
 
   public function setLine(int $line): void {

--- a/tests/phpt/exceptions/inheritance/03_catch_derived_interface.php
+++ b/tests/phpt/exceptions/inheritance/03_catch_derived_interface.php
@@ -13,7 +13,8 @@ interface CustomExceptionInterface extends BaseCustomExceptionInterface {
 
 class BaseException extends Exception implements CustomExceptionInterface {
   public function describe(): string {
-    return "$this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "$relative:$this->line: $this->message";
   }
 
   public function isCustomException(): bool { return true; }

--- a/tests/phpt/exceptions/inheritance/04_catch_throwable.php
+++ b/tests/phpt/exceptions/inheritance/04_catch_throwable.php
@@ -6,7 +6,7 @@ class MyException extends Exception {}
 try {
   throw new Exception();
 } catch (Throwable $e) {
-  var_dump(__LINE__, $e->getFile(), get_class($e));
+  var_dump(__LINE__, basename($e->getFile()), get_class($e));
 }
 
 class Foo {

--- a/tests/phpt/exceptions/inheritance/05_catch_throwable2.php
+++ b/tests/phpt/exceptions/inheritance/05_catch_throwable2.php
@@ -7,13 +7,15 @@ interface CustomException {
 
 class BaseException extends Exception implements CustomException {
   public function toString(): string {
-    return "BaseException $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "BaseException $relative:$this->line: $this->message";
   }
 }
 
 class DerivedException extends Exception {
   public function toString(): string {
-    return "DerivedException $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "DerivedException $relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/inheritance/13_custom_ctor.php
+++ b/tests/phpt/exceptions/inheritance/13_custom_ctor.php
@@ -19,7 +19,7 @@ f($e);
 
 function f(Exception $e) {
   var_dump($e->getLine());
-  var_dump($e->getFile());
+  var_dump(basename($e->getFile()));
   var_dump($e->getMessage());
   var_dump($e->getCode());
 }

--- a/tests/phpt/exceptions/inheritance/14_default_ctor.php
+++ b/tests/phpt/exceptions/inheritance/14_default_ctor.php
@@ -14,7 +14,7 @@ f($e2);
 
 function f(Exception $e) {
   var_dump($e->getLine());
-  var_dump($e->getFile());
+  var_dump(basename($e->getFile()));
   var_dump($e->getMessage());
   var_dump($e->getCode());
 }

--- a/tests/phpt/exceptions/inheritance/16_inner_outer.php
+++ b/tests/phpt/exceptions/inheritance/16_inner_outer.php
@@ -8,7 +8,7 @@ class MyException2 extends \Exception {}
 class MyException1derived extends MyException1 {}
 
 function exception_string(Exception $e, string $tag): string {
-  return $e->getFile() . ':' . $e->getLine() . ':' . $tag;
+  return basename($e->getFile()) . ':' . $e->getLine() . ':' . $tag;
 }
 
 function test1() {

--- a/tests/phpt/exceptions/inheritance/24_throw_error.php
+++ b/tests/phpt/exceptions/inheritance/24_throw_error.php
@@ -7,13 +7,15 @@ interface CustomError {
 
 class BaseError extends Error implements CustomError {
   public function toString(): string {
-    return "BaseError $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "BaseError $relative:$this->line: $this->message";
   }
 }
 
 class DerivedError extends Error {
   public function toString(): string {
-    return "DerivedError $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "DerivedError $relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/inheritance/33_throw_throwable.php
+++ b/tests/phpt/exceptions/inheritance/33_throw_throwable.php
@@ -7,13 +7,15 @@ interface CustomException {
 
 class BaseException extends Exception implements CustomException {
   public function toString(): string {
-    return "BaseException $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "BaseException $relative:$this->line: $this->message";
   }
 }
 
 class DerivedException extends Exception {
   public function toString(): string {
-    return "DerivedException $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "DerivedException $relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/inheritance/37_with_implements.php
+++ b/tests/phpt/exceptions/inheritance/37_with_implements.php
@@ -9,7 +9,8 @@ interface StringInterface {
 
 class MyException extends Exception implements StringInterface {
   public function toString(): string {
-    return "$this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "$relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/inheritance/38_with_implements2.php
+++ b/tests/phpt/exceptions/inheritance/38_with_implements2.php
@@ -13,11 +13,13 @@ interface PrettyStringInterface {
 
 class MyException extends Exception implements StringInterface, PrettyStringInterface {
   public function toString(): string {
-    return "$this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "$relative:$this->line: $this->message";
   }
 
   public function toPrettyString(): string {
-    return "so pretty: $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "so pretty: $relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/inheritance/39_with_implements3.php
+++ b/tests/phpt/exceptions/inheritance/39_with_implements3.php
@@ -13,11 +13,13 @@ interface PrettyStringInterface {
 
 class MyError extends Error implements StringInterface, PrettyStringInterface {
   public function toString(): string {
-    return "$this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "$relative:$this->line: $this->message";
   }
 
   public function toPrettyString(): string {
-    return "so pretty: $this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "so pretty: $relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/exceptions/multicatch/01_catch_interface.php
+++ b/tests/phpt/exceptions/multicatch/01_catch_interface.php
@@ -9,7 +9,8 @@ interface CustomExceptionInterface {
 
 class BaseException extends Exception implements CustomExceptionInterface {
   public function describe(): string {
-    return "$this->file:$this->line: $this->message";
+    $relative = basename($this->file);
+    return "$relative:$this->line: $this->message";
   }
 }
 

--- a/tests/phpt/fork/012_exceptions.php
+++ b/tests/phpt/fork/012_exceptions.php
@@ -26,7 +26,7 @@ function my_pow ($x, $p = 5) {
 function processException (Exception $e) {
   echo 'message: ',  $e->getMessage(), "\n";
   echo "code = ", $e->getCode(), "\n";
-  echo "file = ", $e->getFile(), "\n";
+  echo "file = ", basename($e->getFile()), "\n";
   echo "line = ", $e->getLine(), "\n";
 }
 


### PR DESCRIPTION
This PR uses **relative file names instead of absolute** in several places.
A relative file name is a path **relative to basedir** or composer root:
* `/home/username/data/lib/main.php` -> `lib/main.php`
* `/home/username/data/packages/src/SomeClass.php` -> `packages/src/SomeClass.php`

**1) Hashes of file functions**
All files are implicitly wrapped into a function. Before, its name was a hash of an absolute path, now it's a hash of a relative path. Variables `src_xxx$called` that are created to support `require_once` calls, now also depend on relative paths.

**2) Comments in source code generation**
In C++, we insert a comment like `//source=[lib/main.php]` — now it's also relative.

**3) Exception construction**
`new Exception($message)` and Exception-derived classes were implicitly wrapped into `op_exception_constructor_call` with `__FILE__` and `__LINE__` arguments. Now, the argument is not `__FILE__,` but a relative path, which differs from PHP. I'm sure it's even more convenient, as file names are mostly used for logging and never used for direct files access.

**The purposes of these changes are the following:**
1) Real sources on compilation servers in TeamCity have often `/opt/strange/absolute` paths, strip them off.
2) The result of codegeneration now **doesn't depend on username / project location** — codegenerated C++ files become identical on different machines, which makes them interchangeable.

Also, this PR modifies a codegen hash multiplier to another big prime number. This will force regenerate all C++ sources on next run, and therefore all codegenerated comments will be updated to relative paths.