### PR TITLE
Forbid to pass resumable lambdas to builtin functions

### DIFF
--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -175,6 +175,10 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
 
     FunctionPtr f_passed_to_builtin = call_params[i].as<op_callback_of_builtin>()->func_id;
 
+    kphp_error(!f_passed_to_builtin->is_resumable, fmt_format("Callbacks passed to builtin functions must not be resumable.\n"
+                                                              "But '{}' became resumable because of the calls chain:\n"
+                                                              "{}", f_passed_to_builtin->as_human_readable(), f_passed_to_builtin->get_resumable_path()));
+
     if (auto name = f_passed_to_builtin->local_name(); name == "to_array_debug" || name == "instance_to_array") {
       if (const auto *as_subkey = type_hint_callable->arg_types[0]->try_as<TypeHintArgSubkeyGet>()) {
         auto arg_ref = as_subkey->inner->try_as<TypeHintArgRef>();

--- a/tests/phpt/fork/030_fail_pass_resumable_lambda_to_builtin_function.php
+++ b/tests/phpt/fork/030_fail_pass_resumable_lambda_to_builtin_function.php
@@ -1,0 +1,30 @@
+@kphp_should_fail
+/Callbacks passed to builtin functions must not be resumable./
+<?php
+
+/**
+ * @kphp-required
+ **/
+function child_fork(int $i): int {
+    sched_yield_sleep(0.001);
+    return $i * 100;
+}
+
+function parent_fork() {
+    $arr = [];
+    for ($i = 0; $i < 10; $i++) {
+        $arr[] = $i;
+    }
+    $ans = array_map('child_fork', $arr);
+    return $ans[5];
+}
+
+
+function demo() {
+    $id = fork(parent_fork());
+    $ans = wait($id);
+    var_dump($ans);
+}
+
+demo();
+

--- a/tests/phpt/fork/031_ok_pass_fork_unreachable_resumable_lambda_to_builtin_function.php
+++ b/tests/phpt/fork/031_ok_pass_fork_unreachable_resumable_lambda_to_builtin_function.php
@@ -1,0 +1,28 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+/**
+ * @kphp-required
+ **/
+function child_fork(int $i): int {
+    sched_yield_sleep(0.001);
+    return $i * 100;
+}
+
+function parent_fork() {
+    $arr = [];
+    for ($i = 0; $i < 10; $i++) {
+        $arr[] = $i;
+    }
+    $ans = array_map('child_fork', $arr);
+    return $ans[5];
+}
+
+
+function demo() {
+    var_dump(parent_fork());
+}
+
+demo();


### PR DESCRIPTION
Any lambda passed from client code is potentially resumable. Therefore any builtin function accepting lambda as a parameter (for example `array_map`, `array_filter`, `sort` etc.) must be resumable too and correctly behave when this lambda suspends.

Now, all such builtin function doesn't maintain case when passed resumable lambda suspends. It leads to critical error in runtime and unpredictable worker crashes.

Making all such builtin functions resumable will significantly increase code complexity and extensibility and seems not very useful. Therefore, in this PR it's suggested to forbid such cases in compiler.