### PR TITLE
implement CompileTimeLocation (a parameter auto-filled on call side)

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1382,3 +1382,16 @@ final class FFI {
 
 // Get numa node number which current worker is bound to (see --numa-node-to-bind option) or -1 if no numa node is bound
 function numa_get_bound_node(): int;
+
+/**
+ * @kphp-immutable-class
+ */
+class CompileTimeLocation {
+  public string $file;
+  public string $function;
+  public int $line;
+
+  public function __construct($file, $function, $line) ::: CompileTimeLocation;
+
+  static public function calculate(?CompileTimeLocation $passed) ::: CompileTimeLocation;
+}

--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -444,11 +444,9 @@ VertexPtr GenTree::get_expr_top(bool was_arrow, const PhpDocComment *phpdoc) {
       if (cur_function->is_lambda()) {
         fun_name = "{closure}";
       } else if (!cur_function->is_main_function()) {
-        if (cur_class) {
-          fun_name = cur_class->name + "::" + cur_function->name.substr(cur_function->name.rfind('$') + 1);
-        } else {
-          fun_name = cur_function->name;
-        }
+        fun_name = cur_class
+                   ? cur_class->name + "::" + cur_function->name.substr(cur_function->name.rfind('$') + 1)
+                   : cur_function->name;
       }
       res = get_vertex_with_str_val(VertexAdaptor<op_string>{}, fun_name);
       next_cur();

--- a/compiler/pipes/check-func-calls-and-vararg.h
+++ b/compiler/pipes/check-func-calls-and-vararg.h
@@ -9,6 +9,10 @@
 
 class CheckFuncCallsAndVarargPass final : public FunctionPassBase {
   VertexAdaptor<op_func_call> process_varargs(VertexAdaptor<op_func_call> call, FunctionPtr f_called);
+  VertexPtr maybe_autofill_missing_call_arg(VertexAdaptor<op_func_call> call, FunctionPtr f_called, VertexAdaptor<op_func_param> param);
+  VertexAdaptor<op_func_call> add_call_arg(VertexPtr to_add, VertexAdaptor<op_func_call> call, bool prepend);
+
+  VertexPtr create_CompileTimeLocation_call_arg(const Location &call_location);
 
 public:
   std::string get_description() override {

--- a/runtime/exception.cpp
+++ b/runtime/exception.cpp
@@ -69,6 +69,17 @@ Error f$Error$$__construct(const Error &v$this, const string &message, int64_t c
   return v$this;
 }
 
+CompileTimeLocation f$CompileTimeLocation$$__construct(const CompileTimeLocation &v$this, const string &file, const string &function, int64_t line) {
+  v$this->$file = file;
+  v$this->$function = function;
+  v$this->$line = line;
+  return v$this;
+}
+
+CompileTimeLocation f$CompileTimeLocation$$calculate(const CompileTimeLocation &v$passed) {
+  return v$passed;
+}
+
 Exception new_Exception(const string &file, int64_t line, const string &message, int64_t code) {
   return __exception_set_location(f$Exception$$__construct(Exception().alloc(), message, code), file, line);
 }

--- a/runtime/exception.h
+++ b/runtime/exception.h
@@ -94,9 +94,20 @@ struct C$Error : public C$Throwable {
   const char *get_class() const noexcept override { return "Error"; }
 };
 
+struct C$CompileTimeLocation : public refcountable_php_classes<C$CompileTimeLocation> {
+  string $file;
+  string $function;
+  int64_t $line;
+
+  ~C$CompileTimeLocation() = default;
+
+  const char *get_class() const noexcept { return "CompileTimeLocation"; }
+};
+
 using Throwable = class_instance<C$Throwable>;
 using Exception = class_instance<C$Exception>;
 using Error = class_instance<C$Error>;
+using CompileTimeLocation = class_instance<C$CompileTimeLocation>;
 
 extern Throwable CurException;
 
@@ -129,6 +140,8 @@ void exception_initialize(const Throwable &e, const string &message, int64_t cod
 
 Exception f$Exception$$__construct(const Exception &v$this, const string &message = string(), int64_t code = 0);
 Error f$Error$$__construct(const Error &v$this, const string &message = string(), int64_t code = 0);
+CompileTimeLocation f$CompileTimeLocation$$__construct(const CompileTimeLocation &v$this, const string &file, const string &function, int64_t line);
+CompileTimeLocation f$CompileTimeLocation$$calculate(const CompileTimeLocation &v$passed);
 
 template<typename T>
 T __exception_set_location(const T &e, const string &file, int64_t line) {

--- a/tests/phpt/cl/197_compile_time_location.php
+++ b/tests/phpt/cl/197_compile_time_location.php
@@ -1,0 +1,72 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+function f(CompileTimeLocation $loc = null) {
+    $loc = CompileTimeLocation::calculate($loc);
+    $basename = basename($loc->file);
+    echo "f() called from ", $basename, ' ', $loc->function, ':', $loc->line, "\n";
+}
+
+function log_info(string $message, CompileTimeLocation $loc = null) {
+    $loc = CompileTimeLocation::calculate($loc);
+    $basename = basename($loc->file);
+    echo "$message (in {$loc->function} at {$basename}:{$loc->line})\n";
+}
+
+function my_log_more(string $message, ?CompileTimeLocation $loc = null) {
+    $loc = CompileTimeLocation::calculate($loc);
+    log_info("!!" . $message, $loc);
+}
+
+function demo1() {
+    f();
+    f();
+}
+
+class A {
+    static function demo2() {
+        f();
+    }
+
+    function demo3() {
+        f();
+    }
+}
+
+function demo4() {
+    (function() {
+        f();
+    })();
+}
+
+function demo5() {
+    log_info("start calculation");
+    $arr = [1,2,3,4,5];
+    foreach ($arr as $v) {
+        if ($v > 3)
+            log_info("big v=$v");
+    }
+    log_info("end calculation");
+}
+
+function demo6() {
+    my_log_more("start calculation");
+    $arr = [1,2,3,4,5];
+    foreach ($arr as $v) {
+        if ($v > 3)
+            my_log_more("big v=$v");
+    }
+    my_log_more("end calculation");
+}
+
+
+demo1();
+A::demo2();
+(new A)->demo3();
+demo4();
+f();
+demo5();
+demo6();
+my_log_more('end');

--- a/tests/phpt/cl/Classes/NamespaceTester.php
+++ b/tests/phpt/cl/Classes/NamespaceTester.php
@@ -22,4 +22,8 @@ class NamespaceTester {
     echo "__LINE__: |", __LINE__, "|\n";
     echo "__NAMESPACE__: |", __NAMESPACE__, "|\n";
   }
+
+  static public function test_loc_call_log_info() {
+    log_info("from NamespaceTester");
+  }
 }


### PR DESCRIPTION
`CompileTimeLocation` introduces an ability to access a location of a caller inside a called function.
In other words, from `function f()` body, now it's available have an exact place, where `f()` was called from.

For example, we want to implement `log_info($message)`, to be used like this
```
log_info("start calculation");
$arr = [1,2,3,4,5];
foreach ($arr as $v) {
  if ($v > 3) 
    log_info("big v=$v");
}
log_info("end calculation");
```

which would print a text log like
```
start calculation (in demo5 at dev.php:55)
big v=4 (in demo5 at dev.php:59)
big v=5 (in demo5 at dev.php:59)
end calculation (in demo5 at dev.php:61)
```

**Before this MR, it was impossible to achieve this.**
Now, `log_info()` can be implemented and looks quite trivial:
```
function log_info(string $message, CompileTimeLocation $loc = null) {
  $loc = CompileTimeLocation::calculate($loc);
  echo "$message (in {$loc->function} at {$loc->file}:{$loc->line})\n";
}
```

1) In PHP, it's polyfilled by calling `debug_backtrace` and creating `new CompileTimeLocation` assigning its fields from a trace (https://github.com/VKCOM/kphp-polyfills/pull/44)

2) In KPHP, it works at compile-time: KPHP inserts an implicit call parameter for every call:
```
log_info($s);
// is implicitly replaced to
log_info($s, new CompileTimeLocation(__RELATIVE_FILE__, __METHOD__, __LINE__));
```

It's very handy for logging/debugging purposes, cause now we are able to modify a function and get callers' locations — without modifying how a function is actually called.

By the way, one can easily wrap a logger function into another one, proxying a caller location:
```
function my_log(CompileTimeLocation $loc = null) {
  $loc = CompileTimeLocation::calculate($loc);
  ...
  generic_log($loc);
}
```
Here `my_log` proxies a location, so `general_log` prints out a location where a wrapper `my_log` is being called every time.
