### PR TITLE
[compiler] improve FFI pointer typing

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -185,8 +185,10 @@ void compile_ffi_php2c_conv(VertexAdaptor<op_ffi_php2c_conv> root, CodeGenerator
   const FFIType *conv_type = FFIRoot::get_ffi_type(root->c_type);
   const FFIType *type = conv_type->kind == FFITypeKind::Var ? conv_type->members[0] : conv_type;
   std::string tag;
+  // some tags have unboxed specializations, other types are specialized with CData templates;
+  // see ffi_tag<> specializations in ffi.h for more info
   if (type->is_void_ptr()) {
-    tag = "void*";
+    tag = type->members[0]->is_const() ? "const void*" : "void*";
   } else if (type->is_cstring()) {
     tag = "const char*";
   } else if (vk::any_of_equal(type->kind, FFITypeKind::Pointer, FFITypeKind::Struct, FFITypeKind::StructDef, FFITypeKind::Union, FFITypeKind::UnionDef)) {

--- a/compiler/inferring/type-data.h
+++ b/compiler/inferring/type-data.h
@@ -27,6 +27,7 @@ private:
     or_null_flag_e        = 0b00000010,
     or_false_flag_e       = 0b00000100,
     shape_has_varg_flag_e = 0b00001000,
+    ffi_const_flag_e      = 0b00010000,
   };
 
 public:
@@ -99,6 +100,9 @@ public:
   void set_flags(uint8_t new_flags);
 
   bool is_ffi_ref() const;
+
+  bool ffi_const_flag() const { return get_flag<ffi_const_flag_e>(); }
+  void set_ffi_const_flag() { set_flag<ffi_const_flag_e>(); }
 
   bool or_false_flag() const { return get_flag<or_false_flag_e>(); }
   void set_or_false_flag() { set_flag<or_false_flag_e>(); }

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -111,8 +111,13 @@ void TypeHintCallable::recalc_type_data_in_context_of_call(TypeData *dst, Vertex
 
 static void recalc_ffi_type(TypeData *dst, const std::string &scope_name, const FFIType *type) {
   if (type->kind == FFITypeKind::Pointer) {
-    recalc_ffi_type(dst, scope_name, type->members[0]);
-    dst->set_indirection(type->num);
+    TypeData nested{*TypeData::get_type(tp_any)};
+    recalc_ffi_type(&nested, scope_name, type->members[0]);
+    nested.set_indirection(type->num); // turn it into a pointer
+    if (type->members[0]->is_const()) {
+      nested.set_ffi_const_flag();
+    }
+    dst->set_lca(&nested);
     return;
   }
 

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -257,6 +257,8 @@ const TypeHint *PhpDocTypeHintParser::parse_ffi_cdata() {
       cdef.append("int");
     } else if (tok == tok_times) {
       cdef.push_back('*');
+    } else if (tok == tok_const) {
+      cdef.append("const");
     } else {
       throw std::runtime_error("unexpected token, expected C type, '>' or ')'");
     }

--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -309,6 +309,9 @@ bool is_php2c_valid(VertexAdaptor<op_ffi_php2c_conv> conv, const FFIType *ffi_ty
       if (php_expr->type() == op_null) {
         return true;
       }
+      if (!ffi_type->members[0]->is_const() && php_type->ffi_const_flag()) {
+        return false;
+      }
       if (ffi_type->members[0]->kind == FFITypeKind::Void && ffi_type->num == 1) {
         return true;
       }

--- a/docs/kphp-language/php-extensions/ffi.md
+++ b/docs/kphp-language/php-extensions/ffi.md
@@ -53,7 +53,7 @@ All FFI-related types should be annotated with special annotations:
 * `ffi_cdata<scope_name, type_expr>` for [\FFI\CData](https://www.php.net/manual/ru/class.ffi-cdata.php)
 * `ffi_scope<scope_name>` for [\FFI](https://www.php.net/manual/ru/class.ffi.php) class instances
 
-For `ffi_scope<>`, you can use a pointer-type expression, builtin type name, struct name and
+For `ffi_cdata<>`, you can use a pointer-type expression, builtin type name, struct name and
 any other supported C type expression. For instance, `ffi_cdata<foo, union Event**>` is a valid
 `ffi_cdata` declaration.
 
@@ -82,6 +82,21 @@ $cdef = FFI::cdef('
 ');
 
 f($cdef);
+```
+
+If you need to describe a builtin C type that is not bound to any particular FFI scope,
+use default FFI scope name "C":
+
+```php
+/**
+ * Since void* is a global type, we can use "C" scope name to avoid any dependency
+ * on a custom FFI scope.
+ *
+ * @param ffi_cdata<C, void*> $ptr
+ */
+function as_uint8_ptr($ptr) {
+  FFI::cast('uint8_t*', $ptr);
+}
 ```
 
 KPHP will give compile-time error if types are not compatible

--- a/runtime/ffi.h
+++ b/runtime/ffi.h
@@ -51,6 +51,12 @@ struct CDataPtr {
     return c_value == reinterpret_cast<T*>(1);
   }
 
+  // allow `T*` ptr to `void*` ptr conversion
+  operator CDataPtr<void> () { return CDataPtr<void>(c_value); }
+
+  // allow `T*` ptr to `const T*` ptr conversion
+  operator CDataPtr<const T> () { return CDataPtr<const T>(c_value); }
+
   // construction FFI pointer from KPHP null value
   CDataPtr(Optional<bool> v) {
     if (!v.is_null()) {
@@ -316,6 +322,7 @@ template<> struct ffi_tag<float>{};
 template<> struct ffi_tag<double>{};
 template<> struct ffi_tag<char>{};
 template<> struct ffi_tag<const char*>{};
+template<> struct ffi_tag<const void*>{};
 template<> struct ffi_tag<void*>{};
 template<class T> struct ffi_tag<C$FFI$CData<T>>{};
 
@@ -331,12 +338,16 @@ inline int64_t ffi_php2c(int64_t v, ffi_tag<int64_t>) { return v; }
 inline float ffi_php2c(double v, ffi_tag<float>) { return static_cast<float>(v); }
 inline double ffi_php2c(double v, ffi_tag<double>) { return v; }
 inline const char* ffi_php2c(const string &v, ffi_tag<const char*>) { return v.c_str(); }
+inline const void* ffi_php2c(const string &v, ffi_tag<const void*>) { return v.c_str(); }
 
 template<class T>
 auto ffi_php2c(class_instance<C$FFI$CData<T>> v, ffi_tag<C$FFI$CData<T>>) { return v->c_value; }
 
 template<class T>
 void *ffi_php2c(CDataPtr<T> v, ffi_tag<void*>) { return v.c_value; }
+
+template<class T>
+const void *ffi_php2c(CDataPtr<const T> v, ffi_tag<const void*>) { return v.c_value; }
 
 template<class T>
 T* ffi_php2c(CDataPtr<T> v, ffi_tag<C$FFI$CData<T*>>) { return v.c_value; }

--- a/tests/phpt/ffi/typing/010_cstr_field_read_error.php
+++ b/tests/phpt/ffi/typing/010_cstr_field_read_error.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
 KPHP_ENABLE_FFI=1
-/pass FFI\\CData_char\* to argument/
+/pass const FFI\\CData_char\* to argument/
 /declared as @param string/
 <?php
 

--- a/tests/phpt/ffi/typing/054_const_ptr_error.php
+++ b/tests/phpt/ffi/typing/054_const_ptr_error.php
@@ -1,0 +1,11 @@
+@kphp_should_fail
+KPHP_ENABLE_FFI=1
+/Invalid php2c conversion: const FFI\\CData_int32\* -> int32_t\*/
+<?php
+
+$cdef = FFI::cdef('
+  void f_intptr(int*);
+');
+
+$const_intptr = FFI::new('const int*');
+$cdef->f_intptr($const_intptr);

--- a/tests/phpt/ffi/typing/055_const_ptr_error.php
+++ b/tests/phpt/ffi/typing/055_const_ptr_error.php
@@ -1,0 +1,16 @@
+@kphp_should_fail
+KPHP_ENABLE_FFI=1
+/pass const FFI\\CData_int32\* to argument \$x of f/
+/but it's declared as @param FFI\\CData_int32\*/
+<?php
+
+// Passing `const T*` as `T*` is a type error.
+
+/** @param ffi_cdata<C, int32_t*> $x */
+function f($x) {}
+
+$intptr = FFI::new('int32_t*');
+$const_intptr = FFI::new('const int32_t*');
+
+f($const_intptr);
+f($intptr);

--- a/tests/phpt/ffi/typing/056_const_ptr_error.php
+++ b/tests/phpt/ffi/typing/056_const_ptr_error.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+KPHP_ENABLE_FFI=1
+/pass const FFI\\CData_int32\* to argument \$x of f/
+/but it's declared as @param Foo/
+<?php
+
+class Foo {}
+
+/** @param Foo $x */
+function f($x) {}
+
+$const_intptr = FFI::new('const int32_t*');
+
+f($const_intptr);

--- a/tests/python/tests/ffi/c/pointers.c
+++ b/tests/python/tests/ffi/c/pointers.c
@@ -42,3 +42,15 @@ void bytes_array_set(uint8_t *arr, int offset, uint8_t val) {
 void* ptr_to_void(void *ptr) {
   return ptr;
 }
+
+const void* ptr_to_const_void(const void *ptr) {
+  return ptr;
+}
+
+int void_strlen(const void *s) {
+  return strlen(s);
+}
+
+void cstr_out_param(const char **out) {
+  *out = "example result";
+}

--- a/tests/python/tests/ffi/c/pointers.h
+++ b/tests/python/tests/ffi/c/pointers.h
@@ -21,3 +21,7 @@ uint8_t bytes_array_get(uint8_t *arr, int offset);
 void bytes_array_set(uint8_t *arr, int offset, uint8_t val);
 
 void* ptr_to_void(void *ptr);
+const void* ptr_to_const_void(const void *ptr);
+int void_strlen(const void *s);
+
+void cstr_out_param(const char **out);

--- a/tests/python/tests/ffi/php/pointer/ptr2.php
+++ b/tests/python/tests/ffi/php/pointer/ptr2.php
@@ -37,6 +37,14 @@ function test() {
     var_dump($lib->voidptr_addr_value($ptr1) === $lib->voidptr_addr_value($ptr2));
 }
 
+function test_ptr2_out_param() {
+  $lib = FFI::scope('pointers');
+
+  $out_ptr = FFI::new('const char*');
+  $lib->cstr_out_param(FFI::addr($out_ptr));
+  var_dump(FFI::string($out_ptr));
+}
+
 function test2() {
     $lib = FFI::scope('pointers');
     $u64 = $lib->new('uint64_t');
@@ -50,3 +58,4 @@ function test2() {
 
 test();
 test2();
+test_ptr2_out_param();


### PR DESCRIPTION
* Fix compiler crash when simple instance type T was mixed
  with a FFI pointer type

* Keep pointer constness inside TypeData,
  Make `const T*` -> `T*` a type error (previously it failed
  on g++ compilation phase)

* Make `T*` -> `const T*` conversion legal

* Fix typo in FFI docs

* Add `ffi_cdata<C, builtin_type>` example

Fixes #459
Fixes #362
Fixes #357