### PR TITLE
Nice error message for finally

### DIFF
--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -182,6 +182,7 @@ std::string debugTokenName(TokenType t) {
     {tok_new, "tok_new"},
     {tok_try, "tok_try"},
     {tok_catch, "tok_catch"},
+    {tok_finally, "tok_finally"},
     {tok_public, "tok_public"},
     {tok_private, "tok_private"},
     {tok_protected, "tok_protected"},

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -2076,6 +2076,12 @@ VertexPtr GenTree::get_statement(vk::string_view phpdoc_str) {
         catch_op.set_location(location);
         catch_list.emplace_back(catch_op);
       }
+      if (test_expect(tok_finally)) {
+        kphp_error(0, "finally is unsupported");
+        next_cur();
+        get_statement();
+        return {};
+      }
       CE (!kphp_error(!catch_list.empty(), "Expected at least 1 'catch' statement"));
 
       return VertexAdaptor<op_try>::create(embrace(try_body), std::move(catch_list)).set_location(location);

--- a/compiler/keywords.gperf
+++ b/compiler/keywords.gperf
@@ -89,6 +89,7 @@ new, tok_new
 throw, tok_throw
 try, tok_try
 catch, tok_catch
+finally, tok_finally
 namespace, tok_namespace
 public, tok_public
 private, tok_private

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -176,6 +176,7 @@ enum TokenType {
 
   tok_try,
   tok_catch,
+  tok_finally,
 
   tok_public,
   tok_private,

--- a/tests/phpt/exceptions/18_finally.php
+++ b/tests/phpt/exceptions/18_finally.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/finally is unsupported/
+<?php
+
+try {
+  echo "try\n";
+} finally {
+  echo "finally\n";
+}


### PR DESCRIPTION
Consider simple script

```php
<?php

try {
    throw new Exception('here we go');
} catch (Exception $e) {
    echo $e->getMessage(), PHP_EOL;
} finally {
    echo "finally\n";
}
```

for now `finally` keyword gives strange error message

```
Compilation error at stage: Parse file, gen by gentree.cpp:314
  t.php:8
    echo "finally\n ";

Expected '}', found 'echo'


~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Compilation error at stage: Parse file, gen by gentree.cpp:1577
  t.php:8
    echo "finally\n ";

Failed to parse statement. Expected `;`

line 9: something wrong

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Compilation error at stage: Parse file, gen by gentree.cpp:2251
  t.php:9
    }

Cannot compile (probably problems with brace balance)

Compilation terminated due to errors
```

this pr adds nice error message for finally keyword

```
Compilation error at stage: Parse file, gen by gentree.cpp:2080
  t.php:7
    } finally {

finally is unsupported

Compilation terminated due to errors
```