### PR TITLE
Improved cpp17 support

### DIFF
--- a/common/algorithms/adjacent_find.h
+++ b/common/algorithms/adjacent_find.h
@@ -17,7 +17,7 @@ template<
   typename Iter, // ForwardIterator
   typename Proj, // value_type(Iter) -> T
   typename Cmp
-  = std::equal_to<std::result_of_t<Proj(typename std::iterator_traits<Iter>::reference)>>>
+  = std::equal_to<std::invoke_result_t<Proj, typename std::iterator_traits<Iter>::reference>>>
 Iter adjacent_find(Iter f, Iter l, Proj projector, Cmp cmp = Cmp()) {
   return std::adjacent_find(f, l, [&](const auto &lhs, const auto &rhs) { return cmp(projector(lhs), projector(rhs)); });
 }
@@ -35,7 +35,7 @@ template<
   typename Rng,
   typename Proj, // value_type(Rng) -> T
   typename Cmp
-  = std::equal_to<std::result_of_t<Proj(vk::range_value_type<Rng>)>>>
+  = std::equal_to<std::invoke_result_t<Proj, vk::range_value_type<Rng>>>>
 auto adjacent_find(Rng &&rng, Proj projector, Cmp cmp = Cmp()) {
   return vk::adjacent_find(std::begin(rng), std::end(rng), projector, cmp);
 }

--- a/common/algorithms/lower_bound.h
+++ b/common/algorithms/lower_bound.h
@@ -18,7 +18,7 @@ template<
   typename Proj, // value_type(Iter) -> U
   typename T,
   typename Cmp   // StrictWeakOrdering(U, U)
-  = std::less<typename std::result_of<Proj(typename std::iterator_traits<Iter>::reference)>::type>>
+  = std::less<typename std::invoke_result_t<Proj, typename std::iterator_traits<Iter>::reference>>>
 Iter lower_bound(Iter f, Iter l, const T &val, Proj projector, Cmp cmp = Cmp()) {
   return std::lower_bound(f, l, val, [&](const auto &lhs, const T &rhs) { return cmp(projector(lhs), rhs); });
 }
@@ -38,7 +38,7 @@ template<
   typename T,
   typename Proj, // value_type(Rng) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<typename std::result_of<Proj(vk::range_value_type<Rng>)>::type>>
+  = std::less<typename std::invoke_result_t<Proj, vk::range_value_type<Rng>>>>
 auto lower_bound(Rng &&rng, const T &val, Proj projector, Cmp cmp = Cmp()) -> decltype(std::begin(rng)) {
   return vk::lower_bound(std::begin(rng), std::end(rng), val, projector, cmp);
 }

--- a/common/algorithms/sort.h
+++ b/common/algorithms/sort.h
@@ -17,7 +17,7 @@ template<
   typename Iter, // RandomAccessIterator
   typename Proj, // value_type(Iter) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<std::result_of_t<Proj(typename std::iterator_traits<Iter>::reference)>>>
+  = std::less<std::invoke_result_t<Proj, typename std::iterator_traits<Iter>::reference>>>
 void sort(Iter f, Iter l, Proj projector, Cmp cmp = Cmp()) {
   return std::sort(f, l, [&](const auto &lhs, const auto &rhs) { return cmp(projector(lhs), projector(rhs)); });
 }
@@ -35,7 +35,7 @@ template<
   typename Rng,
   typename Proj, // value_type(Rng) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<std::result_of_t<Proj(vk::range_value_type<Rng>)>>>
+  = std::less<std::invoke_result_t<Proj, vk::range_value_type<Rng>>>>
 void sort(Rng &&rng, Proj projector, Cmp cmp = Cmp()) {
   return vk::sort(std::begin(rng), std::end(rng), projector, cmp);
 }

--- a/common/algorithms/stable_sort.h
+++ b/common/algorithms/stable_sort.h
@@ -17,7 +17,7 @@ template<
   typename Iter, // RandomAccessIterator
   typename Proj, // value_type(Iter) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<std::result_of_t<Proj(typename std::iterator_traits<Iter>::reference)>>>
+  = std::less<std::invoke_result_t<Proj, typename std::iterator_traits<Iter>::reference>>>
 void stable_sort(Iter f, Iter l, Proj projector, Cmp cmp = Cmp()) {
   return std::stable_sort(f, l, [&](const auto &lhs, const auto &rhs) { return cmp(projector(lhs), projector(rhs)); });
 }
@@ -35,7 +35,7 @@ template<
   typename Rng,
   typename Proj, // value_type(Rng) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<std::result_of_t<Proj(vk::range_value_type<Rng>)>>>
+  = std::less<std::invoke_result_t<Proj, vk::range_value_type<Rng>>>>
 void stable_sort(Rng &&rng, Proj projector, Cmp cmp = Cmp()) {
   return vk::stable_sort(std::begin(rng), std::end(rng), projector, cmp);
 }

--- a/common/algorithms/upper_bound.h
+++ b/common/algorithms/upper_bound.h
@@ -18,7 +18,7 @@ template<
   typename Proj, // value_type(Iter) -> U
   typename T,
   typename Cmp   // StrictWeakOrdering(U, U)
-  = std::less<typename std::result_of<Proj(typename std::iterator_traits<Iter>::reference)>::type>>
+  = std::less<typename std::invoke_result_t<Proj, typename std::iterator_traits<Iter>::reference>>>
 Iter upper_bound(Iter f, Iter l, const T &val, Proj projector, Cmp cmp = Cmp()) {
   return std::upper_bound(f, l, val, [&](const T &lhs, const auto &rhs) { return cmp(lhs, projector(rhs)); });
 }
@@ -38,7 +38,7 @@ template<
   typename T,
   typename Proj, // value_type(Rng) -> T
   typename Cmp   // StrictWeakOrdering(T, T)
-  = std::less<typename std::result_of<Proj(vk::range_value_type<Rng>)>::type>>
+  = std::less<typename std::invoke_result_t<Proj, vk::range_value_type<Rng>>>>
 auto upper_bound(Rng &&rng, const T &val, Proj projector, Cmp cmp = Cmp()) -> decltype(std::begin(rng)) {
   return vk::upper_bound(std::begin(rng), std::end(rng), val, projector, cmp);
 }

--- a/common/smart_iterators/transform_iterator.h
+++ b/common/smart_iterators/transform_iterator.h
@@ -19,7 +19,7 @@ private:
 public:
   using iterator_category = typename std::iterator_traits<Iterator>::iterator_category;
   using difference_type   = typename std::iterator_traits<Iterator>::difference_type;
-  using reference         = typename std::result_of<Mapper(typename std::iterator_traits<Iterator>::reference)>::type;
+  using reference         = typename std::invoke_result_t<Mapper, typename std::iterator_traits<Iterator>::reference>;
   using value_type        = typename std::remove_cv<typename std::remove_reference<reference>::type>::type;
   using pointer           = value_type *;
 

--- a/common/tl/store.h
+++ b/common/tl/store.h
@@ -134,7 +134,7 @@ size_t store_vector(bool store_size, Range &&range, Storer &&store_func = {}) {
       detail::good_for_raw_store<range_value_type<Range>>{} &&
       std::is_constructible<vk::span<const range_value_type<Range>>, Range &&>{}
     >{},
-    std::is_same<std::result_of_t<Storer(const range_value_type<Range> &)>, void>{});
+    std::is_same<std::invoke_result_t<Storer, const range_value_type<Range> &>, void>{});
 }
 
 } // namespace detail

--- a/common/wrappers/iterator_range.h
+++ b/common/wrappers/iterator_range.h
@@ -56,7 +56,7 @@ public:
   }
 
   iterator_range<std::reverse_iterator<iterator >> get_reversed_range() const {
-    return {m_end, m_begin};
+    return {std::make_reverse_iterator(m_end), std::make_reverse_iterator(m_begin)};
   }
 
   difference_type size() const {

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -659,7 +659,7 @@ array<T> f$array_filter_by_key(const array<T> &a, const T1 &callback) noexcept {
 }
 
 
-template<class T, class CallbackT, class R = typename std::result_of<std::decay_t<CallbackT>(T)>::type>
+template<class T, class CallbackT, class R = typename std::invoke_result_t<std::decay_t<CallbackT>, T>>
 array<R> f$array_map(const CallbackT &callback, const array<T> &a) {
   array<R> result(a.size());
   for (const auto &it : a) {
@@ -838,7 +838,7 @@ template<class T, class T1, class Proj>
 array<T> array_diff_impl(const array<T> &a1, const array<T1> &a2, const Proj &projector) {
   array<T> result(a1.size());
 
-  constexpr bool is_int_keys = std::is_same<std::result_of_t<Proj(T1)>, int64_t>::value;
+  constexpr bool is_int_keys = std::is_same<std::invoke_result_t<Proj, T1>, int64_t>::value;
   array<int64_t> values(array_size(is_int_keys * a2.count(), (!is_int_keys) * a2.count(), false));
 
   for (const auto &it : a2) {


### PR DESCRIPTION
- std::result_of replaced with std::invoke_result because result_of was deprecated in cpp 17