### PR TITLE
fix class instance can't be null issue

### DIFF
--- a/compiler/inferring/restriction-isset.cpp
+++ b/compiler/inferring/restriction-isset.cpp
@@ -43,7 +43,7 @@ bool RestrictionIsset::isset_is_dangerous(int isset_flags, const TypeData *tp) {
 
   const PrimitiveType ptp = tp->get_real_ptype();
   if (isset_flags & ifi_isset) {
-    return ptp != tp_mixed;
+    return vk::none_of_equal(ptp, tp_Class, tp_mixed);
   }
 
   int check_mask = ifi_is_null;

--- a/tests/phpt/dl/1032_instance_can_be_null.php
+++ b/tests/phpt/dl/1032_instance_can_be_null.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+class A {
+  public $x = 1;
+}
+
+function test_instance_can_be_null() {
+  $arr = ["foo" => new A];
+  $obj = $arr["bar"];
+
+  var_dump(isset($obj) ? "not null" : "null");
+  var_dump($obj !== null ? "not null" : "null");
+}
+
+test_instance_can_be_null();

--- a/tests/phpt/dl/1033_string_cant_be_null.php
+++ b/tests/phpt/dl/1033_string_cant_be_null.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/string can't be null in KPHP, while it can be in PHP/
+/string can't be null in KPHP, while it can be in PHP/
+<?php
+
+function test_string_cant_be_null() {
+  $arr = ["foo" => "baz"];
+  $obj = $arr["bar"];
+
+  var_dump(isset($obj) ? "not null" : "null");
+  var_dump($obj !== null ? "not null" : "null");
+}
+
+test_string_cant_be_null();


### PR DESCRIPTION
Currently, such code:
```
<?php

class A{}

$arr = ["foo" => new A];
$obj = $arr["bar"];

if (isset($obj)) {
  echo "smth";
}
```
Produce next compilation error:
```
Compilation error at stage: Infer types, gen by type-inferer.cpp:53
  demo.php:8  in global scope
    if (isset($obj)) {

isset, !==, ===, is_array or similar function result may differ from PHP
 Probably, this happened because ExprNode $arr[.] at demo.php:6  in global scope : A can't be null in KPHP, while it can be in PHP
 Chain of assignments:
  ExprNode $obj at demo.php:8  in global scope : A
  VarNode ($obj in global scope) : A
  ExprNode $arr[.] at demo.php:6  in global scope : A


Compilation terminated due to errors
```
However, class instance can be null. PR fix this issue.
