### PR TITLE
Trait does not check abstract methods

### DIFF
--- a/compiler/pipes/sort-and-inherit-classes.h
+++ b/compiler/pipes/sort-and-inherit-classes.h
@@ -29,6 +29,7 @@ private:
 
   void inherit_class_from_interface(ClassPtr child_class, InterfacePtr interface_class);
   static void clone_members_from_traits(std::vector<TraitPtr> &&traits, ClassPtr ready_class, DataStream<FunctionPtr> &function_stream);
+  static void check_abstract_methods_for_non_abstract_class(ClassPtr klass);
 
   decltype(ht)::HTNode *get_not_ready_dependency(ClassPtr klass);
 


### PR DESCRIPTION
## Information
- function **clone_members_from_traits** is called when trait is connected to the class
- function **clone_members_from_traits** no longer checks methods for abstract
- function **check_abstract_methods_for_non_abstract_class** checks that abstract methods are in abstract classes