### PR TITLE
add memory_get_allocations builtin KPHP function

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -181,6 +181,12 @@ function memory_get_total_usage() ::: int;
 function memory_get_static_usage() ::: int;
 function memory_get_detailed_stats() ::: int[];
 
+// memory_get_allocations returns a tuple of (num_allocations, memory_allocated)
+// the benefit of this function is that it can be used to measure the allocations
+// between two execution points: how many allocations happened and how much memory we allocated;
+// since it returns a tuple instead of array, it doesn't do any heap allocations on its own
+function memory_get_allocations() ::: tuple(int, int);
+
 function estimate_memory_usage($value ::: any) ::: int;
 // to enable this function, set KPHP_ENABLE_GLOBAL_VARS_MEMORY_STATS=1
 function get_global_vars_memory_stats($lower_bound ::: int = 0) ::: int[];

--- a/runtime/kphp_core.h
+++ b/runtime/kphp_core.h
@@ -477,6 +477,8 @@ inline int64_t f$memory_get_total_usage();
 
 inline array<int64_t> f$memory_get_detailed_stats();
 
+inline std::tuple<int64_t, int64_t> f$memory_get_allocations();
+
 template<class T>
 inline int64_t f$get_reference_counter(const array<T> &v);
 
@@ -1365,6 +1367,11 @@ array<int64_t> f$memory_get_detailed_stats() {
       std::make_pair(string{"small_memory_pieces"}, static_cast<int64_t>(stats.small_memory_pieces)),
       std::make_pair(string{"heap_memory_used"}, static_cast<int64_t>(dl::get_heap_memory_used()))
     });
+}
+
+std::tuple<int64_t, int64_t> f$memory_get_allocations() {
+  const auto &stats = dl::get_script_memory_stats();
+  return {stats.total_allocations, stats.total_memory_allocated};
 }
 
 

--- a/tests/phpt/memory_usage/9_memory_allocs.php
+++ b/tests/phpt/memory_usage/9_memory_allocs.php
@@ -1,0 +1,16 @@
+@ok
+<?php
+
+function f(int $x) {
+#ifndef KPHP
+  var_dump(1);
+  return [$x];
+#endif
+  [$num_allocs, ] = memory_get_allocations();
+  $arr = [$x];
+  [$new_num_allocs, ] = memory_get_allocations();
+  var_dump($new_num_allocs - $num_allocs);
+  return $arr;
+}
+
+var_dump(f(0));


### PR DESCRIPTION
memory_get_allocations returns a tuple of `(num_allocations, memory_allocated)`.

The benefit of this function is that it can be used to
measure the allocations between two execution points:
how many allocations happened and how much memory we allocated.

	[$old_num_allocs, $old_mem_allocated] = memory_get_allocations();
	do_something();
	[$new_num_allocs, $new_mem_allocated] = memory_get_allocations();
	$num_allocs = $new_num_allocs - $old_num_allocs;
	$mem_allocated = $new_mem_allocated - $old_mem_allocated;

This is especially useful in benchmarking (see ktest bench).

Since it returns a tuple instead of array,
it doesn't do any heap allocations on its own