### PR TITLE
Fix class name with trait bug

### DIFF
--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -99,6 +99,7 @@ prepend(KPHP_COMPILER_PIPES_SOURCES pipes/
         calc-empty-functions.cpp
         calc-func-dep.cpp
         calc-locations.cpp
+        calc-magic-const.cpp
         calc-real-defines-values.cpp
         calc-rl.cpp
         calc-val-ref.cpp

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -160,7 +160,7 @@ using PipeStream = PipeWithProgress<
   PipeFunctionT,
   DataStream<ExecuteFunctionInput<PipeFunctionT>>,
   ExecuteFunctionOutput<PipeFunctionT>
-  >;
+>;
 
 using SyncNode = sync_node_tag<PipeWithProgress>;
 

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -32,6 +32,7 @@
 #include "compiler/pipes/calc-const-types.h"
 #include "compiler/pipes/calc-empty-functions.h"
 #include "compiler/pipes/calc-locations.h"
+#include "compiler/pipes/calc-magic-const.h"
 #include "compiler/pipes/calc-real-defines-values.h"
 #include "compiler/pipes/calc-rl.h"
 #include "compiler/pipes/calc-val-ref.h"
@@ -159,7 +160,7 @@ using PipeStream = PipeWithProgress<
   PipeFunctionT,
   DataStream<ExecuteFunctionInput<PipeFunctionT>>,
   ExecuteFunctionOutput<PipeFunctionT>
->;
+  >;
 
 using SyncNode = sync_node_tag<PipeWithProgress>;
 
@@ -256,6 +257,7 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PassC<ConvertInvokeToFuncCallPass>{}
     >> PassC<CheckFuncCallsAndVarargPass>{}
     >> PassC<InstantiateFFIOperationsPass>{}
+    >> PassC<CalcMagicConstPass>{}
     >> PipeC<CheckAbstractFunctionDefaults>{}
     >> PipeC<CalcEmptyFunctions>{}
     >> PassC<CalcActualCallsEdgesPass>{}

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -432,7 +432,7 @@ VertexPtr GenTree::get_expr_top(bool was_arrow, vk::string_view phpdoc_str) {
       break;
     }
     case tok_class_c: {
-      res = get_vertex_with_str_val(VertexAdaptor<op_string>{}, cur_class ? cur_class->name : "");
+      res = VertexAdaptor<op_class_c>::create().set_location(auto_location());
       next_cur();
       break;
     }
@@ -1731,7 +1731,7 @@ VertexPtr GenTree::process_arrow(VertexPtr lhs, VertexPtr rhs) {
     new_root->extra_type = op_ex_func_call_arrow;
     new_root->str_val = rhs->get_string();
     return new_root;
-    
+
   } else {
     kphp_error (false, "Operator '->' expects property or function call as its right operand");
     return {};

--- a/compiler/pipes/calc-magic-const.cpp
+++ b/compiler/pipes/calc-magic-const.cpp
@@ -1,0 +1,22 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/pipes/calc-magic-const.h"
+
+#include "compiler/data/class-data.h"
+
+VertexPtr CalcMagicConstPass::on_enter_vertex(VertexPtr root) {
+  if (root->type() == op_class_c) {
+    auto cur_class = current_function->class_id;
+    auto class_name = cur_class ? cur_class->name : "";
+
+    auto r = VertexAdaptor<op_string>::create();
+    r->location = root->get_location();
+    r->str_val = std::move(class_name);
+
+    return r;
+  }
+
+  return root;
+}

--- a/compiler/pipes/calc-magic-const.h
+++ b/compiler/pipes/calc-magic-const.h
@@ -1,0 +1,16 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "compiler/function-pass.h"
+
+class CalcMagicConstPass final : public FunctionPassBase {
+public:
+  string get_description() override {
+    return "Calculate magic constants ";
+  }
+
+  VertexPtr on_enter_vertex(VertexPtr root) override;
+};

--- a/compiler/pipes/calc-rl.cpp
+++ b/compiler/pipes/calc-rl.cpp
@@ -80,6 +80,7 @@ void rl_other_calc(VertexPtr root, RLValueType expected_rl_type) {
     case op_noerr:
       rl_calc(root.as<op_noerr>()->expr(), expected_rl_type);
       break;
+    case op_class_c:
     case op_phpdoc_var:
       break;
     case op_list_keyval: {

--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -427,6 +427,11 @@ void CFG::create_cfg(VertexPtr tree_node, Node *res_start, Node *res_finish, boo
       *res_finish = end;
       break;
     }
+    case op_class_c: {
+      Node res = new_node();
+      *res_start = *res_finish = res;
+      break;
+    }
 
     // simple just-value operators
     case op_ffi_new:

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -837,6 +837,13 @@
     "base_name": "meta_op_base"
   },
   {
+    "name": "op_class_c",
+    "base_name": "meta_op_base",
+    "props": {
+      "rl": "rl_other"
+    }
+  },
+  {
     "comment": "global statement that binds global vars to the current scope",
     "name": "op_global",
     "base_name": "meta_op_varg",


### PR DESCRIPTION
## Information
- Type: Bugfix
- Issue: #434 

## Code
```php
<?php
trait Test {
  public function test() {
    echo __CLASS__;
  }
}

class Bu {
 use Test;
}

(new Bu())->test();
```

#### Before
`Test`

#### After 
`Bu`

