### PR TITLE
avoid conflict with vk-tl-package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN apt-get update && \
 
 RUN mkdir -p /var/www/vkontakte/data/www/vkontakte.com/tl/ && \
     tl-compiler -e /var/www/vkontakte/data/www/vkontakte.com/tl/scheme.tlo -w 4 \
-    /usr/share/vkontakte/tl-files/common.tl /usr/share/vkontakte/tl-files/tl.tl
+    /usr/share/vkontakte/examples/tl-files/common.tl /usr/share/vkontakte/examples/tl-files/tl.tl
 
 RUN useradd -ms /bin/bash kitten

--- a/common/tl/tl.cmake
+++ b/common/tl/tl.cmake
@@ -8,7 +8,7 @@ install(TARGETS tl-compiler tl2php
 
 install(DIRECTORY ${COMMON_DIR}/tl-files
         COMPONENT TL_TOOLS
-        DESTINATION ${VK_INSTALL_DIR}/doc
+        DESTINATION ${VK_INSTALL_DIR}/examples
         FILES_MATCHING PATTERN "*.tl")
 
 set(CPACK_DEBIAN_TL_TOOLS_PACKAGE_NAME "vk-tl-tools")

--- a/docs/kphp-basics/installation.md
+++ b/docs/kphp-basics/installation.md
@@ -63,7 +63,7 @@ sudo apt update
 sudo apt install kphp vk-tl-tools
 
 sudo mkdir -p /var/www/vkontakte/data/www/vkontakte.com/tl/
-sudo tl-compiler -e /var/www/vkontakte/data/www/vkontakte.com/tl/scheme.tlo /usr/share/vkontakte/tl-files/common.tl /usr/share/vkontakte/tl-files/tl.tl
+sudo tl-compiler -e /var/www/vkontakte/data/www/vkontakte.com/tl/scheme.tlo /usr/share/vkontakte/examples/tl-files/common.tl /usr/share/vkontakte/examples/tl-files/tl.tl
 ```
 
 Having done all these steps, you'll have the `kphp` command and related ones to use later on.


### PR DESCRIPTION
Move *.tl files located in vk-tl-tools package from /usr/share/vkontakte/doc/tl-files/ to /usr/share/vkontakte/examples/tl-files/ to avoid conflict with other packages.
