### PR TITLE
sending raw stats to statshouse

### DIFF
--- a/common/resolver.cpp
+++ b/common/resolver.cpp
@@ -409,5 +409,5 @@ const char *kdb_gethostname() {
     tried = 1;
   }
 
-  return !failed ? hostname : NULL;
+  return !failed ? hostname : nullptr;
 }

--- a/common/server/statsd-client.cpp
+++ b/common/server/statsd-client.cpp
@@ -59,6 +59,10 @@ protected:
     sb_printf(&sb, "%lld", value);
     sb_printf(&sb, "|%c\n", type);
   }
+
+  void add_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
+    assert(false && "unimplemented");
+  }
 };
 } // namespace
 

--- a/common/server/statsd-client.cpp
+++ b/common/server/statsd-client.cpp
@@ -60,7 +60,7 @@ protected:
     sb_printf(&sb, "|%c\n", type);
   }
 
-  void add_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
+  void add_multiple_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
     assert(false && "unimplemented");
   }
 };

--- a/common/server/tl-stats-t.h
+++ b/common/server/tl-stats-t.h
@@ -34,7 +34,7 @@ protected:
     sb_printf(&sb, "\n");
   }
 
-  void add_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
+  void add_multiple_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
     assert(false && "unimplemented");
   }
 };

--- a/common/server/tl-stats-t.h
+++ b/common/server/tl-stats-t.h
@@ -33,4 +33,8 @@ protected:
     sb_printf(&sb, "%lld", value);
     sb_printf(&sb, "\n");
   }
+
+  void add_stats(const char *key [[maybe_unused]], std::vector<double> &&values [[maybe_unused]]) noexcept final {
+    assert(false && "unimplemented");
+  }
 };

--- a/common/stats/provider.h
+++ b/common/stats/provider.h
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <cstring>
 #include <type_traits>
+#include <vector>
 
 #include "common/stats/buffer.h"
 
@@ -56,6 +57,16 @@ public:
     add_gauge_stat(stat_key, value);
   }
 
+  void add_multiple_gauge_stats(std::vector<double> &&values, const char *key1, const char *key2 = "") noexcept {
+    const size_t key1_len = std::strlen(key1);
+    const size_t key2_len = std::strlen(key2);
+    char stat_key[key1_len + key2_len + 1];
+    std::memcpy(stat_key, key1, key1_len);
+    std::memcpy(stat_key + key1_len, key2, key2_len);
+
+    add_stats(stat_key, std::move(values));
+  }
+
   template<typename T>
   void add_gauge_stat(const std::atomic<T> &value, const char *key1, const char *key2 = "", const char *key3 = "") noexcept {
     add_gauge_stat(value.load(std::memory_order_relaxed), key1, key2, key3);
@@ -69,6 +80,8 @@ public:
 protected:
   virtual void add_stat(char type, const char *key, double value) noexcept = 0;
   virtual void add_stat(char type, const char *key, long long value) noexcept = 0;
+
+  virtual void add_stats(const char *key, std::vector<double> &&values) noexcept = 0;
 
   char *normalize_key(const char *key, const char *format, const char *prefix) noexcept;
 };

--- a/common/stats/provider.h
+++ b/common/stats/provider.h
@@ -64,7 +64,7 @@ public:
     std::memcpy(stat_key, key1, key1_len);
     std::memcpy(stat_key + key1_len, key2, key2_len);
 
-    add_stats(stat_key, std::move(values));
+    add_multiple_stats(stat_key, std::move(values));
   }
 
   template<typename T>
@@ -81,7 +81,7 @@ protected:
   virtual void add_stat(char type, const char *key, double value) noexcept = 0;
   virtual void add_stat(char type, const char *key, long long value) noexcept = 0;
 
-  virtual void add_stats(const char *key, std::vector<double> &&values) noexcept = 0;
+  virtual void add_multiple_stats(const char *key, std::vector<double> &&values) noexcept = 0;
 
   char *normalize_key(const char *key, const char *format, const char *prefix) noexcept;
 };

--- a/common/stats/provider.h
+++ b/common/stats/provider.h
@@ -62,7 +62,7 @@ public:
     const size_t key2_len = std::strlen(key2);
     char stat_key[key1_len + key2_len + 1];
     std::memcpy(stat_key, key1, key1_len);
-    std::memcpy(stat_key + key1_len, key2, key2_len);
+    std::memcpy(stat_key + key1_len, key2, key2_len + 1);
 
     add_multiple_stats(stat_key, std::move(values));
   }

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -80,6 +80,7 @@
 #include "server/server-stats.h"
 #include "server/statshouse/statshouse-client.h"
 #include "server/workers-control.h"
+#include "server/statshouse/worker-stats-buffer.h"
 
 using job_workers::JobWorkersContext;
 using job_workers::JobWorkerClient;
@@ -1407,6 +1408,7 @@ void cron() {
     turn_sigterm_on();
   }
   vk::singleton<ServerStats>::get().update_this_worker_stats();
+  vk::singleton<statshouse::WorkerStatsBuffer>::get().flush_if_needed();
 }
 
 int try_get_http_fd() {
@@ -1665,6 +1667,7 @@ void init_all() {
 
   init_php_scripts();
   vk::singleton<ServerStats>::get().set_idle_worker_status();
+  vk::singleton<StatsHouseClient>::get();
 
   worker_id = (int)lrand48();
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1667,7 +1667,7 @@ void init_all() {
 
   init_php_scripts();
   vk::singleton<ServerStats>::get().set_idle_worker_status();
-  vk::singleton<StatsHouseClient>::get();
+  vk::singleton<StatsHouseClient>::get().init_connection();
 
   worker_id = (int)lrand48();
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2051,6 +2051,7 @@ int main_args_handler(int i, const char *long_option) {
       auto &statshouse_client = vk::singleton<StatsHouseClient>::get();
       statshouse_client.set_host(std::string(optarg, colon - optarg));
       statshouse_client.set_port(atoi(colon + 1));
+      vk::singleton<statshouse::WorkerStatsBuffer>::get().enable();
       return 0;
     }
     default:

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1667,7 +1667,7 @@ void init_all() {
 
   init_php_scripts();
   vk::singleton<ServerStats>::get().set_idle_worker_status();
-  vk::singleton<StatsHouseClient>::get().init_connection();
+  vk::singleton<StatsHouseClient>::get();
 
   worker_id = (int)lrand48();
 

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1323,7 +1323,7 @@ static void cron() {
   if (!other->is_alive || in_old_master_on_restart()) {
     // write stats at the beginning to avoid spikes in graphs
     send_data_to_statsd_with_prefix(vk::singleton<ClusterName>::get().get_statsd_prefix(), stats_tag_kphp_server);
-    vk::singleton<StatsHouseClient>::get().send_master_metrics();
+    vk::singleton<StatsHouseClient>::get().master_send_metrics();
   }
   create_all_outbound_connections();
   vk::singleton<ServerStats>::get().aggregate_stats();

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1323,7 +1323,7 @@ static void cron() {
   if (!other->is_alive || in_old_master_on_restart()) {
     // write stats at the beginning to avoid spikes in graphs
     send_data_to_statsd_with_prefix(vk::singleton<ClusterName>::get().get_statsd_prefix(), stats_tag_kphp_server);
-    vk::singleton<StatsHouseClient>::get().send_metrics();
+    vk::singleton<StatsHouseClient>::get().send_master_metrics();
   }
   create_all_outbound_connections();
   vk::singleton<ServerStats>::get().aggregate_stats();

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -1089,9 +1089,7 @@ STATS_PROVIDER_TAGGED(kphp_stats, 100, stats_tag_kphp_server) {
   stats->add_gauge_stat(instance_cache_element_stats.elements_logically_expired_but_fetched, "instance_cache.elements.logically_expired_but_fetched");
 
   write_confdata_stats_to(stats);
-  if (stats->need_aggr_stats()) {
-    vk::singleton<ServerStats>::get().write_stats_to(stats);
-  }
+  vk::singleton<ServerStats>::get().write_stats_to(stats);
 
   stats->add_gauge_stat("graceful_restart.warmup.final_new_instance_cache_size", WarmUpContext::get().get_final_new_instance_cache_size());
   stats->add_gauge_stat("graceful_restart.warmup.final_old_instance_cache_size", WarmUpContext::get().get_final_old_instance_cache_size());

--- a/server/server-stats.cpp
+++ b/server/server-stats.cpp
@@ -604,9 +604,9 @@ void ServerStats::add_request_stats(double script_time_sec, double net_time_sec,
   shared_stats_->workers.add_worker_stats(queries_stat, worker_process_id_);
 
   using namespace statshouse;
-  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(QueryStatKey::general_memory_used, memory_used);
-  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(QueryStatKey::general_real_memory_used, real_memory_used);
-  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(QueryStatKey::general_total_allocated_by_curl, curl_total_allocated);
+  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(GenericQueryStatKey::memory_used, worker_type_, memory_used);
+  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(GenericQueryStatKey::real_memory_used, worker_type_, real_memory_used);
+  vk::singleton<WorkerStatsBuffer>::get().add_query_stat(GenericQueryStatKey::total_allocated_by_curl, worker_type_, curl_total_allocated);
 
   vk::singleton<WorkerStatsBuffer>::get().add_query_stat(GenericQueryStatKey::script_time, worker_type_, script_time.count());
   vk::singleton<WorkerStatsBuffer>::get().add_query_stat(GenericQueryStatKey::net_time, worker_type_, net_time.count());

--- a/server/server-stats.cpp
+++ b/server/server-stats.cpp
@@ -673,18 +673,26 @@ uint64_t kb2bytes(uint64_t kb) noexcept {
 
 template<typename T, typename Mapper = vk::identity>
 void write_to(stats_t *stats, const char *prefix, const char *suffix, const AggregatedSamples<T> &samples, const Mapper &mapper = {}) {
-  stats->add_gauge_stat(mapper(samples.percentiles.p50), prefix, suffix, ".p50");
-  stats->add_gauge_stat(mapper(samples.percentiles.p95), prefix, suffix, ".p95");
-  stats->add_gauge_stat(mapper(samples.percentiles.p99), prefix, suffix, ".p99");
-  stats->add_gauge_stat(mapper(samples.percentiles.max), prefix, suffix, ".max");
+  if (stats->need_aggr_stats()) {
+    stats->add_gauge_stat(mapper(samples.percentiles.p50), prefix, suffix, ".p50");
+    stats->add_gauge_stat(mapper(samples.percentiles.p95), prefix, suffix, ".p95");
+    stats->add_gauge_stat(mapper(samples.percentiles.p99), prefix, suffix, ".p99");
+    stats->add_gauge_stat(mapper(samples.percentiles.max), prefix, suffix, ".max");
+  }
 }
 
 template<typename T, typename Mapper = vk::identity>
 void write_to(stats_t *stats, const char *prefix, const char *suffix, const WorkerSamples<T> &samples, const Mapper &mapper = {}) {
-  stats->add_gauge_stat(mapper(samples.percentiles.p50), prefix, suffix, ".p50");
-  stats->add_gauge_stat(mapper(samples.percentiles.p95), prefix, suffix, ".p95");
-  stats->add_gauge_stat(mapper(samples.percentiles.p99), prefix, suffix, ".p99");
-  stats->add_gauge_stat(mapper(samples.percentiles.max), prefix, suffix, ".max");
+  if (stats->need_aggr_stats()) {
+    stats->add_gauge_stat(mapper(samples.percentiles.p50), prefix, suffix, ".p50");
+    stats->add_gauge_stat(mapper(samples.percentiles.p95), prefix, suffix, ".p95");
+    stats->add_gauge_stat(mapper(samples.percentiles.p99), prefix, suffix, ".p99");
+    stats->add_gauge_stat(mapper(samples.percentiles.max), prefix, suffix, ".max");
+  } else {
+    const uint16_t workers_count = vk::singleton<WorkersControl>::get().get_total_workers_count();
+    std::vector<double> values(samples.samples.begin(), samples.samples.begin() + workers_count);
+    stats->add_multiple_gauge_stats(std::move(values), prefix, suffix);
+  }
 }
 
 void write_to(stats_t *stats, const char *prefix, const WorkerAggregatedStats &agg, const WorkerSharedStats &shared) noexcept {

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -24,7 +24,8 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         slot-ids-factory.cpp
         workers-control.cpp
         statshouse/statshouse-client.cpp
-        statshouse/add-metrics-batch.cpp)
+        statshouse/add-metrics-batch.cpp
+        statshouse/worker-stats-buffer.cpp)
 
 prepend(KPHP_JOB_WORKERS_SOURCES ${BASE_DIR}/server/job-workers/
         job-stats.cpp

--- a/server/statshouse/add-metrics-batch.cpp
+++ b/server/statshouse/add-metrics-batch.cpp
@@ -41,7 +41,12 @@ void StatsHouseAddMetricsBatch::tl_store() const {
   tl_store_int(metrics_size);
 }
 
-StatsHouseMetric make_statshouse_value_metric(std::string name, double value, const std::vector<std::pair<std::string, std::string>> &tags) {
+StatsHouseMetric make_statshouse_value_metric(std::string &&name, double value, const std::vector<std::pair<std::string, std::string>> &tags) {
   constexpr int fields_mask = vk::tl::statshouse::metric_fields_mask::value;
   return {.fields_mask = fields_mask, .name = std::move(name), .tags = tags, .value = {value}};
+}
+
+StatsHouseMetric make_statshouse_value_metrics(std::string &&name, std::vector<double> &&value, const std::vector<std::pair<std::string, std::string>> &tags) {
+  constexpr int fields_mask = vk::tl::statshouse::metric_fields_mask::value;
+  return {.fields_mask = fields_mask, .name = std::move(name), .tags = tags, .counter = 0, .t = 0, .value = std::move(value)};
 }

--- a/server/statshouse/add-metrics-batch.h
+++ b/server/statshouse/add-metrics-batch.h
@@ -27,4 +27,6 @@ struct StatsHouseAddMetricsBatch {
   void tl_store() const;
 };
 
-StatsHouseMetric make_statshouse_value_metric(std::string name, double value, const std::vector<std::pair<std::string, std::string>> &tags);
+StatsHouseMetric make_statshouse_value_metric(std::string &&name, double value, const std::vector<std::pair<std::string, std::string>> &tags);
+
+StatsHouseMetric make_statshouse_value_metrics(std::string &&name, std::vector<double> &&value, const std::vector<std::pair<std::string, std::string>> &tags);

--- a/server/statshouse/add-metrics-batch.h
+++ b/server/statshouse/add-metrics-batch.h
@@ -10,7 +10,7 @@
 struct StatsHouseMetric {
   int fields_mask{0};
   std::string name;
-  const std::vector<std::pair<std::string, std::string>> &tags;
+  std::vector<std::pair<std::string, std::string>> tags;
   double counter{0.0};           // fields_mask bit #0
   long long t{};                 // fields_mask bit #5
   std::vector<double> value;     // fields_mask bit #1

--- a/server/statshouse/statshouse-client.cpp
+++ b/server/statshouse/statshouse-client.cpp
@@ -110,7 +110,7 @@ bool StatsHouseClient::init_connection() {
   return true;
 }
 
-void StatsHouseClient::send_master_metrics() {
+void StatsHouseClient::master_send_metrics() {
   auto [result, len] = prepare_statshouse_stats(statshouse_stats_t{tags});
   send_metrics(result, len);
 }

--- a/server/statshouse/statshouse-client.cpp
+++ b/server/statshouse/statshouse-client.cpp
@@ -49,7 +49,7 @@ protected:
 
   void add_stats(const char *key, std::vector<double> &&values) noexcept final {
     auto metric = make_statshouse_value_metrics(normalize_key(key, "_%s", stats_prefix), std::move(values), tags);
-    auto len = vk::tl::store_to_buffer(sb.buff + sb.pos, sb.size, metric);
+    auto len = vk::tl::store_to_buffer(sb.buff + sb.pos, sb.size - sb.pos, metric);
     sb.pos += len;
     ++counter;
   }
@@ -111,11 +111,14 @@ bool StatsHouseClient::init_connection() {
 }
 
 void StatsHouseClient::send_metrics() {
+  auto [result, len] = prepare_statshouse_stats(statshouse_stats_t{tags});
+  send_metrics(result, len);
+}
+
+void StatsHouseClient::send_metrics(char *result, int len) {
   if (port == 0 || (sock_fd <= 0 && !init_connection())) {
     return;
   }
-
-  auto [result, len] = prepare_statshouse_stats(statshouse_stats_t{tags});
 
   ssize_t slen = send(sock_fd, result, len, 0);
   if (slen < 0) {
@@ -124,12 +127,10 @@ void StatsHouseClient::send_metrics() {
 }
 
 StatsHouseClient::StatsHouseClient() {
-  char hostname[128];
-  int res = gethostname(hostname, 128);
-  if (res == -1) {
-    log_server_error("Can't gethostname for statshouse metrics: %s", strerror(errno));
-  } else {
+  if (const char *hostname = kdb_gethostname()) {
     tags = {{"host", std::string(hostname)}};
+  } else {
+    log_server_error("Can't gethostname for statshouse metrics: %s", strerror(errno));
   }
 }
 

--- a/server/statshouse/statshouse-client.cpp
+++ b/server/statshouse/statshouse-client.cpp
@@ -47,6 +47,13 @@ protected:
     add_stat(type, key, static_cast<double>(value));
   }
 
+  void add_stats(const char *key, std::vector<double> &&values) noexcept final {
+    auto metric = make_statshouse_value_metrics(normalize_key(key, "_%s", stats_prefix), std::move(values), tags);
+    auto len = vk::tl::store_to_buffer(sb.buff + sb.pos, sb.size, metric);
+    sb.pos += len;
+    ++counter;
+  }
+
 private:
   int counter{0};
   const std::vector<std::pair<std::string, std::string>> &tags;

--- a/server/statshouse/statshouse-client.cpp
+++ b/server/statshouse/statshouse-client.cpp
@@ -47,7 +47,7 @@ protected:
     add_stat(type, key, static_cast<double>(value));
   }
 
-  void add_stats(const char *key, std::vector<double> &&values) noexcept final {
+  void add_multiple_stats(const char *key, std::vector<double> &&values) noexcept final {
     auto metric = make_statshouse_value_metrics(normalize_key(key, "_%s", stats_prefix), std::move(values), tags);
     auto len = vk::tl::store_to_buffer(sb.buff + sb.pos, sb.size - sb.pos, metric);
     sb.pos += len;

--- a/server/statshouse/statshouse-client.cpp
+++ b/server/statshouse/statshouse-client.cpp
@@ -110,7 +110,7 @@ bool StatsHouseClient::init_connection() {
   return true;
 }
 
-void StatsHouseClient::send_metrics() {
+void StatsHouseClient::send_master_metrics() {
   auto [result, len] = prepare_statshouse_stats(statshouse_stats_t{tags});
   send_metrics(result, len);
 }

--- a/server/statshouse/statshouse-client.h
+++ b/server/statshouse/statshouse-client.h
@@ -16,17 +16,18 @@ public:
   /**
    * Must be called from master process only
    */
-  void send_master_metrics();
+  void master_send_metrics();
   void send_metrics(char* result, int len);
-  bool init_connection();
-
 private:
+  int port = 0;
+  int sock_fd = 0;
+  std::string host;
+  std::vector<std::pair<std::string, std::string>> tags;
+
   StatsHouseClient();
   ~StatsHouseClient();
-  friend class vk::singleton<StatsHouseClient>;
 
-  int port = 0;
-  std::string host;
-  int sock_fd = 0;
-  std::vector<std::pair<std::string, std::string>> tags;
+  bool init_connection();
+
+  friend class vk::singleton<StatsHouseClient>;
 };

--- a/server/statshouse/statshouse-client.h
+++ b/server/statshouse/statshouse-client.h
@@ -14,6 +14,7 @@ public:
   void set_port(int value);
   void set_host(std::string value);
   void send_metrics();
+  void send_metrics(char* result, int len);
 
 private:
   StatsHouseClient();

--- a/server/statshouse/statshouse-client.h
+++ b/server/statshouse/statshouse-client.h
@@ -13,15 +13,17 @@ class StatsHouseClient : vk::not_copyable {
 public:
   void set_port(int value);
   void set_host(std::string value);
-  void send_metrics();
+  /**
+   * Must be called from master process only
+   */
+  void send_master_metrics();
   void send_metrics(char* result, int len);
+  bool init_connection();
 
 private:
   StatsHouseClient();
   ~StatsHouseClient();
   friend class vk::singleton<StatsHouseClient>;
-
-  bool init_connection();
 
   int port = 0;
   std::string host;

--- a/server/statshouse/worker-stats-buffer.cpp
+++ b/server/statshouse/worker-stats-buffer.cpp
@@ -1,0 +1,124 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "worker-stats-buffer.h"
+#include "common/tl/constants/statshouse.h"
+#include "runtime/critical_section.h"
+#include "statshouse-client.h"
+#include "common/resolver.h"
+
+namespace statshouse {
+
+constexpr size_t buffer_size = 50000;
+static char buffer[buffer_size];
+
+bool StatsBuffer::is_need_to_flush() {
+  return size >= data.size();
+}
+
+bool StatsBuffer::empty() const {
+  return size == 0;
+}
+
+void StatsBuffer::add_stat(double value) {
+  data[size++] = value;
+}
+
+std::vector<double> StatsBuffer::get_data_and_reset_buffer() {
+  std::vector<double> result(data.begin(), data.begin() + size);
+  size = 0;
+  return result;
+}
+
+WorkerStatsBuffer::WorkerStatsBuffer() {
+  last_send_time = std::chrono::steady_clock::now();
+}
+
+void WorkerStatsBuffer::add_query_stat(GenericQueryStatKey key, WorkerType worker_type, double value) {
+  auto &worker_type_buffer = generic_query_stats[static_cast<size_t>(worker_type)];
+  auto &stats_buffer = worker_type_buffer[static_cast<size_t>(key)];
+  auto now = std::chrono::steady_clock::now();
+
+  if (stats_buffer.is_need_to_flush() || now - last_send_time >= std::chrono::seconds{1}) {
+    flush();
+  }
+  stats_buffer.add_stat(value);
+}
+
+void WorkerStatsBuffer::add_query_stat(QueryStatKey key, double value) {
+  auto &stats_buffer = query_stats[static_cast<size_t>(key)];
+  auto now = std::chrono::steady_clock::now();
+
+  if (stats_buffer.is_need_to_flush() || now - last_send_time >= std::chrono::seconds{1}) {
+    last_send_time = now;
+    flush();
+  }
+  stats_buffer.add_stat(value);
+}
+
+void WorkerStatsBuffer::make_generic_metric(std::vector<StatsHouseMetric> &metrics, const char *name, GenericQueryStatKey stat_key, size_t worker_type,
+                                            const std::vector<tag> &tags) {
+  auto &stats_buffer = generic_query_stats[worker_type][static_cast<size_t>(stat_key)];
+  if (!stats_buffer.empty()) {
+    metrics.push_back(make_statshouse_value_metrics(name, stats_buffer.get_data_and_reset_buffer(), tags));
+  }
+}
+
+void WorkerStatsBuffer::make_metric(std::vector<StatsHouseMetric> &metrics, const char *name, QueryStatKey stat_key, const std::vector<tag> &tags) {
+  auto &stats_buffer = query_stats[static_cast<size_t>(stat_key)];
+  if (!stats_buffer.empty()) {
+    metrics.push_back(make_statshouse_value_metrics(name, stats_buffer.get_data_and_reset_buffer(), tags));
+  }
+}
+
+void WorkerStatsBuffer::flush() {
+  dl::CriticalSectionGuard critical_section;
+  std::vector<StatsHouseMetric> metrics;
+  const char* hostname = kdb_gethostname();
+
+  for (size_t i = 0; i < static_cast<size_t>(WorkerType::types_count); ++i) {
+    std::vector<tag> tags;
+    tags.emplace_back("worker_type", i == static_cast<size_t>(WorkerType::general_worker) ? "general" : "job");
+    if (hostname != nullptr) {
+      tags.emplace_back("host", kdb_gethostname());
+    }
+
+    make_generic_metric(metrics, "kphp_requests_outgoing_queries", GenericQueryStatKey::outgoing_queries, i, tags);
+    make_generic_metric(metrics, "kphp_requests_outgoing_long_queries", GenericQueryStatKey::outgoing_long_queries, i, tags);
+    make_generic_metric(metrics, "kphp_requests_net_time", GenericQueryStatKey::script_time, i, tags);
+    make_generic_metric(metrics, "kphp_requests_script_time", GenericQueryStatKey::net_time, i, tags);
+  }
+
+  std::vector<tag> tags;
+  if (hostname != nullptr) {
+    tags.emplace_back("host", hostname);
+  }
+  make_metric(metrics, "kphp_memory_script_usage", QueryStatKey::general_memory_used, tags);
+  make_metric(metrics, "kphp_memory_script_real_usage", QueryStatKey::general_real_memory_used, tags);
+  make_metric(metrics, "kphp_memory_script_total_allocated_by_curl", QueryStatKey::general_total_allocated_by_curl, tags);
+
+  make_metric(metrics, "kphp_jobs_queue_time", QueryStatKey::job_wait_time, tags);
+  make_metric(metrics, "kphp_memory_job_request_usage", QueryStatKey::job_request_memory_usage, tags);
+  make_metric(metrics, "kphp_memory_job_request_real_usage", QueryStatKey::job_request_real_memory_usage, tags);
+  make_metric(metrics, "kphp_memory_job_response_usage", QueryStatKey::job_response_memory_usage, tags);
+  make_metric(metrics, "kphp_memory_job_response_real_usage", QueryStatKey::job_response_real_memory_usage, tags);
+
+  make_metric(metrics, "kphp_memory_job_common_request_usage", QueryStatKey::job_common_request_memory_usage, tags);
+  make_metric(metrics, "kphp_memory_job_common_request_real_usage", QueryStatKey::job_common_request_real_memory_usage, tags);
+
+  int offset = vk::tl::store_to_buffer(buffer, buffer_size, TL_STATSHOUSE_ADD_METRICS_BATCH);
+  offset = offset + vk::tl::store_to_buffer(buffer + offset, buffer_size - offset, static_cast<int>(vk::tl::statshouse::add_metrics_batch_fields_mask::ALL));
+  int len = vk::tl::store_to_buffer(buffer + offset, buffer_size - offset, metrics);
+  vk::singleton<StatsHouseClient>::get().send_metrics(buffer, offset + len);
+}
+
+void WorkerStatsBuffer::flush_if_needed() {
+  const auto now_tp = std::chrono::steady_clock::now();
+  if (now_tp - last_send_time >= std::chrono::seconds{1}) {
+    vk::singleton<statshouse::WorkerStatsBuffer>::get().flush();
+    last_send_time = now_tp;
+  }
+}
+
+} // namespace statshouse

--- a/server/statshouse/worker-stats-buffer.cpp
+++ b/server/statshouse/worker-stats-buffer.cpp
@@ -10,7 +10,7 @@
 
 namespace statshouse {
 
-constexpr size_t buffer_size = 50000;
+constexpr size_t buffer_size = 1 << 20;
 static char buffer[buffer_size];
 
 bool StatsBuffer::is_need_to_flush() {

--- a/server/statshouse/worker-stats-buffer.cpp
+++ b/server/statshouse/worker-stats-buffer.cpp
@@ -31,8 +31,8 @@ std::vector<double> StatsBuffer::get_data_and_reset_buffer() {
   return result;
 }
 
-WorkerStatsBuffer::WorkerStatsBuffer() {
-  last_send_time = std::chrono::steady_clock::now();
+WorkerStatsBuffer::WorkerStatsBuffer() : last_send_time(std::chrono::steady_clock::now()) {
+
 }
 
 void WorkerStatsBuffer::add_query_stat(GenericQueryStatKey key, WorkerType worker_type, double value) {

--- a/server/statshouse/worker-stats-buffer.h
+++ b/server/statshouse/worker-stats-buffer.h
@@ -1,0 +1,79 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <array>
+#include <chrono>
+#include <ostream>
+
+#include "add-metrics-batch.h"
+#include "common/mixin/not_copyable.h"
+#include "common/tl/methods/string.h"
+#include "server/workers-control.h"
+
+namespace statshouse {
+
+/**
+ * TODO
+ */
+enum class GenericQueryStatKey {
+  outgoing_queries,
+  outgoing_long_queries,
+  script_time,
+  net_time,
+  types_count
+};
+
+/**
+ * TODO
+ */
+enum class QueryStatKey {
+  general_memory_used,
+  general_real_memory_used,
+  general_total_allocated_by_curl,
+
+  job_wait_time,
+  job_request_memory_usage,
+  job_request_real_memory_usage,
+  job_response_memory_usage,
+  job_response_real_memory_usage,
+
+  job_common_request_memory_usage,
+  job_common_request_real_memory_usage,
+
+  types_count
+};
+
+class StatsBuffer : vk::not_copyable {
+public:
+  bool is_need_to_flush();
+  bool empty() const;
+  void add_stat(double value);
+  std::vector<double> get_data_and_reset_buffer();
+
+private:
+  std::array<double, 50> data;
+  size_t size{0};
+};
+
+class WorkerStatsBuffer : vk::not_copyable {
+public:
+  WorkerStatsBuffer();
+  void add_query_stat(GenericQueryStatKey key, WorkerType worker_type, double value);
+  void add_query_stat(QueryStatKey key, double value);
+  void flush();
+  void flush_if_needed();
+  using tag = std::pair<std::string, std::string>;
+private:
+//  StatsHouseMetric make_generic_metric(const char* name, GenericQueryStatKey stat_key, size_t worker_type, const std::vector<std::pair<std::string, std::string>> &tags);
+  void make_generic_metric(std::vector<StatsHouseMetric> &metrics, const char *name, GenericQueryStatKey stat_key, size_t worker_type, const std::vector<tag> &tags);
+  void make_metric(std::vector<StatsHouseMetric> &metrics, const char* name, QueryStatKey stat_key, const std::vector<tag> &tags);
+
+  std::array<std::array<StatsBuffer, static_cast<size_t>(GenericQueryStatKey::types_count)>, static_cast<size_t>(WorkerType::types_count)> generic_query_stats;
+  std::array<StatsBuffer, static_cast<size_t>(QueryStatKey::types_count)> query_stats;
+  std::chrono::steady_clock::time_point last_send_time;
+};
+
+} // namespace statshouse

--- a/server/statshouse/worker-stats-buffer.h
+++ b/server/statshouse/worker-stats-buffer.h
@@ -15,25 +15,20 @@
 
 namespace statshouse {
 
-/**
- * TODO
- */
 enum class GenericQueryStatKey {
   outgoing_queries,
   outgoing_long_queries,
   script_time,
   net_time,
+
+  memory_used,
+  real_memory_used,
+  total_allocated_by_curl,
+
   types_count
 };
 
-/**
- * TODO
- */
 enum class QueryStatKey {
-  general_memory_used,
-  general_real_memory_used,
-  general_total_allocated_by_curl,
-
   job_wait_time,
   job_request_memory_usage,
   job_request_real_memory_usage,
@@ -63,17 +58,18 @@ public:
   WorkerStatsBuffer();
   void add_query_stat(GenericQueryStatKey key, WorkerType worker_type, double value);
   void add_query_stat(QueryStatKey key, double value);
-  void flush();
   void flush_if_needed();
+  void enable();
   using tag = std::pair<std::string, std::string>;
 private:
-//  StatsHouseMetric make_generic_metric(const char* name, GenericQueryStatKey stat_key, size_t worker_type, const std::vector<std::pair<std::string, std::string>> &tags);
+  void flush();
   void make_generic_metric(std::vector<StatsHouseMetric> &metrics, const char *name, GenericQueryStatKey stat_key, size_t worker_type, const std::vector<tag> &tags);
   void make_metric(std::vector<StatsHouseMetric> &metrics, const char* name, QueryStatKey stat_key, const std::vector<tag> &tags);
 
   std::array<std::array<StatsBuffer, static_cast<size_t>(GenericQueryStatKey::types_count)>, static_cast<size_t>(WorkerType::types_count)> generic_query_stats;
   std::array<StatsBuffer, static_cast<size_t>(QueryStatKey::types_count)> query_stats;
   std::chrono::steady_clock::time_point last_send_time;
+  bool enabled = false;
 };
 
 } // namespace statshouse


### PR DESCRIPTION
- [x]  worker stats (e.g. memory.rss_bytes, memory.malloc_mappep_bytes)
- [x] script stats (e.g. requests.outgoing_queries, memory.script_usage)