### PR TITLE
speedup phpdoc parsing and store PhpDocComment instead of phpdoc_str

### DIFF
--- a/common/algorithms/hashes.h
+++ b/common/algorithms/hashes.h
@@ -71,18 +71,6 @@ size_t hash_sequence(const Ts &... val) {
   return res;
 }
 
-// http://www.cse.yorku.ca/~oz/hash.html
-inline uint64_t string_hash_5381(const std::string &_input) {
-  uint64_t hash = 5381;
-
-  for (auto ch : _input) {
-    int c = (unsigned char)ch;
-    hash = ((hash << 5) + hash) + c; /* hash * 33 + c */
-  }
-
-  return hash;
-}
-
 } // namespace vk
 
 namespace std {

--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -517,7 +517,7 @@ static Assumption calc_assumption_for_var(FunctionPtr f, const std::string &var_
 
   if (f->type == FunctionData::func_main || f->type == FunctionData::func_switch) {
     if (var_name == "MC" || var_name == "PMC") {
-      assumption_add_for_var(f, var_name, Assumption(G->get_memcache_class()), f->root);
+      return Assumption(G->get_memcache_class());
     }
   }
 

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -143,7 +143,7 @@ void ClassData::create_constructor_with_parent_call(DataStream<FunctionPtr> &os)
   parent_call->set_string("parent::__construct");
   has_custom_constructor = true;
 
-  create_constructor(list, VertexAdaptor<op_seq>::create(parent_call), parent_constructor->phpdoc_str, os);
+  create_constructor(list, VertexAdaptor<op_seq>::create(parent_call), parent_constructor->phpdoc, os);
   construct_function->is_auto_inherited = true;
 }
 
@@ -159,11 +159,11 @@ void ClassData::create_default_constructor_if_required(DataStream<FunctionPtr> &
   }
 }
 
-void ClassData::create_constructor(VertexAdaptor<op_func_param_list> param_list, VertexAdaptor<op_seq> body, vk::string_view phpdoc, DataStream<FunctionPtr> &os) {
+void ClassData::create_constructor(VertexAdaptor<op_func_param_list> param_list, VertexAdaptor<op_seq> body, const PhpDocComment *phpdoc, DataStream<FunctionPtr> &os) {
   auto func = VertexAdaptor<op_function>::create(param_list, body);
   func.set_location_recursively(Location{location_line_num});
   create_constructor(func);
-  construct_function->phpdoc_str = phpdoc;
+  construct_function->phpdoc = phpdoc;
 
   G->register_and_require_function(construct_function, os, true);
 }

--- a/compiler/data/class-data.h
+++ b/compiler/data/class-data.h
@@ -50,9 +50,9 @@ public:
   ClassPtr parent_class;                       // extends
   std::vector<InterfacePtr> implements;
   std::vector<ClassPtr> derived_classes;
-
   FunctionPtr construct_function;
-  vk::string_view phpdoc_str;
+
+  const PhpDocComment *phpdoc{nullptr};
 
   bool can_be_php_autoloaded{false};
   bool is_immutable{false};
@@ -95,7 +95,7 @@ public:
 
   void create_constructor_with_parent_call(DataStream<FunctionPtr> &os);
   void create_default_constructor_if_required(DataStream<FunctionPtr> &os);
-  void create_constructor(VertexAdaptor<op_func_param_list> param_list, VertexAdaptor<op_seq> body, vk::string_view phpdoc, DataStream<FunctionPtr> &os);
+  void create_constructor(VertexAdaptor<op_func_param_list> param_list, VertexAdaptor<op_seq> body, const PhpDocComment *phpdoc, DataStream<FunctionPtr> &os);
   void create_constructor(VertexAdaptor<op_function> func);
 
   static auto gen_param_this(Location location) {

--- a/compiler/data/class-members.cpp
+++ b/compiler/data/class-members.cpp
@@ -51,10 +51,10 @@ std::string ClassMemberInstanceMethod::get_hash_name() const {
   return hash_name(local_name());
 }
 
-inline ClassMemberStaticField::ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) :
+inline ClassMemberStaticField::ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint) :
   modifiers(modifiers),
   root(root),
-  phpdoc_str(phpdoc_str),
+  phpdoc(phpdoc),
   type_hint(type_hint) {
 
   std::string global_var_name = replace_backslashes(klass->name) + "$$" + root->get_string();
@@ -92,10 +92,10 @@ std::string ClassMemberInstanceField::get_hash_name() const {
   return hash_name(local_name());
 }
 
-ClassMemberInstanceField::ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) :
+ClassMemberInstanceField::ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint) :
   modifiers(modifiers),
   root(root),
-  phpdoc_str(phpdoc_str),
+  phpdoc(phpdoc),
   type_hint(type_hint) {
 
   std::string local_var_name = root->get_string();
@@ -103,7 +103,7 @@ ClassMemberInstanceField::ClassMemberInstanceField(ClassPtr klass, VertexAdaptor
   root->var_id = var;
   var->init_val = def_val;
   var->class_id = klass;
-  var->marked_as_const = klass->is_immutable || phpdoc_tag_exists(phpdoc_str, php_doc_tag::kphp_const);
+  var->marked_as_const = klass->is_immutable || (phpdoc && phpdoc->has_tag(PhpDocType::kphp_const));
 }
 
 const TypeData *ClassMemberInstanceField::get_inferred_type() const {
@@ -175,12 +175,12 @@ void ClassMembersContainer::add_instance_method(FunctionPtr function) {
   }
 }
 
-void ClassMembersContainer::add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) {
-  append_member(ClassMemberStaticField{klass, root, def_val, modifiers, phpdoc_str, type_hint});
+void ClassMembersContainer::add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint) {
+  append_member(ClassMemberStaticField{klass, root, def_val, modifiers, phpdoc, type_hint});
 }
 
-void ClassMembersContainer::add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint) {
-  append_member(ClassMemberInstanceField{klass, root, def_val, modifiers, phpdoc_str, type_hint});
+void ClassMembersContainer::add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint) {
+  append_member(ClassMemberInstanceField{klass, root, def_val, modifiers, phpdoc, type_hint});
 }
 
 void ClassMembersContainer::add_constant(const std::string &const_name, VertexPtr value, AccessModifiers access) {

--- a/compiler/data/class-members.h
+++ b/compiler/data/class-members.h
@@ -70,10 +70,10 @@ struct ClassMemberStaticField {
   FieldModifiers modifiers;
   VertexAdaptor<op_var> root;
   VarPtr var;
-  vk::string_view phpdoc_str;
+  const PhpDocComment *phpdoc{nullptr};
   const TypeHint *type_hint{nullptr};  // from @var / php 7.4 type hint / default value
 
-  ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
+  ClassMemberStaticField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint);
 
   vk::string_view local_name() const &;
   static std::string hash_name(vk::string_view name);
@@ -85,12 +85,12 @@ struct ClassMemberInstanceField {
   FieldModifiers modifiers;
   VertexAdaptor<op_var> root;
   VarPtr var;
-  vk::string_view phpdoc_str;
+  const PhpDocComment *phpdoc{nullptr};
   const TypeHint *type_hint{nullptr};  // from @var / php 7.4 type hint / default value
   int8_t serialization_tag = -1;
   bool serialize_as_float32{false};
 
-  ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
+  ClassMemberInstanceField(ClassPtr klass, VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint);
 
   vk::string_view local_name() const &;
   vk::string_view local_name() const && = delete;
@@ -188,8 +188,8 @@ public:
 
   void add_static_method(FunctionPtr function);
   void add_instance_method(FunctionPtr function);
-  void add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
-  void add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, vk::string_view phpdoc_str, const TypeHint *type_hint);
+  void add_static_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint);
+  void add_instance_field(VertexAdaptor<op_var> root, VertexPtr def_val, FieldModifiers modifiers, const PhpDocComment *phpdoc, const TypeHint *type_hint);
   void add_constant(const std::string &const_name, VertexPtr value, AccessModifiers access);
 
   bool has_constant(vk::string_view local_name) const;

--- a/compiler/data/data_ptr.h
+++ b/compiler/data/data_ptr.h
@@ -102,6 +102,7 @@ class FunctionData;
 class LibData;
 class SrcFile;
 class TypeHint;
+class PhpDocComment;
 struct GenericsInstantiationMixin;
 
 using VarPtr = Id<VarData>;

--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -92,6 +92,8 @@ public:
   const TypeHint *return_typehint{nullptr};
   tinf::VarNode tinf_node;              // tinf node for return
 
+  const PhpDocComment *phpdoc{nullptr};
+  
   bool has_variadic_param = false;
   bool should_be_sync = false;
   bool should_not_throw = false;
@@ -106,6 +108,7 @@ public:
   bool is_overridden_method = false;
   bool is_no_return = false;
   bool has_lambdas_inside = false;      // used for optimization after cloning (not to launch CloneNestedLambdasPass)
+  bool has_var_tags_inside = false;     // used for optimization (not to traverse body when applying phpdoc if no @var inside)
   bool warn_unused_result = false;
   bool is_flatten = false;
   bool is_pure = false;
@@ -137,7 +140,6 @@ public:
   ClassPtr class_id;
   ClassPtr context_class;
   FunctionModifiers modifiers = FunctionModifiers::nonmember();
-  vk::string_view phpdoc_str;
 
   enum class body_value {
     empty,

--- a/compiler/data/generics-mixins.h
+++ b/compiler/data/generics-mixins.h
@@ -34,7 +34,7 @@ struct GenericsDeclarationMixin {
   void add_itemT(const std::string &nameT, const TypeHint *extends_hint);
   const TypeHint *find(const std::string &nameT) const;
 
-  static void apply_from_phpdoc(FunctionPtr f, vk::string_view phpdoc_str);
+  static void apply_from_phpdoc(FunctionPtr f, const PhpDocComment *phpdoc);
   static void make_function_generics_on_callable_arg(FunctionPtr f, VertexPtr func_param);
 };
 

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -80,15 +80,15 @@ public:
   VertexAdaptor<op_func_param> get_func_param();
   VertexAdaptor<op_var> get_var_name();
   VertexAdaptor<op_var> get_var_name_ref();
-  VertexPtr get_expr_top(bool was_arrow, vk::string_view phpdoc_str = vk::string_view{});
+  VertexPtr get_expr_top(bool was_arrow, const PhpDocComment *phpdoc = nullptr);
   VertexPtr get_postfix_expression(VertexPtr res, bool parenthesized);
   VertexPtr get_unary_op(int op_priority_cur, Operation unary_op_tp, bool till_ternary);
   VertexPtr get_binary_op(int op_priority_cur, bool till_ternary);
   VertexPtr get_expression_impl(bool till_ternary);
   VertexPtr get_expression();
-  VertexPtr get_statement(vk::string_view phpdoc_str = vk::string_view{});
+  VertexPtr get_statement(const PhpDocComment *phpdoc = nullptr);
   VertexAdaptor<op_catch> get_catch();
-  void get_instance_var_list(vk::string_view phpdoc_str, FieldModifiers modifiers, const TypeHint *type_hint);
+  void get_instance_var_list(const PhpDocComment *phpdoc, FieldModifiers modifiers, const TypeHint *type_hint);
   void get_traits_uses();
   void get_use();
   void get_seq(std::vector<VertexPtr> &seq_next);
@@ -128,11 +128,11 @@ public:
   VertexPtr get_phpdoc_inside_function();
   bool parse_cur_function_uses();
   static bool test_if_uses_and_arguments_intersect(const std::forward_list<VertexAdaptor<op_var>> &uses_list, const VertexRange &params);
-  VertexAdaptor<op_lambda> get_lambda_function(vk::string_view phpdoc_str, FunctionModifiers modifiers);
-  VertexAdaptor<op_function> get_function(bool is_lambda, vk::string_view phpdoc_str, FunctionModifiers modifiers);
+  VertexAdaptor<op_lambda> get_lambda_function(const PhpDocComment *phpdoc, FunctionModifiers modifiers);
+  VertexAdaptor<op_function> get_function(bool is_lambda, const PhpDocComment *phpdoc, FunctionModifiers modifiers);
 
   ClassMemberModifiers parse_class_member_modifier_mask();
-  VertexPtr get_class_member(vk::string_view phpdoc_str);
+  VertexPtr get_class_member(const PhpDocComment *phpdoc);
 
   std::string get_identifier();
 
@@ -140,7 +140,7 @@ public:
   static VertexAdaptor<op_func_call> gen_constructor_call_with_args(ClassPtr allocated_class, std::vector<VertexPtr> args, const Location &locaction);
   static VertexAdaptor<op_var> auto_capture_this_in_lambda(FunctionPtr f_lambda);
 
-  VertexPtr get_class(vk::string_view phpdoc_str, ClassType class_type);
+  VertexPtr get_class(const PhpDocComment *phpdoc, ClassType class_type);
   void parse_extends_implements();
 
   static VertexPtr process_arrow(VertexPtr lhs, VertexPtr rhs);
@@ -153,7 +153,7 @@ private:
 
   VertexAdaptor<op_func_param_list> parse_cur_function_param_list();
 
-  VertexAdaptor<op_empty> get_static_field_list(vk::string_view phpdoc_str, FieldModifiers modifiers, const TypeHint *type_hint);
+  VertexAdaptor<op_empty> get_static_field_list(const PhpDocComment *phpdoc, FieldModifiers modifiers, const TypeHint *type_hint);
   VertexAdaptor<op_var> get_function_use_var_name_ref();
   VertexPtr get_foreach_value();
   std::pair<VertexAdaptor<op_foreach_param>, VertexPtr> get_foreach_param();

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -78,10 +78,11 @@ void TypeHintArgRefInstance::recalc_type_data_in_context_of_call(TypeData *dst, 
         dst->set_lca(klass->type_data);
         return;
       }
+      kphp_error(0, fmt_format("Can't find class {}", *class_name));
     }
   }
 
-  kphp_error(0, fmt_format("Bad parameter #{}: can't find this class", arg_num));
+  kphp_error(0, fmt_format("Can't find class: argument #{} is not a const string", arg_num));
   dst->set_lca(TypeData::get_type(tp_Error));
 }
 

--- a/compiler/lambda-utils.cpp
+++ b/compiler/lambda-utils.cpp
@@ -280,7 +280,7 @@ ClassPtr generate_lambda_class_wrapping_lambda_function(FunctionPtr f_lambda) {
   for (auto var_as_use : f_lambda->uses_list) {
     auto var_as_field = VertexAdaptor<op_var>::create().set_location(f_lambda->root);
     var_as_field->str_val = var_as_use->str_val;
-    c_lambda->members.add_instance_field(var_as_field, {}, FieldModifiers{}.set_public(), vk::string_view{}, nullptr);
+    c_lambda->members.add_instance_field(var_as_field, {}, FieldModifiers{}.set_public(), nullptr, nullptr);
 
     kphp_error(!f_lambda->modifiers.is_static_lambda() || var_as_use->extra_type != op_ex_var_this,
                "Using $this in a static lambda");

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -33,14 +33,6 @@ LexerData::LexerData(vk::string_view new_code) :
   tokens.reserve(static_cast<size_t >(code_len * 0.3));
 }
 
-const char *LexerData::get_code() const {
-  return code;
-}
-
-vk::string_view LexerData::get_code_view() const {
-  return {code, code_end};
-}
-
 void LexerData::pass(int shift) {
   line_num += std::count_if(code, code + shift, [](char c) { return c == '\n'; });
   pass_raw(shift);
@@ -1196,7 +1188,7 @@ std::vector<Token> php_text_to_tokens(vk::string_view text) {
 std::vector<Token> phpdoc_to_tokens(vk::string_view text) {
   LexerData lexer_data{text};
   lexer_data.set_dont_hack_last_tokens(); // like in op_conv_int, future(int) doesn't need (int)
-  while (*lexer_data.get_code()) {
+  while (!lexer_data.get_code_view().empty()) {
     if (!vk::singleton<TokenLexerPHPDoc>::get().parse(&lexer_data)) {
       break;
     }

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -17,8 +17,8 @@
 struct LexerData : private vk::not_copyable {
   explicit LexerData(vk::string_view new_code);
   void new_line();
-  const char *get_code() const;
-  vk::string_view get_code_view() const;
+  const char *get_code() const { return code; }
+  vk::string_view get_code_view() const { return vk::string_view{code, code_end}; };
   void pass(int shift);
   void pass_raw(int shift);
   template <typename ...Args>

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -21,115 +21,195 @@
 #include "compiler/utils/string-utils.h"
 #include "compiler/ffi/ffi_parser.h"
 
-using std::vector;
-using std::string;
+struct KnownPhpDocTag {
+  unsigned int hash;
+  PhpDocType type;
+  const char *tag_name;
 
-const std::map<string, php_doc_tag::doc_type> php_doc_tag::str2doc_type = {
-  {"@param",                     param},
-  {"@kphp-inline",               kphp_inline},
-  {"@kphp-flatten",              kphp_flatten},
-  {"@kphp-infer",                kphp_infer},
-  {"@kphp-required",             kphp_required},
-  {"@kphp-lib-export",           kphp_lib_export},
-  {"@kphp-sync",                 kphp_sync},
-  {"@kphp-should-not-throw",     kphp_should_not_throw},
-  {"@kphp-throws",               kphp_throws},
-  {"@type",                      var},
-  {"@var",                       var},
-  {"@return",                    returns},
-  {"@returns",                   returns},
-  {"@kphp-disable-warnings",     kphp_disable_warnings},
-  {"@kphp-extern-func-info",     kphp_extern_func_info},
-  {"@kphp-pure-function",        kphp_pure_function},
-  {"@kphp-template",             kphp_template},
-  {"@kphp-param",                kphp_param},
-  {"@kphp-return",               kphp_return},
-  {"@kphp-memcache-class",       kphp_memcache_class},
-  {"@kphp-immutable-class",      kphp_immutable_class},
-  {"@kphp-tl-class",             kphp_tl_class},
-  {"@kphp-const",                kphp_const},
-  {"@kphp-no-return",            kphp_noreturn},
-  {"@kphp-warn-unused-result",   kphp_warn_unused_result},
-  {"@kphp-warn-performance",     kphp_warn_performance},
-  {"@kphp-analyze-performance",  kphp_analyze_performance},
-  {"@kphp-serializable",         kphp_serializable},
-  {"@kphp-reserved-fields",      kphp_reserved_fields},
-  {"@kphp-serialized-field",     kphp_serialized_field},
-  {"@kphp-serialized-float32",   kphp_serialized_float32},
-  {"@kphp-profile",              kphp_profile},
-  {"@kphp-profile-allow-inline", kphp_profile_allow_inline},
-  {"@kphp-strict-types-enable",  kphp_strict_types_enable},
-  {"@kphp-color",                kphp_color},
+  constexpr KnownPhpDocTag(const char *tag_name, PhpDocType type)
+    : hash(5381), type(type), tag_name(tag_name) {
+    for (const char *c = tag_name; *c; ++c) {
+      hash = (hash << 5) + hash + *c;
+    }
+  }
 };
 
-vector<php_doc_tag> parse_php_doc(vk::string_view phpdoc) {
-  if (phpdoc.empty()) {
-    return {};
+class AllDocTags {
+  static constexpr int N_TAGS = 35;
+  static const KnownPhpDocTag ALL_TAGS[N_TAGS];
+
+public:
+  static PhpDocType name2type(const char *start, const char *end) __attribute__((always_inline)) {
+    unsigned int hash = 5381;
+    for (const char *c = start; c != end; ++c) {
+      hash = (hash << 5) + hash + *c;
+    }
+
+    for (const KnownPhpDocTag &tag: ALL_TAGS) {
+      if (tag.hash == hash) {
+        return tag.type;
+      }
+    }
+    return PhpDocType::unknown;
   }
 
-  int line_num_of_function_declaration = stage::get_line();
-
-  vector<string> lines(1);
-  bool have_star = false;
-  for (char c : phpdoc) {
-    if (!have_star) {
-      if (c == ' ' || c == '\t') {
-        continue;
+  static const char *type2name(PhpDocType type) {
+    for (const KnownPhpDocTag &tag: ALL_TAGS) {
+      if (tag.type == type) {
+        return tag.tag_name;
       }
-      if (c == '*') {
-        have_star = true;
-        continue;
-      }
-      kphp_error(0, "failed to parse php_doc");
-      return {};
     }
-    if (c == '\n') {
-      lines.push_back("");
-      have_star = false;
+    return "@tag";
+  }
+};
+
+const KnownPhpDocTag AllDocTags::ALL_TAGS[] = {
+  KnownPhpDocTag("@param", PhpDocType::param),
+  KnownPhpDocTag("@var", PhpDocType::var),
+  KnownPhpDocTag("@return", PhpDocType::returns),
+  KnownPhpDocTag("@type", PhpDocType::var),
+  KnownPhpDocTag("@returns", PhpDocType::returns),
+  KnownPhpDocTag("@kphp-inline", PhpDocType::kphp_inline),
+  KnownPhpDocTag("@kphp-flatten", PhpDocType::kphp_flatten),
+  KnownPhpDocTag("@kphp-infer", PhpDocType::kphp_infer),
+  KnownPhpDocTag("@kphp-required", PhpDocType::kphp_required),
+  KnownPhpDocTag("@kphp-lib-export", PhpDocType::kphp_lib_export),
+  KnownPhpDocTag("@kphp-sync", PhpDocType::kphp_sync),
+  KnownPhpDocTag("@kphp-should-not-throw", PhpDocType::kphp_should_not_throw),
+  KnownPhpDocTag("@kphp-throws", PhpDocType::kphp_throws),
+  KnownPhpDocTag("@kphp-disable-warnings", PhpDocType::kphp_disable_warnings),
+  KnownPhpDocTag("@kphp-extern-func-info", PhpDocType::kphp_extern_func_info),
+  KnownPhpDocTag("@kphp-pure-function", PhpDocType::kphp_pure_function),
+  KnownPhpDocTag("@kphp-template", PhpDocType::kphp_template),
+  KnownPhpDocTag("@kphp-param", PhpDocType::kphp_param),
+  KnownPhpDocTag("@kphp-return", PhpDocType::kphp_return),
+  KnownPhpDocTag("@kphp-memcache-class", PhpDocType::kphp_memcache_class),
+  KnownPhpDocTag("@kphp-immutable-class", PhpDocType::kphp_immutable_class),
+  KnownPhpDocTag("@kphp-tl-class", PhpDocType::kphp_tl_class),
+  KnownPhpDocTag("@kphp-const", PhpDocType::kphp_const),
+  KnownPhpDocTag("@kphp-no-return", PhpDocType::kphp_noreturn),
+  KnownPhpDocTag("@kphp-warn-unused-result", PhpDocType::kphp_warn_unused_result),
+  KnownPhpDocTag("@kphp-warn-performance", PhpDocType::kphp_warn_performance),
+  KnownPhpDocTag("@kphp-analyze-performance", PhpDocType::kphp_analyze_performance),
+  KnownPhpDocTag("@kphp-serializable", PhpDocType::kphp_serializable),
+  KnownPhpDocTag("@kphp-reserved-fields", PhpDocType::kphp_reserved_fields),
+  KnownPhpDocTag("@kphp-serialized-field", PhpDocType::kphp_serialized_field),
+  KnownPhpDocTag("@kphp-serialized-float32", PhpDocType::kphp_serialized_float32),
+  KnownPhpDocTag("@kphp-profile", PhpDocType::kphp_profile),
+  KnownPhpDocTag("@kphp-profile-allow-inline", PhpDocType::kphp_profile_allow_inline),
+  KnownPhpDocTag("@kphp-strict-types-enable", PhpDocType::kphp_strict_types_enable),
+  KnownPhpDocTag("@kphp-color", PhpDocType::kphp_color),
+};
+
+
+PhpDocComment::PhpDocComment(vk::string_view phpdoc_str) {
+  const char *c = phpdoc_str.data();
+  const char *end = phpdoc_str.end();
+  auto iter_next = tags.before_begin();
+
+  while (c != end) {
+    // we are at line start, waiting for '*' after spaces
+    if (*c == ' ' || *c == '\t' || *c == '\n') {
+      ++c;
       continue;
     }
-    if (lines.back().empty() && (c == ' ' || c == '\t')) {
+    // if not '*', skip this line
+    if (*c != '*') {
+      while (c != end && *c != '\n') {
+        ++c;
+      }
       continue;
     }
-    lines.back() += c;
-  }
-  vector<php_doc_tag> result;
-  for (int i = 0; i < lines.size(); i++) {
-    if (lines[i][0] == '@') {
-      result.emplace_back(php_doc_tag());
-      size_t pos = lines[i].find(' ');
-
-      auto name = lines[i].substr(0, pos);
-      auto type = php_doc_tag::get_doc_type(name);
-      if (vk::string_view{name}.starts_with("@kphp") && type == php_doc_tag::unknown) {
-        kphp_error(0, fmt_format("unrecognized kphp tag: {}", name));
+    // wait for '@' after spaces
+    ++c;
+    while (c != end && *c == ' ') {
+      ++c;
+    }
+    // if not @ after *, skip this line
+    if (*c != '@') {
+      while (c != end && *c != '\n') {
+        ++c;
       }
-
-      result.back().name = std::move(name);
-      result.back().type = type;
-
-      if (pos != string::npos) {
-        int ltrim_pos = pos + 1;
-        while (lines[i][ltrim_pos] == ' ') {
-          ltrim_pos++;
-        }
-        result.back().value = lines[i].substr(ltrim_pos);
-      }
+      continue;
     }
 
-    if (line_num_of_function_declaration > 0 && !result.empty()) {
-      int new_line_num = line_num_of_function_declaration - (static_cast<int>(lines.size()) - i);
-      bool is_singleline = lines.size() < 2;  // if /** ... */ as a single line, otherwise assume */ to be on a separate line
-      result.back().line_num = std::min(new_line_num, line_num_of_function_declaration - (is_singleline ? 1 : 2));
+    // c points to '@', read tag name until space
+    const char *start = c;
+    while (c != end && *c != ' ' && *c != '\n' && *c != '\t') {
+      ++c;
     }
+
+    // convert @tag-name to enum; linear search is better, since most common cases are placed at the top
+    PhpDocType type = AllDocTags::name2type(start, c);
+    if (type == PhpDocType::unknown && vk::string_view{start, 5}.starts_with("@kphp")) {
+      kphp_error(0, fmt_format("unrecognized @kphp tag: '{}'", std::string(start, c)));
+    }
+
+    // after @tag-name, there are spaces and a tag value until end of line
+    while (c != end && *c == ' ') {
+      ++c;
+    }
+    start = c;
+    while (c != end && *c != '\n') {
+      ++c;
+    }
+
+    // append tag to the end of forward list
+    iter_next = tags.emplace_after(iter_next, type, vk::string_view(start, c));
   }
-//  for (int i = 0; i < result.size(); i++) {
-//    fprintf(stderr, "|%s| : |%s|\n", result[i].name.c_str(), result[i].value.c_str());
-//  }
-  return result;
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_classname(const std::string &phpdoc_class_name) {
+std::string PhpDocTag::get_tag_name() const {
+  return AllDocTags::type2name(type);
+}
+
+/*
+ * With a phpdoc string after a @param/@return/@var like "int|false $a maybe comment"
+ * or "$var tuple(int, string) maybe comment" or "A[] maybe comment"
+ * parse a type (turn it into the TypeHint tree representation) and a variable name (if present).
+ */
+PhpDocTag::TypeAndVarName PhpDocTag::value_as_type_and_var_name(FunctionPtr current_function) const {
+  std::vector<Token> tokens = phpdoc_to_tokens(value);
+  auto tok_iter = tokens.cbegin();
+  vk::string_view var_name;
+
+  // $var_name phpdoc|type maybe comment
+  if (tokens.front().type() == tok_var_name) {
+    var_name = tokens.front().str_val;
+    tok_iter++;
+    if (tokens.size() <= 2) {     // only tok_end is left
+      return {nullptr, var_name};
+    }
+  }
+
+  PhpDocTypeHintParser parser(current_function);
+  const TypeHint *type_hint{nullptr};
+  try {
+    type_hint = parser.parse_from_tokens(tok_iter);
+  } catch (std::runtime_error &ex) {
+    kphp_error(0, fmt_format("{}: {}\n{}",
+                             TermStringFormat::paint_red(TermStringFormat::add_text_attribute("Could not parse " + get_tag_name(), TermStringFormat::bold)),
+                             TermStringFormat::add_text_attribute(value_as_string(), TermStringFormat::underline),
+                             ex.what()));
+  }
+
+  if (!type_hint) {
+    return {nullptr, var_name};
+  }
+
+  if (var_name.empty()) {
+    kphp_assert(tok_iter != tokens.end());
+    // phpdoc|type $var_name maybe comment
+    if (tok_iter->type() == tok_var_name) {   // tok_iter — right after the parsing is finished
+      var_name = tok_iter->str_val;
+    }
+  }
+
+  return {type_hint, var_name};
+}
+
+
+const TypeHint *PhpDocTypeHintParser::parse_classname(const std::string &phpdoc_class_name) {
   cur_tok++;
   // here we have a relative class name, that can be resolved into full unless self/static/parent
   // if self/static/parent, it will be resolved at context, see phpdoc_finalize_type_hint_and_resolve()
@@ -142,7 +222,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_classname(const std::string &phpdoc_
   return TypeHintInstance::create(resolve_uses(current_function, phpdoc_class_name));
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_ffi_cdata() {
+const TypeHint *PhpDocTypeHintParser::parse_ffi_cdata() {
   if (vk::none_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {
     throw std::runtime_error("expected '<' or '('");
   }
@@ -196,7 +276,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_ffi_cdata() {
   return TypeHintFFIType::create(scope_name, type, transfer_ownership);
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_ffi_scope() {
+const TypeHint *PhpDocTypeHintParser::parse_ffi_scope() {
   if (vk::none_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {
     throw std::runtime_error("expected '<' or '('");
   }
@@ -225,7 +305,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_ffi_scope() {
   return TypeHintFFIScope::create(std::string(scope_name));
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_simple_type() {
+const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
   TokenType cur_type = cur_tok->type();
   // some type names inside phpdoc are not keywords/tokens, but they should be interpreted as such
   if (cur_type == tok_func_name) {
@@ -367,7 +447,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_simple_type() {
   }
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_arg_ref() {   // ^1, ^2[*][*], ^3()
+const TypeHint *PhpDocTypeHintParser::parse_arg_ref() {   // ^1, ^2[*][*], ^3()
   if (cur_tok->type() != tok_int_const) {
     throw std::runtime_error("Invalid number after ^");
   }
@@ -388,7 +468,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_arg_ref() {   // ^1, ^2[*][*], ^3()
   return res;
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_type_array() {
+const TypeHint *PhpDocTypeHintParser::parse_type_array() {
   const TypeHint *inner = parse_simple_type();
 
   if (cur_tok->type() == tok_double_colon) {      // T::fieldName
@@ -409,7 +489,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_type_array() {
   return inner;
 }
 
-std::vector<const TypeHint *> PhpDocTypeRuleParser::parse_nested_type_hints() {
+std::vector<const TypeHint *> PhpDocTypeHintParser::parse_nested_type_hints() {
   if (vk::none_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {
     throw std::runtime_error("expected '('");
   }
@@ -430,7 +510,7 @@ std::vector<const TypeHint *> PhpDocTypeRuleParser::parse_nested_type_hints() {
   return sub_types;
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_nested_one_type_hint() {
+const TypeHint *PhpDocTypeHintParser::parse_nested_one_type_hint() {
   if (vk::none_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {
     throw std::runtime_error("expected '('");
   }
@@ -445,7 +525,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_nested_one_type_hint() {
   return sub_type;
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_typed_callable() {  // callable(int, int):?string, callable(int $x), callable():void
+const TypeHint *PhpDocTypeHintParser::parse_typed_callable() {  // callable(int, int):?string, callable(int $x), callable():void
   if (cur_tok->type() != tok_oppar) {
     throw std::runtime_error("expected '('");
   }
@@ -480,7 +560,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_typed_callable() {  // callable(int,
   return TypeHintCallable::create(std::move(arg_types), return_type);
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_shape_type() {
+const TypeHint *PhpDocTypeHintParser::parse_shape_type() {
   if (vk::none_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {
     throw std::runtime_error("expected '('");
   }
@@ -539,7 +619,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_shape_type() {
   return TypeHintShape::create(std::move(shape_items), has_varg);
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_type_expression() {
+const TypeHint *PhpDocTypeHintParser::parse_type_expression() {
   const TypeHint *result = parse_type_array();
   if (cur_tok->type() != tok_or) {
     return result;
@@ -583,7 +663,7 @@ const TypeHint *PhpDocTypeRuleParser::parse_type_expression() {
   return TypeHintPipe::create(std::move(items));
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_from_tokens(std::vector<Token>::const_iterator &tok_iter) {
+const TypeHint *PhpDocTypeHintParser::parse_from_tokens(std::vector<Token>::const_iterator &tok_iter) {
   cur_tok = tok_iter;
   const TypeHint *v = parse_type_expression();      // could throw an exception
 
@@ -597,119 +677,12 @@ const TypeHint *PhpDocTypeRuleParser::parse_from_tokens(std::vector<Token>::cons
   return v;                                   // not null if an exception was not thrown
 }
 
-const TypeHint *PhpDocTypeRuleParser::parse_from_tokens_silent(std::vector<Token>::const_iterator &tok_iter) noexcept {
+const TypeHint *PhpDocTypeHintParser::parse_from_tokens_silent(std::vector<Token>::const_iterator &tok_iter) noexcept {
   try {
     return parse_from_tokens(tok_iter);
   } catch (std::runtime_error &) {
     return {};
   }
-}
-
-/*
- * With a phpdoc string after a @param/@return/@var like "int|false $a maybe comment"
- * or "$var tuple(int, string) maybe comment" or "A[] maybe comment"
- * parse a type (turn it into the TypeHint tree representation) and a variable name (if present).
- */
-PhpDocTagParseResult phpdoc_parse_type_and_var_name(vk::string_view phpdoc_tag_str, FunctionPtr current_function) {
-  std::vector<Token> tokens = phpdoc_to_tokens(phpdoc_tag_str);
-  std::vector<Token>::const_iterator tok_iter = tokens.begin();
-  std::string var_name;
-
-  // $var_name phpdoc|type maybe comment
-  if (tokens.front().type() == tok_var_name) {
-    var_name = std::string(tokens.front().str_val);
-    tok_iter++;
-    if (tokens.size() <= 2) {     // only tok_end is left
-      return {nullptr, std::move(var_name)};
-    }
-  }
-
-  PhpDocTypeRuleParser parser(current_function);
-  const TypeHint *type_hint{nullptr};
-  try {
-    type_hint = parser.parse_from_tokens(tok_iter);
-  } catch (std::runtime_error &ex) {
-    stage::set_location(current_function->root->location);
-    kphp_error(0, fmt_format("{}: {}\n{}",
-                             TermStringFormat::paint_red(TermStringFormat::add_text_attribute("Could not parse phpdoc tag", TermStringFormat::bold)),
-                             TermStringFormat::add_text_attribute(std::string(phpdoc_tag_str), TermStringFormat::underline),
-                             ex.what()));
-  }
-
-  if (!type_hint) {
-    return {nullptr, std::move(var_name)};
-  }
-
-  if (var_name.empty()) {
-    kphp_assert(tok_iter != tokens.end());
-    // phpdoc|type $var_name maybe comment
-    if (tok_iter->type() == tok_var_name) {   // tok_iter — right after the parsing is finished
-      var_name = std::string(tok_iter->str_val);
-    }
-  }
-
-  return {type_hint, std::move(var_name)};
-}
-
-/*
- * With a full phpdoc string / ** ... * / with various tags inside,
- * find the first @tag and parse everything on its right side.
- * Returns result which has a bool() operator (reports whether this tag was found or not).
- */
-PhpDocTagParseResult phpdoc_find_tag(vk::string_view phpdoc, php_doc_tag::doc_type tag_type, FunctionPtr current_function) {
-  if (auto found_tag = phpdoc_find_tag_as_string(phpdoc, tag_type)) {
-    return phpdoc_parse_type_and_var_name(*found_tag, current_function);
-  }
-  return {nullptr, std::string()};
-}
-
-/*
- * With a full phpdoc string / ** ... * /,
- * find all @tag and parse everything on their right side.
- * Useful for @param tags.
- */
-std::vector<PhpDocTagParseResult> phpdoc_find_tag_multi(vk::string_view phpdoc, php_doc_tag::doc_type tag_type, FunctionPtr current_function) {
-  std::vector<PhpDocTagParseResult> result;
-  for (const auto &tag : parse_php_doc(phpdoc)) {
-    if (tag.type == tag_type) {
-      if (auto parsed = phpdoc_parse_type_and_var_name(tag.value, current_function)) {
-        result.emplace_back(std::move(parsed));
-      }
-    }
-  }
-  return result;
-}
-
-/*
- * With a full phpdoc string / ** ... * /,
- * find the first @tag and return everything on its right side as a string.
- */
-std::optional<std::string> phpdoc_find_tag_as_string(vk::string_view phpdoc, php_doc_tag::doc_type tag_type) {
-  for (const auto &tag : parse_php_doc(phpdoc)) {
-    if (tag.type == tag_type) {
-      return tag.value;
-    }
-  }
-  return {};
-}
-
-/*
- * With a full phpdoc string / ** ... * /,
- * find all @tag and return everything on their right side as a string.
- * Useful for @kphp-template tags.
- */
-std::vector<std::string> phpdoc_find_tag_as_string_multi(vk::string_view phpdoc, php_doc_tag::doc_type tag_type) {
-  std::vector<std::string> result;
-  for (const auto &tag : parse_php_doc(phpdoc)) {
-    if (tag.type == tag_type) {
-      result.emplace_back(tag.value);
-    }
-  }
-  return result;
-}
-
-bool phpdoc_tag_exists(vk::string_view phpdoc, php_doc_tag::doc_type tag_type) {
-  return static_cast<bool>(phpdoc_find_tag_as_string(phpdoc, tag_type));
 }
 
 /*

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -21,17 +21,22 @@
 #include "compiler/utils/string-utils.h"
 #include "compiler/ffi/ffi_parser.h"
 
+
+static constexpr unsigned int calcHashOfTagName(const char *start, const char *end) {
+  unsigned int hash = 5381;
+  for (const char *c = start; c != end; ++c) {
+    hash = (hash << 5) + hash + *c;
+  }
+  return hash;
+}
+
 struct KnownPhpDocTag {
   unsigned int hash;
   PhpDocType type;
   const char *tag_name;
 
   constexpr KnownPhpDocTag(const char *tag_name, PhpDocType type)
-    : hash(5381), type(type), tag_name(tag_name) {
-    for (const char *c = tag_name; *c; ++c) {
-      hash = (hash << 5) + hash + *c;
-    }
-  }
+    : hash(calcHashOfTagName(tag_name, tag_name + __builtin_strlen(tag_name))), type(type), tag_name(tag_name) {}
 };
 
 class AllDocTags {
@@ -40,10 +45,7 @@ class AllDocTags {
 
 public:
   [[gnu::always_inline]] static PhpDocType name2type(const char *start, const char *end) {
-    unsigned int hash = 5381;
-    for (const char *c = start; c != end; ++c) {
-      hash = (hash << 5) + hash + *c;
-    }
+    unsigned int hash = calcHashOfTagName(start, end);
 
     for (const KnownPhpDocTag &tag: ALL_TAGS) {
       if (tag.hash == hash) {

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -39,7 +39,7 @@ class AllDocTags {
   static const KnownPhpDocTag ALL_TAGS[N_TAGS];
 
 public:
-  static PhpDocType name2type(const char *start, const char *end) __attribute__((always_inline)) {
+  [[gnu::always_inline]] static PhpDocType name2type(const char *start, const char *end) {
     unsigned int hash = 5381;
     for (const char *c = start; c != end; ++c) {
       hash = (hash << 5) + hash + *c;
@@ -159,7 +159,7 @@ PhpDocComment::PhpDocComment(vk::string_view phpdoc_str) {
   }
 }
 
-std::string PhpDocTag::get_tag_name() const {
+std::string PhpDocTag::get_tag_name() const noexcept {
   return AllDocTags::type2name(type);
 }
 

--- a/compiler/phpdoc.h
+++ b/compiler/phpdoc.h
@@ -57,7 +57,7 @@ struct PhpDocTag {
     const TypeHint *type_hint{nullptr};
     vk::string_view var_name;     // stored without leading "$"; could be empty if omitted in phpdoc
 
-    operator bool() const { return static_cast<bool>(type_hint); }
+    operator bool() const noexcept { return static_cast<bool>(type_hint); }
   };
 
 
@@ -66,9 +66,9 @@ struct PhpDocTag {
 
   PhpDocTag(PhpDocType type, vk::string_view value) : type(type), value(value) {}
 
-  std::string get_tag_name() const;
+  std::string get_tag_name() const noexcept;
 
-  std::string value_as_string() const { return std::string(value); }
+  std::string value_as_string() const noexcept { return std::string(value); }
   TypeAndVarName value_as_type_and_var_name(FunctionPtr current_function) const;
 };
 
@@ -81,7 +81,7 @@ public:
 
   explicit PhpDocComment(vk::string_view phpdoc_str);
 
-  bool has_tag(PhpDocType type) const {
+  bool has_tag(PhpDocType type) const noexcept {
     for (const PhpDocTag &tag: tags) {
       if (tag.type == type) {
         return true;
@@ -90,7 +90,7 @@ public:
     return false;
   }
 
-  bool has_tag(PhpDocType type, PhpDocType or_type2) const {
+  bool has_tag(PhpDocType type, PhpDocType or_type2) const noexcept {
     for (const PhpDocTag &tag: tags) {
       if (tag.type == type || tag.type == or_type2) {
         return true;
@@ -99,7 +99,7 @@ public:
     return false;
   }
 
-  const PhpDocTag *find_tag(PhpDocType type) const {
+  const PhpDocTag *find_tag(PhpDocType type) const noexcept {
     for (const PhpDocTag &tag: tags) {
       if (tag.type == type) {
         return &tag;

--- a/compiler/pipes/calc-locations.cpp
+++ b/compiler/pipes/calc-locations.cpp
@@ -8,9 +8,17 @@
 
 void CalcLocationsPass::on_start() {
   if (current_function->type == FunctionData::func_class_holder) {
-    current_function->class_id->members.for_each([](ClassMemberConstant &constant) {
-      stage::set_line(constant.value->location.line);
-      constant.value.set_location(stage::get_location());
+    current_function->class_id->members.for_each([](ClassMemberInstanceField &f) {
+      stage::set_line(f.root->location.line);
+      f.root->location = stage::get_location();
+    });
+    current_function->class_id->members.for_each([](ClassMemberStaticField &f) {
+      stage::set_line(f.root->location.line);
+      f.root->location = stage::get_location();
+    });
+    current_function->class_id->members.for_each([](ClassMemberConstant &c) {
+      stage::set_line(c.value->location.line);
+      c.value.set_location(stage::get_location());
     });
   }
 }

--- a/compiler/pipes/check-tl-classes.cpp
+++ b/compiler/pipes/check-tl-classes.cpp
@@ -18,7 +18,7 @@ void verify_class_against_repr(ClassPtr class_id, const vk::tl::PhpClassRepresen
                     fmt_format("Tl-class '{}' is{} expected to be an interface", class_id->name, repr.is_interface ? "" : " not"));
 
   for (const auto &child : class_id->derived_classes) {
-    kphp_error_return(phpdoc_tag_exists(child->phpdoc_str, php_doc_tag::kphp_tl_class),
+    kphp_error_return(child->phpdoc->has_tag(PhpDocType::kphp_tl_class),
                       fmt_format("Class '{}' is expected to be tl-class, because it inherits from tl-class '{}'",
                                  child->name, class_id->name));
   }

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -83,29 +83,29 @@ private:
       if (f.var->init_val) {
         run_function_pass(f.var->init_val, this);
       }
-      if (!f.phpdoc_str.empty()) {
-        require_all_classes_in_field_phpdoc(f.phpdoc_str);
+      if (f.phpdoc) {
+        require_all_classes_in_field_phpdoc(f.phpdoc);
       }
     });
     cur_class->members.for_each([&](ClassMemberInstanceField &f) {
       if (f.var->init_val) {
         run_function_pass(f.var->init_val, this);
       }
-      if (!f.phpdoc_str.empty()) {
-        require_all_classes_in_field_phpdoc(f.phpdoc_str);
+      if (f.phpdoc) {
+        require_all_classes_in_field_phpdoc(f.phpdoc);
       }
     });
   }
 
   // When looking at /** @var Photo */ under the instance field, assume that we
   // need to load the Photo class even if there is no explicit constructor call
-  inline void require_all_classes_in_field_phpdoc(vk::string_view phpdoc_str) {
-    if (auto type_and_var_name = phpdoc_find_tag_as_string(phpdoc_str, php_doc_tag::var)) {
-      // we don't use phpdoc_parse_type_and_var_name() here since classes
-      // are not available at this point and we need to fetch these unknown classes
-      std::vector<Token> tokens = phpdoc_to_tokens(*type_and_var_name);
-      std::vector<Token>::const_iterator cur_tok = tokens.begin();
-      PhpDocTypeRuleParser parser(current_function);
+  inline void require_all_classes_in_field_phpdoc(const PhpDocComment *phpdoc) {
+    if (const PhpDocTag *type_and_var_name = phpdoc->find_tag(PhpDocType::var)) {
+      // we can't use parse_type_and_var_name() here
+      // since classes are not available at this point: we need to fetch these unknown classes
+      std::vector<Token> tokens = phpdoc_to_tokens(type_and_var_name->value);
+      auto cur_tok = tokens.cbegin();
+      PhpDocTypeHintParser parser(current_function);
       const TypeHint *type_hint = parser.parse_from_tokens_silent(cur_tok);
       require_all_classes_in_phpdoc_type(type_hint);
     }

--- a/compiler/pipes/register-ffi-scopes.cpp
+++ b/compiler/pipes/register-ffi-scopes.cpp
@@ -50,7 +50,7 @@ private:
     kphp_error_return(type_hint, fmt_format("unsupported C variable type: {}", ffi_decltype_string(type->members[0])));
     auto var = VertexAdaptor<op_var>::create().set_location(call);
     var->str_val = type->str;
-    scope_class->members.add_instance_field(var, {}, FieldModifiers{}.set_public(), vk::string_view{}, type_hint);
+    scope_class->members.add_instance_field(var, {}, FieldModifiers{}.set_public(), nullptr, type_hint);
   }
 
   void add_function(VertexAdaptor<op_func_call> call, ClassPtr scope_class, const FFIType *type, const FFIParseResult &result) {
@@ -108,14 +108,13 @@ private:
     for (const FFIType *field : type->members) {
       auto var = VertexAdaptor<op_var>::create().set_location(call);
       var->set_string(field->str);
-      vk::string_view phpdoc{};
       VertexPtr default_value;
       const TypeHint *type_hint = G->get_ffi_root().create_type_hint(field->members[0], result.scope);
       kphp_error_return(type_hint, fmt_format("unsupported C {} field type: {}",
                                               is_struct ? "struct" : "union",
                                               ffi_decltype_string(field->members[0])));
-      cdata_class->members.add_instance_field(var, default_value, FieldModifiers{}.set_public(), phpdoc, type_hint);
-      cdata_class_ref->members.add_instance_field(var, default_value, FieldModifiers{}.set_public(), phpdoc, type_hint);
+      cdata_class->members.add_instance_field(var, default_value, FieldModifiers{}.set_public(), nullptr, type_hint);
+      cdata_class_ref->members.add_instance_field(var, default_value, FieldModifiers{}.set_public(), nullptr, type_hint);
     }
 
     register_class(cdata_class);
@@ -130,7 +129,7 @@ private:
     // in PHP/KPHP, we access enum constants via an arrow: $cdef->CONST
     // so, make it be an instance field, not a static const; it'll pass all checks of fields existence
     // later on, when ffi operations are processed, they will be inlined: see InstantiateFFIOperationsPass
-    scope_class->members.add_instance_field(fake_op_var, fake_def_val, FieldModifiers{}.set_public(), "", nullptr);
+    scope_class->members.add_instance_field(fake_op_var, fake_def_val, FieldModifiers{}.set_public(), nullptr, nullptr);
   }
 
   VertexPtr make_ffi_load_call(VertexAdaptor<op_func_call> call, FFIScopeDataMixin *scope, const FFIParseResult &result) {

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -103,11 +103,6 @@ VertexPtr ResolveSelfStaticParentPass::on_enter_vertex(VertexPtr v) {
 
     as_alloc->allocated_class = ref_class;        // if not exists, checked later, on func_call bind
 
-  } else if (auto as_phpdoc_var = v.try_as<op_phpdoc_var>()) {
-    // replace 'self' and others if exist in @var, check classes existence
-    as_phpdoc_var->type_hint = phpdoc_finalize_type_hint_and_resolve(as_phpdoc_var->type_hint, current_function);
-    kphp_error(as_phpdoc_var->type_hint, fmt_format("Failed to parse @var inside {}", current_function->as_human_readable()));
-
   } else if (auto as_instanceof = v.try_as<op_instanceof>()) {
     // ... instanceof XXX, the right was replaced by XXX::class
     const std::string &instanceof_class = GenTree::get_actual_value(as_instanceof->rhs())->get_string();

--- a/compiler/pipes/sort-and-inherit-classes.cpp
+++ b/compiler/pipes/sort-and-inherit-classes.cpp
@@ -258,11 +258,11 @@ void SortAndInheritClassesF::clone_members_from_traits(std::vector<TraitPtr> &&t
     traits[i]->members.for_each([&](ClassMemberStaticMethod   &m) { check_other_traits_doesnt_contain_method_and_clone(m.function); });
 
     traits[i]->members.for_each([&](const ClassMemberInstanceField &f) {
-      ready_class->members.add_instance_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str, f.type_hint);
+      ready_class->members.add_instance_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc, f.type_hint);
     });
 
     traits[i]->members.for_each([&](const ClassMemberStaticField &f) {
-      ready_class->members.add_static_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc_str, f.type_hint);
+      ready_class->members.add_static_field(f.root.clone(), f.var->init_val.clone(), f.modifiers, f.phpdoc, f.type_hint);
     });
   }
 

--- a/compiler/pipes/split-switch.cpp
+++ b/compiler/pipes/split-switch.cpp
@@ -114,7 +114,10 @@ public:
       auto func = VertexAdaptor<op_function>::create(func_params, seq);
       func = prepare_switch_func(func, case_state_name, 1).as<op_function>();
       GenTree::func_force_return(func, VertexAdaptor<op_null>::create());
-      new_functions.push_back(FunctionData::create_function(func_name, func, FunctionData::func_switch));
+
+      FunctionPtr switch_f = FunctionData::create_function(func_name, func, FunctionData::func_switch);
+      new_functions.push_back(switch_f);
+      switch_f->has_var_tags_inside = current_function->has_var_tags_inside;
 
       auto func_call = VertexAdaptor<op_func_call>::create(case_state_0);
       func_call->str_val = func_name;

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -1959,7 +1959,7 @@
     }
   },
   {
-    "comment": "artificial op that holds phpdoc @var info",
+    "comment": "artificial op that holds phpdoc @var info inside a function (not above a field)",
     "sons": {
       "var": {
         "id": 0,
@@ -1975,6 +1975,12 @@
       "str": "@var"
     },
     "extra_fields": {
+      "next_var_name": {
+        "type": "std::string"
+      },
+      "tag_value": {
+        "type": "std::string"
+      },
       "type_hint": {
         "type": "const TypeHint *",
         "default": "nullptr"

--- a/tests/cpp/compiler/phpdoc-test.cpp
+++ b/tests/cpp/compiler/phpdoc-test.cpp
@@ -3,13 +3,12 @@
 #include "compiler/phpdoc.h"
 
 TEST(phpdoc_test, parse_php_doc) {
-  auto parsing_result = parse_php_doc(
+  PhpDocComment doc(
     "**\n"
     " * @kphp-infer\n"
     " *\n");
-  ASSERT_EQ(parsing_result.size(), 1);
-  ASSERT_EQ(parsing_result.front().type, php_doc_tag::kphp_infer);
-  ASSERT_EQ(parsing_result.front().name, "@kphp-infer");
-  ASSERT_TRUE(parsing_result.front().value.empty());
-  ASSERT_EQ(parsing_result.front().line_num, -1);
+  ASSERT_TRUE(doc.tags.begin() != doc.tags.end());
+  ASSERT_EQ(doc.tags.front().type, PhpDocType::kphp_infer);
+  ASSERT_EQ(doc.tags.front().get_tag_name(), "@kphp-infer");
+  ASSERT_TRUE(doc.tags.front().value_as_string().empty());
 }


### PR DESCRIPTION
There are three main purposes of this PR.

## `PhpDocComment *` instead of `vk::string_view`

For functions, classes, fields, vars, etc. we now store `const PhpDocComment *phpdoc` instead of `vk::string_view phpdoc_str`.

Storing a meaningful object instead of a string is much more reliable, since we use methods like `phpdoc->has_tag(type)` instead of `phpdoc_tag_exists(phpdoc_str, type)`. 

Phpdoc comment is now parsed in gentree — it's split in tags, these tags are kept in `forward_list`. But the values of tags are analyzed later in the pipeline on demand.

## Speed up phpdoc parsing and accessing

When we stored `vk::string_view`, every time we had to access it like `phpdoc_tag_exists` / `phpdoc_parse_var_and_type_name` / etc. — at first we parsed `phpdoc_str`, when we did an actual query. Some doc comments were parsed more than once. Now they all are parsed exactly once in gentree, and no double parsing is done, never.

The algorithm that parses phpdoc comment to tags was completely rewritten, now it's much faster (but a bit more complicated, especially by introducing hashes).

All in all, we have **about 1 second boost for vkcom** and use slightly less memory.

## `@var` parsing is compatible with `@kphp-template`

Prior to this PR, `@var` inside a function (not above a class field) was parsed right in gentree. That's completely wrong for future generics, since
```
/**
 * @kphp-template T
 * @kphp-param T $obj
 */
function f($obj) {
  /** @var T[] $arr */
  $arr = [$obj];
}
```
We can parse `@var T[]` correctly only when we know that `f` is actually `f<T>`, which means that `T` is a generics type, not a `class T`.

This PR does `@var` parsing in a right place to make it compatible with my future branches.