### PR TITLE
[compiler] improve composer autoload files handling

### DIFF
--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -531,10 +531,7 @@ void CompilerCore::init_composer_class_loader() {
     return;
   }
 
-  // we use negated "no-dev" since it's spelled like this in composer CLI;
-  // remove the negation here and imply that it's "use-dev"
-  bool use_dev = !settings().composer_no_dev.get();
-  composer_class_loader.set_use_dev(use_dev);
+  composer_class_loader.set_use_dev(settings().composer_autoload_dev.get());
 
   composer_class_loader.load_root_file(settings().composer_root.get());
 

--- a/compiler/compiler-settings.h
+++ b/compiler/compiler-settings.h
@@ -122,7 +122,7 @@ public:
   KphpOption<std::string> static_lib_out_dir;
 
   KphpOption<std::string> composer_root;
-  KphpOption<bool> composer_no_dev;
+  KphpOption<bool> composer_autoload_dev;
 
   KphpOption<bool> ffi_enabled;
 

--- a/compiler/composer.h
+++ b/compiler/composer.h
@@ -8,6 +8,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common/mixin/not_copyable.h"
@@ -52,6 +53,7 @@ private:
 
   bool use_dev_;
   std::map<std::string, std::vector<std::string>, std::less<>> autoload_psr4_;
+  std::unordered_set<std::string> deps_;
 
   std::string autoload_filename_;
   std::vector<std::string> files_to_require_;

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -289,8 +289,8 @@ int main(int argc, char *argv[]) {
              "show-progress", "KPHP_SHOW_PROGRESS");
   parser.add("A folder that contains composer.json file", settings->composer_root,
              "composer-root", "KPHP_COMPOSER_ROOT");
-  parser.add("Simulate the composer -no-dev flag behavior when handling composer files", settings->composer_no_dev,
-             "composer-no-dev", "KPHP_COMPOSER_NO_DEV");
+  parser.add("Include autoload-dev section for the root composer file", settings->composer_autoload_dev,
+             "composer-autoload-dev", "KPHP_COMPOSER_AUTOLOAD_DEV");
   parser.add("Enable KPHP experimental FFI support", settings->ffi_enabled,
              "enable-ffi", "KPHP_ENABLE_FFI");
   parser.add("Require functions typing (1 - @param / type hint is mandatory, 0 - auto infer or check if exists)", settings->require_functions_typing,

--- a/docs/kphp-language/kphp-vs-php/compiler-cmd-options.md
+++ b/docs/kphp-language/kphp-vs-php/compiler-cmd-options.md
@@ -146,9 +146,9 @@ Show codegeneration progress, each step, line by line, default **0**.
 A folder that contains *composer.json* file and *vendor/* folder, default **empty**.  
 If empty, KPHP won't search for Composer modules at all, so specify this option to enable psr-4 [autoload](../../kphp-language/kphp-vs-php/reachability-compilation.md#class-autoloading-and-composer-modules).
 
-<aside>--composer-no-dev / KPHP_COMPOSER_NO_DEV = 0 | 1</aside>
+<aside>--composer-autoload-dev / KPHP_COMPOSER_AUTOLOAD_DEV = 0 | 1</aside>
 
-Simulate the *-no-dev* flag behavior when handling Composer files, default **0**.
+Include autoload-dev section for the root Composer file, default **0**.
 
 <aside>--require-functions-typing / KPHP_REQUIRE_FUNCTIONS_TYPING = 0 | 1</aside>
 

--- a/tests/python/tests/composer/test_composer.py
+++ b/tests/python/tests/composer/test_composer.py
@@ -10,15 +10,15 @@ class TestComposer(KphpCompilerAutoTestCase):
         self.build_and_compare_with_php(
             php_script_path="php/index.php",
             kphp_env={
-                "KPHP_COMPOSER_ROOT": os.path.join(self.test_dir, "php")
+                "KPHP_COMPOSER_ROOT": os.path.join(self.test_dir, "php"),
+                "KPHP_COMPOSER_AUTOLOAD_DEV": "1",
             })
 
     def test_psr4_class_loading_no_dev(self):
         once_runner = self.make_kphp_once_runner("php/index.php")
-        # tests/ are not registered in autoloader if we're using -composer-no-dev
+        # tests/ are not registered in autoloader if we're not using -composer-autoload-dev
         self.assertFalse(once_runner.compile_with_kphp({
             "KPHP_COMPOSER_ROOT": os.path.join(self.test_dir, "php"),
-            "KPHP_COMPOSER_NO_DEV": "1",
         }))
         with open(once_runner.kphp_build_stderr_artifact.file, "r") as error_file:
             self.assertRegex(error_file.read(), r"Class VK\\Feed\\FeedTester not found")
@@ -27,5 +27,6 @@ class TestComposer(KphpCompilerAutoTestCase):
         self.build_and_compare_with_php(
             php_script_path="php/test_autoload_files/index.php",
             kphp_env={
-                "KPHP_COMPOSER_ROOT": os.path.join(self.test_dir, "php/test_autoload_files")
+                "KPHP_COMPOSER_ROOT": os.path.join(self.test_dir, "php/test_autoload_files"),
+                "KPHP_COMPOSER_AUTOLOAD_DEV": "1",
             })


### PR DESCRIPTION
How `autoload.files` behaved before:

	All vendored packages, direct and indirect dependencies
	were traversed. composer.json files that were found
	and scanned. Every autoload.files key was added to
	the must-require file list. --composer-no-dev had
	no effect on this as it only works with autoload-dev
	section of the root composer file.

This lead to a problem: if there is are dev-only dependencies,
could be incompatible with KPHP. phpstorm, composer itself and
many other PHP packages that use too much runtime magic.
If they happen to have some `autoload.files` among them, our
project will stop to build even if `--composer-no-dev` is specified.

How `autoload.files` behaves now:

	We start from collecting the dependencies list ("composer.require").
	This operation is performed only for a root composer file.
	When we see an autoload.files later, we add it to our
	must-require list only if it's a root composer file
	or its package name is contained inside the dependencies list.

This also helps against unexpected (uncategorized) PHP packages
under the `vendor/` folder. Their `autoload.files` will never be
pulled in unless required.

Since in most cases it's desirable to specify `--composer-no-dev`
while building the project with KPHP, this option has been
inversed. Now it's called `--composer-autoload-dev`.
By default, it's false, so we get a more useful default value.