### PR TITLE
Improved error handling in master process

### DIFF
--- a/common/dl-utils-lite.cpp
+++ b/common/dl-utils-lite.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <cassert>
 #include <cinttypes>
+#include <errno.h>
 #include <execinfo.h>
 #include <fcntl.h>
 #include <limits>
@@ -95,11 +96,10 @@ void __assert_fail(const char *assertion, const char *file, unsigned int line, c
 void dl_assert__(const char *expr __attribute__((unused)), const char *file_name, const char *func_name,
                  int line, const char *desc, int use_perror) {
   snprintf(assert_message.data(), assert_message.size(),
-           "dl_assert failed [%s:%d: %s]: %s", kbasename(file_name), line, func_name, desc);
+           "dl_assert failed [%s:%d: %s]: %s%s%s", kbasename(file_name), line, func_name, desc,
+           use_perror ? "; errno message = " : "",
+           use_perror ? strerror(errno) : "");
   fprintf(stderr, "%s\n", assert_message.data());
-  if (use_perror) {
-    perror("perror description");
-  }
   abort();
 }
 

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -564,6 +564,10 @@ int run_worker(WorkerType worker_type) {
   tot_workers_started++;
   const uint16_t worker_unique_id = vk::singleton<WorkersControl>::get().on_worker_creating(worker_type);
   pid_t new_pid = fork();
+  if (new_pid == -1) {
+    log_server_critical("fork error on launching %s worker: %s", (worker_type == WorkerType::general_worker ? "general" : "job"), strerror(errno));
+    assert(false);
+  }
   assert (new_pid != -1 && "failed to fork");
 
   if (new_pid == 0) {

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1330,8 +1330,10 @@ static void cron() {
   unsigned long long utime = 0;
   unsigned long long stime = 0;
 #if !defined(__APPLE__)
-  const bool get_cpu_err = get_cpu_total(&cpu_total);
-  dl_assert (get_cpu_err, "get_cpu_total failed");
+  const bool get_cpu_ok = get_cpu_total(&cpu_total);
+  if (!get_cpu_ok) {
+    log_server_error("get_cpu_total failed");
+  }
 #endif
   const uint16_t alive_workers_count = vk::singleton<WorkersControl>::get().get_all_alive();
   for (uint16_t i = 0; i < alive_workers_count; ++i) {


### PR DESCRIPTION
Here are several small enhancements:
- improved `dl_passert` logging to make `perror` message available in sentry
- softer error handling in several places in master process (relates to `KPHP-1350`)
- more detailed logging on fork errors