### PR TITLE
shuffle optimization on vectors

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -394,7 +394,7 @@ function preg_quote ($str ::: string, $delimiter ::: string = '') ::: string;
 function preg_last_error() ::: int;
 function preg_split ($pattern ::: regexp, $subject ::: string, $limit ::: int = -1, $flags ::: int = 0) ::: mixed[] | false;
 
-function shuffle (&$a ::: array) ::: void;
+function shuffle (&$a ::: array) ::: bool;
 function sort (&$a ::: array, $flag ::: int = SORT_REGULAR) ::: void;
 function rsort (&$a ::: array, $flag ::: int = SORT_REGULAR) ::: void;
 function usort (&$a ::: array, callable(^1[*] $x, ^1[*] $y):int $callback) ::: void;

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -226,7 +226,7 @@ array<mixed> f$range(const mixed &from, const mixed &to, int64_t step = 1);
 
 
 template<class T>
-void f$shuffle(array<T> &a);
+bool f$shuffle(array<T> &a);
 
 template<class T>
 void f$sort(array<T> &a, int64_t flag = SORT_REGULAR);
@@ -1259,23 +1259,31 @@ bool f$array_is_vector(const array<T> &a) {
 
 
 template<class T>
-void f$shuffle(array<T> &a) {
+bool f$shuffle(array<T> &a) {
   int64_t n = a.count();
-  if (n <= 1) {
-    return;
+
+  if (n == 0) {
+    return true;
   }
 
-  array<T> result(array_size(n, 0, true));
-  const auto &const_arr = a;
-  for (const auto &it : const_arr) {
-    result.push_back(it.get_value());
+  if (!a.is_vector()) {
+    array<T> tmp(array_size(n, 0, true));
+    const auto &const_arr = a;
+    for (const auto &it : const_arr) {
+      tmp.push_back(it.get_value());
+    }
+    a = std::move(tmp);
+  }
+
+  if (n == 1) {
+    return true;
   }
 
   for (int64_t i = 1; i < n; i++) {
-    swap(result[i], result[f$mt_rand(0, i)]);
+    swap(a[i], a[f$mt_rand(0, i)]);
   }
 
-  a = std::move(result);
+  return true;
 }
 
 template<class T>

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -335,6 +335,7 @@ ext/standard/tests/array/in_array_variation1.phpt
 ext/standard/tests/array/in_array_variation2.phpt
 ext/standard/tests/array/natsort_basic.phpt
 ext/standard/tests/array/negative_index.phpt
+ext/standard/tests/array/array_shuffle_basic.phpt
 ext/standard/tests/bug64370_var2.phpt
 ext/standard/tests/bug71827.phpt
 ext/standard/tests/file/002.phpt


### PR DESCRIPTION
few changes

- `shuffle` returns `true` as in php
- reset keys even with 1 element array

```php
$x = [2 => 1];
shuffle($x);
var_dump($x);
// kphp master: [2 => 1]
// php: [0 => 1]
```

- don't allocate new memory if array is already vector

```php
$x = range(0, 100000);

$start = microtime(true);

for ($i = 0; $i < 1000; $i++) {
 shuffle($x);
}

var_dump(microtime(true) - $start);
// this branch: 1.5391621589661
// master: 2.5984324812889
```