### PR TITLE
introduce strict typing in instance_cache api

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1270,10 +1270,10 @@ function instance_to_array($instance ::: any, $with_class_names ::: bool = false
 
 /** Instance cache interface (like APC) **/
 /** @kphp-extern-func-info cpp_template_call */
-function instance_cache_fetch($type ::: string, $key ::: string, $even_if_expired ::: bool = false) ::: instance<^1>;
-function instance_cache_store($key ::: string, $value ::: any, $ttl ::: int = 0) ::: bool;
-function instance_cache_update_ttl($key ::: string, $ttl ::: int = 0) ::: bool;
-function instance_cache_delete($key ::: string) ::: bool;
+function instance_cache_fetch(string $type, string $key, bool $even_if_expired = false) ::: instance<^1>;
+function instance_cache_store(string $key, any $value, int $ttl = 0) ::: bool;
+function instance_cache_update_ttl(string $key, int $ttl = 0) ::: bool;
+function instance_cache_delete(string $key) ::: bool;
 
 function instance_serialize($instance ::: any) ::: string | null;
 /** @kphp-extern-func-info cpp_template_call */

--- a/tests/python/tests/instance_cache/php/index.php
+++ b/tests/python/tests/instance_cache/php/index.php
@@ -126,13 +126,13 @@ class TestClassABC {
 
 function test_store() {
   $data = json_decode(file_get_contents('php://input'));
-  echo json_encode(["result" => instance_cache_store($data["key"], new TestClassABC, 5)]);
+  echo json_encode(["result" => instance_cache_store((string)$data["key"], new TestClassABC, 5)]);
 }
 
 function test_fetch_and_verify() {
   $data = json_decode(file_get_contents('php://input'));
   /** @var TestClassABC $instance */
-  $instance = instance_cache_fetch(TestClassABC::class, $data["key"]);
+  $instance = instance_cache_fetch(TestClassABC::class, (string)$data["key"]);
   echo json_encode([
     "a" => $instance->a[0] === $instance->a[2]->a[0],
     "b" => $instance->b[0] === $instance->b[1]->a[1]->b[0][0],
@@ -142,7 +142,7 @@ function test_fetch_and_verify() {
 
 function test_delete() {
   $data = json_decode(file_get_contents('php://input'));
-  instance_cache_delete($data["key"]);
+  instance_cache_delete((string)$data["key"]);
 }
 
 main();


### PR DESCRIPTION
PR removes cast operator (:::) from instance_cache api. After patch calls with incorrect typing won't compile anymore. e.g. code:
```/** @kphp-immutable-class */
class A {
  public int $x = 0;
}

instance_cache_store("key", new A, 'wtf');
```
Produce next error:

```Compilation error at stage: Calc actual calls, gen by type-inferer.cpp:53
  demo.php:29  in global scope
    instance_cache_store("key", new A, 'wtf');

pass string to argument $ttl of instance_cache_store
but it's declared as @param int

  demo.php:29  in global scope
    instance_cache_store("key", new A, 'wtf');
    "wtf" is string


Compilation terminated due to errors```