### PR TITLE
[vkext] return empty array instead of false in `rpc_tl_query` and `typed_rpc_tl_query`

### DIFF
--- a/tests/kphp_ci_pipeline_runner.py
+++ b/tests/kphp_ci_pipeline_runner.py
@@ -281,7 +281,7 @@ if __name__ == "__main__":
             "{distcc_cmake_option}"
             "-DCMAKE_CXX_COMPILER={cxx} {cmake_options} && "
             "{env_vars} make -C {kphp_repo_root}/build -j{{jobs}} all test && "
-            "{env_vars} make -C {kphp_repo_root}/build vkext7.2 vkext7.4 && "
+            "{env_vars} make -C {kphp_repo_root}/build vkext7.4 && "
             "cd {kphp_repo_root}/build && cpack".format(
                 kphp_repo_root=kphp_repo_root,
                 distcc_cmake_option=distcc_cmake_option,

--- a/vkext/vkext-schema-memcache.cpp
+++ b/vkext/vkext-schema-memcache.cpp
@@ -1180,13 +1180,13 @@ void vk_memcache_query(INTERNAL_FUNCTION_PARAMETERS) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_INVALID_CALL, "Not enough parameters for rpc_tl_query");
     END_TIMER (parse);
-    RETURN_FALSE;
+    RETURN_EMPTY_ARRAY();
   }
   if (zend_get_parameters_array_ex (argc > 4 ? 4 : argc, z) == FAILURE) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_INVALID_CALL, "Can't parse parameters for rpc_tl_query");
     END_TIMER (parse);
-    RETURN_FALSE;
+    RETURN_EMPTY_ARRAY();
   }
 
   int fd = parse_zend_fd(VK_ZVAL_ARRAY_TO_API_P(z[0]));
@@ -1194,7 +1194,7 @@ void vk_memcache_query(INTERNAL_FUNCTION_PARAMETERS) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_WRONG_TYPE, "Invalid connection type");
     END_TIMER (parse);
-    RETURN_FALSE;
+    RETURN_EMPTY_ARRAY();
   }
 
   struct rpc_connection *c = rpc_connection_get(fd);
@@ -1203,7 +1203,7 @@ void vk_memcache_query(INTERNAL_FUNCTION_PARAMETERS) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_NETWORK, "Invalid connection in rpc_tl_query");
     END_TIMER (parse);
-    RETURN_FALSE;
+    RETURN_EMPTY_ARRAY();
   }
 
   double timeout = argc > 2 ? parse_zend_double(VK_ZVAL_ARRAY_TO_API_P(z[2])) : c->default_query_timeout;
@@ -1214,8 +1214,7 @@ void vk_memcache_query(INTERNAL_FUNCTION_PARAMETERS) {
   if (VK_Z_API_TYPE (VK_ZVAL_ARRAY_TO_API_P(z[1])) != IS_ARRAY) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_INVALID_CALL, "Can't parse parameters for rpc_tl_query");
-    RETURN_FALSE;
-    return;
+    RETURN_EMPTY_ARRAY();
   }
   END_TIMER (parse);
 
@@ -1225,7 +1224,7 @@ void vk_memcache_query(INTERNAL_FUNCTION_PARAMETERS) {
     vkext_reset_error();
     vkext_error(VKEXT_ERROR_NETWORK, "Can't send query");
     zval_dtor (return_value);
-    RETURN_FALSE;
+    RETURN_EMPTY_ARRAY();
   }
 }
 

--- a/vkext/vkext.cmake
+++ b/vkext/vkext.cmake
@@ -54,7 +54,7 @@ prepend(VKEXT_SOURCES ${VKEXT_DIR}/
         vkext-stats.cpp
         vkext-sp.cpp)
 
-foreach(PHP_VERSION IN ITEMS "" "7.2" "7.4")
+foreach(PHP_VERSION IN ITEMS "" "7.4")
     find_program(PHP_CONFIG_EXEC${PHP_VERSION} php-config${PHP_VERSION})
     set(PHP_CONFIG_EXEC ${PHP_CONFIG_EXEC${PHP_VERSION}})
     if(PHP_CONFIG_EXEC)


### PR DESCRIPTION
relates to `KPHP-1425`