### PR TITLE
refactoring instance_to_array()

### DIFF
--- a/runtime/instance-to-array-processor.h
+++ b/runtime/instance-to-array-processor.h
@@ -56,7 +56,7 @@ private:
     InstanceToArrayVisitor tuple_processor{with_class_names_};
     tuple_processor.result_.reserve(sizeof...(Args), 0, true);
 
-    process_tuple(value, tuple_processor);
+    process_tuple(value, tuple_processor, std::index_sequence_for<Args...>{});
     add_value(field_name, std::move(tuple_processor).flush_result());
   }
 
@@ -69,14 +69,9 @@ private:
     add_value(field_name, std::move(shape_processor).flush_result());
   }
 
-  template<size_t Index = 0, class ...Args>
-  std::enable_if_t<Index != sizeof...(Args)> process_tuple(const std::tuple<Args...> &value, InstanceToArrayVisitor &tuple_visitor) {
-    tuple_visitor.process_impl("", std::get<Index>(value));
-    process_tuple<Index + 1>(value, tuple_visitor);
-  }
-
-  template<size_t Index = 0, class ...Args>
-  std::enable_if_t<Index == sizeof...(Args)> process_tuple(const std::tuple<Args...> &, InstanceToArrayVisitor &/*tuple_processor*/) {
+  template<class... Args, std::size_t... Indexes>
+  void process_tuple(const std::tuple<Args...> &tuple, InstanceToArrayVisitor &visitor, std::index_sequence<Indexes...> /*indexes*/) {
+    (visitor.process_impl("", std::get<Indexes>(tuple)), ...);
   }
 
   template<size_t ...Is, typename ...T>

--- a/runtime/instance-to-array-processor.h
+++ b/runtime/instance-to-array-processor.h
@@ -74,10 +74,10 @@ private:
     (visitor.process_impl("", std::get<Indexes>(tuple)), ...);
   }
 
-  template<size_t ...Is, typename ...T>
-  void process_shape(const shape<std::index_sequence<Is...>, T...> &value, InstanceToArrayVisitor &shape_visitor) {
+  template<size_t... Is, typename... T>
+  void process_shape(const shape<std::index_sequence<Is...>, T...> &shape, InstanceToArrayVisitor &visitor) {
     // shape doesn't have key names at runtime, that's why result will be a vector-array (whereas associative in PHP)
-    std::initializer_list<int32_t>{((void)shape_visitor.process_impl("", value.template get<Is>()), 0)...};
+    (visitor.process_impl("", shape.template get<Is>()), ...);
   }
 
   template<class T>


### PR DESCRIPTION
This refactoring mostly consists of DRY `instance_to_array()` implementation and removing recuring of variadic templates for tuple processing. The last one allow to reduce number of `process_tuple()` instantiations, e.g. for:
```
<?php

class A {
  /** @var tuple(int, string, bool) $t */
  public $t;
}

$arr = instance_to_array(new A);
var_dump($arr);
```
there was four instantiations:
![image](https://user-images.githubusercontent.com/14000874/150376191-25298038-7318-4a19-8580-feac6dde587f.png)

while after only one:
![image](https://user-images.githubusercontent.com/14000874/150376329-89a7e8a5-d289-469f-9533-7331d38b2d22.png)
