### PR TITLE
to_array_debug() now able to print shape keys

### DIFF
--- a/compiler/code-gen/files/init-scripts.cpp
+++ b/compiler/code-gen/files/init-scripts.cpp
@@ -6,6 +6,7 @@
 
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/declarations.h"
+#include "compiler/code-gen/files/shape-keys.h"
 #include "compiler/code-gen/includes.h"
 #include "compiler/code-gen/namespace.h"
 #include "compiler/code-gen/naming.h"
@@ -208,6 +209,9 @@ void InitScriptsCpp::compile(CodeGenerator &W) const {
   W << GlobalResetFunction(main_file_id->main_function) << NL;
 
   FunctionSignatureGenerator(W) << "void init_php_scripts() " << BEGIN;
+
+  W << ShapeKeys::get_function_declaration() << ";" << NL;
+  W << ShapeKeys::get_function_name() << "();" << NL << NL;
 
   W << FunctionName(main_file_id->main_function) << "$global_reset();" << NL;
 

--- a/compiler/code-gen/files/shape-keys.cpp
+++ b/compiler/code-gen/files/shape-keys.cpp
@@ -1,0 +1,39 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/code-gen/files/shape-keys.h"
+
+#include "compiler/code-gen/code-generator.h"
+#include "compiler/code-gen/common.h"
+#include "compiler/code-gen/includes.h"
+#include "compiler/code-gen/naming.h"
+#include "compiler/compiler-core.h"
+
+std::string ShapeKeys::get_function_name() noexcept {
+  return "init_shape_demangler";
+}
+
+std::string ShapeKeys::get_function_declaration() noexcept {
+  return "void " + get_function_name() + "()";
+}
+
+void ShapeKeys::compile(CodeGenerator &W) const {
+  W << OpenFile{"_shape_keys.cpp"};
+  W << ExternInclude{G->settings().runtime_headers.get()};
+
+  FunctionSignatureGenerator{W} << NL << get_function_declaration() << BEGIN;
+  W << "std::unordered_map<std::int64_t, std::string_view> shape_keys_storage{" << NL;
+
+  for (const auto &[hash, key] : shape_keys_storage_) {
+    W << Indent{2} << "{" << hash << ", \"" << key.data() << "\"}," << NL << Indent{-2};
+  }
+
+  W << "};" << NL << NL;
+
+  W << "vk::singleton<ShapeKeyDemangle>::get().init(std::move(shape_keys_storage));" << NL;
+
+  W << END << NL << NL;
+
+  W << CloseFile{};
+}

--- a/compiler/code-gen/files/shape-keys.h
+++ b/compiler/code-gen/files/shape-keys.h
@@ -1,0 +1,25 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "compiler/code-gen/code-gen-root-cmd.h"
+
+class CodeGenerator;
+
+struct ShapeKeys : CodeGenRootCmd {
+  explicit ShapeKeys(std::map<std::int64_t, std::string> shape_keys_storage) noexcept :
+    shape_keys_storage_(std::move(shape_keys_storage)) {}
+
+  void compile(CodeGenerator &W) const final;
+
+  static std::string get_function_name() noexcept;
+  static std::string get_function_declaration() noexcept;
+
+private:
+  const std::map<std::int64_t, std::string> shape_keys_storage_;
+};

--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -81,6 +81,7 @@ prepend(KPHP_COMPILER_CODEGEN_SOURCES code-gen/
         files/tl2cpp/tl-type.cpp
         files/tl2cpp/tl2cpp-utils.cpp
         files/tl2cpp/tl2cpp.cpp
+        files/shape-keys.cpp
         files/type-tagger.cpp
         files/vars-cpp.cpp
         files/vars-reset.cpp

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1285,7 +1285,9 @@ VertexAdaptor<op_shape> GenTree::get_shape() {
     auto key_v = double_arrow->lhs();
     CE (!kphp_error(vk::any_of_equal(key_v->type(), op_int_const, op_string, op_func_name), "keys of shape() must be constant"));
     const std::string &key_str = key_v->get_string();
-    CE (!kphp_error(keys_hashes.insert(string_hash(key_str.c_str(), key_str.size())).second, "keys of shape() are not unique"));
+    const std::int64_t hash = string_hash(key_str.data(), key_str.size());
+    CE (!kphp_error(keys_hashes.insert(hash).second, "keys of shape() are not unique"));
+    TypeHintShape::register_known_key(hash, key_str);
   }
 
   // shape->args() is a sequence of op_double_arrow

--- a/compiler/pipes/code-gen.cpp
+++ b/compiler/pipes/code-gen.cpp
@@ -15,6 +15,7 @@
 #include "compiler/code-gen/files/init-scripts.h"
 #include "compiler/code-gen/files/lib-header.h"
 #include "compiler/code-gen/files/tl2cpp/tl2cpp.h"
+#include "compiler/code-gen/files/shape-keys.h"
 #include "compiler/code-gen/files/type-tagger.h"
 #include "compiler/code-gen/files/vars-cpp.h"
 #include "compiler/code-gen/files/vars-reset.h"
@@ -27,6 +28,7 @@
 #include "compiler/function-pass.h"
 #include "compiler/inferring/public.h"
 #include "compiler/pipes/collect-forkable-types.h"
+#include "compiler/type-hint.h"
 
 size_t CodeGenF::calc_count_of_parts(size_t cnt_global_vars) {
   return 1u + cnt_global_vars / G->settings().globals_split_count.get();
@@ -124,6 +126,7 @@ void CodeGenF::on_finish(DataStream<std::unique_ptr<CodeGenRootCmd>> &os) {
   // TODO: should be done in lib mode also, but in some other way
   if (!G->settings().is_static_lib_mode()) {
     code_gen_start_root_task(os, std::make_unique<TypeTagger>(vk::singleton<ForkableTypeStorage>::get().flush_forkable_types(), vk::singleton<ForkableTypeStorage>::get().flush_waitable_types()));
+    code_gen_start_root_task(os, std::make_unique<ShapeKeys>(TypeHintShape::get_all_registered_keys()));
   }
 
   code_gen_start_root_task(os, std::make_unique<TlSchemaToCpp>());

--- a/compiler/type-hint.cpp
+++ b/compiler/type-hint.cpp
@@ -4,6 +4,8 @@
 
 #include "compiler/type-hint.h"
 
+#include <mutex>
+
 #include "common/php-functions.h"
 
 #include "compiler/data/class-data.h"
@@ -122,6 +124,18 @@ const TypeHint *TypeHintShape::find_at(const string &key) const {
   return nullptr;
 }
 
+std::map<std::int64_t, std::string> TypeHintShape::shape_keys_storage_;
+
+void TypeHintShape::register_known_key(std::int64_t key_hash, std::string_view key) noexcept {
+  static std::mutex mutex;
+
+  std::lock_guard lock{mutex};
+  shape_keys_storage_.emplace(key_hash, key);
+}
+
+const std::map<std::int64_t, std::string> &TypeHintShape::get_all_registered_keys() noexcept {
+  return shape_keys_storage_;
+}
 
 // --------------------------------------------
 //    create()

--- a/compiler/type-hint.h
+++ b/compiler/type-hint.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <string>
+#include <string_view>
 #include <vector>
 
 #include "compiler/compiler-core.h"
@@ -454,11 +456,16 @@ class TypeHintShape : public TypeHint {
     , items(items)
     , is_vararg(is_vararg) {}
 
+  static std::map<std::int64_t, std::string> shape_keys_storage_;
+
 public:
   std::vector<std::pair<std::string, const TypeHint *>> items;
-  bool is_vararg;
+  bool is_vararg{false};
 
   static const TypeHint *create(std::vector<std::pair<std::string, const TypeHint *>> &&items, bool is_vararg);
+
+  static void register_known_key(std::int64_t key_hash, std::string_view key) noexcept;
+  static const std::map<std::int64_t, std::string> &get_all_registered_keys() noexcept;
 
   std::string as_human_readable() const final;
   void traverse(const TraverserCallbackT &callback) const final;

--- a/runtime/shape.h
+++ b/runtime/shape.h
@@ -94,13 +94,13 @@ public:
   template<size_t ...Is2, typename ...T2, typename = enable_if_sequence_is_subset<Is2...>>
   explicit shape(shape<std::index_sequence<Is2...>, T2...> &&other) noexcept :
     shape_node<Is, T>()... {
-    std::initializer_list<int>{(set(std::forward<shape_node<Is2, T2>>(other)), 0)...};
+    (set(std::forward<shape_node<Is2, T2>>(other)), ...);
   }
 
   template<size_t ...Is2, typename ...T2, typename = enable_if_sequence_is_subset<Is2...>>
   shape(const shape<std::index_sequence<Is2...>, T2...> &other) noexcept :
     shape_node<Is, T>()... {
-    std::initializer_list<int>{(set(static_cast<const shape_node<Is2, T2> &>(other)), 0)...};
+    (set(static_cast<const shape_node<Is2, T2> &>(other)), ...);
   }
 
   template<size_t ...Is2, typename ...T2, typename = enable_if_sequence_is_subset<Is2...>>

--- a/tests/phpt/dl/1034_to_array_debug_shape.php
+++ b/tests/phpt/dl/1034_to_array_debug_shape.php
@@ -23,10 +23,10 @@ function to_array_debug_shape(bool $with_class_names) {
 
   $dump = to_array_debug($shape, $with_class_names);
   #ifndef KPHP
-  $dump = [42, ['a_obj' => ['i' => 88, 'b_shape' => ['qax']]]];
+  $dump = ['foo' => 42, 'bar' => ['a_obj' => ['i' => 88, 'b_shape' => ['baz' => 'qax']]]];
   if ($with_class_names) {
-    $dump[1]['__class_name'] = 'A';
-    $dump[1]['a_obj']['__class_name'] = 'B';
+    $dump['bar']['__class_name'] = 'A';
+    $dump['bar']['a_obj']['__class_name'] = 'B';
   }
   #endif
   var_dump($dump);

--- a/tests/phpt/dl/1036_to_array_debug_shape_nullable.php
+++ b/tests/phpt/dl/1036_to_array_debug_shape_nullable.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+function to_array_debug_shape_nullable() {
+  /** @var shape(foo:string, bar?:int) */
+  $shape = shape(["foo" => "baz"]);
+  $dump = to_array_debug($shape);
+
+  #ifndef KPHP
+  $dump = ['foo' => 'baz', 'bar' => null];
+  #endif
+  var_dump($dump);
+}
+
+to_array_debug_shape_nullable();

--- a/tests/phpt/instance_cache/1_instance_cache.php
+++ b/tests/phpt/instance_cache/1_instance_cache.php
@@ -242,8 +242,8 @@ function test_with_shape() {
 
   $a2 = instance_cache_fetch(HasShape::class, 'has_shape');
   $dump = to_array_debug($a2);
-#ifndef KPHP   // in KPHP shapes produce non-assoiative array at runtime
-  $dump['sh'] = [19, 'y', null];
+#ifndef KPHP // in KPHP order of keys will differs from php
+  $dump['sh'] = ['x' => 19, 'y' => 'y', 'z' => null];
 #endif
   var_dump($dump);
   var_dump($a2->sh['x']);
@@ -254,8 +254,8 @@ function test_with_shape() {
   instance_cache_store('has_shape_more', $a);
   $a3 = instance_cache_fetch(HasShape::class, 'has_shape_more');
   $dump = to_array_debug($a3);
-#ifndef KPHP   // in KPHP shapes produce non-assoiative array at runtime
-  $dump['sh'] = [2, 'y', [1,2,3]];
+#ifndef KPHP // in KPHP order of keys will differs from php
+  $dump['sh'] = ['x' => 2, 'y' => 'y', 'z' => [1,2,3]];
 #endif
   var_dump($dump);
   var_dump($a3->sh['x']);

--- a/tests/phpt/shapes/019_shape_to_array.php
+++ b/tests/phpt/shapes/019_shape_to_array.php
@@ -21,14 +21,14 @@ class A {
 
 $a = new A;
 $dump = to_array_debug($a);
-#ifndef KPHP   // in KPHP shapes produce non-assoiative array at runtime
-$dump['sh'] = [2, 'y', null];
+#ifndef KPHP // in KPHP order of keys will differs from php
+$dump['sh'] = ['x' => 2, 'y' => 'y', 'z' => null];
 #endif
 var_dump($dump);
 
 $a->setZ();
 $dump = to_array_debug($a);
-#ifndef KPHP   // in KPHP shapes produce non-assoiative array at runtime
-$dump['sh'] = [2, 'y', [1,2,3]];
+#ifndef KPHP // in KPHP order of keys will differs from php
+$dump['sh'] = ['x' => 2, 'y' => 'y', 'z' => [1,2,3]];
 #endif
 var_dump($dump);


### PR DESCRIPTION
Currently, to_array_debug() print just index of key for 'shape' instead of real string name. After this PR it will be real string keys.