### PR TITLE
to_array_debug() now correctly handle defines as shape's key

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1287,7 +1287,6 @@ VertexAdaptor<op_shape> GenTree::get_shape() {
     const std::string &key_str = key_v->get_string();
     const std::int64_t hash = string_hash(key_str.data(), key_str.size());
     CE (!kphp_error(keys_hashes.insert(hash).second, "keys of shape() are not unique"));
-    TypeHintShape::register_known_key(hash, key_str);
   }
 
   // shape->args() is a sequence of op_double_arrow

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -4,6 +4,8 @@
 
 #include "compiler/inferring/expr-node.h"
 
+#include "common/php-functions.h"
+
 #include "compiler/compiler-core.h"
 #include "compiler/data/define-data.h"
 #include "compiler/data/function-data.h"
@@ -189,6 +191,9 @@ void ExprNodeRecalc::recalc_shape(VertexAdaptor<op_shape> shape) {
     vector<Key> i_key_index{Key::string_key(str_index)};
     MultiKey key(i_key_index);
     set_lca_at(&key, double_arrow->value());
+
+    const std::int64_t hash = string_hash(str_index.data(), str_index.size());
+    TypeHintShape::register_known_key(hash, str_index);
   }
 }
 

--- a/tests/phpt/dl/1037_to_array_debug_shape_define.php
+++ b/tests/phpt/dl/1037_to_array_debug_shape_define.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class Foo {
+  const FIELD = "foo";
+}
+
+function to_array_debug_shape_define() {
+  /** @var shape(foo:string, bar:int) */
+  $shape = shape([Foo::FIELD => "baz", "bar" => 42]);
+  $dump = to_array_debug($shape);
+  var_dump($dump);
+}
+
+to_array_debug_shape_define();


### PR DESCRIPTION
Prior patch such code processed incorrectly:
```
class Foo {
  const DATA = "foo";
}

$s = shape([Foo::DATA => 42]);
var_dump(to_array_debug($s));
```
The problem was that shape's keys put in storage too early, before any defines was processed. So, instead of "foo" key in storage, there was a "Foo::DATA" key.