### PR TITLE
speed up tagger.cpp compilation

### DIFF
--- a/compiler/code-gen/files/type-tagger.cpp
+++ b/compiler/code-gen/files/type-tagger.cpp
@@ -77,8 +77,8 @@ void TypeTagger::compile_tagger(CodeGenerator &W, const IncludesCollector &inclu
   W << CloseFile{};
 }
 
-void TypeTagger::compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept {
-  W << OpenFile{"_loader.cpp"};
+void TypeTagger::compile_loader_header(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept {
+  W << OpenFile{loader_file_};
   W << ExternInclude{G->settings().runtime_headers.get()};
   W << includes << NL;
 
@@ -93,6 +93,18 @@ void TypeTagger::compile_loader(CodeGenerator &W, const IncludesCollector &inclu
   W << "php_assert(0);" << NL;
   W << END << NL;
 
+  W << CloseFile{};
+}
+
+void TypeTagger::compile_loader_instantiations(CodeGenerator &W, const IncludesCollector &includes) const noexcept {
+  W << OpenFile{"_loader_instantiations.cpp"};
+  W << ExternInclude{G->settings().runtime_headers.get()};
+  W << includes << NL;
+
+  IncludesCollector loader_header;
+  loader_header.add_raw_filename_include(loader_file_);
+  W << loader_header << NL;
+
   std::set<std::string> waitable_types_str;
   for (const auto *type : waitable_types_) {
     waitable_types_str.emplace(type_out(type, gen_out_style::tagger));
@@ -102,6 +114,11 @@ void TypeTagger::compile_loader(CodeGenerator &W, const IncludesCollector &inclu
   }
 
   W << CloseFile{};
+}
+
+void TypeTagger::compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept {
+  compile_loader_header(W, includes, hash_of_types);
+  compile_loader_instantiations(W, includes);
 }
 
 void TypeTagger::compile(CodeGenerator &W) const {

--- a/compiler/code-gen/files/type-tagger.cpp
+++ b/compiler/code-gen/files/type-tagger.cpp
@@ -97,12 +97,8 @@ void TypeTagger::compile_loader(CodeGenerator &W, const IncludesCollector &inclu
   for (const auto *type : waitable_types_) {
     waitable_types_str.emplace(type_out(type, gen_out_style::tagger));
   }
-  if (!waitable_types_str.empty()) {
-    W << "auto unused_loaders_list __attribute__((unused)) = " << BEGIN;
-    for (const auto &type : waitable_types_str) {
-      W << "(void*)(Storage::loader<" << type << ">::get_function)," << NL;
-    }
-    W << END << ";" << NL;
+  for (const auto &type : waitable_types_str) {
+    W << "template Storage::loader<" << type << ">::loader_fun Storage::loader<" << type << ">::get_function(int);" << NL;
   }
 
   W << CloseFile{};

--- a/compiler/code-gen/files/type-tagger.h
+++ b/compiler/code-gen/files/type-tagger.h
@@ -4,18 +4,18 @@
 
 #pragma once
 
-#include <string>
 #include <map>
+#include <string>
 #include <vector>
 
 #include "compiler/code-gen/code-gen-root-cmd.h"
-#include "compiler/code-gen/code-generator.h"
-#include "compiler/inferring/type-data.h"
 
+class CodeGenerator;
+class TypeData;
 struct IncludesCollector;
 
 struct TypeTagger : CodeGenRootCmd {
-  TypeTagger(std::vector<const TypeData *> &&forkable_types, std::vector<const TypeData *> &&waitable_types);
+  TypeTagger(std::vector<const TypeData *> &&forkable_types, std::vector<const TypeData *> &&waitable_types) noexcept;
   void compile(CodeGenerator &W) const final;
 
 private:
@@ -24,6 +24,6 @@ private:
   void compile_tagger(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
   void compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
 
-  std::vector<const TypeData *> forkable_types;
-  std::vector<const TypeData *> waitable_types;
+  const std::vector<const TypeData *> forkable_types_;
+  const std::vector<const TypeData *> waitable_types_;
 };

--- a/compiler/code-gen/files/type-tagger.h
+++ b/compiler/code-gen/files/type-tagger.h
@@ -5,17 +5,25 @@
 #pragma once
 
 #include <string>
+#include <map>
 #include <vector>
 
 #include "compiler/code-gen/code-gen-root-cmd.h"
 #include "compiler/code-gen/code-generator.h"
 #include "compiler/inferring/type-data.h"
 
+struct IncludesCollector;
+
 struct TypeTagger : CodeGenRootCmd {
   TypeTagger(std::vector<const TypeData *> &&forkable_types, std::vector<const TypeData *> &&waitable_types);
   void compile(CodeGenerator &W) const final;
 
 private:
+  IncludesCollector collect_includes() const noexcept;
+  std::map<int, std::string> collect_hash_of_types() const noexcept;
+  void compile_tagger(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
+  void compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
+
   std::vector<const TypeData *> forkable_types;
   std::vector<const TypeData *> waitable_types;
 };

--- a/compiler/code-gen/files/type-tagger.h
+++ b/compiler/code-gen/files/type-tagger.h
@@ -22,8 +22,11 @@ private:
   IncludesCollector collect_includes() const noexcept;
   std::map<int, std::string> collect_hash_of_types() const noexcept;
   void compile_tagger(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
+  void compile_loader_header(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
+  void compile_loader_instantiations(CodeGenerator &W, const IncludesCollector &includes) const noexcept;
   void compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
 
+  const std::string loader_file_{"_loader.h"};
   const std::vector<const TypeData *> forkable_types_;
   const std::vector<const TypeData *> waitable_types_;
 };

--- a/compiler/code-gen/files/type-tagger.h
+++ b/compiler/code-gen/files/type-tagger.h
@@ -23,9 +23,10 @@ private:
   std::map<int, std::string> collect_hash_of_types() const noexcept;
   void compile_tagger(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
   void compile_loader_header(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
-  void compile_loader_instantiations(CodeGenerator &W, const IncludesCollector &includes) const noexcept;
+  void compile_loader_instantiations(CodeGenerator &W) const noexcept;
   void compile_loader(CodeGenerator &W, const IncludesCollector &includes, const std::map<int, std::string> &hash_of_types) const noexcept;
 
+  constexpr static std::size_t loader_split_granularity_{20};
   const std::string loader_file_{"_loader.h"};
   const std::vector<const TypeData *> forkable_types_;
   const std::vector<const TypeData *> waitable_types_;


### PR DESCRIPTION
Currently autogenerated _tagger.cpp file consists of 3 quite big parts:
```

template<>
int Storage::tagger<Foo>::get_tag()  noexcept {
  return -1717182174;
}
// tons of similar get_tag()

template<typename T>
typename Storage::loader<T>::loader_fun Storage::loader<T>::get_function(int tag) noexcept {
  switch(tag){
    case -2043716967: return Storage::load_implementation_helper<Foo, T>::load;
    // tons of similar cases
  }
  php_assert(0);
}

auto unused_loaders_list __attribute__((unused)) = {
  (void*)(Storage::loader<class_instance<C$A>>::get_function),
  // tons of similar instantiations
};
```
So, it can be compiled as only one translation unit. This PR split _tagger.cpp into _tagger.cpp, but now containing only fist part of code (with get_tag() specializations), _loader.h with second part of code (definition of big template get_function()) and banch of _loader_instantiation{n}.cpp files with third part (namely instantiations of get_function() template). That split allow to compile such code in parallel and speed up final build.
I also changed 3rd part of code with explicit template instantiation syntax.