### PR TITLE
Multiple listening HTTP sockets

### DIFF
--- a/server/http-server-context.cpp
+++ b/server/http-server-context.cpp
@@ -1,0 +1,98 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "server/http-server-context.h"
+
+#include <sstream>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+#include "common/algorithms/string-algorithms.h"
+#include "common/dl-utils-lite.h"
+#include "common/kprintf.h"
+#include "net/net-socket.h"
+
+const std::vector<uint16_t> &HttpServerContext::http_ports() const noexcept {
+  return http_ports_;
+}
+
+const std::vector<int> &HttpServerContext::http_socket_fds() const noexcept {
+  return http_sfds_;
+}
+
+bool HttpServerContext::http_server_enabled() const noexcept {
+  return !http_ports_.empty();
+}
+
+bool HttpServerContext::init_from_option(const char *option) {
+  std::stringstream ss(option);
+  std::string segment;
+
+  while(std::getline(ss, segment, ',')) {
+    auto trimmed = vk::trim(segment);
+    int val = std::atoi(trimmed.data());
+    auto port = static_cast<uint16_t>(val);
+    if (port != val) {
+      kprintf("Incorrect port %d\n", val);
+      return false;
+    }
+    http_ports_.emplace_back(port);
+  }
+
+  // sort and remove duplicates:
+  std::sort(http_ports_.begin(), http_ports_.end());
+  http_ports_.erase(std::unique(http_ports_.begin(), http_ports_.end() ), http_ports_.end());
+
+  if (http_ports_.size() > MAX_HTTP_PORTS) {
+    kprintf("Can't listen more than %d HTTP ports\n", MAX_HTTP_PORTS);
+    return false;
+  }
+
+  return true;
+}
+
+bool HttpServerContext::master_create_http_sockets() {
+  http_sfds_.reserve(http_ports_.size());
+  for (auto port : http_ports_) {
+    int socket = server_socket(port, settings_addr, backlog, 0);
+    if (socket == -1) {
+      return false;
+    }
+    http_sfds_.emplace_back(socket);
+  }
+  return true;
+}
+
+void HttpServerContext::master_set_open_http_sockets(std::vector<int> &&open_http_sockets) {
+  dl_assert(open_http_sockets.size() == http_ports_.size(),
+            dl_pstr("Got inconsistent number of open http sockets. Expected %zu, but got %zu", http_ports_.size(), open_http_sockets.size()));
+  http_sfds_ = std::move(open_http_sockets);
+}
+
+void HttpServerContext::dedicate_http_socket_to_worker(uint16_t worker_unique_id) {
+  if (!http_server_enabled()) {
+    return;
+  }
+  cur_worker_socket_idx_ = worker_unique_id % http_sfds_.size();
+  for (int i = 0; i < http_sfds_.size(); ++i) {
+    if (i != cur_worker_socket_idx_) {
+      close(http_sfds_[i]);
+    }
+  }
+}
+
+int HttpServerContext::worker_http_socket_fd() const noexcept {
+  if (!http_server_enabled()) {
+    return -1;
+  }
+  return http_sfds_[cur_worker_socket_idx_];
+}
+
+int HttpServerContext::worker_http_port() const noexcept {
+  if (!http_server_enabled()) {
+    return -1;
+  }
+  return http_ports_[cur_worker_socket_idx_];
+}

--- a/server/http-server-context.h
+++ b/server/http-server-context.h
@@ -1,0 +1,38 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+
+class HttpServerContext : vk::not_copyable {
+public:
+ static constexpr int MAX_HTTP_PORTS = 64;
+
+ bool init_from_option(const char *option);
+ bool http_server_enabled() const noexcept;
+ const std::vector<uint16_t> &http_ports() const noexcept;
+ const std::vector<int> &http_socket_fds() const noexcept;
+
+ bool master_create_http_sockets();
+ void master_set_open_http_sockets(std::vector<int> &&http_sfds);
+
+ void dedicate_http_socket_to_worker(uint16_t worker_unique_id);
+ int worker_http_socket_fd() const noexcept;
+ int worker_http_port() const noexcept;
+
+private:
+  std::vector<uint16_t> http_ports_;
+  std::vector<int> http_sfds_;
+
+  int cur_worker_socket_idx_{-1};
+
+  HttpServerContext() = default;
+
+  friend class vk::singleton<HttpServerContext>;
+};

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -31,10 +31,6 @@ int run_once_return_code = 0;
 
 int die_on_fail = 0;
 
-/** http **/
-int http_port = -1;
-int http_sfd = -1;
-
 /** rpc **/
 int rpc_port = -1;
 int rpc_sfd = -1;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -40,10 +40,6 @@ extern int run_once_return_code;
 
 extern int die_on_fail;
 
-/** http **/
-extern int http_port;
-extern int http_sfd;
-
 /** rpc **/
 extern int rpc_port;
 extern int rpc_sfd;

--- a/server/php-master-restart.cpp
+++ b/server/php-master-restart.cpp
@@ -168,11 +168,11 @@ void master_init(master_data_t *me, master_data_t *other) {
   me->dying_http_workers_n = 0;
   me->to_kill = 0;
 
-  me->own_http_fd = 0;
-  me->http_fd_port = -1;
+  me->own_http_fds = 0;
+  me->http_ports_count = -1;
 
-  me->ask_http_fd_generation = 0;
-  me->sent_http_fd_generation = 0;
+  me->ask_http_fds_generation = 0;
+  me->sent_http_fds_generation = 0;
 
   me->instance_cache_elements_cached = 0;
 

--- a/server/php-master-restart.h
+++ b/server/php-master-restart.h
@@ -8,6 +8,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "server/http-server-context.h"
+
 //ATTENTION: do NOT change this structures without changing the magic
 #define SHARED_DATA_MAGIC 0x3b720002
 
@@ -26,14 +28,16 @@ struct master_data_t {
   int to_kill;
   long long to_kill_generation;
 
-  int own_http_fd;
-  int http_fd_port;
-  int ask_http_fd_generation;
-  int sent_http_fd_generation;
+  int own_http_fds;
+  int http_ports_count;
+  int ask_http_fds_generation;
+  int sent_http_fds_generation;
 
   uint32_t instance_cache_elements_cached;
 
-  int reserved[50 - 1];
+  uint16_t http_ports[HttpServerContext::MAX_HTTP_PORTS];
+
+  int reserved[50 - 1 - HttpServerContext::MAX_HTTP_PORTS / 2];
 };
 
 struct shared_data_t {

--- a/server/php-master.h
+++ b/server/php-master.h
@@ -7,4 +7,4 @@
 #include "net/net-connections.h"
 #include "server/workers-control.h"
 
-WorkerType start_master(int *http_fd, int (*try_get_http_fd)(), int http_fd_port);
+WorkerType start_master();

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -2,6 +2,7 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         cluster-name.cpp
         confdata-binlog-replay.cpp
         confdata-stats.cpp
+        http-server-context.cpp
         json-logger.cpp
         lease-config-parser.cpp
         lease-rpc-client.cpp

--- a/tests/python/lib/kphp_server.py
+++ b/tests/python/lib/kphp_server.py
@@ -68,15 +68,16 @@ class KphpServer(Engine):
         """
         return self._http_port
 
-    def http_request(self, uri='/', method='GET', **kwargs):
+    def http_request(self, uri='/', method='GET', http_port=None, **kwargs):
         """
         Послать запрос в kphp сервер
+        :param http_port: порт в который посылать, если их несколько
         :param uri: uri запроса
         :param method: метод запроса
         :param kwargs: дополнительные параметры, передаваемые в request
         :return: ответ на запрос
         """
-        return send_http_request(self._http_port, uri, method, **kwargs)
+        return send_http_request(self._http_port if http_port is None else http_port, uri, method, **kwargs)
 
     def http_post(self, uri='/', **kwargs):
         """

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -46,6 +46,8 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
         $res = 0;
     }
     echo json_encode(['len' => $res]);
+} else if ($_SERVER["PHP_SELF"] === "/pid") {
+    echo "pid=" . posix_getpid();
 } else {
   echo "Hello world!";
 }

--- a/tests/python/tests/http_server/test_multiple_http_ports.py
+++ b/tests/python/tests/http_server/test_multiple_http_ports.py
@@ -1,0 +1,40 @@
+from python.lib.testcase import KphpServerAutoTestCase
+from python.lib.port_generator import get_port
+
+
+class TestMultipleHttpPorts(KphpServerAutoTestCase):
+    WORKERS_NUM = 8
+    PORTS_NUM = 4
+    http_ports = [get_port() for _ in range(PORTS_NUM)]
+
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": cls.WORKERS_NUM,
+            "--http-port": ",".join([str(port) for port in cls.http_ports]),
+            "--verbosity-graceful-restart=1": True
+        })
+
+    def test_all_workers_working(self):
+        total_worked_pids = set()
+        for port in self.http_ports:
+            worked_pids = set()
+            for _ in range(20):
+                resp = self.kphp_server.http_request(uri="/pid", http_port=port)
+                self.assertEqual(resp.status_code, 200)
+                self.assertTrue(resp.text.startswith("pid="))
+                worked_pids.add(int(resp.text[4:]))
+            self.assertEqual(len(worked_pids), self.WORKERS_NUM / self.PORTS_NUM)
+            total_worked_pids.update(worked_pids)
+        self.assertEqual(len(total_worked_pids), self.WORKERS_NUM)
+
+    def test_sending_http_fds_on_graceful_restart(self):
+        self.kphp_server.start()
+        self.kphp_server.assert_log(
+            ["Graceful restart: http fds sent successfully",
+             "Graceful restart: http fds received successfully, got {} fds from old master".format(self.PORTS_NUM)],
+            timeout=5)
+        for port in self.http_ports:
+            resp = self.kphp_server.http_request(uri="/", http_port=port)
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.text, "Hello world!")


### PR DESCRIPTION
This change allows to pass several HTTP ports on server start. Master process will create listening socket for every port on start and then distribute each socket for each worker uniformly.

Graceful restart for several sockets is supported too. On graceful restart old master sends all corresponding open file descriptors to new master via unix socket with help of [SCM_RIGHTS](https://man7.org/linux/man-pages/man3/cmsg.3.html).