### PR TITLE
fix false positive warning in tests

### DIFF
--- a/tests/python/lib/kphp_builder.py
+++ b/tests/python/lib/kphp_builder.py
@@ -155,6 +155,7 @@ class KphpBuilder:
             ignore_patterns=[
                 "^Starting php to cpp transpiling\\.\\.\\.$",
                 "^Starting make\\.\\.\\.$",
+                "^Compiling pch stage started\\.\\.\\.$",
                 "^objs cnt = \\d+$",
                 "^Compiling stage started\\.\\.\\.$",
                 "^Linking stage started\\.\\.\\.$",


### PR DESCRIPTION
Fix false positive warning in tests occurred while compiling pch:
![image](https://user-images.githubusercontent.com/14000874/151753181-73d78187-4daf-4a94-8b33-edb1386ff47c.png)
