### PR TITLE
fix bug in less than array operator

### DIFF
--- a/runtime/comparison_operators.inl
+++ b/runtime/comparison_operators.inl
@@ -607,8 +607,12 @@ inline bool lt(const array<T1> &lhs, const array<T2> &rhs) {
     if (!rhs.has_key(key)) {
       return false;
     }
-    if (lt(lhs_it.get_value(), rhs.get_value(key))) {
+    auto lhs_val = lhs_it.get_value();
+    auto rhs_val = rhs.get_value(key);
+    if (lt(lhs_val, rhs_val)) {
       return true;
+    } else if (lt(rhs_val, lhs_val)) {
+      return false;
     }
   }
 

--- a/tests/phpt/dl/1034_array_lt.php
+++ b/tests/phpt/dl/1034_array_lt.php
@@ -1,0 +1,18 @@
+@ok
+<?php
+
+function test_array_lt() {
+  var_dump([] < []);
+  var_dump([1] < []);
+  var_dump([] < [1]);
+  var_dump([1] < [1]);
+  var_dump([1] < [2]);
+  var_dump([1, 2] < [2]);
+  var_dump([1] < [1, 2]);
+  var_dump([1, 2] < [1, 2]);
+  var_dump([1, 2] < [2, 1]);
+  var_dump([2, 1] < [2, 1]);
+  var_dump([2, 1] < [1, 2]);
+}
+
+test_array_lt();


### PR DESCRIPTION
Such code: `[2, 1] < [1, 2]` says that first array less than second, while it don't.

This lead to e.g. incorrect sorting of such array:
```
$arr = [[3, 6], [3, 4], [1, 10], [3, 5], [6, 2], [1, 3]];
sort($arr);
print_r($arr);
// PHP:  [[1, 3], [1, 10], [3, 4], [3, 5], [3, 6], [6, 2]]
// KPHP: [[1, 3], [3, 4], [3, 5], [3, 6], [6, 2], [1, 10]]
```
