### PR TITLE
fixed `string::try_to_float_as_php8` function

### DIFF
--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -705,7 +705,10 @@ bool string::try_to_float_as_php8(double *val) const {
   char *end_ptr = nullptr;
   *val = strtod(p, &end_ptr);
 
-  return std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
+  // If end_ptr == p then this means that strtod could not perform
+  // the conversion (otherwise end_ptr would have shifted relative
+  // to p), which means it is not a valid number.
+  return end_ptr != p && std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
 }
 
 bool string::try_to_float_as_php7(double *val) const {

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -702,13 +702,12 @@ bool string::try_to_float_as_php8(double *val) const {
   if (empty() || (size() >= 2 && p[0] == '0' && vk::any_of_equal(p[1], 'x', 'X'))) {
     return false;
   }
+  errno = 0;
   char *end_ptr = nullptr;
   *val = strtod(p, &end_ptr);
 
-  // If end_ptr == p then this means that strtod could not perform
-  // the conversion (otherwise end_ptr would have shifted relative
-  // to p), which means it is not a valid number.
-  return end_ptr != p && std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
+  // see 'man strtod'
+  return errno == 0 && std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
 }
 
 bool string::try_to_float_as_php7(double *val) const {

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -702,12 +702,13 @@ bool string::try_to_float_as_php8(double *val) const {
   if (empty() || (size() >= 2 && p[0] == '0' && vk::any_of_equal(p[1], 'x', 'X'))) {
     return false;
   }
-  errno = 0;
   char *end_ptr = nullptr;
   *val = strtod(p, &end_ptr);
 
-  // see 'man strtod'
-  return errno == 0 && std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
+  // If end_ptr == p then this means that strtod could not perform
+  // the conversion (otherwise end_ptr would have shifted relative
+  // to p), which means it is not a valid number.
+  return end_ptr != p && std::all_of(end_ptr, p + size(), [](char c) { return isspace(static_cast<unsigned char>(c)); });
 }
 
 bool string::try_to_float_as_php7(double *val) const {

--- a/tests/phpt/migration_php8/009_blank_no_warning.php
+++ b/tests/phpt/migration_php8/009_blank_no_warning.php
@@ -1,4 +1,4 @@
-@kphp_runtime_should_not_warn
+@ok kphp_runtime_should_not_warn
 <?php
 
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/migration_php8/009_blank_no_warning.php
+++ b/tests/phpt/migration_php8/009_blank_no_warning.php
@@ -1,0 +1,20 @@
+@kphp_runtime_should_not_warn
+<?php
+
+require_once 'kphp_tester_include.php';
+
+set_migration_php8_warning(0b011);
+
+$blank = " ";
+$blank_more = "   \t";
+
+var_dump(is_numeric($blank));
+var_dump(is_numeric($blank_more));
+
+$blank = " ";
+$blank_more = "  \t";
+$normal = "100";
+
+var_dump($blank == $normal);
+var_dump($blank_more == $normal);
+var_dump($normal >= '0');


### PR DESCRIPTION
Fixed behavior when an empty string was considered a valid number, which led
to incorrect runtime warnings about the difference in behavior between PHP 7
and 8.

Added a new type of test `@kphp_runtime_should_not_warn` for tests that need to
make sure that the code in it does not generate warnings at runtime.