### PR TITLE
clang-tidy: readability-qualified-auto

### DIFF
--- a/common/algorithms/string-algorithms.h
+++ b/common/algorithms/string-algorithms.h
@@ -43,12 +43,12 @@ inline std::string to_upper(std::string s) {
 }
 
 inline vk::string_view ltrim(vk::string_view s) {
-  auto first_not_space = std::find_if(s.begin(), s.end(), [](uint8_t ch) { return !std::isspace(ch); });
+  const auto *first_not_space = std::find_if(s.begin(), s.end(), [](uint8_t ch) { return !std::isspace(ch); });
   return {first_not_space, s.end()};
 }
 
 inline vk::string_view rtrim(vk::string_view s) {
-  auto last_not_space = std::find_if(s.rbegin(), s.rend(), [](uint8_t ch) { return !std::isspace(ch); }).base();
+  const auto *last_not_space = std::find_if(s.rbegin(), s.rend(), [](uint8_t ch) { return !std::isspace(ch); }).base();
   return {s.begin(), last_not_space};
 }
 

--- a/common/allocators/lockfree-slab-test.cpp
+++ b/common/allocators/lockfree-slab-test.cpp
@@ -20,7 +20,7 @@
 TEST(lockfree_slab, basic) {
   const std::size_t sizes[] = { 8, 12, 16, 31, 100 };
 
-  for (auto size = std::begin(sizes); size != std::end(sizes); ++size) {
+  for (const auto *size = std::begin(sizes); size != std::end(sizes); ++size) {
     const std::size_t pointers_size = 1000;
 
     std::vector<void*> pointers;
@@ -36,7 +36,7 @@ TEST(lockfree_slab, basic) {
     }
 
     std::shuffle(pointers.begin(), pointers.end(), std::mt19937{});
-    for(auto pointer : pointers) {
+    for(auto *pointer : pointers) {
       lockfree_slab_cache_free(&cache_tls, pointer);
     }
 
@@ -58,10 +58,10 @@ TEST(lockfree_slab, alloc0) {
     pointers.push_back(lockfree_slab_cache_alloc0(&cache_tls));
   }
 
-  for(auto pointer : pointers) {
-    const auto begin = static_cast<const char*>(pointer);
-    const auto end = std::next(begin, object_size);
-    const auto found = std::find_if(begin, end,[](const char value) { return value != 0; });
+  for(auto *pointer : pointers) {
+    const auto *begin = static_cast<const char*>(pointer);
+    const auto *end = std::next(begin, object_size);
+    const auto *found = std::find_if(begin, end,[](const char value) { return value != 0; });
 
     EXPECT_EQ(found, end);
   }
@@ -85,7 +85,7 @@ TEST(lockfree_slab, stress) {
         return nullptr;
       }
 
-      auto elem = queue_.front();
+      auto *elem = queue_.front();
       queue_.pop();
 
       return elem;
@@ -146,7 +146,7 @@ TEST(lockfree_slab, stress) {
 
         std::this_thread::sleep_for(std::chrono::milliseconds(out_buffers_num));
 
-        for (auto in_buffer : in_buffers) {
+        for (auto *in_buffer : in_buffers) {
           lockfree_slab_cache_free(&cache_tls, in_buffer);
         }
       }

--- a/common/binlog/binlog-buffer-aio.cpp
+++ b/common/binlog/binlog-buffer-aio.cpp
@@ -129,7 +129,7 @@ static int bbw_local_replica_try_read (bb_writer_t *W, int len) {
   const long long offset = B->log_last_wpos - P->log_slice_start_pos;
   if (P->Binlog->info->flags & KFS_FILE_ZIPPED) {
     r = 0x1000000;
-    auto a = static_cast<char*>(malloc (r));
+    auto *a = static_cast<char*>(malloc (r));
     assert (a);
     if (kfs_bz_decode (P->Binlog, offset, a, &r, NULL) < 0) {
       print_backtrace();

--- a/common/binlog/binlog-buffer-rotation-points.cpp
+++ b/common/binlog/binlog-buffer-rotation-points.cpp
@@ -73,7 +73,7 @@ static void bb_buffer_insert_rotation_point (bb_buffer_t *B, bb_rotation_point_t
 }
 
 bb_rotation_point_t *bb_rotation_point_alloc (bb_buffer_t *B, enum bb_rotation_point_type tp, long long log_pos) {
-  auto p = static_cast<bb_rotation_point_t *>(calloc(sizeof(bb_rotation_point_t), 1));
+  auto *p = static_cast<bb_rotation_point_t *>(calloc(sizeof(bb_rotation_point_t), 1));
   assert (p);
   p->tp = tp;
   p->log_pos = log_pos;

--- a/common/kfs/kfs-binlog.cpp
+++ b/common/kfs/kfs-binlog.cpp
@@ -92,7 +92,7 @@ kfs_file_handle_t open_binlog(const kfs_replica_t *R, long long log_pos) {
       //kprintf ("FI->file_size:%lld, FI->flags: %d, FI->kfs_headers:%d, file:%s, file_pos: %lld, log_pos: %lld\n", FI->file_size, FI->flags, FI->kfs_headers, FI->filename, file_pos, log_pos);
       assert (lseek(fd, file_pos, SEEK_SET) == file_pos);
 
-      auto F = static_cast<kfs_file *>(calloc(1, sizeof(struct kfs_file)));
+      auto *F = static_cast<kfs_file *>(calloc(1, sizeof(struct kfs_file)));
       assert (F);
       F->info = FI;
       F->fd = fd;

--- a/common/kfs/kfs-snapshot.cpp
+++ b/common/kfs/kfs-snapshot.cpp
@@ -51,7 +51,7 @@ kfs_file_handle_t open_snapshot(kfs_replica_handle_t r, int snapshot_index) {
     return 0;
   }
 
-  auto f = static_cast<kfs_file *>(malloc(sizeof(struct kfs_file)));
+  auto *f = static_cast<kfs_file *>(malloc(sizeof(struct kfs_file)));
   assert (f);
   memset(f, 0, sizeof(*f));
   f->info = fi;

--- a/common/parallel/maximum-test.cpp
+++ b/common/parallel/maximum-test.cpp
@@ -34,7 +34,7 @@ TEST(parallel_maximum, basic) {
     std::array<std::size_t, nr_threads> thread_consumption;
 
     std::size_t remains = expected_max;
-    for (auto t = thread_consumption.begin(); t < std::prev(thread_consumption.end()); ++t) {
+    for (auto *t = thread_consumption.begin(); t < std::prev(thread_consumption.end()); ++t) {
       std::uniform_int_distribution<size_t> distribution(0, remains);
       *t = distribution(random_engine);
       assert(remains >= *t);
@@ -44,7 +44,7 @@ TEST(parallel_maximum, basic) {
     EXPECT_EQ(expected_max, std::accumulate(thread_consumption.begin(), thread_consumption.end(), 0LL));
 
     std::array<std::thread, nr_threads> threads;
-    for (auto t = threads.begin(); t < threads.end(); ++t) {
+    for (auto *t = threads.begin(); t < threads.end(); ++t) {
       const std::size_t consumption = thread_consumption[std::distance(threads.begin(), t)];
 
       *t = std::thread([=]() {

--- a/common/server/signals.cpp
+++ b/common/server/signals.cpp
@@ -161,7 +161,7 @@ static void generic_debug_handler(int sig, siginfo_t *info, void *ucontext) {
   if (sig == SIGABRT) {
     dump_stats();
   }
-  auto name = signal_shortname(sig);
+  const auto *name = signal_shortname(sig);
   write_to_stderr(name, true);
   if (info->si_code == SI_USER) {
     write_to_stderr(" received from process ");

--- a/common/stats/provider.cpp
+++ b/common/stats/provider.cpp
@@ -79,7 +79,7 @@ static int read_whole_file(const char *filename, void *output, int olen) {
     vkprintf(1, "%s: output buffer is too small (%d bytes).\n", __func__, olen);
     return -1;
   }
-  auto p = static_cast<unsigned char *>(output);
+  auto *p = static_cast<unsigned char *>(output);
   p[n] = 0;
   return n;
 }

--- a/common/tl/compiler/tl-parser-new.cpp
+++ b/common/tl/compiler/tl-parser-new.cpp
@@ -2227,8 +2227,8 @@ void change_var_ptrs(struct tl_combinator_tree *O, struct tl_combinator_tree *D,
 }
 
 tl_combinator_tree *change_first_var(struct tl_combinator_tree *O, struct tl_combinator_tree **X, struct tl_combinator_tree *Y) {
-  auto minus_one = reinterpret_cast<tl_combinator_tree *>(-1l);
-  auto minus_two = reinterpret_cast<tl_combinator_tree *>(-2l);
+  auto *minus_one = reinterpret_cast<tl_combinator_tree *>(-1l);
+  auto *minus_two = reinterpret_cast<tl_combinator_tree *>(-2l);
   if (!O) {
     return minus_one;
   };
@@ -2354,8 +2354,8 @@ struct tl_combinator_tree *reduce_type(struct tl_combinator_tree *A, struct tl_t
 }
 
 struct tl_combinator_tree *change_value_var(struct tl_combinator_tree *O, tree_var_value_t **X) {
-  auto minus_one = reinterpret_cast<tl_combinator_tree *>(-1l);
-  auto minus_two = reinterpret_cast<tl_combinator_tree *>(-2l);
+  auto *minus_one = reinterpret_cast<tl_combinator_tree *>(-1l);
+  auto *minus_two = reinterpret_cast<tl_combinator_tree *>(-2l);
   if (!O) {
     return minus_two;
   };

--- a/common/tl/methods/rwm.cpp
+++ b/common/tl/methods/rwm.cpp
@@ -12,7 +12,7 @@
 #include "common/tl/parse.h"
 
 static inline int rwm_do_xor_compress(void *extra __attribute__((unused)), void *data_, int len) {
-  auto data = static_cast<uint8_t *>(data_);
+  auto *data = static_cast<uint8_t *>(data_);
   for (int i = 0; i < len; i++) {
     data[i] ^= 0xbe;
   }
@@ -27,7 +27,7 @@ struct zstd_compression_extra_t {
 };
 
 static inline int tl_raw_msg_zstd_compress(void *_extra, const void *data, int len) {
-  auto extra = static_cast<zstd_compression_extra_t *>(_extra);
+  auto *extra = static_cast<zstd_compression_extra_t *>(_extra);
   ZSTD_outBuffer output = {.dst = extra->buffer, .size = extra->buf_len, .pos = 0};
   ZSTD_inBuffer input = {.src = data, .size = (size_t)len, .pos = 0};
   while (input.pos < input.size) {
@@ -82,7 +82,7 @@ struct zstd_decompression_extra_t {
 };
 
 static inline int tl_raw_msg_zstd_decompress(void *_extra, const void *data, int len) {
-  auto extra = static_cast<zstd_decompression_extra_t *>(_extra);
+  auto *extra = static_cast<zstd_decompression_extra_t *>(_extra);
   ZSTD_outBuffer output = {.dst = extra->buffer, .size = extra->buf_len, .pos = 0};
   ZSTD_inBuffer input = {.src = data, .size = (size_t)len, .pos = 0};
   while (input.pos < input.size) {

--- a/common/tl/methods/rwm.h
+++ b/common/tl/methods/rwm.h
@@ -87,7 +87,7 @@ struct tl_out_methods_raw_msg_base : Base {
     assert (rwm_push_data(get_rwm(), buf, len) == len);
   }
   void copy_through(tl_in_methods *in, int len, int advance) noexcept final {
-    if (auto rwm_in = dynamic_cast<tl_in_methods_raw_msg*>(in)) {
+    if (auto *rwm_in = dynamic_cast<tl_in_methods_raw_msg*>(in)) {
       if (!advance) {
         raw_message_t r;
         rwm_clone(&r, &rwm_in->in);

--- a/common/tl2php/function-to-php.cpp
+++ b/common/tl2php/function-to-php.cpp
@@ -60,7 +60,7 @@ void FunctionToPhp::apply(const tlo_parsing::type_var &tl_type_var) {
       }
     }
   }
-  auto arg_ptr = tl_combinator_.get_var_num_arg(tl_type_var.var_num);
+  auto *arg_ptr = tl_combinator_.get_var_num_arg(tl_type_var.var_num);
   assert(arg_ptr);
   arg_ptr->type_expr->visit(*this);
 }

--- a/common/tlo-parsing/flat-optimization.cpp
+++ b/common/tlo-parsing/flat-optimization.cpp
@@ -50,7 +50,7 @@ private:
     cloned->type_id = tl_type_expr.type_id;
     cloned->children.reserve(tl_type_expr.children.size());
 
-    for (auto &child : tl_type_expr.children) {
+    for (const auto &child : tl_type_expr.children) {
       child->visit(*this);
       if (new_type_child_) {
         assert(!new_nat_child_);
@@ -121,7 +121,7 @@ private:
 
   void prepare_new_child(int donor_var_num) {
     const size_t template_arg_number = donor_.constructor->get_type_parameter_input_index(donor_var_num);
-    auto *replacing_type_expr = old_expr_.as<type_expr>();
+    const auto *replacing_type_expr = old_expr_.as<type_expr>();
     assert(replacing_type_expr);
     assert(template_arg_number < replacing_type_expr->children.size());
 
@@ -261,7 +261,7 @@ private:
     }
 
     to_inline_.constructor = tl_type.constructors.front().get();
-    for (auto &ctr_arg : to_inline_.constructor->args) {
+    for (const auto &ctr_arg : to_inline_.constructor->args) {
       if (!(ctr_arg->is_optional())) {
         if (to_inline_.argument) {
           to_inline_.clear();

--- a/common/tlo-parsing/remove-odd-types.cpp
+++ b/common/tlo-parsing/remove-odd-types.cpp
@@ -14,9 +14,9 @@ static void remove_node_types(vk::tlo_parsing::tl_scheme &scheme, const vk::tlo_
   std::unordered_set<const vk::tlo_parsing::combinator *> functions_to_delete;
 
   for (const auto &node_id : nodes_to_delete) {
-    auto &node = graph.get_node_info(node_id);
+    const auto &node = graph.get_node_info(node_id);
     if (node.is_combinator()) {
-      auto *c = node.get_combinator();
+      const auto *c = node.get_combinator();
       if (c->is_function()) {
         functions_to_delete.insert(c);
       } else if (c->is_constructor()) {

--- a/common/tlo-parsing/replace-anonymous-args.cpp
+++ b/common/tlo-parsing/replace-anonymous-args.cpp
@@ -121,7 +121,7 @@ private:
     }
 
     bool has_other = false;
-    for (auto &tl_arg : processing_combinator_->args) {
+    for (const auto &tl_arg : processing_combinator_->args) {
       if (!(tl_arg->is_optional()) && processing_arg_ != tl_arg.get()) {
         has_other = true;
       }

--- a/common/tlo-parsing/tl-objects.cpp
+++ b/common/tlo-parsing/tl-objects.cpp
@@ -238,7 +238,7 @@ type::type(tlo_parser *reader) {
 }
 
 bool arg::is_type() const {
-  if (auto casted = type_expr->as<vk::tlo_parsing::type_expr>()) {
+  if (auto *casted = type_expr->as<vk::tlo_parsing::type_expr>()) {
     if (casted->type_id == TL_TYPE_ID) {
       return true;
     }
@@ -247,7 +247,7 @@ bool arg::is_type() const {
 }
 
 bool arg::is_sharp() const {
-  if (auto casted = type_expr->as<vk::tlo_parsing::type_expr>()) {
+  if (auto *casted = type_expr->as<vk::tlo_parsing::type_expr>()) {
     if (casted->type_id == TL_SHARP_ID) {
       return true;
     }
@@ -490,7 +490,7 @@ bool arg::is_forwarded_function() const {
 }
 
 bool arg::is_named_fields_mask_bit() const {
-  if (auto expr = type_expr->as<vk::tlo_parsing::type_expr>()) {
+  if (auto *expr = type_expr->as<vk::tlo_parsing::type_expr>()) {
     return is_fields_mask_optional() && expr->type_id == TL_TRUE_ID && expr->is_bare();
   }
   return false;

--- a/common/tlo-parsing/tl-scheme-final-check.cpp
+++ b/common/tlo-parsing/tl-scheme-final-check.cpp
@@ -66,7 +66,7 @@ private:
     if (tl_type->name == "Maybe") {
       assert(tl_type_expr.children.size() == 1);
       const auto &child = tl_type_expr.children.back();
-      if (auto child_as_type_expr = child->as<vk::tlo_parsing::type_expr>()) {
+      if (auto *child_as_type_expr = child->as<vk::tlo_parsing::type_expr>()) {
         auto *child_type = scheme_.get_type_by_magic(child_as_type_expr->type_id);
         assert(child_type);
         if (child_type->name == "True") {
@@ -105,11 +105,11 @@ private:
       }
     }
     std::vector<int> params_order;
-    auto as_type_expr = c.result->as<vk::tlo_parsing::type_expr>();
+    auto *as_type_expr = c.result->as<vk::tlo_parsing::type_expr>();
     for (const auto &child : as_type_expr->children) {
-      if (auto as_nat_var = child->as<vk::tlo_parsing::nat_var>()) {
+      if (auto *as_nat_var = child->as<vk::tlo_parsing::nat_var>()) {
         params_order.push_back(as_nat_var->var_num);
-      } else if (auto as_type_var = child->as<vk::tlo_parsing::type_var>()) {
+      } else if (auto *as_type_var = child->as<vk::tlo_parsing::type_var>()) {
         params_order.push_back(as_type_var->var_num);
       }
     }
@@ -162,7 +162,7 @@ private:
 
 void tl_scheme_final_check(const tl_scheme &scheme) {
   TlSchemaChecker schema_checker{scheme};
-  for (auto &tl_function : scheme.functions) {
+  for (const auto &tl_function : scheme.functions) {
     schema_checker.check_combinator(*tl_function.second);
   }
 }

--- a/common/wrappers/string_view.h
+++ b/common/wrappers/string_view.h
@@ -155,7 +155,7 @@ public:
     if (empty()) {
       return std::string::npos;
     }
-    auto *ans = static_cast<const char *>(memmem(data() + pos, size() - pos, needle.data(), needle.size()));
+    const auto *ans = static_cast<const char *>(memmem(data() + pos, size() - pos, needle.data(), needle.size()));
     if (ans) {
       return ans - data();
     } else {
@@ -168,7 +168,7 @@ public:
     if (empty()) {
       return std::string::npos;
     }
-    auto *ans = static_cast<const char *>(memchr(data() + pos, c, size() - pos));
+    const auto *ans = static_cast<const char *>(memchr(data() + pos, c, size() - pos));
     if (ans) {
       return ans - data();
     } else {
@@ -185,8 +185,8 @@ public:
     }
 
     if (needle.size() <= size()) {
-      auto end_it = begin() + (std::min(size() - needle.size(), pos) + needle.size());
-      auto found_it = std::find_end(begin(), end_it, needle.begin(), needle.end());
+      const auto *end_it = begin() + (std::min(size() - needle.size(), pos) + needle.size());
+      const auto *found_it = std::find_end(begin(), end_it, needle.begin(), needle.end());
 
       if (found_it != end_it) {
         return std::distance(begin(), found_it);

--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -237,7 +237,7 @@ TlDependentTypesUsings::DeducingInfo::DeducingInfo(std::string deduced_type, vec
 //  test {t:Type} [x:t] = Test;
 // All such cases (vector, tuple) are implemented manually in tl_builtins.h
 void TlDependentTypesUsings::deduce_params_from_type_tree(vk::tlo_parsing::type_expr_base *type_tree, std::vector<InnerParamTypeAccess> &recursion_stack) {
-  if (auto type_var = dynamic_cast<vk::tlo_parsing::type_var *>(type_tree)) {
+  if (auto *type_var = dynamic_cast<vk::tlo_parsing::type_var *>(type_tree)) {
     std::string type_var_name = cur_tl_constructor->get_var_num_arg(type_var->var_num)->name;
     if (!deduced_params.count(type_var_name)) {
       ClassPtr tl_constructor_php_class = tl2cpp::get_php_class_of_tl_constructor_specialization(cur_tl_constructor, specialization_suffix);
@@ -252,10 +252,10 @@ void TlDependentTypesUsings::deduce_params_from_type_tree(vk::tlo_parsing::type_
     }
     return;
   }
-  if (auto type_expr = dynamic_cast<vk::tlo_parsing::type_expr *>(type_tree)) {
+  if (auto *type_expr = dynamic_cast<vk::tlo_parsing::type_expr *>(type_tree)) {
     int i = 0;
     for (const auto &child : type_expr->children) {
-      if (auto casted_child = dynamic_cast<vk::tlo_parsing::type_expr_base *>(child.get())) {
+      if (auto *casted_child = dynamic_cast<vk::tlo_parsing::type_expr_base *>(child.get())) {
         vk::tlo_parsing::type *parent_tl_type = G->get_tl_classes().get_scheme()->get_type_by_magic(type_expr->type_id);
         kphp_assert(parent_tl_type);
 
@@ -269,7 +269,7 @@ void TlDependentTypesUsings::deduce_params_from_type_tree(vk::tlo_parsing::type_
             // Can't deduce in cases like 'Maybe t', where {t: Type}: don't know if 't' is wrapped to optional or not
             continue;
           }
-          auto child_type_expr = dynamic_cast<vk::tlo_parsing::type_expr *>(casted_child);
+          auto *child_type_expr = dynamic_cast<vk::tlo_parsing::type_expr *>(casted_child);
           kphp_assert(child_type_expr);
           vk::tlo_parsing::type *child_tl_type = G->get_tl_classes().get_scheme()->get_type_by_magic(child_type_expr->type_id);
           kphp_assert(child_tl_type);

--- a/compiler/code-gen/files/tl2cpp/tl-combinator.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-combinator.cpp
@@ -96,7 +96,7 @@ void CombinatorStore::gen_arg_processing(CodeGenerator &W, const std::unique_ptr
   // Exclamation mark "!" handling
   if (arg->is_forwarded_function()) {
     kphp_assert(combinator->is_function());
-    auto as_type_var = arg->type_expr->as<vk::tlo_parsing::type_var>();
+    auto *as_type_var = arg->type_expr->as<vk::tlo_parsing::type_var>();
     kphp_assert(as_type_var);
     if (!typed_mode) {
       W << "auto _cur_arg = "
@@ -223,7 +223,7 @@ void CombinatorFetch::gen_result_expr_processing(CodeGenerator &W) const {
     W << "return " << tl2cpp::get_full_value(combinator->result.get(), "") << ".fetch();" << NL;
     return;
   }
-  if (auto type_var = combinator->result->as<vk::tlo_parsing::type_var>()) {
+  if (auto *type_var = combinator->result->as<vk::tlo_parsing::type_var>()) {
     // multiexclamation optimization
     W << "return " << tl2cpp::cur_combinator->get_var_num_arg(type_var->var_num)->name << ".fetcher->typed_fetch();" << NL;
     return;

--- a/compiler/code-gen/files/tl2cpp/tl-module.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-module.cpp
@@ -106,7 +106,7 @@ void Module::update_dependencies(const std::unique_ptr<vk::tlo_parsing::type> &t
 }
 
 void Module::collect_deps_from_type_tree(vk::tlo_parsing::expr_base *expr) {
-  if (auto as_type_expr = expr->as<vk::tlo_parsing::type_expr>()) {
+  if (auto *as_type_expr = expr->as<vk::tlo_parsing::type_expr>()) {
     std::string expr_module = get_module_name(tl->types[as_type_expr->type_id]->name);
     if (name != expr_module) {
       h_includes.add_raw_filename_include("tl/" + expr_module + ".h");
@@ -114,7 +114,7 @@ void Module::collect_deps_from_type_tree(vk::tlo_parsing::expr_base *expr) {
     for (const auto &child : as_type_expr->children) {
       collect_deps_from_type_tree(child.get());
     }
-  } else if (auto as_type_array = expr->as<vk::tlo_parsing::type_array>()) {
+  } else if (auto *as_type_array = expr->as<vk::tlo_parsing::type_array>()) {
     for (const auto &arg : as_type_array->args) {
       collect_deps_from_type_tree(arg->type_expr.get());
     }

--- a/compiler/code-gen/files/tl2cpp/tl-type-expr.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-type-expr.cpp
@@ -9,13 +9,13 @@
 namespace tl2cpp {
 // Recursively traverse the type expression tree and return <type, value> pair
 std::pair<std::string, std::string> get_full_type_expr_str(vk::tlo_parsing::expr_base *type_expr, const std::string &var_num_access) {
-  if (auto as_nat_var = type_expr->as<vk::tlo_parsing::nat_var>()) {
+  if (auto *as_nat_var = type_expr->as<vk::tlo_parsing::nat_var>()) {
     return {"", var_num_access + cur_combinator->get_var_num_arg(as_nat_var->var_num)->name};
   }
-  if (auto as_nat_const = type_expr->as<vk::tlo_parsing::nat_const>()) {
+  if (auto *as_nat_const = type_expr->as<vk::tlo_parsing::nat_const>()) {
     return {"", std::to_string(as_nat_const->num)};
   }
-  if (auto as_type_var = type_expr->as<vk::tlo_parsing::type_var>()) {
+  if (auto *as_type_var = type_expr->as<vk::tlo_parsing::type_var>()) {
     std::string expr = "std::move(" + cur_combinator->get_var_num_arg(as_type_var->var_num)->name + ")";
     if (cur_combinator->is_constructor()) {
       return {"T" + std::to_string(as_type_var->var_num), expr};
@@ -23,13 +23,13 @@ std::pair<std::string, std::string> get_full_type_expr_str(vk::tlo_parsing::expr
       return {"tl_exclamation_fetch_wrapper", expr};
     }
   }
-  if (auto as_type_array = type_expr->as<vk::tlo_parsing::type_array>()) {
+  if (auto *as_type_array = type_expr->as<vk::tlo_parsing::type_array>()) {
     std::string inner_magic = "0";
     // after the replace_anonymous_args TL array that had multiple items now has only one item
     // that became a named type that contains all data from the original item;
     // size*[A B] -> size*[T] where T has A and B as its fields
     kphp_assert(as_type_array->args.size() == 1);
-    if (auto casted = as_type_array->args[0]->type_expr->as<vk::tlo_parsing::type_expr>()) {
+    if (auto *casted = as_type_array->args[0]->type_expr->as<vk::tlo_parsing::type_expr>()) {
       if (is_magic_processing_needed(casted)) {
         inner_magic = fmt_format("{:#010x}", static_cast<unsigned int>(type_of(casted)->id));
       }
@@ -42,7 +42,7 @@ std::pair<std::string, std::string> get_full_type_expr_str(vk::tlo_parsing::expr
                                     get_full_value(as_type_array->multiplicity.get(), var_num_access),
                                     array_item_type_name)};
   }
-  auto as_type_expr = type_expr->as<vk::tlo_parsing::type_expr>();
+  auto *as_type_expr = type_expr->as<vk::tlo_parsing::type_expr>();
   kphp_assert(as_type_expr);
   const auto &type = tl->types[as_type_expr->type_id];
   std::vector<std::string> template_params;
@@ -55,13 +55,13 @@ std::pair<std::string, std::string> get_full_type_expr_str(vk::tlo_parsing::expr
     if (!child_type_name.empty()) {
       kphp_assert(child->as<vk::tlo_parsing::type_expr_base>());
       template_params.emplace_back(child_type_name);
-      if (auto child_as_type_expr = child->as<vk::tlo_parsing::type_expr>()) {
+      if (auto *child_as_type_expr = child->as<vk::tlo_parsing::type_expr>()) {
         if (is_magic_processing_needed(child_as_type_expr)) {
           template_params.emplace_back(fmt_format("{:#010x}", static_cast<unsigned int>(type_of(child_as_type_expr)->id)));
         } else {
           template_params.emplace_back("0");
         }
-      } else if (auto child_as_type_var = child->as<vk::tlo_parsing::type_var>()) {
+      } else if (auto *child_as_type_var = child->as<vk::tlo_parsing::type_var>()) {
         if (vk::string_view(child_type_name).starts_with("T")) {
           template_params.emplace_back(fmt_format("inner_magic{}", child_as_type_var->var_num));
         } else {

--- a/compiler/code-gen/files/tl2cpp/tl-type.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl-type.cpp
@@ -30,7 +30,7 @@ void TypeStore::compile(CodeGenerator &W) const {
     return;
   }
 
-  auto default_constructor = (type->flags & FLAG_DEFAULT_CONSTRUCTOR ? type->constructors.back().get() : nullptr);
+  auto *default_constructor = (type->flags & FLAG_DEFAULT_CONSTRUCTOR ? type->constructors.back().get() : nullptr);
   // for polymorphic types:
   // typed TL: ifs with dynamic_cast, similar to the interface methods
   if (typed_mode) {
@@ -86,7 +86,7 @@ void TypeFetch::compile(CodeGenerator &W) const {
 
   // non-polymorphic types are fetched in a trivial way - their fetch is delegated to the constructor
   if (!type->is_polymorphic()) {
-    auto &constructor = type->constructors.front();
+    const auto &constructor = type->constructors.front();
     if (typed_mode) {
       W << "CHECK_EXCEPTION(return);" << NL;
       W << get_php_runtime_type(constructor.get(), true) << " result;" << NL;
@@ -107,7 +107,7 @@ void TypeFetch::compile(CodeGenerator &W) const {
     W << "array<mixed> result;" << NL;
   }
   W << "CHECK_EXCEPTION(return" << (typed_mode ? "" : " result") << ");" << NL;
-  auto default_constructor = (type->flags & FLAG_DEFAULT_CONSTRUCTOR ? type->constructors.back().get() : nullptr);
+  auto *default_constructor = (type->flags & FLAG_DEFAULT_CONSTRUCTOR ? type->constructors.back().get() : nullptr);
   bool has_name = type->constructors_num > 1 && !(type->flags & FLAG_NOCONS);
   if (default_constructor != nullptr) {
     W << "int pos = tl_parse_save_pos();" << NL;
@@ -167,7 +167,7 @@ void TlTypeDeclaration::compile(CodeGenerator &W) const {
     W << TlTemplatePhpTypeHelpers(t);
   }
   std::string struct_name = cpp_tl_struct_name("t_", t->name);
-  auto constructor = t->constructors[0].get();
+  auto *constructor = t->constructors[0].get();
   std::string template_decl = get_template_declaration(constructor);
   if (!template_decl.empty()) {
     W << template_decl << NL;
@@ -210,7 +210,7 @@ void TlTypeDeclaration::compile(CodeGenerator &W) const {
 void TlTypeDefinition::compile(CodeGenerator &W) const {
   const bool needs_typed_fetch_store = TlTypeDeclaration::does_tl_type_need_typed_fetch_store(t);
 
-  auto constructor = t->constructors[0].get();
+  auto *constructor = t->constructors[0].get();
   std::string struct_name = cpp_tl_struct_name("t_", t->name);
   std::string template_decl = get_template_declaration(constructor);
   std::string template_def = get_template_definition(constructor);

--- a/compiler/code-gen/files/vars-cpp.cpp
+++ b/compiler/code-gen/files/vars-cpp.cpp
@@ -148,7 +148,7 @@ static void compile_vars_part(CodeGenerator &W, const std::vector<VarPtr> &vars,
     for (const auto &var: other_const_vars) {
       if (var->dependency_level == dep_level) {
         W << InitVar(var);
-        auto type_data = var->tinf_node.get_type();
+        const auto *type_data = var->tinf_node.get_type();
         PrimitiveType ptype = type_data->ptype();
         if (vk::any_of_equal(ptype, tp_array, tp_mixed, tp_string)) {
           W << VarName(var);

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -434,14 +434,14 @@ void compile_binary_func_op(VertexAdaptor<meta_op_binary> root, CodeGenerator &W
 
 
 void compile_binary_op(VertexAdaptor<meta_op_binary> root, CodeGenerator &W) {
-  auto &root_type_str = OpInfo::str(root->type());
+  const auto &root_type_str = OpInfo::str(root->type());
   kphp_error_return (root_type_str[0] != '@', fmt_format("Unexpected {}\n", vk::string_view{root_type_str}.substr(1)));
 
   auto lhs = root->lhs();
   auto rhs = root->rhs();
 
-  auto lhs_tp = tinf::get_type(lhs);
-  auto rhs_tp = tinf::get_type(rhs);
+  const auto *lhs_tp = tinf::get_type(lhs);
+  const auto *rhs_tp = tinf::get_type(rhs);
 
   if (auto instanceof = root.try_as<op_instanceof>()) {
     W << "f$is_a<" << instanceof->derived_class->src_name << ">(" << lhs << ")";
@@ -937,7 +937,7 @@ void compile_switch_str(VertexAdaptor<op_switch> root, CodeGenerator &W) {
   std::transform(cases_vertices.begin(), cases_vertices.end(), cases.begin(), [](auto v) { return CaseInfo(v); });
 
   auto default_case_it = std::find_if(cases.begin(), cases.end(), vk::make_field_getter(&CaseInfo::is_default));
-  auto default_case = default_case_it != cases.end() ? &(*default_case_it) : nullptr;
+  auto *default_case = default_case_it != cases.end() ? &(*default_case_it) : nullptr;
 
   int n = static_cast<int>(cases.size());
   std::map<unsigned int, int> hash_to_last_id;
@@ -957,7 +957,7 @@ void compile_switch_str(VertexAdaptor<op_switch> root, CodeGenerator &W) {
       cases[i].next = &cases[next_i];
     }
 
-    auto next = cases[i].next;
+    auto *next = cases[i].next;
     if (next && next->goto_name.empty()) {
       next->goto_name = gen_unique_name("switch_goto");
     }
@@ -1960,7 +1960,7 @@ void compile_common_op(VertexPtr root, CodeGenerator &W) {
       compile_noerr(root.as<op_noerr>(), W);
       break;
     case op_clone: {
-      auto tp = tinf::get_type(root);
+      const auto *tp = tinf::get_type(root);
       if (auto klass = tp->class_type()) {
         if (klass->is_class()) {
           W << root.as<op_clone>()->expr() << ".clone()";
@@ -1977,7 +1977,7 @@ void compile_common_op(VertexPtr root, CodeGenerator &W) {
     case op_alloc: {
       const TypeData *tp = tinf::get_type(root);
       kphp_assert(tp->ptype() == tp_Class);
-      auto alloc_function = tp->class_type()->is_empty_class() ? "().empty_alloc()" : "().alloc()";
+      const auto *alloc_function = tp->class_type()->is_empty_class() ? "().empty_alloc()" : "().alloc()";
       W << TypeName(tp) << alloc_function;
       break;
     }

--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -332,7 +332,7 @@ SrcFilePtr CompilerCore::require_file(const string &file_name, LibPtr owner_lib,
 
 
 ClassPtr CompilerCore::get_class(vk::string_view name) {
-  auto result = classes_ht.find(vk::std_hash(name));
+  const auto *result = classes_ht.find(vk::std_hash(name));
   return result ? *result : ClassPtr{};
 }
 

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -216,7 +216,7 @@ bool compiler_execute(CompilerSettings *settings) {
     scheduler = new OneThreadScheduler();
     vk::singleton<CppDestDirInitializer>::get().initialize_sync();
   } else {
-    auto s = new Scheduler();
+    auto *s = new Scheduler();
     s->set_threads_count(scheduler_threads);
     scheduler = s;
     vk::singleton<CppDestDirInitializer>::get().initialize_async(scheduler_threads + 1);

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -425,7 +425,7 @@ void ClassData::add_str_dependent(FunctionPtr cur_function, ClassType type, vk::
 
 void ClassData::register_defines() const {
   members.for_each([this](const ClassMemberConstant &c) {
-    auto data = new DefineData(std::string{c.global_name()}, c.value, DefineData::def_unknown);
+    auto *data = new DefineData(std::string{c.global_name()}, c.value, DefineData::def_unknown);
     data->file_id = file_id;
     data->access = c.access;
     data->class_id = get_self();

--- a/compiler/inferring/key.cpp
+++ b/compiler/inferring/key.cpp
@@ -16,7 +16,7 @@ static TSHashTable<std::string *> string_key_names_ht;
 static int n_string_keys_ht = 0;
 
 Key Key::string_key(const std::string &key) {
-  auto node = string_keys_ht.at(vk::std_hash(key));
+  auto *node = string_keys_ht.at(vk::std_hash(key));
   if (node->data != nullptr) {
     return *node->data;
   }
@@ -29,7 +29,7 @@ Key Key::string_key(const std::string &key) {
   int old_n = __sync_fetch_and_add(&n_string_keys_ht, 1);
   node->data = new Key(old_n * 2 + 2);
 
-  auto name_node = string_key_names_ht.at(node->data->id);
+  auto *name_node = string_key_names_ht.at(node->data->id);
   name_node->data = new std::string(key);
 
   return *node->data;

--- a/compiler/inferring/restriction-isset.cpp
+++ b/compiler/inferring/restriction-isset.cpp
@@ -29,7 +29,7 @@ void RestrictionIsset::find_dangerous_isset_warning(vector<tinf::Node *> *bt, ti
   desc += " can't be null in KPHP, while it can be in PHP\n Chain of assignments:\n";
 
   bt->emplace_back(node);
-  for (auto const n : *bt) {
+  for (auto *const n : *bt) {
     desc += "  ";
     desc += n->get_description();
     desc += "\n";

--- a/compiler/inferring/type-data.cpp
+++ b/compiler/inferring/type-data.cpp
@@ -215,7 +215,7 @@ void TypeData::set_ffi_pointer_type(const TypeData *new_ptr_type, int new_indire
     return;
   }
 
-  auto ptr_class = class_type()->ffi_class_mixin;
+  auto *ptr_class = class_type()->ffi_class_mixin;
 
   if (ptr_class->ffi_type->kind == FFITypeKind::Void && indirection_ == 1) {
     // any pointer is compatible with `void*`,
@@ -223,7 +223,7 @@ void TypeData::set_ffi_pointer_type(const TypeData *new_ptr_type, int new_indire
     return;
   }
 
-  auto new_ptr_class = new_ptr_type->class_type()->ffi_class_mixin;
+  auto *new_ptr_class = new_ptr_type->class_type()->ffi_class_mixin;
   if (ptr_class != new_ptr_class) {
     set_ptype(tp_Error);
     return;
@@ -502,7 +502,7 @@ void TypeData::set_lca_at(const MultiKey &multi_key, const TypeData *rhs, bool s
   TypeData *cur = this;
   
   for (const Key &key : multi_key) {
-    auto prev = cur;
+    auto *prev = cur;
     cur = cur->write_at(key);
     // handle writing to a subkey of mixed (when cur is not structured)
     if (cur == nullptr) {
@@ -892,7 +892,7 @@ bool is_implicit_array_conversion(const TypeData *from, const TypeData *to) noex
     return false;
   }
   if (from->get_real_ptype() == tp_array) {
-    auto from_array_value_type = from->lookup_at_any_key();
+    const auto *from_array_value_type = from->lookup_at_any_key();
     if (from_array_value_type->get_real_ptype() == tp_any) {
       return false;
     }

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -45,7 +45,7 @@ void TypeHintArgRefCallbackCall::recalc_type_data_in_context_of_call(TypeData *d
     }
 
     std::vector<VertexPtr> fake_call_params;    // e.g., only one here for fake array_filter call: ^2[*]
-    for (auto callback_param_hint : callback_param->type_hint->try_as<TypeHintCallable>()->arg_types) {
+    for (const auto *callback_param_hint : callback_param->type_hint->try_as<TypeHintCallable>()->arg_types) {
       prevent_recursion_thread_safe([provided_callback](std::vector<std::string> &recursion) {
         recursion.emplace_back(provided_callback->name);
       });
@@ -73,7 +73,7 @@ void TypeHintArgRefCallbackCall::recalc_type_data_in_context_of_call(TypeData *d
 
 void TypeHintArgRefInstance::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
   if (auto v = GenTree::get_call_arg_ref(arg_num, call)) {
-    if (auto *class_name = GenTree::get_constexpr_string(v)) {
+    if (const auto *class_name = GenTree::get_constexpr_string(v)) {
       if (auto klass = G->get_class(*class_name)) {
         dst->set_lca(klass->type_data);
         return;

--- a/compiler/make/cpp-to-obj-target.h
+++ b/compiler/make/cpp-to-obj-target.h
@@ -36,7 +36,7 @@ public:
 
   void compute_priority() final {
     priority = 0;
-    for (auto dep : deps) {
+    for (auto *dep : deps) {
       if (File *dep_file = dep->get_file()) {
         priority += dep_file->file_size;
       }

--- a/compiler/make/make-runner.cpp
+++ b/compiler/make/make-runner.cpp
@@ -15,7 +15,7 @@
 void MakeRunner::run_target(Target *target) {
   bool ready = target->mtime != 0;
   if (ready) {
-    for (auto const dep : target->deps) {
+    for (const auto *dep : target->deps) {
       if (dep->mtime > target->mtime) {
         ready = false;
         break;
@@ -37,7 +37,7 @@ void MakeRunner::ready_target(Target *target) {
 
   targets_left--;
   target->is_ready = true;
-  for (auto const rdep : target->rdeps) {
+  for (auto *rdep : target->rdeps) {
     one_dep_ready_target(rdep);
   }
 }
@@ -83,7 +83,7 @@ void MakeRunner::require_target(Target *target) {
     run_target(target);
   } else {
     wait_target(target);
-    for (auto const dep : target->deps) {
+    for (auto *dep : target->deps) {
       require_target(dep);
     }
   }
@@ -284,7 +284,7 @@ MakeRunner::MakeRunner(FILE *stats_file) noexcept:
 
 MakeRunner::~MakeRunner() {
   //TODO: delete targets
-  for (auto target : all_targets) {
+  for (auto *target : all_targets) {
     delete target;
   }
 }

--- a/compiler/make/make.cpp
+++ b/compiler/make/make.cpp
@@ -329,7 +329,7 @@ static std::vector<File *> create_obj_files(MakeSetup *make, Index &obj_dir, con
 
   std::map<vk::string_view, vector<File *>> subdirs;
   std::vector<File *> tmp_objs;
-  for (auto obj_file : objs) {
+  for (auto *obj_file : objs) {
     auto name = obj_file->subdir;
     if (!name.empty()) {
       name.remove_suffix(1);

--- a/compiler/make/target.cpp
+++ b/compiler/make/target.cpp
@@ -48,7 +48,7 @@ std::string Target::target() {
 
 std::string Target::dep_list() {
   std::string ss;
-  for (auto const dep : deps) {
+  for (auto *dep : deps) {
     ss += dep->get_name();
     ss += " ";
   }

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -162,7 +162,7 @@ constexpr auto get_reserve_function_names() noexcept {
 }
 
 VertexPtr get_first_arg_from_array_reserve_call(VertexAdaptor<op_func_call> func_call) noexcept {
-  for (auto reserve_function : get_reserve_function_names()) {
+  for (const auto *reserve_function : get_reserve_function_names()) {
     if (auto first_arg = get_first_arg_from_builtin_call(func_call, reserve_function)) {
       return first_arg;
     }

--- a/compiler/pipes/calc-func-dep.cpp
+++ b/compiler/pipes/calc-func-dep.cpp
@@ -62,7 +62,7 @@ VertexPtr CalcFuncDepPass::on_enter_vertex(VertexPtr vertex) {
     calls.push_back(other_function);
     if (other_function->is_extern()) {
       if (other_function->cpp_template_call) {
-        auto tp = tinf::get_type(call);
+        const auto *tp = tinf::get_type(call);
         if (auto klass = tp->class_type()) {
           current_function->class_dep.insert(klass);
         }

--- a/compiler/pipes/check-access-modifiers.cpp
+++ b/compiler/pipes/check-access-modifiers.cpp
@@ -16,14 +16,14 @@ VertexPtr CheckAccessModifiersPass::on_enter_vertex(VertexPtr root) {
   if (auto var = root.try_as<op_var>()) {
     VarPtr var_id = var->var_id;
     if (var_id->is_class_static_var()) {
-      auto member = var_id->as_class_static_field();
+      const auto *member = var_id->as_class_static_field();
       kphp_assert(member);
       check_access(class_id, lambda_class_id, member->modifiers, var_id->class_id, "static field", member->local_name());
     }
   } else if (auto prop = root.try_as<op_instance_prop>()) {
     VarPtr var_id = prop->var_id;
     if (var_id->is_class_instance_var()) {
-      auto member = var_id->as_class_instance_field();
+      const auto *member = var_id->as_class_instance_field();
       kphp_assert(member);
       check_access(class_id, lambda_class_id, member->modifiers, var_id->class_id, "field", member->local_name());
     }

--- a/compiler/pipes/check-classes.cpp
+++ b/compiler/pipes/check-classes.cpp
@@ -16,7 +16,7 @@
 #include "compiler/phpdoc.h"
 
 VertexPtr CheckClassesPass::on_enter_vertex(VertexPtr root) {
-  auto type_data = root->tinf_node.get_type();
+  const auto *type_data = root->tinf_node.get_type();
   if (auto var = root.try_as<op_var>()) {
     type_data = var->var_id ? var->var_id->tinf_node.get_type() : type_data;
   }

--- a/compiler/pipes/check-tl-classes.cpp
+++ b/compiler/pipes/check-tl-classes.cpp
@@ -33,7 +33,7 @@ void verify_class_against_repr(ClassPtr class_id, const vk::tl::PhpClassRepresen
   }
 
   for (const auto &field : repr.class_fields) {
-    auto member = class_id->members.find_by_local_name<ClassMemberInstanceField>(field.field_name);
+    const auto *member = class_id->members.find_by_local_name<ClassMemberInstanceField>(field.field_name);
     kphp_error_return(member, fmt_format("Can't find field '{}' in tl-class '{}'", field.field_name, class_id->name));
   }
 }

--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -187,7 +187,7 @@ void CollectMainEdgesPass::on_func_call_extern_modifying_arg_type(VertexAdaptor<
     VertexRange args = call->args();
     LValue val = as_lvalue(args[0]);
 
-    auto key = new MultiKey(*val.key);
+    auto *key = new MultiKey(*val.key);
     key->push_back(Key::any_key());
     val.key = key;
 

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -76,7 +76,7 @@ void check_instance_cache_fetch_call(VertexAdaptor<op_func_call> call) {
 }
 
 void check_instance_cache_store_call(VertexAdaptor<op_func_call> call) {
-  auto type = tinf::get_type(call->args()[1]);
+  const auto *type = tinf::get_type(call->args()[1]);
   kphp_error_return(type->ptype() == tp_Class, "Called instance_cache_store() with a non-instance argument");
   auto klass = type->class_type();
   klass->deeply_require_instance_cache_visitor();
@@ -108,19 +108,19 @@ void check_to_array_debug_call(VertexAdaptor<op_func_call> call) {
 }
 
 void check_instance_serialize_call(VertexAdaptor<op_func_call> call) {
-  auto type = tinf::get_type(call->args()[0]);
+  const auto *type = tinf::get_type(call->args()[0]);
   kphp_error_return(type->ptype() == tp_Class, "Called instance_serialize() with a non-instance argument");
   kphp_error(type->class_type()->is_serializable, fmt_format("Called instance_serialize() for class {}, but it's not marked with @kphp-serializable", type->class_type()->name));
 }
 
 void check_instance_deserialize_call(VertexAdaptor<op_func_call> call) {
-  auto type = tinf::get_type(call);
+  const auto *type = tinf::get_type(call);
   kphp_assert(type->ptype() == tp_Class);
   kphp_error(type->class_type()->is_serializable, fmt_format("Called instance_deserialize() for class {}, but it's not marked with @kphp-serializable", type->class_type()->name));
 }
 
 void check_estimate_memory_usage_call(VertexAdaptor<op_func_call> call) {
-  auto type = tinf::get_type(call->args()[0]);
+  const auto *type = tinf::get_type(call->args()[0]);
   std::unordered_set<ClassPtr> classes_inside;
   type->get_all_class_types_inside(classes_inside);
   for (auto klass: classes_inside) {
@@ -181,9 +181,9 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
 
     if (auto name = f_passed_to_builtin->local_name(); name == "to_array_debug" || name == "instance_to_array") {
       if (const auto *as_subkey = type_hint_callable->arg_types[0]->try_as<TypeHintArgSubkeyGet>()) {
-        auto arg_ref = as_subkey->inner->try_as<TypeHintArgRef>();
+        const auto *arg_ref = as_subkey->inner->try_as<TypeHintArgRef>();
         if (auto arg = GenTree::get_call_arg_ref(arg_ref ? arg_ref->arg_num : -1, call)) {
-          auto value_type = tinf::get_type(arg)->lookup_at_any_key();
+          const auto *value_type = tinf::get_type(arg)->lookup_at_any_key();
           auto out_class = value_type->class_type();
           kphp_error_return(out_class, "type of argument for to_array_debug has to be array of Classes");
           out_class->deeply_require_to_array_debug_visitor();
@@ -194,8 +194,8 @@ void check_func_call_params(VertexAdaptor<op_func_call> call) {
 }
 
 void check_null_usage_in_binary_operations(VertexAdaptor<meta_op_binary> binary_vertex) {
-  auto lhs_type = tinf::get_type(binary_vertex->lhs());
-  auto rhs_type = tinf::get_type(binary_vertex->rhs());
+  const auto *lhs_type = tinf::get_type(binary_vertex->lhs());
+  const auto *rhs_type = tinf::get_type(binary_vertex->rhs());
 
   switch (binary_vertex->type()) {
     case op_add:
@@ -635,7 +635,7 @@ void FinalCheckPass::check_op_func_call(VertexAdaptor<op_func_call> call) {
     if (is_value_sort_function) {
       // Forbid arrays with elements that would be rejected by check_comparisons().
       const TypeData *array_type = tinf::get_type(call->args()[0]);
-      auto *elem_type = array_type->lookup_at_any_key();
+      const auto *elem_type = array_type->lookup_at_any_key();
       kphp_error(vk::none_of_equal(elem_type->ptype(), tp_Class, tp_tuple, tp_shape),
                  fmt_format("{} is not comparable and cannot be sorted", elem_type->as_human_readable()));
     }
@@ -669,8 +669,8 @@ void FinalCheckPass::check_lib_exported_function(FunctionPtr function) {
 }
 
 void FinalCheckPass::check_eq3(VertexPtr lhs, VertexPtr rhs) {
-  auto lhs_type = tinf::get_type(lhs);
-  auto rhs_type = tinf::get_type(rhs);
+  const auto *lhs_type = tinf::get_type(lhs);
+  const auto *rhs_type = tinf::get_type(rhs);
 
   if ((lhs_type->ptype() == tp_float && !lhs_type->or_false_flag() && !lhs_type->or_null_flag()) ||
       (rhs_type->ptype() == tp_float && !rhs_type->or_false_flag() && !rhs_type->or_null_flag())) {
@@ -687,8 +687,8 @@ void FinalCheckPass::check_comparisons(VertexPtr lhs, VertexPtr rhs, Operation o
     std::swap(lhs, rhs);
   }
 
-  auto lhs_t = tinf::get_type(lhs);
-  auto rhs_t = tinf::get_type(rhs);
+  const auto *lhs_t = tinf::get_type(lhs);
+  const auto *rhs_t = tinf::get_type(rhs);
 
   if (lhs_t->ptype() == tp_Class) {
     if (op == op_eq2) {

--- a/compiler/pipes/gen-tree-postprocess.cpp
+++ b/compiler/pipes/gen-tree-postprocess.cpp
@@ -179,7 +179,7 @@ VertexPtr GenTreePostprocessPass::on_enter_vertex(VertexPtr root) {
   }
 
   if (auto call = root.try_as<op_func_call>()) {
-    auto &name = call->get_string();
+    const auto &name = call->get_string();
 
     auto builtin = get_builtin_function(name);
     if (builtin.op != op_err && call->size() == builtin.args) {

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -71,7 +71,7 @@ void cast_array_creation_type(VertexAdaptor<op_array> op_array_vertex, const Typ
 }
 
 void explicit_cast_array_type(VertexPtr &type_acceptor, const TypeData *required_type, std::set<VarPtr> *new_var_out = nullptr) noexcept {
-  auto existed_type = tinf::get_type(type_acceptor);
+  const auto *existed_type = tinf::get_type(type_acceptor);
   if (existed_type->get_real_ptype() != tp_array ||
       !is_implicit_array_conversion(existed_type, required_type)) {
     return;

--- a/compiler/pipes/register-defines.cpp
+++ b/compiler/pipes/register-defines.cpp
@@ -16,7 +16,7 @@ VertexPtr RegisterDefinesPass::on_exit_vertex(VertexPtr root) {
 
     kphp_error_act(name->type() == op_string, "Define name should be a valid string", return root);
 
-    auto data = new DefineData(name->get_string(), val, DefineData::def_unknown);
+    auto *data = new DefineData(name->get_string(), val, DefineData::def_unknown);
     data->file_id = stage::get_file();
     G->register_define(DefinePtr(data));
 

--- a/compiler/pipes/register-variables.cpp
+++ b/compiler/pipes/register-variables.cpp
@@ -114,7 +114,7 @@ void RegisterVariablesPass::register_var(VertexAdaptor<op_var> var_vertex) {
         klass = klass->parent_class;
       }
       kphp_error_return(klass, fmt_format("static field not found: {}", name));
-      auto field = klass->members.get_static_field(var_name);
+      const auto *field = klass->members.get_static_field(var_name);
       kphp_error_return(field, fmt_format("field {} is not static in klass {}", var_name, used_klass->name));
       kphp_error_return(klass == used_klass || !field->modifiers.is_private(),
                         fmt_format("Can't access private static field using derived class: {}", name));

--- a/compiler/pipes/sort-and-inherit-classes.cpp
+++ b/compiler/pipes/sort-and-inherit-classes.cpp
@@ -37,7 +37,7 @@ void mark_virtual_and_overridden_methods(ClassPtr cur_class, DataStream<Function
       if (ancestor == cur_class) {
         continue;
       }
-      if (auto parent_member = ancestor->members.get_instance_method(method.local_name())) {
+      if (auto *parent_member = ancestor->members.get_instance_method(method.local_name())) {
         auto parent_function = parent_member->function;
 
         kphp_error(parent_function->modifiers.is_abstract() || !parent_function->modifiers.is_final(),
@@ -91,7 +91,7 @@ bool clone_method(FunctionPtr from, ClassPtr to_class, DataStream<FunctionPtr> &
 // Otherwise it returns a pointer to a dependent class/interface that needs to be processed.
 auto SortAndInheritClassesF::get_not_ready_dependency(ClassPtr klass) -> decltype(ht)::HTNode* {
   for (const auto &dep : klass->get_str_dependents()) {
-    auto node = ht.at(vk::std_hash(dep.class_name));
+    auto *node = ht.at(vk::std_hash(dep.class_name));
     kphp_assert(node);
     if (!node->data.done) {
       return node;
@@ -217,7 +217,7 @@ void SortAndInheritClassesF::inherit_child_class_from_parent(ClassPtr child_clas
       }
     });
     parent_class->members.for_each([&](const ClassMemberConstant &c) {
-      if (auto child_const = child_class->get_constant(c.local_name())) {
+      if (const auto *child_const = child_class->get_constant(c.local_name())) {
         kphp_error(child_const->access == c.access,
                    fmt_format("Can't change access type for constant {} in class {}", c.local_name(), child_class->name));
       }
@@ -316,7 +316,7 @@ void SortAndInheritClassesF::execute(ClassPtr klass, MultipleDataStreams<Functio
   auto &function_stream = *os.template project_to_nth_data_stream<0>();
   auto &restart_class_stream = *os.template project_to_nth_data_stream<1>();
 
-  if (auto dependency = get_not_ready_dependency(klass)) {
+  if (auto *dependency = get_not_ready_dependency(klass)) {
     AutoLocker<Lockable*> locker(dependency);
     // check whether done is changed at this point
     if (dependency->data.done) {
@@ -329,7 +329,7 @@ void SortAndInheritClassesF::execute(ClassPtr klass, MultipleDataStreams<Functio
 
   on_class_ready(klass, function_stream);
 
-  auto node = ht.at(vk::std_hash(klass->name));
+  auto *node = ht.at(vk::std_hash(klass->name));
   kphp_assert(!node->data.done);
 
   AutoLocker<Lockable *> locker(node);
@@ -348,7 +348,7 @@ void SortAndInheritClassesF::check_on_finish(DataStream<FunctionPtr> &os) {
   auto classes = G->get_classes();
 
   for (ClassPtr c : classes) {
-    auto node = ht.at(vk::std_hash(c->name));
+    auto *node = ht.at(vk::std_hash(c->name));
     if (!node->data.done) {
       auto is_not_done = [](const ClassData::StrDependence &dep) { return !ht.at(vk::std_hash(dep.class_name))->data.done; };
       auto str_dep_to_string = [](const ClassData::StrDependence &dep) { return dep.class_name; };

--- a/compiler/scheduler/one-thread-scheduler.cpp
+++ b/compiler/scheduler/one-thread-scheduler.cpp
@@ -35,7 +35,7 @@ void OneThreadScheduler::execute() {
   bool run_flag = true;
   while (run_flag) {
     run_flag = false;
-    for (auto node : nodes) {
+    for (auto *node : nodes) {
       Task *task;
       while ((task = node->get_task()) != nullptr) {
         run_flag = true;
@@ -49,7 +49,7 @@ void OneThreadScheduler::execute() {
       run_flag = true;
     }
   }
-  for (auto node : nodes) {
+  for (auto *node : nodes) {
     delete node;
   }
 }

--- a/compiler/scheduler/scheduler.cpp
+++ b/compiler/scheduler/scheduler.cpp
@@ -23,7 +23,7 @@ public:
 
 
 void *scheduler_thread_execute(void *arg) {
-  auto tls = (ThreadContext *)arg;
+  auto *tls = (ThreadContext *)arg;
   tls->scheduler->thread_execute(tls);
   return nullptr;
 }
@@ -84,7 +84,7 @@ void Scheduler::execute() {
     pthread_join(threads[i].pthread_id, nullptr);
   }
 
-  for (auto node : nodes) {
+  for (auto *node : nodes) {
     delete node;
   }
 }

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -104,7 +104,7 @@ std::string Location::as_human_readable() const {
 
   // if it's a method of an PSR-4 class /path/to/A.php, output only A::methodName, not fully-qualified path\to\A::methodName
   // if we are inside a lambda, print out the outermost named function
-  auto f_outer = function ? function->get_this_or_topmost_if_lambda() : nullptr;
+  const auto *f_outer = function ? function->get_this_or_topmost_if_lambda() : nullptr;
   if (f_outer && f_outer->type == FunctionData::func_local) {
     std::string function_name = f_outer->as_human_readable();
     std::string psr4_file_name = replace_characters(function_name.substr(0, function_name.find(':')), '\\', '/') + ".php";

--- a/compiler/threading/profiler.h
+++ b/compiler/threading/profiler.h
@@ -110,7 +110,7 @@ public:
   }
 
   ProfilerRaw *operator->() {
-    auto raw = *raws_;
+    auto *raw = *raws_;
     if (raw == nullptr) {
       raw = &get_profiler(name_);
       *raws_ = raw;

--- a/compiler/vertex.h
+++ b/compiler/vertex.h
@@ -68,7 +68,7 @@ VertexPtr create_vertex(Operation op, Args&& ...args) {
 // op_int_const string representation can be "123", "0x123", "0002", "-123", "0b0010101"
 // but it is guaranteed to be a valid int
 inline long parse_int_from_string(VertexAdaptor<op_int_const> v) {
-  auto start = v->get_string().c_str();
+  const auto *start = v->get_string().c_str();
 
   if (start[0] == '0' && start[1] == 'b') {
     return std::strtol(start + 2, nullptr, 2);

--- a/net/net-aes-keys-test.cpp
+++ b/net/net-aes-keys-test.cpp
@@ -21,7 +21,7 @@ TEST(net_aes_keys, basic) {
   EXPECT_EQ(find_aes_key_by_id(key->id), key);
   EXPECT_EQ(find_aes_key_by_filename(key->filename), key);
 
-  auto first_not_zero = std::find_if_not(std::next(key_body), std::next(key_body, AES_KEY_MAX_LEN), [](uint8_t byte) { return byte != 0; });
+  auto *first_not_zero = std::find_if_not(std::next(key_body), std::next(key_body, AES_KEY_MAX_LEN), [](uint8_t byte) { return byte != 0; });
   EXPECT_EQ(first_not_zero, std::next(key_body, AES_KEY_MAX_LEN));
 
   free_aes_key(key);

--- a/net/net-msg-test.cpp
+++ b/net/net-msg-test.cpp
@@ -24,7 +24,7 @@ public:
   }
 
   static int compare(void *extra, const void *data, int len) {
-    auto stream_comparator = static_cast<stream_comparator_t *>(extra);
+    auto *stream_comparator = static_cast<stream_comparator_t *>(extra);
     stream_comparator->compare(data, len);
     return 0;
   }
@@ -383,10 +383,10 @@ TEST(net_msg, fork_message_chain) {
     EXPECT_EQ(x.first->refcnt, 2);
 
     fork_message_chain(&x);
-    for(auto mp = x.first; mp != x.last; mp = mp->next) {
+    for(auto *mp = x.first; mp != x.last; mp = mp->next) {
       EXPECT_EQ(mp->refcnt, 1);
     }
-    for(auto mp = y.first; mp != y.last; mp = mp->next) {
+    for(auto *mp = y.first; mp != y.last; mp = mp->next) {
       EXPECT_EQ(mp->refcnt, 1);
     }
     EXPECT_EQ(x.total_bytes, payload.size() * 3);
@@ -625,8 +625,8 @@ TEST(net_msg, rwm_union_large) {
     rwms[i].first_offset = 92;
     rwms[i].last_offset = 68;
 
-    auto buffer = alloc_msg_buffer(buffer_size);
-    auto mp = new_msg_part(buffer);
+    auto *buffer = alloc_msg_buffer(buffer_size);
+    auto *mp = new_msg_part(buffer);
     mp->offset = 0;
     mp->len = buffer_size;
     rwms[i].first = mp;

--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -98,7 +98,7 @@ void free_script_allocator() noexcept {
 void *allocate(size_t size) noexcept {
   php_assert(size);
   auto &dealer = get_memory_dealer();
-  if (auto heap_replacer = dealer.heap_script_resource_replacer()) {
+  if (auto *heap_replacer = dealer.heap_script_resource_replacer()) {
     return heap_replacer->allocate(size);
   }
   if (unlikely(!script_allocator_enabled)) {
@@ -112,7 +112,7 @@ void *allocate(size_t size) noexcept {
 void *allocate0(size_t size) noexcept {
   php_assert(size);
   auto &dealer = get_memory_dealer();
-  if (auto heap_replacer = dealer.heap_script_resource_replacer()) {
+  if (auto *heap_replacer = dealer.heap_script_resource_replacer()) {
     return heap_replacer->allocate0(size);
   }
   if (unlikely(!script_allocator_enabled)) {
@@ -126,7 +126,7 @@ void *allocate0(size_t size) noexcept {
 void *reallocate(void *mem, size_t new_size, size_t old_size) noexcept {
   php_assert(new_size > old_size);
   auto &dealer = get_memory_dealer();
-  if (auto heap_replacer = dealer.heap_script_resource_replacer()) {
+  if (auto *heap_replacer = dealer.heap_script_resource_replacer()) {
     return heap_replacer->reallocate(mem, new_size, old_size);
   }
   if (unlikely(!script_allocator_enabled)) {
@@ -140,7 +140,7 @@ void *reallocate(void *mem, size_t new_size, size_t old_size) noexcept {
 void deallocate(void *mem, size_t size) noexcept {
   php_assert(size);
   auto &dealer = get_memory_dealer();
-  if (auto heap_replacer = dealer.heap_script_resource_replacer()) {
+  if (auto *heap_replacer = dealer.heap_script_resource_replacer()) {
     return heap_replacer->deallocate(mem, size);
   }
 
@@ -309,7 +309,7 @@ MemoryReplacementGuard::~MemoryReplacementGuard() {
 
 // replace global operators new and delete for linked C++ code
 void *operator new(size_t size) {
-  auto res = std::malloc(size);
+  auto *res = std::malloc(size);
   if (!res) {
     php_critical_error("nullptr from malloc");
   }

--- a/runtime/confdata-functions.cpp
+++ b/runtime/confdata-functions.cpp
@@ -105,7 +105,7 @@ mixed f$confdata_get_value(const string &key) noexcept {
     }
     // it must be an array (we loaded it this way)
     php_assert(it->second.is_array());
-    if (auto *value = it->second.as_array().find_value(key_maker.get_second_key())) {
+    if (const auto *value = it->second.as_array().find_value(key_maker.get_second_key())) {
       return *value;
     }
   }

--- a/runtime/confdata-keys.cpp
+++ b/runtime/confdata-keys.cpp
@@ -41,7 +41,7 @@ ConfdataFirstKeyType ConfdataPredefinedWildcards::detect_first_key_type(vk::stri
 ConfdataFirstKeyType ConfdataPredefinedWildcards::get_wildcard_type(vk::string_view wildcard) noexcept {
   size_t dots = 0;
   if (!wildcard.empty() && *wildcard.rbegin() == '.') {
-    for (auto c = wildcard.begin(); c != wildcard.end() && dots <= 2; ++c) {
+    for (const auto *c = wildcard.begin(); c != wildcard.end() && dots <= 2; ++c) {
       dots += (*c == '.');
     }
   }

--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -966,7 +966,7 @@ template<class CTX>
 void clear_contexts(array<CTX *> &contexts) {
   std::for_each(contexts.cbegin(), contexts.cend(),
                 [](const typename array<CTX *>::const_iterator &it) {
-                  if (auto easy_context = it.get_value()) {
+                  if (auto *easy_context = it.get_value()) {
                     easy_context->release();
                   }
                 });

--- a/runtime/instance-cache.cpp
+++ b/runtime/instance-cache.cpp
@@ -148,10 +148,10 @@ void CacheContext::move_to_garbage(ElementHolder *element) noexcept {
 }
 
 void CacheContext::clear_garbage() noexcept {
-  auto element = cache_garbage_.exchange(nullptr);
+  auto *element = cache_garbage_.exchange(nullptr);
 
   while (element) {
-    auto next = element->next_in_garbage_list.load();
+    auto *next = element->next_in_garbage_list.load();
     element->destroy();
     element = next;
   }

--- a/runtime/kphp-backtrace.cpp
+++ b/runtime/kphp-backtrace.cpp
@@ -115,8 +115,8 @@ array<string> f$kphp_backtrace(bool pretty) noexcept {
       continue;
     }
     string pretty_name{static_cast<string::size_type>(func_name.size()), true};
-    for (auto it = func_name.begin(); it != func_name.end();) {
-      auto next = std::next(it);
+    for (const auto *it = func_name.begin(); it != func_name.end();) {
+      const auto *next = std::next(it);
       if (*it == '$') {
         if (next != func_name.end() && *next == '$') {
           pretty_name.append_unsafe("::", 2);

--- a/runtime/memory_resource/details/memory_chunk_tree.cpp
+++ b/runtime/memory_resource/details/memory_chunk_tree.cpp
@@ -33,7 +33,7 @@ public:
     if (!parent || !parent->parent) {
       return nullptr;
     }
-    auto grandpa = parent->parent;
+    auto *grandpa = parent->parent;
     return parent->is_left() ? grandpa->right : grandpa->left;
   }
 

--- a/runtime/memory_resource/unsynchronized_pool_resource.cpp
+++ b/runtime/memory_resource/unsynchronized_pool_resource.cpp
@@ -48,7 +48,7 @@ void unsynchronized_pool_resource::perform_defragmentation() noexcept {
   stats_.small_memory_pieces = 0;
   stats_.huge_memory_pieces = 0;
   for (auto *free_mem = mem_list.flush(); free_mem;) {
-    const auto next_mem = mem_list.get_next(free_mem);
+    auto *next_mem = mem_list.get_next(free_mem);
     put_memory_back(free_mem, free_mem->size());
     free_mem = next_mem;
   }

--- a/runtime/memory_resource/unsynchronized_pool_resource.h
+++ b/runtime/memory_resource/unsynchronized_pool_resource.h
@@ -45,7 +45,7 @@ public:
   }
 
   void *allocate0(size_t size) noexcept {
-    auto mem = allocate(size);
+    auto *mem = allocate(size);
     if (likely(mem != nullptr)) {
       memset(mem, 0x00, size);
     }

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -104,7 +104,7 @@ const auto &get_supported_hash_algorithms() noexcept {
 
 const HashTraits &find_hash_algorithm(const char *algo) noexcept {
   const auto &supported_algorithms = get_supported_hash_algorithms();
-  const auto it = std::find_if(supported_algorithms.begin(), supported_algorithms.end(),
+  const auto *const it = std::find_if(supported_algorithms.begin(), supported_algorithms.end(),
                                [algo](const HashTraits &traits) { return !strcmp(algo, traits.name); });
   if (it == supported_algorithms.end()) {
     php_critical_error ("algo %s not supported in function hash", algo);
@@ -1280,8 +1280,8 @@ private:
     char *issuer_copy = nullptr;
     {
       dl::CriticalSectionGuard critical_section;
-      auto issuer_name = X509_get_subject_name(x509_);
-      auto issuer = X509_NAME_oneline(issuer_name, nullptr, 0);
+      auto *issuer_name = X509_get_subject_name(x509_);
+      auto *issuer = X509_NAME_oneline(issuer_name, nullptr, 0);
       issuer_copy = dl::script_allocator_strdup(issuer);
       OPENSSL_free(issuer);
     }
@@ -1314,13 +1314,13 @@ private:
 
   int64_t get_time_not_before() const {
     dl::CriticalSectionGuard critical_section;
-    auto asn_time_not_before = X509_getm_notBefore(x509_);
+    auto *asn_time_not_before = X509_getm_notBefore(x509_);
     return convert_asn1_time(asn_time_not_before);
   }
 
   int64_t get_time_not_after() const {
     dl::CriticalSectionGuard critical_section;
-    auto asn_time_not_after = X509_getm_notAfter(x509_);
+    auto *asn_time_not_after = X509_getm_notAfter(x509_);
     return convert_asn1_time(asn_time_not_after);
   }
 
@@ -1360,7 +1360,7 @@ private:
       int nid = OBJ_obj2nid(key);
       const char *key_str = shortnames ? OBJ_nid2sn(nid) : OBJ_nid2ln(nid);
 
-      auto value_str = reinterpret_cast<const char *>(ASN1_STRING_get0_data(value));
+      const auto *value_str = reinterpret_cast<const char *>(ASN1_STRING_get0_data(value));
       int value_len = ASN1_STRING_length(value);
 
       critical_section.leave_critical_section();

--- a/runtime/resumable.cpp
+++ b/runtime/resumable.cpp
@@ -235,7 +235,7 @@ int64_t f$get_running_fork_id() {
 }
 
 Optional<array<mixed>> f$get_fork_stat(int64_t fork_id) {
-  auto info = get_forked_resumable_info(fork_id);
+  auto *info = get_forked_resumable_info(fork_id);
   if (!info) {
     return false;
   }

--- a/server/database-drivers/adaptor.cpp
+++ b/server/database-drivers/adaptor.cpp
@@ -52,7 +52,7 @@ int Adaptor::register_connector(std::unique_ptr<Connector> &&connector) noexcept
 }
 
 void Adaptor::create_outbound_connections() noexcept {
-  for (auto &item : connectors) {
+  for (const auto &item : connectors) {
     const auto &connector = item.second;
     if (!connector->connected()) {
       connector->connect_async_and_epoll_insert();

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -210,7 +210,7 @@ void JsonLogger::write_log(vk::string_view message, int type, int64_t created_at
     return;
   }
 
-  auto json_out_it = buffers_.begin();
+  auto *json_out_it = buffers_.begin();
   for (; json_out_it != buffers_.end() && !json_out_it->try_start_json(); ++json_out_it) {
   }
   assert(json_out_it != buffers_.end());

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -259,7 +259,7 @@ void command_net_write_run_rpc(command_t *base_command, void *data) {
     vkprintf (3, "failed to send rpc request %d\n", slot_id);
     on_net_event(create_rpc_error_event(slot_id, TL_ERROR_NO_CONNECTIONS, "Failed to send query, timeout expired", nullptr));
   } else {
-    auto d = (connection *)data;
+    auto *d = (connection *)data;
     //assert (d->status == conn_ready);
     send_rpc_query(d, TL_RPC_INVOKE_REQ, slot_id, (int *)command->data, command->len);
     d->last_query_sent_time = precise_now;
@@ -285,7 +285,7 @@ command_t command_net_write_rpc_base = {
 
 
 command_t *create_command_net_writer(const char *data, int data_len, command_t *base, long long extra) {
-  auto command = reinterpret_cast<command_net_write_t *>(malloc(sizeof(command_net_write_t)));
+  auto *command = reinterpret_cast<command_net_write_t *>(malloc(sizeof(command_net_write_t)));
   command->base.run = base->run;
   command->base.free = base->free;
 
@@ -580,7 +580,7 @@ int hts_func_execute(connection *c, int op) {
   qUri = ReqHdr + D->uri_offset;
   qUriLen = D->uri_size;
 
-  auto get_qm_ptr = reinterpret_cast<char *>(memchr(qUri, '?', (size_t)qUriLen));
+  auto *get_qm_ptr = reinterpret_cast<char *>(memchr(qUri, '?', (size_t)qUriLen));
   if (get_qm_ptr) {
     qGet = get_qm_ptr + 1;
     qGetLen = (int)(qUri + qUriLen - qGet);
@@ -792,7 +792,7 @@ void rpcc_stop() {
 }
 
 void rpcx_at_query_end(connection *c) {
-  auto D = TCP_RPC_DATA(c);
+  auto *D = TCP_RPC_DATA(c);
 
   clear_connection_timeout(c);
   c->generation = ++conn_generation;
@@ -808,7 +808,7 @@ void rpcx_at_query_end(connection *c) {
 }
 
 int rpcx_func_wakeup(connection *c) {
-  auto D = TCP_RPC_DATA(c);
+  auto *D = TCP_RPC_DATA(c);
 
   assert (c->status == conn_expect_query || c->status == conn_wait_net);
   c->status = conn_expect_query;
@@ -826,7 +826,7 @@ int rpcx_func_wakeup(connection *c) {
 }
 
 int rpcx_func_close(connection *c, int who __attribute__((unused))) {
-  auto D = TCP_RPC_DATA(c);
+  auto *D = TCP_RPC_DATA(c);
 
   auto *worker = reinterpret_cast<php_worker *>(D->extra);
   if (worker != nullptr) {
@@ -1005,7 +1005,7 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
         return 0;
       }
       assert(fetched_bytes == len);
-      auto D = TCP_RPC_DATA(c);
+      auto *D = TCP_RPC_DATA(c);
       rpc_query_data *rpc_data = rpc_query_data_create(std::move(header), reinterpret_cast<int *>(buf), len / static_cast<int>(sizeof(int)), D->remote_pid.ip,
                                                        D->remote_pid.port, D->remote_pid.pid, D->remote_pid.utime);
 
@@ -1089,7 +1089,7 @@ void pnet_query_answer(conn_query *q) {
 }
 
 void pnet_query_delete(conn_query *q) {
-  auto ansgen = (net_ansgen_t *)q->extra;
+  auto *ansgen = (net_ansgen_t *)q->extra;
 
   ansgen->func->free(ansgen);
   q->extra = nullptr;
@@ -1099,7 +1099,7 @@ void pnet_query_delete(conn_query *q) {
 }
 
 int pnet_query_timeout(conn_query *q) {
-  auto net_ansgen = (net_ansgen_t *)q->extra;
+  auto *net_ansgen = (net_ansgen_t *)q->extra;
   net_ansgen->func->timeout(net_ansgen);
 
   pnet_query_answer(q);
@@ -1110,7 +1110,7 @@ int pnet_query_timeout(conn_query *q) {
 }
 
 int pnet_query_term(conn_query *q) {
-  auto net_ansgen = (net_ansgen_t *)q->extra;
+  auto *net_ansgen = (net_ansgen_t *)q->extra;
   net_ansgen->func->error(net_ansgen, "Connection closed by server");
 
   pnet_query_answer(q);
@@ -1120,7 +1120,7 @@ int pnet_query_term(conn_query *q) {
 }
 
 int pnet_query_check(conn_query *q) {
-  auto net_ansgen = (net_ansgen_t *)q->extra;
+  auto *net_ansgen = (net_ansgen_t *)q->extra;
 
   ansgen_state_t state = net_ansgen->state;
   switch (state) {
@@ -1138,7 +1138,7 @@ int pnet_query_check(conn_query *q) {
 }
 
 int delayed_send_term(conn_query *q) {
-  auto command = (command_t *)q->extra;
+  auto *command = (command_t *)q->extra;
 
   if (command != nullptr) {
     command->run(command, nullptr);
@@ -1189,7 +1189,7 @@ conn_query_functions delayed_send_cq_func = [] {
 
 
 void create_pnet_delayed_query(connection *http_conn, conn_target_t *t, net_ansgen_t *gen, double finish_time) {
-  auto q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
+  auto *q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
 
   q->custom_type = 0;
   q->outbound = nullptr;
@@ -1206,7 +1206,7 @@ void create_pnet_delayed_query(connection *http_conn, conn_target_t *t, net_ansg
 
 void create_delayed_send_query(conn_target_t *t, command_t *command,
                                double finish_time) {
-  auto q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
+  auto *q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
 
   q->custom_type = 0;
   q->start_time = precise_now;
@@ -1222,7 +1222,7 @@ void create_delayed_send_query(conn_target_t *t, command_t *command,
 }
 
 conn_query *create_pnet_query(connection *http_conn, connection *conn, net_ansgen_t *gen, double finish_time) {
-  auto q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
+  auto *q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
 
   q->custom_type = 0;
   q->outbound = conn;
@@ -1336,7 +1336,7 @@ int rpcc_send_query(connection *c) {
 //    dl_assert (q->requester != nullptr, "...");
 //    fprintf (stderr, "processing delayed query %p for target %p initiated by %p (%d:%d<=%d)\n", q, c->target, q->requester, q->requester->fd, q->req_generation, q->requester->generation);
 
-    auto command = (command_t *)q->extra;
+    auto *command = (command_t *)q->extra;
     command->run(command, c);
     command->free(command);
     q->extra = nullptr;

--- a/server/php-lease.cpp
+++ b/server/php-lease.cpp
@@ -483,7 +483,7 @@ process_id_t get_lease_pid() {
 
 process_id_t get_rpc_main_target_pid() {
   if (rpc_proxy_target != -1) {
-    if (auto c = get_target_connection(&Targets[rpc_proxy_target], 0)) {
+    if (auto *c = get_target_connection(&Targets[rpc_proxy_target], 0)) {
       return TCP_RPC_DATA(c)->remote_pid;
     }
   }

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -242,7 +242,7 @@ struct Stats {
       misc_stat_for_job_workers[i].set_period(periods_len[i]);
     }
 
-    for (auto period : periods_desc) {
+    for (const auto *period : periods_desc) {
       if (!cpu_desc.empty()) {
         cpu_desc += ",";
       }

--- a/server/php-mc-connections.cpp
+++ b/server/php-mc-connections.cpp
@@ -30,7 +30,7 @@ data_reader_t *create_data_reader(connection *c, int data_len) {
 }
 
 int mc_query_value(conn_query *q, data_reader_t *reader) {
-  auto ansgen = (mc_ansgen_t *)q->extra;
+  auto *ansgen = (mc_ansgen_t *)q->extra;
   ansgen->func->value(ansgen, reader);
 
   int err = pnet_query_check(q);
@@ -38,35 +38,35 @@ int mc_query_value(conn_query *q, data_reader_t *reader) {
 }
 
 int mc_query_other(conn_query *q, data_reader_t *reader) {
-  auto ansgen = (mc_ansgen_t *)q->extra;
+  auto *ansgen = (mc_ansgen_t *)q->extra;
   ansgen->func->other(ansgen, reader);
 
   return pnet_query_check(q);
 }
 
 int mc_query_version(conn_query *q, data_reader_t *reader) {
-  auto ansgen = (mc_ansgen_t *)q->extra;
+  auto *ansgen = (mc_ansgen_t *)q->extra;
   ansgen->func->version(ansgen, reader);
 
   return pnet_query_check(q);
 }
 
 int mc_query_end(conn_query *q) {
-  auto ansgen = (mc_ansgen_t *)q->extra;
+  auto *ansgen = (mc_ansgen_t *)q->extra;
   ansgen->func->end(ansgen);
 
   return pnet_query_check(q);
 }
 
 int mc_query_xstored(conn_query *q, int is_stored) {
-  auto ansgen = (mc_ansgen_t *)q->extra;
+  auto *ansgen = (mc_ansgen_t *)q->extra;
   ansgen->func->xstored(ansgen, is_stored);
 
   return pnet_query_check(q);
 }
 
 int mc_query_error(conn_query *q) {
-  auto ansgen = (net_ansgen_t *)q->extra;
+  auto *ansgen = (net_ansgen_t *)q->extra;
   ansgen->func->error(ansgen, "some protocol error");
 
   return pnet_query_check(q);
@@ -256,7 +256,7 @@ void php_worker_run_mc_query_packet(php_worker *worker, php_net_query_packet_t *
   mc_ansgen_t *ansgen = mc_ansgen_packet_create();
   ansgen->func->set_query_type(ansgen, query->extra_type);
 
-  auto net_ansgen = (net_ansgen_t *)ansgen;
+  auto *net_ansgen = (net_ansgen_t *)ansgen;
   int connection_id = query->connection_id;
 
   if (connection_id < 0 || connection_id >= MAX_TARGETS) {

--- a/server/php-sql-connections.cpp
+++ b/server/php-sql-connections.cpp
@@ -88,10 +88,10 @@ conn_target_t db_ct = [] {
 
 void command_net_write_run_sql(command_t *base_command, void *data) {
   //fprintf (stderr, "command_net_write [ptr=%p]\n", base_command);
-  auto command = (command_net_write_t *)base_command;
+  auto *command = (command_net_write_t *)base_command;
 
   assert (command->data != nullptr);
-  auto d = (connection *)data;
+  auto *d = (connection *)data;
   assert (d->status == conn_ready);
 
   /*
@@ -132,7 +132,7 @@ void php_worker_run_sql_query_packet(php_worker *worker, php_net_query_packet_t 
 
   sql_ansgen_t *ansgen = sql_ansgen_packet_create();
 
-  auto net_ansgen = (net_ansgen_t *)ansgen;
+  auto *net_ansgen = (net_ansgen_t *)ansgen;
   if (connection_id != sql_target_id) {
     net_error(net_ansgen, (php_query_base_t *)query, "Invalid connection_id (sql connection expected)");
     return;
@@ -180,14 +180,14 @@ void php_worker_run_sql_query_packet(php_worker *worker, php_net_query_packet_t 
 }
 
 int sql_query_packet(conn_query *q, data_reader_t *reader) {
-  auto ansgen = (sql_ansgen_t *)q->extra;
+  auto *ansgen = (sql_ansgen_t *)q->extra;
   ansgen->func->packet(ansgen, reader);
 
   return pnet_query_check(q);
 }
 
 int sql_query_done(conn_query *q) {
-  auto ansgen = (sql_ansgen_t *)q->extra;
+  auto *ansgen = (sql_ansgen_t *)q->extra;
   ansgen->func->done(ansgen);
 
   return pnet_query_check(q);
@@ -204,13 +204,13 @@ int sqlp_becomes_ready(connection *c) {
       q->requester->queries_ok++;
       //waiting_queries--;
 
-      auto net_ansgen = (net_ansgen_t *)q->extra;
+      auto *net_ansgen = (net_ansgen_t *)q->extra;
       create_pnet_query(q->requester, c, net_ansgen, q->timer.wakeup_time);
 
       delete_conn_query(q);
       free(q);
 
-      auto ansgen = (sql_ansgen_t *)net_ansgen;
+      auto *ansgen = (sql_ansgen_t *)net_ansgen;
       ansgen->func->ready(ansgen, c);
       break;
     } else {
@@ -254,7 +254,7 @@ int sqlp_authorized(connection *c) {
   int len = 0;
   char ptype = 2;
 
-  auto sql_database = SQLC_FUNC(c)->sql_get_database(c);
+  const auto *sql_database = SQLC_FUNC(c)->sql_get_database(c);
   if (!sql_database || !*sql_database) {
     SQLC_DATA(c)->auth_state = sql_auth_ok;
     c->status = conn_ready;

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -26,7 +26,7 @@ php_worker *active_worker = nullptr;
 
 php_worker *php_worker_create(php_worker_mode_t mode, connection *c, http_query_data *http_data, rpc_query_data *rpc_data, job_query_data *job_data,
                               long long req_id, double timeout) {
-  auto worker = reinterpret_cast<php_worker *>(malloc(sizeof(php_worker)));
+  auto *worker = reinterpret_cast<php_worker *>(malloc(sizeof(php_worker)));
 
   worker->data = php_query_data_create(http_data, rpc_data, job_data);
   worker->conn = c;
@@ -142,7 +142,7 @@ void php_worker_try_start(php_worker *worker) {
   if (php_worker_run_flag) { // put connection into pending_http_query
     vkprintf (2, "php script [req_id = %016llx] is waiting\n", worker->req_id);
 
-    auto pending_q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
+    auto *pending_q = reinterpret_cast<conn_query *>(malloc(sizeof(conn_query)));
 
     pending_q->custom_type = 0;
     pending_q->outbound = (connection *)&pending_http_queue;

--- a/vkext/vkext-schema-memcache.cpp
+++ b/vkext/vkext-schema-memcache.cpp
@@ -2984,7 +2984,7 @@ void *tlsub_create_array(void **IP, void **Data, zval **arr, struct tl_tree **va
  *****/
 void *tlsub_create_type(void **IP, void **Data, zval **arr, struct tl_tree **vars) {
   tl_debug(__FUNCTION__, -1);
-  auto x = reinterpret_cast<tl_tree_type *>(zzemalloc(sizeof(tl_tree_type)));
+  auto *x = reinterpret_cast<tl_tree_type *>(zzemalloc(sizeof(tl_tree_type)));
   dynamic_tree_nodes++;
   total_tree_nodes_existed++;
   x->self.ref_cnt = 1;


### PR DESCRIPTION
This patch contains fixes which help to understand that variable have pointer type. E.g. such declaration `auto pointer_var` transformed `auto *pointer_var`, or even `const auto  *pointer_var` where possible. This done with help of clang-tidy static analyzer, 'readability-qualified-auto' check.