### PR TITLE
clang-tidy: modernize return braced init list

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -26,11 +26,11 @@
 #include "compiler/vertex.h"
 
 VarDeclaration VarExternDeclaration(VarPtr var) {
-  return VarDeclaration(var, true, false);
+  return {var, true, false};
 }
 
 VarDeclaration VarPlainDeclaration(VarPtr var) {
-  return VarDeclaration(var, false, false);
+  return {var, false, false};
 }
 
 VarDeclaration::VarDeclaration(VarPtr var, bool extern_flag, bool defval_flag) :

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -75,7 +75,7 @@ static inline int array_len() {
 
 std::vector<int> compile_arrays_raw_representation(const std::vector<VarPtr> &const_raw_array_vars, CodeGenerator &W) {
   if (const_raw_array_vars.empty()) {
-    return std::vector<int>();
+    return {};
   }
 
   std::vector<int> shifts;

--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -133,7 +133,7 @@ FunctionPtr CompilerCore::get_function(const string &name) {
   TSHashTable<FunctionPtr>::HTNode *node = functions_ht.at(vk::std_hash(name));
   AutoLocker<Lockable *> locker(node);
   if (!node->data || node->data == UNPARSED_BUT_REQUIRED_FUNC_PTR) {
-    return FunctionPtr();
+    return {};
   }
 
   FunctionPtr f = node->data;
@@ -196,7 +196,7 @@ FFIRoot &CompilerCore::get_ffi_root() {
 
 SrcFilePtr CompilerCore::register_file(const string &file_name, LibPtr owner_lib, bool builtin) {
   if (file_name.empty()) {
-    return SrcFilePtr();
+    return {};
   }
 
   string full_file_name = search_required_file(file_name);

--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -382,7 +382,7 @@ std::string CompilerSettings::read_runtime_sha256_file(const std::string &filena
   runtime_sha256_file.read(runtime_sha256, SHA256_LEN);
   kphp_error(runtime_sha256_file.gcount() == SHA256_LEN,
              fmt_format("Can't read runtime sha256 from file '{}'", filename));
-  return std::string(runtime_sha256, runtime_sha256 + SHA256_LEN);
+  return {runtime_sha256, runtime_sha256 + SHA256_LEN};
 }
 
 CompilerSettings::color_settings CompilerSettings::get_color_settings() const {

--- a/compiler/const-manipulations.h
+++ b/compiler/const-manipulations.h
@@ -253,7 +253,7 @@ static inline std::string collect_string_concatenation(VertexPtr v) {
     auto right = collect_string_concatenation(concat->rhs());
     return (left.empty() || right.empty()) ? std::string() : (left + right);
   }
-  return std::string();
+  return {};
 }
 
 struct MakeConst final

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -703,7 +703,7 @@ VertexPtr GenTree::get_unary_op(int op_priority_cur, Operation unary_op_tp, bool
 
   VertexPtr left = get_binary_op(op_priority_cur, till_ternary);
   if (!left) {
-    return VertexPtr();
+    return {};
   }
 
   if (unary_op_tp == op_log_not) {

--- a/compiler/inferring/lvalue.cpp
+++ b/compiler/inferring/lvalue.cpp
@@ -41,5 +41,5 @@ LValue as_lvalue(VertexPtr v) {
   }
 
   kphp_assert (value != nullptr);
-  return LValue(value, &MultiKey::any_key(depth));
+  return {value, &MultiKey::any_key(depth)};
 }

--- a/compiler/inferring/lvalue.h
+++ b/compiler/inferring/lvalue.h
@@ -35,11 +35,11 @@ struct LValue {
 LValue as_lvalue(VertexPtr v);
 
 inline LValue as_lvalue(FunctionPtr function, int id) {
-  return LValue(tinf::get_tinf_node(function, id), &MultiKey::any_key(0));
+  return {tinf::get_tinf_node(function, id), &MultiKey::any_key(0)};
 }
 
 inline LValue as_lvalue(VarPtr var) {
-  return LValue(tinf::get_tinf_node(var), &MultiKey::any_key(0));
+  return {tinf::get_tinf_node(var), &MultiKey::any_key(0)};
 }
 
 inline const LValue &as_lvalue(const LValue &lvalue) {

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -81,7 +81,7 @@ vector<php_doc_tag> parse_php_doc(vk::string_view phpdoc) {
         continue;
       }
       kphp_error(0, "failed to parse php_doc");
-      return vector<php_doc_tag>();
+      return {};
     }
     if (c == '\n') {
       lines.push_back("");

--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -43,7 +43,7 @@ RValue CollectMainEdgesPass::as_set_value(VertexPtr v) {
   }
 
   kphp_fail();
-  return RValue();
+  return {};
 }
 
 // an isset check will analyze expressions that may differ from PHP after getting elements from typed arrays

--- a/compiler/utils/string-utils.h
+++ b/compiler/utils/string-utils.h
@@ -71,7 +71,7 @@ static inline int conv_hex_digit(int c) {
 inline vk::string_view string_view_dup(vk::string_view s) {
   char *buf = new char[s.size()];
   memcpy(buf, s.begin(), s.size());
-  return vk::string_view(buf, buf + s.size());
+  return {buf, buf + s.size()};
 }
 
 inline std::vector<std::string> split(const std::string &s, char delimiter = ' ') {

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -167,7 +167,7 @@ public:
 
   VertexPtr &back() { return ith(size() - 1); }
 
-  std::vector<VertexPtr> get_next() { return std::vector<VertexPtr>(begin(), end()); }
+  std::vector<VertexPtr> get_next() { return {begin(), end()}; }
 
   bool empty() const { return size() == 0; }
 

--- a/compiler/vertex.cpp
+++ b/compiler/vertex.cpp
@@ -13,5 +13,5 @@ VertexPtr clone_vertex(VertexPtr from) {
     default:
     kphp_fail();
   }
-  return VertexPtr();
+  return {};
 }

--- a/runtime/array_functions.cpp
+++ b/runtime/array_functions.cpp
@@ -42,7 +42,7 @@ array<string> f$explode(const string &delimiter, const string &str, int64_t limi
   }
   if (d_len == 0) {
     php_warning("Empty delimiter in function explode");
-    return array<string>();
+    return {};
   }
 
   array<string> res(array_size(limit < 10 ? limit : 1, 0, true));
@@ -79,7 +79,7 @@ array<mixed> range_int(int64_t from, int64_t to, int64_t step) {
   if (from < to) {
     if (step <= 0) {
       php_warning("Wrong parameters from = %" PRIi64 ", to = %" PRIi64 ", step = %" PRIi64 " in function range", from, to, step);
-      return array<mixed>();
+      return {};
     }
     array<mixed> res(array_size((to - from + step) / step, 0, true));
     for (int64_t i = from; i <= to; i += step) {
@@ -89,7 +89,7 @@ array<mixed> range_int(int64_t from, int64_t to, int64_t step) {
   } else {
     if (step == 0) {
       php_warning("Wrong parameters from = %" PRIi64 ", to = %" PRIi64 ", step = %" PRIi64 " in function range", from, to, step);
-      return array<mixed>();
+      return {};
     }
     if (step < 0) {
       step = -step;
@@ -105,7 +105,7 @@ array<mixed> range_int(int64_t from, int64_t to, int64_t step) {
 array<mixed> range_string(const string &from_s, const string &to_s, int64_t step) {
   if (from_s.empty() || to_s.empty() || from_s.size() > 1 || to_s.size() > 1) {
     php_warning("Wrong parameters \"%s\" and \"%s\" for function range", from_s.c_str(), to_s.c_str());
-    return array<mixed>();
+    return {};
   }
   if (step != 1) {
     php_critical_error ("unsupported step = %" PRIi64 " in function range", step);

--- a/runtime/bcmath.cpp
+++ b/runtime/bcmath.cpp
@@ -158,7 +158,7 @@ static string bc_round(char *lhs, int lint, int ldot, int lfrac, int lscale, int
   }
 
   if (lscale == scale || !add_trailing_zeroes) {
-    return string(lhs + lint, lfrac + lscale - lint);
+    return {lhs + lint, static_cast<string::size_type>(lfrac + lscale - lint)};
   } else {
     string result(lhs + lint, lfrac + lscale - lint);
     if (lscale == 0) {
@@ -569,7 +569,7 @@ string f$bcmod(const string &lhs, const string &rhs) {
     buffer[--cur_pos] = '-';
   }
 
-  return string(buffer + cur_pos, 20 - cur_pos);
+  return {buffer + cur_pos, static_cast<string::size_type>(20 - cur_pos)};
 }
 
 string f$bcpow(const string &lhs, const string &rhs) {

--- a/runtime/datetime.cpp
+++ b/runtime/datetime.cpp
@@ -495,7 +495,7 @@ static string microtime_string() {
   php_assert (clock_gettime(CLOCK_REALTIME, &T) >= 0);
   char buf[45];
   int len = sprintf(buf, "0.%09d %d", (int)T.tv_nsec, (int)T.tv_sec);
-  return string(buf, len);
+  return {buf, static_cast<string::size_type>(len)};
 }
 
 double microtime() {
@@ -555,7 +555,7 @@ string f$strftime(const string &format, int64_t timestamp) {
   localtime_r(&timestamp_t, &t);
 
   if (!strftime(php_buf, PHP_BUF_LEN, format.c_str(), &t)) {
-    return string();
+    return {};
   }
 
   return string(php_buf);

--- a/runtime/ffi.h
+++ b/runtime/ffi.h
@@ -175,7 +175,7 @@ string f$FFI$$string(const T &v) {
 
 template<class T>
 string f$FFI$$string(const T &v, int64_t size) {
-  return string(reinterpret_cast<const char*>(ffi_c_value_ptr(v)), size);
+  return {reinterpret_cast<const char*>(ffi_c_value_ptr(v)), static_cast<string::size_type>(size)};
 }
 
 template<class T>
@@ -279,7 +279,7 @@ inline int64_t ffi_c2php(int64_t v) { return v; }
 inline double ffi_c2php(float v) { return v; }
 inline double ffi_c2php(double v) { return v; }
 inline string ffi_c2php(const char *v) { return string(v); }
-inline string ffi_c2php(char v) { return string(1, v); }
+inline string ffi_c2php(char v) { return {1, v}; }
 
 template<class T>
 CDataPtr<T> ffi_c2php(T* v) {

--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -110,7 +110,7 @@ string f$basename(const string &name, const string &suffix) {
   if ((int)suffix.size() <= l && !strcmp(result_c_str + l - suffix.size(), suffix.c_str())) {
     l -= suffix.size();
   }
-  return string(result_c_str, static_cast<string::size_type>(l));
+  return {result_c_str, static_cast<string::size_type>(l)};
 }
 
 bool f$chmod(const string &s, int64_t mode) {
@@ -345,7 +345,7 @@ string f$php_uname(const string &name) {
   dl::enter_critical_section();//OK
   if (uname(&res)) {
     dl::leave_critical_section();
-    return string();
+    return {};
   }
   dl::leave_critical_section();
 

--- a/runtime/json-functions.cpp
+++ b/runtime/json-functions.cpp
@@ -536,5 +536,5 @@ mixed f$json_decode(const string &v, bool assoc) noexcept {
     }
   }
 
-  return mixed();
+  return {};
 }

--- a/runtime/json-functions.h
+++ b/runtime/json-functions.h
@@ -124,7 +124,7 @@ string f$vk_json_encode_safe(const T &v, bool simple_encode = true) noexcept {
     static_SB.clean();
     string_buffer::string_buffer_error_flag = STRING_BUFFER_ERROR_FLAG_OFF;
     THROW_EXCEPTION (new_Exception(string(__FILE__), __LINE__, string("json_encode buffer overflow", 27)));
-    return string();
+    return {};
   }
   string_buffer::string_buffer_error_flag = STRING_BUFFER_ERROR_FLAG_OFF;
   return static_SB.str();

--- a/runtime/kphp_core.h
+++ b/runtime/kphp_core.h
@@ -1223,39 +1223,39 @@ const char *get_type_c_str(const class_instance<T> &) {
 template<class T>
 string f$get_type(const T &v) {
   const char *res = get_type_c_str(v);
-  return string(res, strlen(res));
+  return {res, static_cast<string::size_type>(strlen(res))};
 }
 
 
 string f$get_class(bool) {
   php_warning("Called get_class() on boolean");
-  return string();
+  return {};
 }
 
 string f$get_class(int64_t) {
   php_warning("Called get_class() on integer");
-  return string();
+  return {};
 }
 
 string f$get_class(double) {
   php_warning("Called get_class() on double");
-  return string();
+  return {};
 }
 
 string f$get_class(const string &) {
   php_warning("Called get_class() on string");
-  return string();
+  return {};
 }
 
 string f$get_class(const mixed &v) {
   php_warning("Called get_class() on %s", v.get_type_c_str());
-  return string();
+  return {};
 }
 
 template<class T>
 string f$get_class(const array<T> &) {
   php_warning("Called get_class() on array");
-  return string();
+  return {};
 }
 
 template<class T>
@@ -1309,7 +1309,7 @@ bool f$function_exists(const T &) {
 
 
 mixed f$error_get_last() {
-  return mixed();
+  return {};
 }
 
 int64_t f$error_reporting(int64_t level) {

--- a/runtime/math_functions.cpp
+++ b/runtime/math_functions.cpp
@@ -56,7 +56,7 @@ string f$decbin(int64_t number) noexcept {
     v >>= 1;
   } while (v > 0);
 
-  return string(s + i, static_cast<string::size_type>(65 - i));
+  return {s + i, static_cast<string::size_type>(65 - i)};
 }
 
 string f$dechex(int64_t number) noexcept {
@@ -70,7 +70,7 @@ string f$dechex(int64_t number) noexcept {
     v >>= 4;
   } while (v > 0);
 
-  return string(s + i, 16 - i);
+  return {s + i, static_cast<string::size_type>(16 - i)};
 }
 
 int64_t f$hexdec(const string &number) noexcept {

--- a/runtime/mbstring.cpp
+++ b/runtime/mbstring.cpp
@@ -325,7 +325,7 @@ string f$mb_substr(const string &str, int64_t start, const mixed &length_var, co
   if (encoding_num == 1251) {
     Optional<string> res = f$substr(str, start, length);
     if (!res.has_value()) {
-      return string();
+      return {};
     }
     return res.val();
   }
@@ -341,7 +341,7 @@ string f$mb_substr(const string &str, int64_t start, const mixed &length_var, co
     length = len - start + length;
   }
   if (length <= 0 || start < 0) {
-    return string();
+    return {};
   }
   if (len - start < length) {
     length = len - start;
@@ -350,5 +350,5 @@ string f$mb_substr(const string &str, int64_t start, const mixed &length_var, co
   int64_t UTF8_start = mb_UTF8_advance(str.c_str(), start);
   int64_t UTF8_length = mb_UTF8_advance(str.c_str() + UTF8_start, length);
 
-  return string(str.c_str() + UTF8_start, static_cast<string::size_type>(UTF8_length));
+  return {str.c_str() + UTF8_start, static_cast<string::size_type>(UTF8_length)};
 }

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -673,7 +673,7 @@ string f$print_r(const mixed &v, bool buffered) {
     dprintf(kstdout, "%s", f$ob_get_contents().c_str());
     f$ob_clean();
   }
-  return string();
+  return {};
 }
 
 void f$var_dump(const mixed &v) {
@@ -698,7 +698,7 @@ string f$var_export(const mixed &v, bool buffered) {
     dprintf(kstdout, "%s", f$ob_get_contents().c_str());
     f$ob_clean();
   }
-  return string();
+  return {};
 }
 
 string f$cp1251(const string &utf8_string) {

--- a/runtime/mysql.cpp
+++ b/runtime/mysql.cpp
@@ -54,14 +54,14 @@ static unsigned long long mysql_read_long_long(const unsigned char *&result, int
 
 static string mysql_read_string(const unsigned char *&result, int &result_len, bool &is_null, bool need_value = false) {
   if (result_len < 0) {
-    return string();
+    return {};
   }
 
   long long value_len = mysql_read_long_long(result, result_len, is_null);
   if (is_null || result_len < value_len || !need_value) {
     result_len -= (int)value_len;
     result += value_len;
-    return string();
+    return {};
   }
   string value((const char *)result, (int)value_len);
   result_len -= (int)value_len;

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -205,8 +205,8 @@ int64_t f$fetch_lookup_int() {
 string f$fetch_lookup_data(int64_t x4_bytes_length) {
   TRY_CALL_VOID(string, (check_rpc_data_len(x4_bytes_length)));
   rpc_data_len += static_cast<int32_t>(x4_bytes_length);
-  return string(reinterpret_cast<const char *>(rpc_data),
-                static_cast<string::size_type>(x4_bytes_length * 4));
+  return {reinterpret_cast<const char *>(rpc_data),
+                static_cast<string::size_type>(x4_bytes_length * 4)};
 }
 
 int64_t f$fetch_long() {
@@ -264,7 +264,7 @@ static inline const char *f$fetch_string_raw(int *string_len) {
 string f$fetch_string() {
   int result_len = 0;
   const char *str = TRY_CALL(const char*, string, f$fetch_string_raw(&result_len));
-  return string(str, result_len);
+  return {str, static_cast<string::size_type>(result_len)};
 }
 
 int64_t f$fetch_string_as_int() {
@@ -302,7 +302,7 @@ mixed f$fetch_memcache_value() {
     default: {
       php_warning("Wrong memcache.Value constructor = %x", res);
       THROW_EXCEPTION(new_Exception(rpc_filename, __LINE__, string("Wrong memcache.Value constructor"), -1));
-      return mixed();
+      return {};
     }
   }
 }

--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -136,7 +136,7 @@ string f$chop(const string &s, const string &what) {
 }
 
 string f$chr(int64_t v) {
-  return string(1, static_cast<char>(v));
+  return {1, static_cast<char>(v)};
 }
 
 static const unsigned char win_to_koi[] = {
@@ -236,7 +236,7 @@ string f$hex2bin(const string &str) {
   int len = str.size();
   if (len & 1) {
     php_warning("Wrong argument \"%s\" supplied for function hex2bin", str.c_str());
-    return string();
+    return {};
   }
 
   string result(len / 2, false);
@@ -245,7 +245,7 @@ string f$hex2bin(const string &str) {
     int num_low = hex_to_int(str[i + 1]);
     if (num_high == 16 || num_low == 16) {
       php_warning("Wrong argument \"%s\" supplied for function hex2bin", str.c_str());
-      return string();
+      return {};
     }
     result[i / 2] = (char)((num_high << 4) + num_low);
   }
@@ -624,7 +624,7 @@ string f$ltrim(const string &s, const string &what) {
   while (l < len && mask[(unsigned char)s[l]]) {
     l++;
   }
-  return string(s.c_str() + l, len - l);
+  return {s.c_str() + l, static_cast<string::size_type>(len - l)};
 }
 
 string f$mysql_escape_string(const string &str) {
@@ -674,7 +674,7 @@ string f$number_format(double number, int64_t decimals, const string &dec_point,
 
   if (decimals < 0 || decimals > 100) {
     php_warning("Wrong parameter decimals (%" PRIi64 ") in function number_format", decimals);
-    return string();
+    return {};
   }
   bool negative = false;
   if (number < 0) {
@@ -736,10 +736,10 @@ string f$number_format(double number, int64_t decimals, const string &dec_point,
 
   if (result_begin <= php_buf) {
     php_critical_error ("maximum length of result (%d) exceeded", PHP_BUF_LEN);
-    return string();
+    return {};
   }
 
-  return string(result_begin, static_cast<string::size_type>(php_buf + PHP_BUF_LEN - result_begin));
+  return {result_begin, static_cast<string::size_type>(php_buf + PHP_BUF_LEN - result_begin)};
 }
 
 int64_t f$ord(const string &s) {
@@ -765,7 +765,7 @@ string f$pack(const string &pattern, const array<mixed> &a) {
 
       if (cnt <= 0) {
         php_warning("Wrong count specifier in pattern \"%s\"", pattern.c_str());
-        return string();
+        return {};
       }
     } else if (pattern[i] == '*') {
       cnt = 0;
@@ -775,11 +775,11 @@ string f$pack(const string &pattern, const array<mixed> &a) {
     if (arg_num >= a.count()) {
       if (format == 'A' || format == 'a' || format == 'H' || format == 'h' || cnt != 0) {
         php_warning("Not enough parameters to call function pack");
-        return string();
+        return {};
       }
       if (i + 1 != (int)pattern.size()) {
         php_warning("Misplaced symbol '*' in pattern \"%s\"", pattern.c_str());
-        return string();
+        return {};
       }
       break;
     }
@@ -789,7 +789,7 @@ string f$pack(const string &pattern, const array<mixed> &a) {
 
     if (arg.is_array()) {
       php_warning("Argument %d of function pack is array", arg_num);
-      return string();
+      return {};
     }
 
     char filler = 0;
@@ -825,7 +825,7 @@ string f$pack(const string &pattern, const array<mixed> &a) {
           cnt -= 2;
           if (num_high == 16 || num_low == 16) {
             php_warning("Wrong argument \"%s\" supplied for format '%c' in function pack", arg_str.c_str(), format);
-            return string();
+            return {};
           }
           if (format == 'H') {
             static_SB << (char)((num_high << 4) + num_low);
@@ -911,21 +911,21 @@ string f$pack(const string &pattern, const array<mixed> &a) {
             }
             default:
               php_warning("Format code \"%c\" not supported", format);
-              return string();
+              return {};
           }
 
           if (cnt > 1) {
             arg_num = cur_arg++;
             if (arg_num >= a.count()) {
               php_warning("Not enough parameters to call function pack");
-              return string();
+              return {};
             }
 
             arg = a.get_value(arg_num);
 
             if (arg.is_array()) {
               php_warning("Argument %d of function pack is array", arg_num);
-              return string();
+              return {};
             }
           }
         } while (--cnt > 0);
@@ -966,7 +966,7 @@ string f$rtrim(const string &s, const string &what) {
     len--;
   }
 
-  return string(s.c_str(), len);
+  return {s.c_str(), static_cast<string::size_type>(len)};
 }
 
 Optional<string> f$setlocale(int64_t category, const string &locale) {
@@ -1056,19 +1056,19 @@ string f$sprintf(const string &format, const array<mixed> &a) {
 
       if (arg_num >= a.count()) {
         php_warning("Not enough parameters to call function sprintf with format \"%s\"", format.c_str());
-        return string();
+        return {};
       }
 
       if (arg_num == -1) {
         php_warning("Wrong parameter number 0 specified in function sprintf with format \"%s\"", format.c_str());
-        return string();
+        return {};
       }
 
       const mixed &arg = a.get_value(arg_num);
 
       if (arg.is_array()) {
         php_warning("Argument %d of function sprintf is array", arg_num);
-        return string();
+        return {};
       }
 
       switch (format[i]) {
@@ -1178,7 +1178,7 @@ string f$sprintf(const string &format, const array<mixed> &a) {
         }
         default:
           php_warning("Unsupported specifier %%%c in sprintf with format \"%s\"", format[i], format.c_str());
-          return string();
+          return {};
       }
     }
 
@@ -1187,7 +1187,7 @@ string f$sprintf(const string &format, const array<mixed> &a) {
 
   if (error_too_big) {
     php_warning("Too big result in function sprintf");
-    return string();
+    return {};
   }
 
   return result;
@@ -1930,7 +1930,7 @@ string f$str_pad(const string &input, int64_t len, const string &pad_str, int64_
 string f$str_repeat(const string &s, int64_t multiplier) {
   const string::size_type len = s.size();
   if (multiplier <= 0 || len == 0) {
-    return string();
+    return {};
   }
 
   auto mult = static_cast<string::size_type>(multiplier);
@@ -1939,7 +1939,7 @@ string f$str_repeat(const string &s, int64_t multiplier) {
   }
 
   if (len == 1) {
-    return string(mult, s[0]);
+    return {mult, s[0]};
   }
 
   string result(mult * len, false);
@@ -1993,7 +1993,7 @@ static string str_replace_char(char c, const string &replace, const string &subj
     piece = pos + 1;
   }
   php_assert (0); // unreachable
-  return string();
+  return {};
 }
 
 static const char *find_substr(const char *where, const char *where_end, const string &what, bool with_case) {
@@ -2080,7 +2080,7 @@ string str_replace(const string &search, const string &replace, const string &su
     piece = pos + search.size();
   }
   php_assert (0); // unreachable
-  return string();
+  return {};
 }
 
 // common for f$str_replace(string) and f$str_ireplace(string)
@@ -2340,14 +2340,14 @@ string f$trim(const string &s, const string &what) {
   }
 
   if (len == 0) {
-    return string();
+    return {};
   }
 
   int l = 0;
   while (mask[(unsigned char)s[l]]) {
     l++;
   }
-  return string(s.c_str() + l, len - l);
+  return {s.c_str() + l, static_cast<string::size_type>(len - l)};
 }
 
 string f$ucfirst(const string &str) {

--- a/runtime/tl/tl_builtins.h
+++ b/runtime/tl/tl_builtins.h
@@ -47,7 +47,7 @@ using tl_storer_ptr = std::unique_ptr<tl_func_base>(*)(const mixed &);
 inline mixed tl_arr_get(const mixed &arr, const string &str_key, int64_t num_key, int64_t precomputed_hash = 0) {
   if (!arr.is_array()) {
     CurrentProcessingQuery::get().raise_storing_error("Array expected, when trying to access field #%" PRIi64 " : %s", num_key, str_key.c_str());
-    return mixed();
+    return {};
   }
   const mixed &num_v = arr.get_value(num_key);
   if (!num_v.is_null()) {
@@ -58,7 +58,7 @@ inline mixed tl_arr_get(const mixed &arr, const string &str_key, int64_t num_key
     return str_v;
   }
   CurrentProcessingQuery::get().raise_storing_error("Field %s (#%" PRIi64 ") not found", str_key.c_str(), num_key);
-  return mixed();
+  return {};
 }
 
 inline void store_magic_if_not_bare(unsigned int inner_magic) {
@@ -306,7 +306,7 @@ struct t_True {
   void store(const mixed &__attribute__((unused))) {}
 
   array<mixed> fetch() {
-    return array<mixed>();
+    return {};
   }
 
   void typed_store(const PhpType &__attribute__((unused))) {}
@@ -347,7 +347,7 @@ struct t_Vector {
     int n = rpc_fetch_int();
     if (n < 0) {
       CurrentProcessingQuery::get().raise_fetching_error("Vector size is negative");
-      return array<mixed>();
+      return {};
     }
     array<mixed> result(array_size(std::min(n, 10000), 0, true));
     for (int i = 0; i < n; ++i) {

--- a/runtime/url.cpp
+++ b/runtime/url.cpp
@@ -161,7 +161,7 @@ string f$base64_encode(const string &s) {
   result_len = base64_encode(reinterpret_cast <const unsigned char *> (s.c_str()), (int)s.size(), res.buffer(), result_len + 1);
 
   if (result_len != 0) {
-    return string();
+    return {};
   }
 
   return res;

--- a/runtime/vkext.cpp
+++ b/runtime/vkext.cpp
@@ -151,7 +151,7 @@ inline string finish_buff(int64_t max_len) {
     return res;
   }
 
-  return string(buff, static_cast<string::size_type>(len));
+  return {buff, static_cast<string::size_type>(len)};
 }
 
 inline void write_buff(const char *s, int l) {
@@ -488,7 +488,7 @@ string f$vk_utf8_to_win(const string &text, int64_t max_len, bool exit_on_error)
     if (!max_len || text.size() <= static_cast<string::size_type>(max_len)) {
       return text;
     }
-    return string(text.c_str(), static_cast<string::size_type>(max_len));
+    return {text.c_str(), static_cast<string::size_type>(max_len)};
   }
 }
 
@@ -558,88 +558,88 @@ string f$vk_sp_simplify(const string &s) {
   sp_init();
   char *t = sp_simplify(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_full_simplify(const string &s) {
   sp_init();
   char *t = sp_full_simplify(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_deunicode(const string &s) {
   sp_init();
   char *t = sp_deunicode(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_to_upper(const string &s) {
   sp_init();
   char *t = sp_to_upper(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_to_lower(const string &s) {
   sp_init();
   char *t = sp_to_lower(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_to_sort(const string &s) {
   sp_init();
   char *t = sp_sort(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_remove_repeats(const string &s) {
   sp_init();
   char *t = sp_remove_repeats(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_to_cyrillic(const string &s) {
   sp_init();
   char *t = sp_to_cyrillic(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }
 
 string f$vk_sp_words_only(const string &s) {
   sp_init();
   char *t = sp_words_only(s.c_str());
   if (!t) {
-    return string();
+    return {};
   }
 
-  return string(t, (string::size_type)strlen(t));
+  return {t, (string::size_type)strlen(t)};
 }

--- a/runtime/vkext_stats.cpp
+++ b/runtime/vkext_stats.cpp
@@ -252,7 +252,7 @@ string hll_pack(const string &s, int len) {
     }
     assert (p < HLL_BUF_SIZE);
   }
-  return string((char*) buf, p);
+  return {(char*) buf, static_cast<string::size_type>(p)};
 }
 //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/runtime/zlib.cpp
+++ b/runtime/zlib.cpp
@@ -144,9 +144,9 @@ const char *gzuncompress_raw(vk::string_view s, string::size_type *result_len) {
 string zlib_decode(const string&s, int encoding) {
   int len = zlib_decode_raw({s.c_str(), s.size()}, encoding);
   if (len == -1u) {
-    return string();
+    return {};
   }
-  return string(php_buf, len);
+  return {php_buf, static_cast<string::size_type>(len)};
 }
 
 string f$gzdecode(const string &s) {


### PR DESCRIPTION
In this patch I remove duplicating of function return type with help of clang-tidy static analyzer. This check in clang-tidy called 'modernize-return-braced-init-list'