### PR TITLE
[compiler,runtime] fix intval() related issues

### DIFF
--- a/common/php-functions.h
+++ b/common/php-functions.h
@@ -6,6 +6,7 @@
 
 #include <climits>
 #include <cstring>
+#include <cctype>
 #include <limits>
 #include <type_traits>
 
@@ -89,6 +90,50 @@ int64_t string_hash(const char *p, size_t l) {
   return (result != std::numeric_limits<int64_t>::min()) * result;
 }
 
+inline bool php_is_numeric(const char *s) {
+  while (isspace(*s)) {
+    s++;
+  }
+
+  if (*s == '+' || *s == '-') {
+    s++;
+  }
+
+  int l = 0;
+  while (*s >= '0' && *s <= '9') {
+    l++;
+    s++;
+  }
+
+  if (*s == '.') {
+    s++;
+    while (*s >= '0' && *s <= '9') {
+      l++;
+      s++;
+    }
+  }
+
+  if (l == 0) {
+    return false;
+  }
+
+  if (*s == 'e' || *s == 'E') {
+    s++;
+    if (*s == '+' || *s == '-') {
+      s++;
+    }
+
+    if (*s == '\0') {
+      return false;
+    }
+
+    while (*s >= '0' && *s <= '9') {
+      s++;
+    }
+  }
+
+  return *s == '\0';
+}
 
 inline bool php_is_int(const char *s, size_t l) __attribute__ ((always_inline));
 

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -763,6 +763,10 @@ bool string::to_bool() const {
 }
 
 int64_t string::to_int(const char *s, size_type l) {
+  while (isspace(*s)) {
+    s++;
+  }
+
   int64_t mul = 1, cur = 0;
   if (l > 0 && (s[0] == '-' || s[0] == '+')) {
     if (s[0] == '-') {
@@ -873,49 +877,9 @@ bool string::is_numeric_as_php8() const {
 }
 
 bool string::is_numeric_as_php7() const {
-  const char *s = c_str();
-  while (isspace(*s)) {
-    s++;
-  }
-
-  if (*s == '+' || *s == '-') {
-    s++;
-  }
-
-  int l = 0;
-  while (*s >= '0' && *s <= '9') {
-    l++;
-    s++;
-  }
-
-  if (*s == '.') {
-    s++;
-    while (*s >= '0' && *s <= '9') {
-      l++;
-      s++;
-    }
-  }
-
-  if (l == 0) {
-    return false;
-  }
-
-  if (*s == 'e' || *s == 'E') {
-    s++;
-    if (*s == '+' || *s == '-') {
-      s++;
-    }
-
-    if (*s == '\0') {
-      return false;
-    }
-
-    while (*s >= '0' && *s <= '9') {
-      s++;
-    }
-  }
-
-  return *s == '\0';
+  // using default PHP7-based function;
+  // this function is also used by the compiler
+  return php_is_numeric(c_str());
 }
 
 bool string::is_numeric() const {

--- a/tests/phpt/regress/issue487/test.php
+++ b/tests/phpt/regress/issue487/test.php
@@ -1,0 +1,58 @@
+@ok
+<?php
+
+function test1($x) {
+  switch ($x) {
+  case '1':
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+function test2(string $s) {
+  switch ($s) {
+  case '5':
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+function test3(string $s) {
+  switch ($s) {
+  case ' 5':
+    return 1;
+  default:
+    return 0;
+  }
+}
+
+$values = [
+  1, 2, 5, 0, 10, 20,
+  '1', '2', '5', '0', '10', '20',
+];
+$all_values = [];
+foreach ($values as $x) {
+  $all_values[] = $x;
+  if (!is_string($x)) {
+    continue;
+  }
+  $all_values[] = "\n" . $x;
+  $all_values[] = $x . "\n";
+  $all_values[] = ' ' . $x;
+  $all_values[] = $x . ' ';
+  $all_values[] = '+' . $x;
+  $all_values[] = '-' . $x;
+  $all_values[] = ' +' . $x;
+  $all_values[] = ' -' . $x;
+  $all_values[] = ' +' . $x . ' ';
+  $all_values[] = ' -' . $x . ' ';
+}
+foreach ($all_values as $i => $x) {
+  echo "[$i] test1(`$x`) => " . test1($x) . "\n";
+  if (is_string($x)) {
+    echo "[$i] test2(`$x`) => " . test2((string)$x) . "\n";
+    echo "[$i] test3(`$x`) => " . test3((string)$x) . "\n";
+  }
+}

--- a/tests/phpt/regress/issue489/test.php
+++ b/tests/phpt/regress/issue489/test.php
@@ -1,0 +1,47 @@
+@ok
+<?php
+
+function test_string_index() {
+  $s = 'hello';
+  $indexes = [' 1', '+1', ' +1', '  +1', '    1', 1];
+  foreach ($indexes as $index) {
+    var_dump($s[$index]);
+  }
+}
+
+function test_intval($x) {
+  var_dump("`$x`: intval = " . intval($x));
+  var_dump("`$x`: intcast = " . (int)($x));
+}
+
+function test_array_key($x) {
+  $arr = [$x => 10];
+  $arr2 = [intval($x) => 10];
+  var_dump($arr);
+  var_dump($arr2);
+}
+
+test_string_index();
+
+$values = [
+  '1', '12439', '14a', '0x5', 'ab',
+  '0a', '00b', '00', '001',
+];
+$all_values = [];
+foreach ($values as $x) {
+  $all_values[] = $x;
+  $all_values[] = "\n" . $x;
+  $all_values[] = $x . "\n";
+  $all_values[] = ' ' . $x;
+  $all_values[] = $x . ' ';
+  $all_values[] = ' ' . $x . ' ';
+  $all_values[] = '  +' . $x . ' ';
+  $all_values[] = '  -' . $x . ' ';
+  $all_values[] = '+ ' . $x;
+  $all_values[] = '++ ' . $x;
+  $all_values[] = '+-' . $x;
+}
+foreach ($all_values as $x) {
+  test_intval($x);
+  test_array_key($x);
+}


### PR DESCRIPTION
* When compiling a switch, don't apply a string-only-cases
  optimization if any of the constant strings look like
  something that can be interpreted as a numeric string by PHP;
  this would lead to unexpected results like `" 1"` being matched
  by PHP with `case "1"`, but rejected by KPHP

* For string::to_int, that is supposed to implement `(int)$x` as
  well as `intval($x)` where `$x` is string-typed, skip leading
  whitespace to be consistent with PHP behavior

Fixes #487
Fixes #489