### PR TITLE
avoid conflict with vk-tl-tool package

### DIFF
--- a/common/tl/tl.cmake
+++ b/common/tl/tl.cmake
@@ -8,7 +8,7 @@ install(TARGETS tl-compiler tl2php
 
 install(DIRECTORY ${COMMON_DIR}/tl-files
         COMPONENT TL_TOOLS
-        DESTINATION ${VK_INSTALL_DIR}
+        DESTINATION ${VK_INSTALL_DIR}/doc
         FILES_MATCHING PATTERN "*.tl")
 
 set(CPACK_DEBIAN_TL_TOOLS_PACKAGE_NAME "vk-tl-tools")


### PR DESCRIPTION
Move *.tl files located in vk-tl-tools package from /usr/share/vkontakte/tl-files/ to /usr/share/vkontakte/doc/tl-files/ to avoid conflict with other packages