### PR TITLE
zstd now compress at zero level

### DIFF
--- a/runtime/zstd.cpp
+++ b/runtime/zstd.cpp
@@ -131,10 +131,6 @@ Optional<string> zstd_uncompress_impl(const string &data, const string &dict = s
 } // namespace
 
 Optional<string> f$zstd_compress(const string &data, int64_t level) noexcept {
-  if (!level) {
-    return data;
-  }
-
   const int min_level = ZSTD_minCLevel();
   const int max_level = ZSTD_maxCLevel();
   if (min_level > level || level > max_level) {

--- a/tests/phpt/zstd/1_compress.php
+++ b/tests/phpt/zstd/1_compress.php
@@ -5,8 +5,24 @@ function test_compress_levels() {
   var_dump(zstd_compress("foo bar baz", 23));
 
   for ($i = -100; $i < 23; ++$i) {
+    if ($i == 0) {
+      continue;
+    }
     echo "Level $i: ", base64_encode(zstd_compress(str_repeat("foo bar baz", 1000), $i)), "\n";
   }
+}
+
+
+// zstd 0.11.0 version starts to compress at 0 level, see
+// https://pecl.php.net/package-info.php?package=zstd&version=0.11.0
+function test_zero_compress_level() {
+  $zero_level = 0;
+  #ifndef KPHP
+  if (version_compare(phpversion("zstd"), "0.11.0") < 0) {
+    $zero_level = 1;
+  }
+  #endif
+  echo "Level 0: ", base64_encode(zstd_compress(str_repeat("foo bar baz", 1000), $zero_level)), "\n";
 }
 
 function test_compress_dict() {
@@ -16,4 +32,5 @@ function test_compress_dict() {
 }
 
 test_compress_levels();
+test_zero_compress_level();
 test_compress_dict();


### PR DESCRIPTION
php zstd 0.11.0 version starts to compress at zero level as described [here](https://pecl.php.net/package-info.php?package=zstd&version=0.11.0). This PR changed kphp behavior in same way.