### PR TITLE
several fixes caused by compiling vkcom with clang++-11 

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -557,7 +557,8 @@ void ClassDeclaration::compile(CodeGenerator &W) const {
 
 template<class ReturnValueT>
 void ClassDeclaration::compile_class_method(FunctionSignatureGenerator &&W, ClassPtr klass, vk::string_view method_signature, const ReturnValueT &return_value) {
-  const bool has_parent = (klass->parent_class && klass->parent_class->does_need_codegen()) || vk::any_of(klass->implements, [](InterfacePtr i) { return i->does_need_codegen(); });
+  const bool has_parent = (klass->parent_class && klass->parent_class->does_need_codegen()) ||
+    vk::any_of(klass->implements, [](InterfacePtr i) { return i->does_need_codegen() || i->is_builtin(); });
   const bool has_derived = !klass->derived_classes.empty();
   const bool is_overridden = has_parent && has_derived;
   const bool is_final = has_parent && !has_derived;

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -237,8 +237,8 @@ void compile_try(VertexAdaptor<op_try> root, CodeGenerator &W) {
       return;
     }
     std::string e = gen_unique_name("e");
-    W << "auto " << e << " = std::move(CurException);" << NL <<
-         dst << " = " << e << ".template cast_to<" << caught_class->src_name << ">();" << NL;
+    W << BEGIN << "auto " << e << " = std::move(CurException);" << NL <<
+         dst << " = " << e << ".template cast_to<" << caught_class->src_name << ">();" << NL << END << NL;
     // we don't allow catching arbitrary classes, but we don't check
     // interfaces at compile time; to be on the safe side, check that
     // exception dynamic_cast succeeded

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -28,7 +28,7 @@ bool mc_is_immediate_query(const string &key);
 constexpr int64_t MEMCACHE_SERIALIZED = 1;
 constexpr int64_t MEMCACHE_COMPRESSED = 2;
 
-class C$Memcache : public abstract_refcountable_php_interface {
+struct C$Memcache : public abstract_refcountable_php_interface {
 public:
   virtual void accept(InstanceMemoryEstimateVisitor &) = 0;
   virtual const char *get_class() const = 0;


### PR DESCRIPTION
484f63a commit allow kphp to mark virtual functions that override one from base class with `final` keyword.
78e355f commit fix problem caused by `goto` usage. Imagine this code:
```
int main() {
    int a =0;

    goto exit;
    int *b = nullptr;

exit:
    return 0;
}
```
This code violate C++11 §6.7/3:

> It is possible to transfer into a block, but not in a way that bypasses declarations with initialization. A program that jumps from a point where a variable with automatic storage duration is not in scope to a point where it is in scope is ill-formed unless the variable has scalar type, class type with a trivial default constructor and a trivial destructor, a cv-qualified version of one of these types, or an array of one of the preceding types and is declared without an initializer (8.5).

In order to fix it you can limit lifetime of variable using braces like:
```
int main() {
    int a =0;

    goto exit;
    {
        int *b = nullptr;
    }

exit:
    return 0;
}
```
