### PR TITLE
NUMA and CPU affinity

### DIFF
--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -17,7 +17,7 @@ RUN apt-get update && \
       git cmake-data=3.18* cmake=3.18* make g++ gperf netcat \
       python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk kphp-timelib libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
-      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev mysql-server libmysqlclient-dev && \
+      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev mysql-server libmysqlclient-dev libnuma-dev && \
     pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist pytest-mysql zstandard && \
     rm -rf /var/lib/apt/lists/*
 

--- a/.github/workflows/Dockerfile.focal
+++ b/.github/workflows/Dockerfile.focal
@@ -10,7 +10,7 @@ RUN apt-get update && \
       git cmake make clang g++ g++-10 gperf netcat \
       python3-minimal python3-dev libpython3-dev python3-jsonschema python3-setuptools python3-pip \
       curl-kphp-vk kphp-timelib libuber-h3-dev libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
-      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev mysql-server libmysqlclient-dev && \
+      libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev mysql-server libmysqlclient-dev libnuma-dev && \
     pip3 install wheel portalocker psutil requests-toolbelt pytest pytest-xdist pytest-mysql zstandard && \
     rm -rf /var/lib/apt/lists/*
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ install(FILES ${AUTO_DIR}/runtime/runtime-headers.h
         DESTINATION ${INSTALL_KPHP_SOURCE}/objs/generated/auto/runtime/)
 
 set(CPACK_DEBIAN_KPHP_PACKAGE_DEPENDS "vk-flex-data, curl-kphp-vk, libuber-h3, libpcre3-dev, libre2-dev, libyaml-cpp-dev, libssl-dev, zlib1g-dev, \
-                                       libzstd-dev, g++, libnghttp2-dev, libmsgpack-dev, kphp-timelib, libmysqlclient-dev")
+                                       libzstd-dev, g++, libnghttp2-dev, libmsgpack-dev, kphp-timelib, libmysqlclient-dev, libnuma-dev")
 set(CPACK_DEBIAN_KPHP_PACKAGE_RECOMMENDS "php7.4-vkext, vk-tl-tools")
 set(CPACK_DEBIAN_KPHP_DESCRIPTION "kphp2cpp compiler and runtime for it")
 set(CPACK_DEBIAN_KPHP_PACKAGE_NAME "kphp")

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1373,3 +1373,6 @@ final class FFI {
 
   private function __construct();
 }
+
+// Get numa node number which current worker is bound to (see --numa-node-to-bind option) or -1 if no numa node is bound
+function numa_get_bound_node(): int;

--- a/cmake/init-global-vars.cmake
+++ b/cmake/init-global-vars.cmake
@@ -13,6 +13,7 @@ if(APPLE)
 else()
     set(CURL_LIB /opt/curl7600/lib/libcurl.a)
     set(RT_LIB rt)
+    set(NUMA_LIB numa)
 endif()
 
 find_package(Git REQUIRED)

--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -309,7 +309,7 @@ void CompilerSettings::init() {
   ld_flags.value_ = extra_ld_flags.get();
   append_curl(cxx_default_flags, ld_flags.value_);
   append_apple_options(cxx_default_flags, ld_flags.value_);
-  std::vector<vk::string_view> external_static_libs{"pcre", "re2", "yaml-cpp", "h3", "ssl", "z", "zstd", "nghttp2", "kphp-timelib", "mysqlclient", "numa"};
+  std::vector<vk::string_view> external_static_libs{"pcre", "re2", "yaml-cpp", "h3", "ssl", "z", "zstd", "nghttp2", "kphp-timelib", "mysqlclient"};
 
 #ifdef KPHP_TIMELIB_LIB_DIR
   ld_flags.value_ += " -L" KPHP_TIMELIB_LIB_DIR;
@@ -333,6 +333,7 @@ void CompilerSettings::init() {
   append_if_doesnt_contain(ld_flags.value_, vk::to_array({"vk-flex-data"}), flex_prefix, ".a");
   external_libs.emplace_back("iconv");
 #else
+  external_static_libs.emplace_back("numa");
   external_static_libs.emplace_back("vk-flex-data");
   append_if_doesnt_contain(ld_flags.value_, external_static_libs, "-l:lib", ".a");
   external_libs.emplace_back("rt");

--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -309,7 +309,7 @@ void CompilerSettings::init() {
   ld_flags.value_ = extra_ld_flags.get();
   append_curl(cxx_default_flags, ld_flags.value_);
   append_apple_options(cxx_default_flags, ld_flags.value_);
-  std::vector<vk::string_view> external_static_libs{"pcre", "re2", "yaml-cpp", "h3", "ssl", "z", "zstd", "nghttp2", "kphp-timelib", "mysqlclient"};
+  std::vector<vk::string_view> external_static_libs{"pcre", "re2", "yaml-cpp", "h3", "ssl", "z", "zstd", "nghttp2", "kphp-timelib", "mysqlclient", "numa"};
 
 #ifdef KPHP_TIMELIB_LIB_DIR
   ld_flags.value_ += " -L" KPHP_TIMELIB_LIB_DIR;

--- a/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
+++ b/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
@@ -51,7 +51,7 @@ Install packages
 apt-get update
 apt install git cmake-data=3.16* cmake=3.16* make g++ gperf python3-minimal python3-jsonschema \
             curl-kphp-vk libuber-h3-dev kphp-timelib libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
-            libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev libmysqlclient-dev
+            libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev libmysqlclient-dev libnuma-dev
 ```
 
 
@@ -70,7 +70,7 @@ Install packages
 apt-get update
 apt install git cmake make g++ gperf python3-minimal python3-jsonschema \
             curl-kphp-vk libuber-h3-dev kphp-timelib libfmt-dev libgtest-dev libgmock-dev libre2-dev libpcre3-dev \
-            libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev libmysqlclient-dev
+            libzstd-dev libyaml-cpp-dev libmsgpack-dev libnghttp2-dev zlib1g-dev php7.4-dev libmysqlclient-dev libnuma-dev
 ```
 
 

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -51,6 +51,7 @@
 #include "server/database-drivers/adaptor.h"
 #include "server/job-workers/job-message.h"
 #include "server/json-logger.h"
+#include "server/numa-configuration.h"
 #include "server/php-engine-vars.h"
 #include "server/php-queries.h"
 #include "server/php-query-data.h"
@@ -2335,4 +2336,12 @@ void f$raise_sigsegv() {
 
 void use_utf8() {
   is_utf8_enabled = true;
+}
+
+int64_t f$numa_get_bound_node() {
+  auto &numa = vk::singleton<NumaConfiguration>::get();
+  if (!numa.enabled()) {
+    return -1;
+  }
+  return numa.get_worker_numa_node(logname_id);
 }

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -186,3 +186,5 @@ extern bool is_json_log_on_timeout_enabled;
 inline void f$set_json_log_on_timeout_mode(bool enabled) {
   is_json_log_on_timeout_enabled = enabled;
 }
+
+int64_t f$numa_get_bound_node();

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -111,7 +111,7 @@ target_link_libraries(kphp-full-runtime PUBLIC ${RUNTIME_LIBS})
 set_target_properties(kphp-full-runtime PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${OBJS_DIR})
 
 prepare_cross_platform_libs(RUNTIME_LINK_TEST_LIBS pcre nghttp2 kphp-timelib)
-set(RUNTIME_LINK_TEST_LIBS vk::flex_data_static OpenSSL::SSL mysqlclient ${CURL_LIB} ${RUNTIME_LINK_TEST_LIBS} ${EPOLL_SHIM_LIB} ${ICONV_LIB} ${RT_LIB})
+set(RUNTIME_LINK_TEST_LIBS vk::flex_data_static OpenSSL::SSL mysqlclient numa ${CURL_LIB} ${RUNTIME_LINK_TEST_LIBS} ${EPOLL_SHIM_LIB} ${ICONV_LIB} ${RT_LIB})
 
 file(GLOB_RECURSE KPHP_RUNTIME_ALL_HEADERS
      RELATIVE ${BASE_DIR}

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -111,7 +111,7 @@ target_link_libraries(kphp-full-runtime PUBLIC ${RUNTIME_LIBS})
 set_target_properties(kphp-full-runtime PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${OBJS_DIR})
 
 prepare_cross_platform_libs(RUNTIME_LINK_TEST_LIBS pcre nghttp2 kphp-timelib)
-set(RUNTIME_LINK_TEST_LIBS vk::flex_data_static OpenSSL::SSL mysqlclient numa ${CURL_LIB} ${RUNTIME_LINK_TEST_LIBS} ${EPOLL_SHIM_LIB} ${ICONV_LIB} ${RT_LIB})
+set(RUNTIME_LINK_TEST_LIBS vk::flex_data_static OpenSSL::SSL mysqlclient ${CURL_LIB} ${NUMA_LIB} ${RUNTIME_LINK_TEST_LIBS} ${EPOLL_SHIM_LIB} ${ICONV_LIB} ${RT_LIB})
 
 file(GLOB_RECURSE KPHP_RUNTIME_ALL_HEADERS
      RELATIVE ${BASE_DIR}

--- a/server/numa-configuration.cpp
+++ b/server/numa-configuration.cpp
@@ -1,0 +1,80 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include <algorithm>
+#include <cassert>
+#include <sched.h>
+
+#include "common/kprintf.h"
+#include "server/numa-configuration.h"
+#include "common/dl-utils-lite.h"
+
+
+bool NumaConfiguration::add_numa_node([[maybe_unused]] int numa_node_id, [[maybe_unused]] const bitmask *cpu_mask) {
+#if defined(__APPLE__)
+  return false;
+#else
+  assert(numa_available() == 0);
+
+  if (!inited) {
+    total_cpus = numa_num_configured_cpus();
+    total_numa_nodes = numa_num_configured_nodes();
+    numa_node_masks.resize(total_numa_nodes);
+    for (auto &mask : numa_node_masks) {
+      CPU_ZERO(&mask);
+    }
+    inited = true;
+  }
+
+  for (int cpu = 0; cpu < total_cpus; ++cpu) {
+    if (numa_bitmask_isbitset(cpu_mask, cpu)) {
+      int actual_numa_node = numa_node_of_cpu(cpu);
+      if (actual_numa_node != numa_node_id) {
+        kprintf("CPU #%d belongs to %d NUMA node, but %d is given\n", cpu, actual_numa_node, numa_node_id);
+        return false;
+      }
+      CPU_SET(cpu, &numa_node_masks[numa_node_id]);
+    }
+  }
+
+  numa_nodes.emplace_back(numa_node_id);
+  // remove duplicates:
+  std::sort(numa_nodes.begin(), numa_nodes.end());
+  numa_nodes.erase(std::unique( numa_nodes.begin(), numa_nodes.end() ), numa_nodes.end());
+  return true;
+#endif
+}
+
+void NumaConfiguration::distribute_worker([[maybe_unused]] int worker_index) const {
+#if !defined(__APPLE__)
+  assert(numa_available() == 0);
+
+  int numa_node_to_bind = numa_nodes[worker_index % numa_nodes.size()];
+  const auto *cpu_mask_to_bind = &numa_node_masks[numa_node_to_bind];
+
+  int res = sched_setaffinity(0, sizeof(cpu_set_t), cpu_mask_to_bind);
+  dl_passert(res != -1, "Can't bind worker to cpu");
+
+  switch (memory_policy) {
+    case MemoryPolicy::bind: {
+      auto *node_mask = numa_allocate_nodemask();
+      numa_bitmask_setbit(node_mask, numa_node_to_bind);
+      numa_set_membind(node_mask);
+      numa_free_nodemask(node_mask);
+      break;
+    }
+    case MemoryPolicy::local:
+      numa_set_localalloc(); // this is set by default, but let's set it here just in case
+      break;
+  }
+#endif
+}
+
+void NumaConfiguration::set_memory_policy(NumaConfiguration::MemoryPolicy policy) {
+  memory_policy = policy;
+}
+
+bool NumaConfiguration::enabled() const {
+  return inited;
+}

--- a/server/numa-configuration.h
+++ b/server/numa-configuration.h
@@ -4,11 +4,11 @@
 
 #if defined(__APPLE__)
 struct bitmask {};
+struct cpu_set_t {};
 #else
 #include <numa.h>
 #endif
 
-#include <map>
 #include <sched.h>
 #include <vector>
 
@@ -21,8 +21,10 @@ public:
 
   bool add_numa_node(int numa_node_id, const bitmask *cpu_mask);
   bool enabled() const;
+  int get_worker_numa_node(int worker_index) const;
   void distribute_worker(int worker_index) const;
   void set_memory_policy(MemoryPolicy policy);
+
 private:
   std::vector<int> numa_nodes;
   std::vector<cpu_set_t> numa_node_masks;
@@ -30,6 +32,8 @@ private:
   int total_cpus{0};
   int total_numa_nodes{0};
   bool inited{false};
+
+  void distribute_process(int numa_node_id, const cpu_set_t &cpu_mask) const;
 
   friend class vk::singleton<NumaConfiguration>;
 };

--- a/server/numa-configuration.h
+++ b/server/numa-configuration.h
@@ -1,0 +1,35 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#if defined(__APPLE__)
+struct bitmask {};
+#else
+#include <numa.h>
+#endif
+
+#include <map>
+#include <sched.h>
+#include <vector>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+
+class NumaConfiguration : vk::not_copyable {
+public:
+  enum class MemoryPolicy { local, bind };
+
+  bool add_numa_node(int numa_node_id, const bitmask *cpu_mask);
+  bool enabled() const;
+  void distribute_worker(int worker_index) const;
+  void set_memory_policy(MemoryPolicy policy);
+private:
+  std::vector<int> numa_nodes;
+  std::vector<cpu_set_t> numa_node_masks;
+  MemoryPolicy memory_policy;
+  int total_cpus{0};
+  int total_numa_nodes{0};
+  bool inited{false};
+
+  friend class vk::singleton<NumaConfiguration>;
+};

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1725,14 +1725,14 @@ int parse_numeric_option(const char *option_name, T min_value, T max_value, cons
   try {
     result = std::is_floating_point<T>{} ? static_cast<T>(std::stod(optarg)) : static_cast<T>(std::stoi(optarg));
   } catch (const std::exception &e) {
-    kprintf("--%s option: parse error: %s", option_name, e.what());
+    kprintf("--%s option: parse error: %s\n", option_name, e.what());
     return -1;
   }
   if (min_value <= result && result <= max_value) {
     setter(result);
     return 0;
   }
-  kprintf("--%s option: the argument value should be in [%s; %s]", option_name, std::to_string(min_value).c_str(), std::to_string(max_value).c_str());
+  kprintf("--%s option: the argument value should be in [%s; %s]\n", option_name, std::to_string(min_value).c_str(), std::to_string(max_value).c_str());
   return -1;
 }
 

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -56,6 +56,7 @@
 #include "server/php-engine-vars.h"
 #include "server/php-engine.h"
 #include "server/php-master-tl-handlers.h"
+#include "server/numa-configuration.h"
 #include "server/server-stats.h"
 #include "server/statshouse/add-metrics-batch.h"
 #include "server/statshouse/statshouse-client.h"
@@ -575,6 +576,11 @@ int run_worker(WorkerType worker_type) {
     if (getppid() != me->pid) {
       vkprintf(0, "parent is dead just after start\n");
       exit(123);
+    }
+
+    auto &numa = vk::singleton<NumaConfiguration>::get();
+    if (numa.enabled()) {
+      numa.distribute_worker(worker_unique_id);
     }
 
     // TODO should we just use net_reset_after_fork()?

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -5,6 +5,7 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         json-logger.cpp
         lease-config-parser.cpp
         lease-rpc-client.cpp
+        numa-configuration.cpp
         php-engine-vars.cpp
         php-engine.cpp
         php-lease.cpp


### PR DESCRIPTION
Here're 2 new options for kphp server:
- `--numa-node-to-bind '0: 0-7, 12-28'`
- `--numa-memory-policy bind`

Given these options, kphp master process will distribute workers among specified numa nodes, binding them to the corresponding CPU ranges and setting specified memory policy for them.

Implementation is based on [libnuma](https://manpages.debian.org/testing/libnuma-dev/numa.3.en.html).