### PR TITLE
[compiler] assign autogenerated names for unnamed ffi func args

### DIFF
--- a/compiler/pipes/register-ffi-scopes.cpp
+++ b/compiler/pipes/register-ffi-scopes.cpp
@@ -64,6 +64,11 @@ private:
       auto param = VertexAdaptor<op_func_param>::create(var).set_location(call->location);
       kphp_assert(ffi_type->kind == FFITypeKind::Var);
       var->str_val = ffi_type->str;
+      if (var->str_val.empty()) {
+        // we need to generate some name for unnamed parameter to avoid
+        // broken type assumptions (see issue #424)
+        var->str_val = "_unnamed_arg" + std::to_string(i);
+      }
       param->type_hint = G->get_ffi_root().create_type_hint(ffi_type->members[0], result.scope);
       kphp_error_return(param->type_hint, fmt_format("unsupported C param type: {}", ffi_decltype_string(ffi_type)));
       params.emplace_back(param);

--- a/tests/python/tests/ffi/c/pointers.c
+++ b/tests/python/tests/ffi/c/pointers.c
@@ -1,9 +1,14 @@
 #include <stdint.h>
+#include <string.h>
 
 #include "pointers.h"
 
 SomeData *nullptr_data(void) {
   return (SomeData*)0;
+}
+
+void uint64_memset(uint64_t* ptr, uint8_t v) {
+  memset(ptr, v, 8);
 }
 
 uint64_t intptr_addr_value(int *ptr) {

--- a/tests/python/tests/ffi/c/pointers.h
+++ b/tests/python/tests/ffi/c/pointers.h
@@ -6,6 +6,10 @@ typedef struct SomeData { void *_opaque; } SomeData;
 // Declaring with void argument on purpose.
 SomeData *nullptr_data(void);
 
+// Declaring with 2 unnamed arguments on purpose.
+// See issue #424
+void uint64_memset(uint64_t*, uint8_t);
+
 uint64_t intptr_addr_value(int *ptr);
 uint64_t voidptr_addr_value(void *ptr);
 

--- a/tests/python/tests/ffi/php/pointer/ptr2.php
+++ b/tests/python/tests/ffi/php/pointer/ptr2.php
@@ -37,4 +37,16 @@ function test() {
     var_dump($lib->voidptr_addr_value($ptr1) === $lib->voidptr_addr_value($ptr2));
 }
 
+function test2() {
+    $lib = FFI::scope('pointers');
+    $u64 = $lib->new('uint64_t');
+    $lib->uint64_memset(FFI::addr($u64), 1);
+    var_dump($u64->cdata == 0x101010101010101);
+    var_dump($u64->cdata);
+    $lib->uint64_memset(FFI::addr($u64), 2);
+    var_dump($u64->cdata == 0x202020202020202);
+    var_dump($u64->cdata);
+}
+
 test();
+test2();

--- a/tests/python/tests/ffi/test_ffi.py
+++ b/tests/python/tests/ffi/test_ffi.py
@@ -185,6 +185,9 @@ class TestFFI(KphpCompilerAutoTestCase):
     def test_pointer_null_as_ptr(self):
         self.ffi_build_and_compare_with_php('php/pointer/null_as_ptr.php', shared_libs=['pointers'])
 
+    def test_pointer_null_cdata(self):
+        self.ffi_build_and_compare_with_php('php/pointer/null_cdata.php', shared_libs=['pointers'])
+
     def test_pointer_primitive_ptr_arg(self):
         self.ffi_build_and_compare_with_php('php/pointer/primitive_ptr_arg.php', shared_libs=['pointers'])
 


### PR DESCRIPTION
Previously, we used empty string as a param name.
If there are multiple unnamed params, we'll end up with duplicated
param names with potentially different type hints.

This patch assigns autogenerated names, like `_unnamed_param1`
to these parameters, avoiding the collision error.

Also enabled one of the FFI tests from pointers;
it was intended to be enabled, but perhaps I forgot
to add it to the python script previously (?)

Fixes #424