### PR TITLE
fix race condition in class assumptions

### DIFF
--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -74,6 +74,7 @@ public:
   std::vector<std::pair<std::string, Assumption>> assumptions_for_vars;   // (var_name, assumption)[]
   Assumption assumption_for_return;
 
+  vk::copyable_atomic<int> assumption_vars_mu{0};
   vk::copyable_atomic<AssumptionStatus> assumption_return_status{AssumptionStatus::unknown};
   vk::copyable_atomic<std::thread::id> assumption_return_processing_thread{std::thread::id{}};
 


### PR DESCRIPTION
A race condition could occur in such scenario:
```
function demo() {
$log = function() { ... };

(function() use($log) { $log(); })();
(function() use($log) { $log(); })();
(function() use($log) { $log(); })();
}
```

Multiple lambdas (processed in parallel) want to know assumption for `$log` inside `demo`. 