### PR TITLE
use nocc for kphp tests, drop distcc

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -2,6 +2,9 @@
 <project version="4">
   <component name="CMakeWorkspace" PROJECT_DIR="$PROJECT_DIR$" />
   <component name="CidrRootsConfiguration">
+    <sourceRoots>
+      <file path="$PROJECT_DIR$/tests" />
+    </sourceRoots>
     <libraryRoots>
       <file path="$PROJECT_DIR$/third_party" />
     </libraryRoots>

--- a/docs/kphp-internals/kphp-architecture/internals-compiler.md
+++ b/docs/kphp-internals/kphp-architecture/internals-compiler.md
@@ -304,7 +304,7 @@ Each C++ file has `//crc64` and `//crc64_with_comments` at the very beginning. C
 
 Unless `--no-make` option is set, the compiling and linking process starts. 
 
-For every file that has to be recompiled, KPHP launches `KPHP_CXX` compiler (*g++* by default) with `KPHP_CXX_FLAGS`. For really huge projects, *distcc* can be set up for parallel compilation.  
+For every file that has to be recompiled, KPHP launches `KPHP_CXX` compiler (*g++* by default) with `KPHP_CXX_FLAGS`. For really huge projects, *nocc* can be set up for parallel compilation.  
 To link resulting object files, `KPHP_CXX` is also executed unless `KPHP_DYNAMIC_INCREMENTAL_LINKAGE` is set.  
 See [command-line options](../../kphp-language/kphp-vs-php/compiler-cmd-options.md) for more details. 
 

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -68,17 +68,6 @@ def gen_random_aes_key_file(directory):
     return key_file
 
 
-def read_distcc_hosts(distcc_hosts_file):
-    distcc_hosts = []
-    if distcc_hosts_file:
-        if not os.path.exists(distcc_hosts_file):
-            raise RuntimeError("Can't find distcc host list file '{}'".format(distcc_hosts_file))
-
-        with open(distcc_hosts_file, "r") as f:
-            distcc_hosts = f.readlines()
-    return distcc_hosts
-
-
 def error_can_be_ignored(ignore_patterns, binary_error_text):
     if not binary_error_text:
         return True
@@ -112,15 +101,6 @@ def can_ignore_sanitizer_log(sanitizer_log_file):
         os.remove(sanitizer_log_file)
 
     return ignore_sanitizer
-
-
-def make_distcc_env(distcc_hosts, distcc_dir):
-    os.makedirs(distcc_dir, exist_ok=True)
-    return {
-        "DISTCC_HOSTS": "--randomize localhost/1 {}".format(" ".join(distcc_hosts)),
-        "DISTCC_DIR": distcc_dir,
-        "DISTCC_LOG": os.path.join(distcc_dir, "distcc.log")
-    }
 
 
 def search_php_bin(php8_require=False):

--- a/tests/python/lib/kphp_run_once.py
+++ b/tests/python/lib/kphp_run_once.py
@@ -9,13 +9,13 @@ from .file_utils import error_can_be_ignored
 
 class KphpRunOnce(KphpBuilder):
     def __init__(self, php_script_path, artifacts_dir, working_dir, php_bin,
-                 extra_include_dirs=None, vkext_dir=None, distcc_hosts=None,use_clang=None):
+                 extra_include_dirs=None, vkext_dir=None, use_nocc=False, cxx_name="g++"):
         super(KphpRunOnce, self).__init__(
             php_script_path=php_script_path,
             artifacts_dir=artifacts_dir,
             working_dir=working_dir,
-            distcc_hosts=distcc_hosts,
-            use_clang=use_clang
+            use_nocc=use_nocc,
+            cxx_name=cxx_name,
         )
 
         self._php_stdout = None

--- a/tests/python/lib/nocc_for_kphp_tester.py
+++ b/tests/python/lib/nocc_for_kphp_tester.py
@@ -1,0 +1,48 @@
+import subprocess
+import os
+
+
+def nocc_env(nocc_env_name, default):
+    return os.getenv(nocc_env_name, default)
+
+
+def nocc_prepend_to_cxx(cxx_name):
+    return "{} {}".format(nocc_env('NOCC_EXECUTABLE', "nocc"), cxx_name)
+
+
+def nocc_make_env():
+    nocc_servers_filename = nocc_env('NOCC_SERVERS_FILENAME', None)
+    if nocc_servers_filename == "" or nocc_servers_filename is None:
+        raise RuntimeError("env NOCC_SERVERS_FILENAME not set")
+
+    return {
+        "NOCC_GO_EXECUTABLE": nocc_env('NOCC_GO_EXECUTABLE', "/usr/bin/nocc-daemon"),
+        "NOCC_SERVERS_FILENAME": nocc_servers_filename,
+        "NOCC_CLIENT_ID": "kphp-tester",
+        "NOCC_LOG_FILENAME": nocc_env('NOCC_LOG_FILENAME', "/tmp/nocc-kphp-tests.log"),
+        "NOCC_LOG_VERBOSITY": "1",
+        "NOCC_DISABLE_OBJ_CACHE": "1",
+    }
+
+
+# The first invocation of `nocc` automatically launches a daemon,
+# so that the end user doesn't have to do it manually.
+# However, whyever, python waits for that auto-launched daemon to quit:
+# probably, wait() waits not only for direct children, but for sub-subprocesses also.
+# So, this chain happens:
+# python launches one phpt -> kphp starts make -> `nocc` is launched -> `nocc-daemon` is launched once.
+# After that, this (the first) test becomes "hanging", python doesn't quit until a daemon dies (in 15 seconds after all tests are finished).
+# (when a daemon dies, that first test immediately becomes "accepted").
+#
+# To overcome this, we launch a daemon manually in advance, so that the first `nocc` invocation
+# already would connect to it, and no tests will have background subprocesses.
+# If a daemon quits in the middle of pipeline, it will be launched again by the next `nocc`,
+# and everything would still work, except that there will be a 15 sec hang after all tests finish.
+def nocc_start_daemon_in_background():
+    env = os.environ.copy()
+    env.update(nocc_make_env())
+
+    proc = subprocess.Popen(
+        [nocc_env('NOCC_EXECUTABLE', "nocc"), "start"],
+        env=env, stdout=subprocess.DEVNULL)
+    return proc

--- a/tests/python/tests/ffi/test_ffi.py
+++ b/tests/python/tests/ffi/test_ffi.py
@@ -6,6 +6,10 @@ import re
 from python.lib.testcase import KphpCompilerAutoTestCase
 
 class TestFFI(KphpCompilerAutoTestCase):
+    def should_use_nocc(self):
+        # compiling FFI tests needs special libs to be installed, whey aren't installed on nocc agents
+        return False
+
     def is_shared_lib_installed(self, name):
         if 'GITHUB_ACTIONS' in os.environ:
             return False

--- a/tests/python/tests/instance_cache/test_store_fetch_delete.py
+++ b/tests/python/tests/instance_cache/test_store_fetch_delete.py
@@ -26,6 +26,7 @@ class TestStoreFetchDelete(KphpServerAutoTestCase):
 
             stored_elements = i + 1
             if stored_elements % 300 == 0:
+                # todo this waits for 2 minutes, making this test too long; can we avoid this?
                 self.kphp_server.assert_stats(
                     initial_stats=stats_before,
                     timeout=120,


### PR DESCRIPTION
After merging this PR, nocc (instead of distcc) will be used to run kphp tests 
1) in vk.com private infrastructure 
2) when using `kphp-tester.py`

All changes to kphp-dockerfiles have already been made.

After merging, some changes in teamcity configuration calling `kphp_ci_pipeline_runner.py` would also be needed.