### PR TITLE
Collect classes from @var phpdocs if they are unreachable from php code

### DIFF
--- a/tests/phpt/cl/030_resolve_from_phpdoc.php
+++ b/tests/phpt/cl/030_resolve_from_phpdoc.php
@@ -1,0 +1,28 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class BB {
+    public ?Classes\F $f = null;
+
+    function f() {
+        if ($this->f) $this->f->appendInt(1);
+        else echo "f null\n";
+    }
+}
+
+function f1(?Classes\E $e) {
+    if ($e) $e->makeNextE();
+    else echo "e null\n";
+}
+
+function f2() {
+    /** @var ?Classes\A $a */
+    $a = null;
+    if ($a) $a->printA();
+    else echo "a null\n";
+}
+
+f1(null);
+f2();
+(new BB)->f();


### PR DESCRIPTION
If a class is used in @var and is not created actually,
```
/** @var ?A\B\SomeClass $obj */
$obj = null;
if ($obj) $obj->someMethod();
```
— now becomes visible to KPHP.

Before, KPHP didn't collect such classes. `if (0) new A\B\SomeClass` could help in that case.