### PR TITLE
refactor pch target for nocc support

### DIFF
--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -186,7 +186,7 @@ void CxxFlags::init(const std::string &runtime_sha256, const std::string &cxx,
   flags_sha256.value_ = calc_cxx_flags_sha256(cxx, flags.get());
   flags.value_.append(" -iquote").append(dest_cpp_dir);
   if (enable_pch) {
-    pch_dir.value_.append("/tmp/kphp_gch/").append(runtime_sha256).append("/").append(flags_sha256.get()).append("/");
+    pch_dir.value_.append("/tmp/kphp_pch/").append(runtime_sha256).append("/").append(flags_sha256.get()).append("/");
   }
 }
 

--- a/compiler/make/cpp-to-obj-target.h
+++ b/compiler/make/cpp-to-obj-target.h
@@ -12,19 +12,16 @@
 
 class Cpp2ObjTarget : public Target {
 public:
-  explicit Cpp2ObjTarget(bool make_pch = false) noexcept :
-    make_pch_(make_pch) {
-  }
-
   string get_cmd() final {
     std::stringstream ss;
     const auto cpp_list = dep_list();
-    const char *cpp_type = make_pch_ ? "-x c++-header " : "";
     ss << settings->cxx.get() <<
        " -c -o " << target() <<
-       " " << cpp_type << cpp_list;
+       " " << cpp_list;
     const auto &cxx_flags = get_file()->compile_with_debug_info_flag ? settings->cxx_flags_with_debug : settings->cxx_flags_default;
-    if (!make_pch_ && !settings->no_pch.get()) {
+    // make #include "runtime-headers.h" capture generated pch file
+    // it's done via -iquote to a folder inside /tmp/kphp_gch where runtime-headers.h with pch file are placed
+    if (!settings->no_pch.get()) {
       ss << " -iquote " << cxx_flags.pch_dir.get();
       if (vk::contains(settings->cxx.get(), "clang")) {
         ss << " -include " << cxx_flags.pch_dir.get() << settings->runtime_headers.get();
@@ -44,7 +41,4 @@ public:
       }
     }
   }
-
-private:
-  bool make_pch_{false};
 };

--- a/compiler/make/h-to-pch-target.h
+++ b/compiler/make/h-to-pch-target.h
@@ -1,0 +1,38 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <sstream>
+
+#include "common/algorithms/contains.h"
+
+#include "compiler/make/target.h"
+
+class H2PchTarget : public Target {
+public:
+  string get_cmd() final {
+    kphp_assert(deps.size() == 1);
+
+    std::stringstream ss;
+    const auto &cxx_flags = get_file()->compile_with_debug_info_flag ? settings->cxx_flags_with_debug : settings->cxx_flags_default;
+    ss << settings->cxx.get() <<
+       " -c -o " << target() <<
+       " -x c++-header " << deps[0]->get_name() <<
+       " " << cxx_flags.flags.get();
+
+    // printf("compile pch cmd line %s\n", ss.str().c_str());
+    return ss.str();
+  }
+
+  bool after_run_success() override {
+    long long res = get_file()->read_stat();
+    if (res < 0) {
+      return false;
+    } else if (res > 0) {
+      upd_mtime(get_file()->mtime);
+    }
+    return true;
+  }
+};

--- a/compiler/make/h-to-pch-target.h
+++ b/compiler/make/h-to-pch-target.h
@@ -1,5 +1,5 @@
 // Compiler for PHP (aka KPHP)
-// Copyright (c) 2020 LLC «V Kontakte»
+// Copyright (c) 2022 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #pragma once

--- a/compiler/make/target.h
+++ b/compiler/make/target.h
@@ -27,7 +27,7 @@ private:
   File *file = nullptr;
 
 protected:
-  bool upd_mtime(long long new_mtime) __attribute__ ((warn_unused_result));
+  bool upd_mtime(long long new_mtime);
   void set_mtime(long long new_mtime);
 
   std::vector<Target *> deps;
@@ -43,8 +43,8 @@ public:
   std::string get_name();
 
   void on_require();
-  bool after_run_success() __attribute__ ((warn_unused_result));
-  void after_run_fail();
+  virtual bool after_run_success();
+  virtual void after_run_fail();
 
   void force_changed(long long new_mtime);
   bool require();


### PR DESCRIPTION
Prior to this PR, we had this logic for pch generation:
1) generate kphp_out/objs/runtime-headers.h.gch.{flags}
2) move this file to /tmp/kphp_gch/{runtime_sha}/{flags}/runtime-headers.h.gch
3) copy runtime-headers.h nearby

With this PR, the logic changes to the following:
1) generate kphp_out/objs/pch_{flags}/ with arbitrary contents
2) move this dir to /tmp/kphp_gch/{runtime_sha}/{flags}/*
3) copy runtime-headers.h nearby

The reason behind this change is nocc — an internal tool for remote C++ compilation (like distcc) that will be open sourced some time later.
nocc will NOT compile pch locally — instead, it will compile pch remotely on demand. It does NOT emit runtime-headers.h.gch file locally — it emits runtime-headers.h.nocc-pch file INSTEAD OF .gch. 

In other words, this patch makes KPHP not rely on the resulting .gch existence: KPHP will just copy a folder, regardless of its contents. For g++/distcc it would contain a regular .gch file, for nocc it will contain a .nocc-pch file.