### PR TITLE
enable using pch in _loader_instantiations{i}.cpp translation units

### DIFF
--- a/compiler/code-gen/files/type-tagger.cpp
+++ b/compiler/code-gen/files/type-tagger.cpp
@@ -99,6 +99,7 @@ void TypeTagger::compile_loader_header(CodeGenerator &W, const IncludesCollector
 template <typename It>
 static void compile_loader_instantiations_batch(CodeGenerator &W, const IncludesCollector &includes, It begin, It end, std::size_t batch) noexcept {
   W << OpenFile{fmt_format("_loader_instantiations{}.cpp", batch)};
+  W << ExternInclude{G->settings().runtime_headers.get()};
   W << includes << NL;
 
   for (auto it = begin; it != end; ++it) {


### PR DESCRIPTION
Currently pch in not used in _loader_instantiations{i}.cpp translation units, because corresponding `#include` directive should be first in file. 