### PR TITLE
suppress annoying static analyzer warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -46,7 +46,8 @@ Checks: |-
   -modernize-use-nodiscard,
   -modernize-concat-nested-namespaces,
   -readability-named-parameter,
-  -readability-identifier-length
+  -readability-identifier-length,
+  -bugprone-easily-swappable-parameters
 
 CheckOptions:
   - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -45,7 +45,8 @@ Checks: |-
   -*-magic-numbers,
   -modernize-use-nodiscard,
   -modernize-concat-nested-namespaces,
-  -readability-named-parameter
+  -readability-named-parameter,
+  -readability-identifier-length
 
 CheckOptions:
   - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison

--- a/compiler/kphp_assert.h
+++ b/compiler/kphp_assert.h
@@ -21,12 +21,12 @@
 
 #define kphp_warning(y)  compiler_assert (0, y, WRN_ASSERT_LEVEL)
 #define kphp_error(x, y) compiler_assert (x, y, CE_ASSERT_LEVEL)
-#define kphp_error_act(x, y, act) if (kphp_error (x, y)) act;
+#define kphp_error_act(x, y, act) if (kphp_error (x, y)) act
 #define kphp_error_return(x, y) kphp_error_act (x, y, return)
 #define kphp_assert(x) compiler_assert_noret (x, "Assertion "  #x " failed", FATAL_ASSERT_LEVEL)
 #define kphp_assert_msg(x, y) compiler_assert_noret (x, y, FATAL_ASSERT_LEVEL)
-#define kphp_fail_msg(y) kphp_assert_msg (0, y); _exit(1);
-#define kphp_fail() kphp_assert (0); _exit(1);
+#define kphp_fail_msg(y) kphp_assert_msg (0, y); _exit(1)
+#define kphp_fail() kphp_assert (0); _exit(1)
 
 enum AssertLevelT {
   WRN_ASSERT_LEVEL,


### PR DESCRIPTION
Suppress tons of next annoying clang-tidy warnings:
1) complains about variable name is too short
2) complains about 2 adjacent function parameters have same type(and thus can be easily swapable by mistake)

Also I removed ';' sign from few macro definitions. Expansion of such macros lead to excessive ';' sign after statements and clang-tidy alert about empty statements.