### PR TITLE
add a defined('KPHP_COMPILER_VERSION') test

### DIFF
--- a/tests/phpt/constants/002_kphp_detection.php
+++ b/tests/phpt/constants/002_kphp_detection.php
@@ -1,0 +1,15 @@
+@ok
+<?php
+
+$expected = 'KPHP';
+#ifndef KPHP
+$expected = 'PHP';
+#endif
+
+if (defined('KPHP_COMPILER_VERSION')) {
+  $actual = 'KPHP';
+} else {
+  $actual = 'PHP';
+}
+
+var_dump($actual === $expected);


### PR DESCRIPTION
This idiom can be used to run KPHP-specific code.
It's very close to what people would do with checking
whether their code runs on HHVM:

	if (defined('HHVM_VERSION')) {
		// HHVM-specific code.
	}

In KPHP, this example would translate to this:

	if (defined('KPHP_COMPILER_VERSION')) {
		// KPHP-specific code.
	}