### PR TITLE
use default linker for partial linking

### DIFF
--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -301,7 +301,7 @@ void CompilerSettings::init() {
 
   std::string cxx_default_flags = ss.str();
 
-  incremental_linker.value_ = cxx.get();
+  cxx_toolchain_option.value_ = !cxx_toolchain_dir.value_.empty() ? ("-B" + cxx_toolchain_dir.value_) : "";
   incremental_linker_flags.value_ = dynamic_incremental_linkage.get() ? "-shared" : "-r -nostdlib";
 
   remove_extra_spaces(extra_ld_flags.value_);

--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -301,8 +301,8 @@ void CompilerSettings::init() {
 
   std::string cxx_default_flags = ss.str();
 
-  incremental_linker.value_ = dynamic_incremental_linkage.get() ? cxx.get() : "ld";
-  incremental_linker_flags.value_ = dynamic_incremental_linkage.get() ? "-shared" : "-r";
+  incremental_linker.value_ = cxx.get();
+  incremental_linker_flags.value_ = dynamic_incremental_linkage.get() ? "-shared" : "-r -nostdlib";
 
   remove_extra_spaces(extra_ld_flags.value_);
 

--- a/compiler/compiler-settings.h
+++ b/compiler/compiler-settings.h
@@ -150,6 +150,7 @@ public:
   KphpOption<std::string> php_code_version;
 
   KphpOption<std::string> cxx;
+  KphpOption<std::string> cxx_toolchain_dir;
   KphpOption<std::string> extra_cxx_flags;
   KphpOption<std::string> extra_ld_flags;
   KphpOption<std::string> extra_cxx_debug_level;
@@ -168,7 +169,6 @@ public:
   CxxFlags cxx_flags_default;
   CxxFlags cxx_flags_with_debug;
   KphpImplicitOption ld_flags;
-  KphpImplicitOption incremental_linker;
   KphpImplicitOption incremental_linker_flags;
 
   KphpImplicitOption base_dir;
@@ -178,6 +178,7 @@ public:
   KphpImplicitOption static_lib_name;
   KphpImplicitOption generated_runtime_path;
   KphpImplicitOption performance_analyze_report_path;
+  KphpImplicitOption cxx_toolchain_option;
 
   KphpImplicitOption runtime_headers;
   KphpImplicitOption runtime_sha256;

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -261,6 +261,8 @@ int main(int argc, char *argv[]) {
              "php-code-version", "KPHP_PHP_CODE_VERSION", "unknown");
   parser.add("C++ compiler for building the output binary", settings->cxx,
              "cxx", "KPHP_CXX", get_default_cxx());
+  parser.add("Directory for c++ compiler toolchain. Will be passed to compiler through -B option", settings->cxx_toolchain_dir,
+             "cxx-toolchain-dir", "KPHP_CXX_TOOLCHAIN_DIR");
   parser.add("Extra C++ compiler flags for building the output binary", settings->extra_cxx_flags,
              "extra-cxx-flags", "KPHP_EXTRA_CXXFLAGS", get_default_extra_cxxflags());
   parser.add("Extra linker flags for building the output binary", settings->extra_ld_flags,
@@ -297,7 +299,6 @@ int main(int argc, char *argv[]) {
              "require-class-typing", "KPHP_REQUIRE_CLASS_TYPING");
 
   parser.add_implicit_option("Linker flags", settings->ld_flags);
-  parser.add_implicit_option("Incremental linker", settings->incremental_linker);
   parser.add_implicit_option("Incremental linker flags", settings->incremental_linker_flags);
   parser.add_implicit_option("Base directory", settings->base_dir);
   parser.add_implicit_option("CPP destination directory", settings->dest_cpp_dir);
@@ -314,6 +315,7 @@ int main(int argc, char *argv[]) {
   parser.add_implicit_option("TL classname prefix", settings->tl_classname_prefix);
   parser.add_implicit_option("Generated runtime path", settings->generated_runtime_path);
   parser.add_implicit_option("Performance report path", settings->performance_analyze_report_path);
+  parser.add_implicit_option("C++ compiler toolchain option", settings->cxx_toolchain_option);
 
   try {
     parser.process_args(argc, argv);

--- a/compiler/make/objs-to-bin-target.h
+++ b/compiler/make/objs-to-bin-target.h
@@ -12,14 +12,15 @@ public:
 
   string get_cmd() final {
 #if defined(__APPLE__)
-    vk::string_view open_dep{" -Wl,-all_load "};
-    vk::string_view close_dep;
+    std::string_view open_dep{" -Wl,-all_load "};
+    std::string_view close_dep;
 #else
-    vk::string_view open_dep{" -Wl,--whole-archive -Wl,--start-group "};
-    vk::string_view close_dep{" -Wl,--end-group -Wl,--no-whole-archive "};
+    std::string_view open_dep{" -Wl,--whole-archive -Wl,--start-group "};
+    std::string_view close_dep{" -Wl,--end-group -Wl,--no-whole-archive "};
 #endif
     std::stringstream ss;
-    ss << settings->cxx.get() << " -o " << target() << open_dep << dep_list() << close_dep << settings->ld_flags.get();
+    ss << settings->cxx.get() << " " << settings->cxx_toolchain_option.get()
+       << " -o " << target() << open_dep << dep_list() << close_dep << settings->ld_flags.get();
     if (need_libdl_) {
       ss << " -ldl";
     }

--- a/compiler/make/objs-to-obj-target.h
+++ b/compiler/make/objs-to-obj-target.h
@@ -8,7 +8,8 @@ class Objs2ObjTarget : public Target {
 public:
   string get_cmd() final {
     std::stringstream ss;
-    ss << settings->incremental_linker.get() <<
+    ss << settings->cxx.get() <<
+       " " << settings->cxx_toolchain_option.get() <<
        " " << settings->incremental_linker_flags.get() <<
        " -o " << target() <<
        " " << dep_list();


### PR DESCRIPTION
Prior this patch partial linking performed with hardcoded "ld", which works quite slowly.
After patch, linking will performed indirectly through compiler, and compiler may choose linker from special directory. Clang and gcc allow to specify such directory through "-B" option. At kphp level such dir may be specified through new "--compiler-toolchain-dir" cli option.