### PR TITLE
better behavior on phpdoc inheritance and "phpdoc + type hint" combinations

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1524,8 +1524,8 @@ VertexAdaptor<op_function> GenTree::get_function(bool is_lambda, vk::string_view
     CE (expect(tok_double_arrow, "'=>'"));
     auto body_expr = get_expression();
     CE (!kphp_error(body_expr, "Bad expression in arrow function body"));
-    auto return_stmt = VertexAdaptor<op_return>::create(body_expr);
-    cur_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(return_stmt);
+    auto return_stmt = VertexAdaptor<op_return>::create(body_expr).set_location(func_location);
+    cur_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(return_stmt).set_location(func_location);
     auto_capture_vars_from_body_in_arrow_lambda(cur_function);
   } else if (test_expect(tok_opbrc)) { // then we have '{ cmd }' or ';' — function is marked as func_extern in the latter case
     CE(!kphp_error(!cur_function->modifiers.is_abstract(), fmt_format("abstract methods must have empty body: {}", cur_function->as_human_readable())));

--- a/tests/phpt/class_inheritance/049_deligating_constructor_kphp_infer.php
+++ b/tests/phpt/class_inheritance/049_deligating_constructor_kphp_infer.php
@@ -24,3 +24,19 @@ class D2 extends B2 {
 $d = new D(10);
 $d2 = new D2(10);
 var_dump("OK");
+
+class XX {
+    /** @param int|null $a */
+    function __construct($a = null) {}
+}
+
+class YY extends XX {
+    function __construct() {
+        parent::__construct();
+    }
+}
+
+class ZZ extends YY {
+}
+
+new ZZ;

--- a/tests/phpt/interfaces/signature_compatibility/callable_inherit_error.php
+++ b/tests/phpt/interfaces/signature_compatibility/callable_inherit_error.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/Declaration of Impl::f\(\) must be compatible with Base::f\(\)/
+<?php
+
+abstract class Base {
+  /**
+   * @param $cb callable(int):void
+   */
+  public abstract function f(callable $cb);
+}
+
+class Impl extends Base {
+  /**
+   * @param $cb callable(string):void
+   */
+  public function f(callable $cb) {}
+}
+

--- a/tests/phpt/interfaces/signature_compatibility/callable_inherit_ok.php
+++ b/tests/phpt/interfaces/signature_compatibility/callable_inherit_ok.php
@@ -1,0 +1,17 @@
+@ok
+<?php
+
+abstract class Base {
+  /**
+   * @param $cb callable(int):void
+   */
+  public abstract function f(callable $cb);
+}
+
+class Impl extends Base {
+  /**
+   * @param $cb callable(int):void
+   */
+  public function f(callable $cb) {}
+}
+

--- a/tests/phpt/interfaces/signature_compatibility/iface_return_derived.php
+++ b/tests/phpt/interfaces/signature_compatibility/iface_return_derived.php
@@ -14,3 +14,32 @@ class Impl implements Iface {
 
 /** @var Iface[] $list */
 $list = [new Impl()];
+
+
+interface I {
+    /** @return static */
+    static public function fromArray(array $data);
+}
+
+abstract class Not implements I {
+    static public function fromArray(array $data): ?Not { return static::getMe(); }
+    abstract static public function getMe(): Not;
+    public function m() { echo "Not\n"; }
+}
+
+class D1 extends Not {
+    static public function getMe(): Not { return new self; }
+    public function m() { echo "m1\n"; }
+}
+class D2 extends Not {
+    static public function getMe(): Not { return new self; }
+    public function m() { echo "m2\n"; }
+}
+class D3 extends Not {
+    static public function getMe(): Not { return new self; }
+    public function m() { echo "m3\n"; }
+}
+
+D1::fromArray([1])->m();
+D2::fromArray([1])->m();
+D3::fromArray([1])->m();

--- a/tests/phpt/interfaces/signature_compatibility/multi_level_doc_inherit.php
+++ b/tests/phpt/interfaces/signature_compatibility/multi_level_doc_inherit.php
@@ -1,0 +1,86 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+
+interface IData {
+	function get(): string;
+}
+class DataA implements IData {
+	function get(): string { return "DataA"; }
+}
+class DataB implements IData {
+	function get(): string { return "DataB"; }
+}
+
+interface I
+{
+	/**
+	* @param IData[] $a
+	* @return IData[]
+	*/
+	public function method(array $a);
+}
+
+class A implements I
+{
+	public function method(array $a) {
+		return [new DataA()];
+	}
+}
+
+class B extends A
+{
+	public function method(array $a) {
+		return $this->getB();
+	}
+
+	/** @return DataB[] */
+	function getB(): array  {
+		return [new DataB()];
+	}
+}
+
+function test2(I $i) {
+    foreach ($i->method([new DataB()]) as $idata) {
+        echo $idata->get(), "\n";
+    }
+}
+
+test2(new A);
+test2(new B);
+
+
+interface IWorkWithData {
+    /**
+      * @param IData[] $idata
+      * @return IData[]
+      */
+    function showArray(array $idata): array;
+
+    /**
+     * @param callable(IData):IData $cb
+     */
+    function callAndShow(callable $cb);
+}
+
+class Work implements IWorkWithData {
+    function showArray(array $idata): array {
+        foreach ($idata as $i)
+            echo $i->get(), "\n";
+        return [];
+    }
+
+    function callAndShow(callable $cb) {
+        echo $cb(new DataA)->get(), "\n";
+    }
+}
+
+function demo1() {
+    $w = new Work;
+    $w->showArray([new DataA, new DataB]);
+    $w->callAndShow(function ($a) { $a->get(); return $a; });
+}
+
+demo1();
+

--- a/tests/phpt/phpdocs/027_type_hints_with_phpdocs.php
+++ b/tests/phpt/phpdocs/027_type_hints_with_phpdocs.php
@@ -1,0 +1,35 @@
+@ok
+<?php
+
+/**
+ * @param int $x
+ * @return string|null
+ */
+function f1(int $x): ?string {
+    return null;
+}
+
+/**
+ * @param ?int[] $x
+ * @param callable(int):void $cb
+ * @return string[]
+ */
+function f2(?array $x, callable $cb): array {
+    return [];
+}
+
+/**
+ * @param (int|false)[] $p1
+ * @param int[]|false[] $p2
+ * @param null|int[] $p3
+ * @param null|int[]|array $p4
+ * @param null|float[]|int[] $p5
+ * @return int[]|string[]
+ */
+function f3(array $p1, array $p2, ?array $p3, ?array $p4, ?array $p5): array {
+    return [];
+}
+
+f1(1);
+f2(null,function($x){});
+f3([],[],[],[],[]);

--- a/tests/phpt/phpdocs/101_typehint_doc_mismatch_1.php
+++ b/tests/phpt/phpdocs/101_typehint_doc_mismatch_1.php
@@ -1,0 +1,9 @@
+@todo
+/php type hint array mismatches with @return tuple\(int\)/
+<?php
+
+/** @return tuple(int) */
+function f(): array {
+}
+
+f();

--- a/tests/phpt/phpdocs/102_typehint_doc_mismatch_2.php
+++ b/tests/phpt/phpdocs/102_typehint_doc_mismatch_2.php
@@ -1,0 +1,11 @@
+@todo
+/php type hint bool mismatches with @param mixed/
+<?php
+
+/**
+ * @param mixed $v
+ */
+function f(bool $v) {
+}
+
+f();

--- a/tests/phpt/phpdocs/103_typehint_doc_mismatch_3.php
+++ b/tests/phpt/phpdocs/103_typehint_doc_mismatch_3.php
@@ -1,0 +1,11 @@
+@todo
+/php type hint int mismatches with @param any/
+<?php
+
+/**
+ * @param any $o
+ */
+function f(int $o) {
+}
+
+f();

--- a/tests/phpt/phpdocs/104_typehint_doc_mismatch_4.php
+++ b/tests/phpt/phpdocs/104_typehint_doc_mismatch_4.php
@@ -1,0 +1,11 @@
+@todo
+/php type hint array mismatches with @param \?int\[\]/
+<?php
+
+/**
+ * @param ?int[] $o
+ */
+function f(array $o) {
+}
+
+f();

--- a/tests/phpt/typehints/return_types/15_for_assumption.php
+++ b/tests/phpt/typehints/return_types/15_for_assumption.php
@@ -21,7 +21,7 @@ $a1 = f1(new A);
 echo $a1->a + 1, "\n";
 
 /**
- * @return A
+ * @return ?A
  */
 function f2() : ?A {
   if(true) return new A(7);


### PR DESCRIPTION
Now we deal better with situations like
1) Inherit phpdoc from parent when necessary. For example:
```
interface I {
    /**
     * @param callable(IData):IData $cb
     */
    function callAndShow(callable $cb);
}

class Work implements I {
    // inherit a typed callable from I, don't turn this function into a template one
    function callAndShow(callable $cb) {
    }
}
```

2) Multi-level inheritance and phpdoc discovery throughout all ancestors

3) I've added a check and some tests that phpdoc matches type hint, to fire an error for code like this:
```
/** @return tuple(int, string) */
function f(): array { ... }
```
But finally I had to comment out this check, as vkcom has tons of mismatches (moslty having @return mixed, but :primitive type hint). Tests for this are marked with '@todo' since they don't pass until this check is activated.