### PR TITLE
fix race condition when nested lambdas look for outer assumptions of uses

### DIFF
--- a/compiler/data/function-data.h
+++ b/compiler/data/function-data.h
@@ -71,7 +71,7 @@ public:
   // to check that a function does not throw, should_not_throw flag is used
   std::forward_list<std::string> check_throws;
 
-  std::vector<std::pair<std::string, Assumption>> assumptions_for_vars;   // (var_name, assumption)[]
+  std::forward_list<std::pair<std::string, Assumption>> assumptions_for_vars;   // (var_name, assumption)[]
   Assumption assumption_for_return;
 
   vk::copyable_atomic<AssumptionStatus> assumption_return_status{AssumptionStatus::unknown};


### PR DESCRIPTION
This PR attempts to make race condition much more rare than it happens now. 

### The reason of race condition is the following
```
function demo1() {
  $a = new A;
  (function() use($a) { $a->method(); })();
  (function() use($a) { $a->method(); })();
  (function() use($a) { $a->method(); })();
  ...
}
```
When multiple lambdas (processed in parallel) want to know assumption of `$a`, they see that $a is in `use` scope and ask for assumption of $a inside `demo1()`. So, multiple threads want to calculate `$a` inside `demo1()`, which leads to concurrent accessing a vector `assumptions_for_vars` for both reading and writing.

### Even more tricky is another example
```
function demo1() {
  $log = function() { echo 1, "\n"; };
  $log();
  (function() use($log) { $log(); })();
  (function() use($log) { $log(); })();
  (function() use($log) { $log(); })();
  ...
}
```
When replacing `$log()` to `LambdaXXX$$__invoke($log)`, we need to know the actual lambda class of `function()` assigned to `$log`. To calculate assumptions, we run `CalcAssumptionForVarPass` (see class-assumptions.cpp). As above, this pass is run for `demo1()` in parallel with `ConvertInvokeToFuncCallPass` in different threads. But as you know, the pass modifies an AST tree: even if you write
```
VertexPtr ConvertInvokeToFuncCallPass::on_enter_vertex(VertexPtr root) {
  // ...
  return root;
}
```
Then a root is assigned to itself for every vertex. So, `ConvertInvokeToFuncCallPass` replaces `op_invoke_call` with `op_func_call`, but another thread calculating assumptions at the same time could rollback this replacement. This could lead to an effect when invokes were not replaced actually causing KPHP to fail on "calc rl" stage or somewhere else.

**This race condition happens only having nested lambdas that capture vars with `use` that need assumptions**. All other scenarios are safe, as calculating assumptions does no cross-function calls anywhere else.

### How does this PR fix the race condition?
1) Use `std::forward_list` instead of `std::vector` — even when assumptions are being accessed by different threads, that would most likely lead to a duplicate in `assumptions_for_vars` (that's quite okay), but not to memory reallocation
2) Use a custom runner for `CalcAssumptionForVarPass` that does only traverse an AST tree without replacing vertices.

The reason of race condition doesn't go away, but the amount of facing them periodically in real code should dramatically decrease.
