### PR TITLE
avoid goto statement in autogenerated code for simple switch

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1053,7 +1053,7 @@ void compile_switch_var(VertexAdaptor<op_switch> root, CodeGenerator &W) {
   W << temp_var_matched_with_a_case << " = false;" << NL;
 
   const auto cases = root->cases();
-  const bool default_case_is_the_last = cases.back()->type() == op_default;
+  const bool default_case_is_the_last = !cases.empty() && cases.back()->type() == op_default;
   for (const auto &one_case : cases) {
     VertexAdaptor<op_seq> cmd;
     if (auto cs = one_case.try_as<op_case>()) {


### PR DESCRIPTION
Such code:
```
function do_switch($condition, $case) {
  switch ($condition) {
    case $case:
      return 'case';
    default:
      return 'default';
  }
}
```
in master will be transpiled to:
```
//source = [demo.php]
//3: function do_switch($condition, $case) {
string f$do_switch(int64_t v$condition, int64_t v$case) noexcept  {
  mixed v$condition_on_switch$uddfb36cd3d43ebe6_0;
  bool v$matched_with_one_case$uddfb36cd3d43ebe6_0 = false;
//4:   switch ($condition) {
  do {
    v$condition_on_switch$uddfb36cd3d43ebe6_0 = v$condition;
    v$matched_with_one_case$uddfb36cd3d43ebe6_0 = false;
//5:     case $case:
    if (v$matched_with_one_case$uddfb36cd3d43ebe6_0 || eq2(v$condition_on_switch$uddfb36cd3d43ebe6_0, v$case)){
      v$matched_with_one_case$uddfb36cd3d43ebe6_0 = true;
//6:       return 'case';
      return v$const_string$use3b577866b8d9dde;
    }
    if (v$matched_with_one_case$uddfb36cd3d43ebe6_0) {
//7:     default:
//8:       return 'default';
      switch_goto$uddfb36cd3d43ebe6_0: return v$const_string$us94cee80424a1717e;
    }
    if (v$matched_with_one_case$uddfb36cd3d43ebe6_0) {
      break;
    }
    v$matched_with_one_case$uddfb36cd3d43ebe6_0 = true;
    goto switch_goto$uddfb36cd3d43ebe6_0;
  } while(false);
  ;
}
```
It is clear that in case of $condition != $case execution will go through 'default' statement of operator 'switch'. In c++ level its mean that execution go through 'goto' statement.
However, when 'default' statement is the last in 'switch' it is possible to avoid 'goto' code. With patch corresponding function will looks like:
```
//source = [demo.php]
//3: function do_switch($condition, $case) {
string f$do_switch(int64_t v$condition, int64_t v$case) noexcept  {
  mixed v$condition_on_switch$uddfb36cd3d43ebe6_0;
  bool v$matched_with_one_case$uddfb36cd3d43ebe6_0 = false;
//4:   switch ($condition) {
  do {
    v$condition_on_switch$uddfb36cd3d43ebe6_0 = v$condition;
    v$matched_with_one_case$uddfb36cd3d43ebe6_0 = false;
//5:     case $case:
    if (v$matched_with_one_case$uddfb36cd3d43ebe6_0 || eq2(v$condition_on_switch$uddfb36cd3d43ebe6_0, v$case)) {
      v$matched_with_one_case$uddfb36cd3d43ebe6_0 = true;
//6:       return 'case';
      return v$const_string$use3b577866b8d9dde;
    }
    {
//7:     default:
//8:       return 'default';
      return v$const_string$us94cee80424a1717e;
    }
  } while(false);
  ;
}
```

Side effect of this patch is that now c++ compiler able to check that all path covered with 'return'  statements in function returning non-void, thus there will be no warnings.