### PR TITLE
support 'object' keyword, which auto-converts a function into generics

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -321,7 +321,7 @@ function is_string ($v ::: mixed) ::: bool;
 function is_array ($v ::: any) ::: bool;
 function is_object ($v ::: any) ::: bool;
 function get_class ($v ::: any) ::: string;
-function get_hash_of_class ($klass ::: any) ::: int;
+function get_hash_of_class (object $klass) ::: int;
 function print_r ($v ::: any, $buffered ::: bool = false) ::: string;
 function var_export ($v ::: any, $buffered ::: bool = false) ::: string;
 function print ($v ::: string) ::: int;
@@ -1276,19 +1276,19 @@ function raise_sigsegv () ::: void;
 function make_clone ($x ::: any) ::: ^1;
 
 /** @kphp-extern-func-info cpp_template_call */
-function instance_cast($instance ::: any, $to_type ::: string) ::: instance<^2>;
+function instance_cast(object $instance, $to_type ::: string) ::: instance<^2>;
 
-function instance_to_array($instance ::: any, $with_class_names ::: bool = false) ::: mixed[];
+function instance_to_array(object $instance, $with_class_names ::: bool = false) ::: mixed[];
 function to_array_debug(any $instance, bool $with_class_names = false) ::: mixed[];
 
 /** Instance cache interface (like APC) **/
 /** @kphp-extern-func-info cpp_template_call */
 function instance_cache_fetch(string $type, string $key, bool $even_if_expired = false) ::: instance<^1>;
-function instance_cache_store(string $key, any $value, int $ttl = 0) ::: bool;
+function instance_cache_store(string $key, object $value, int $ttl = 0) ::: bool;
 function instance_cache_update_ttl(string $key, int $ttl = 0) ::: bool;
 function instance_cache_delete(string $key) ::: bool;
 
-function instance_serialize($instance ::: any) ::: string | null;
+function instance_serialize(object $instance) ::: string | null;
 /** @kphp-extern-func-info cpp_template_call */
 function instance_deserialize($serialized ::: string, $to_type ::: string) ::: instance<^2>;
 

--- a/compiler/data/generics-mixins.cpp
+++ b/compiler/data/generics-mixins.cpp
@@ -212,3 +212,15 @@ void GenericsDeclarationMixin::make_function_generics_on_callable_arg(FunctionPt
   const TypeHint *extends_hint_callable = TypeHintCallable::create_untyped_callable();
   f->generics_declaration->add_itemT(nameT, extends_hint_callable);
 }
+
+void GenericsDeclarationMixin::make_function_generics_on_object_arg(FunctionPtr f, VertexPtr func_param) {
+  if (!f->generics_declaration) {
+    f->generics_declaration = new GenericsDeclarationMixin();
+  }
+
+  std::string nameT = "Object" + std::to_string(f->generics_declaration->size() + 1);
+  func_param.as<op_func_param>()->type_hint = TypeHintGenericsT::create(nameT);
+
+  // add a <Cb1: object> rule
+  f->generics_declaration->add_itemT(nameT, TypeHintObject::create());
+}

--- a/compiler/data/generics-mixins.h
+++ b/compiler/data/generics-mixins.h
@@ -36,6 +36,7 @@ struct GenericsDeclarationMixin {
 
   static void apply_from_phpdoc(FunctionPtr f, const PhpDocComment *phpdoc);
   static void make_function_generics_on_callable_arg(FunctionPtr f, VertexPtr func_param);
+  static void make_function_generics_on_object_arg(FunctionPtr f, VertexPtr func_param);
 };
 
 // when we have `f<T1,T2>` and a call `f($o1,$o2)`, then it has call->instantiation_list set

--- a/compiler/inferring/primitive-type.cpp
+++ b/compiler/inferring/primitive-type.cpp
@@ -28,6 +28,7 @@ const char *ptype_name(PrimitiveType id) {
     case tp_future_queue:  return "future_queue";
     case tp_regexp:        return "regexp";
     case tp_Class:         return "Class";
+    case tp_object:        return "object";
     case tp_void:          return "void";
     case tp_Error:         return "Error";
     case ptype_size:       kphp_fail();
@@ -67,6 +68,9 @@ PrimitiveType type_lca(PrimitiveType a, PrimitiveType b) {
   }
 
   if (b >= tp_void) { // instances, future, etc — can mix only with false
+    if (a == tp_Class && b == tp_object) {
+      return tp_object;
+    }
     return tp_Error;
   }
 

--- a/compiler/inferring/primitive-type.h
+++ b/compiler/inferring/primitive-type.h
@@ -23,6 +23,7 @@ enum PrimitiveType {
   tp_future_queue,
   tp_regexp,
   tp_Class,
+  tp_object,
   tp_Error,
   ptype_size
 };

--- a/compiler/inferring/type-data.cpp
+++ b/compiler/inferring/type-data.cpp
@@ -761,6 +761,7 @@ int type_strlen(const TypeData *type) {
     case tp_mixed:
       return STRLEN_VAR;
     case tp_Class:
+    case tp_object:
       return STRLEN_CLASS;
     case tp_void:
       return STRLEN_VOID;
@@ -885,6 +886,8 @@ bool is_less_or_equal_type(const TypeData *given, const TypeData *expected, cons
           }
         }
         break;
+      case tp_object:
+        return tp == tp_Class || tp == tp_object;
       default:
         break;
     }

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -106,6 +106,8 @@ void TypeHintCallable::recalc_type_data_in_context_of_call(TypeData *dst, Vertex
     dst->set_lca(get_lambda_class()->type_data);
   } else {
     // the 'callable' keyword used in phpdoc/type declaration doesn't affect the type inference
+    // if used in param, like function f(callable $cb), f was auto-converted to generics, and 'callable' was dropped away
+    // this branch is reachable when 'callable' is used in @return or in @var, then it's treated like 'any' and replaced by an inferred lambda
   }
 }
 
@@ -195,6 +197,12 @@ void TypeHintPipe::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr 
 
 void TypeHintPrimitive::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call __attribute__ ((unused))) const {
   dst->set_lca(TypeData::get_type(ptype));
+}
+
+void TypeHintObject::recalc_type_data_in_context_of_call(TypeData *dst __attribute__ ((unused)), VertexPtr call __attribute__ ((unused))) const {
+  // 'object' keyword is allowed only in params of functions (it converts a function into a generics and is dropped away)
+//  kphp_error(0, "keyword 'object' is allowed only when declaring param of a function");
+  dst->set_lca(tp_object);
 }
 
 void TypeHintShape::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {

--- a/tests/phpt/class_inheritance/123_istanceof_fail.php
+++ b/tests/phpt/class_inheritance/123_istanceof_fail.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
-/left operand of 'instanceof' should be an instance, but passed int/
-/left operand of 'instanceof' should be an instance, but passed int/
+/pass int to argument \$instance of instance_cast/
+/but it's declared as @param object/
 <?php
 
 interface IBase {}

--- a/tests/phpt/instance_cache/4_instance_cache_non_instance_error.php
+++ b/tests/phpt/instance_cache/4_instance_cache_non_instance_error.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Called instance_cache_store\(\) with a non-instance argument/
+/pass int\[]\ to argument \$value of instance_cache_store/
 <?php
 
 instance_cache_store("key", [1, 2]);

--- a/tests/phpt/interfaces/125_instanceof_on_int_fail.php
+++ b/tests/phpt/interfaces/125_instanceof_on_int_fail.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/left operand of 'instanceof' should be an instance, but passed int/
+/pass int to argument \$instance of instance_cast/
 <?php
 
 class A { public $x = 10; }

--- a/tests/phpt/lambdas/131_fail_array_untyped_callable.php
+++ b/tests/phpt/lambdas/131_fail_array_untyped_callable.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/public \$arrCb = \[\];/
+/function ao\(\$arg\)/
+/Keywords 'callable' and 'object' have special treatment, they are not real types/
+<?php
+
+class CName {
+    /** @var callable[] */
+    public $arrCb = [];
+}
+
+new CName;
+
+/**
+ * @param tuple(object, int) $arg
+ */
+function ao($arg) {
+}
+
+ao(null);

--- a/tests/phpt/templates/008_object_keyword.php
+++ b/tests/phpt/templates/008_object_keyword.php
@@ -1,0 +1,78 @@
+@ok
+<?php
+
+class AMagic {
+    public string $magic = 'a';
+}
+class BMagic {
+    public string $magic = 'b';
+}
+
+function printMagic(object $arg) {
+    var_dump($arg->magic);
+    return $arg;
+}
+
+function demo1() {
+    $b = new BMagic;
+    $b->magic = '100b';
+    printMagic($b);
+
+    printMagic(new AMagic);
+}
+demo1();
+
+
+class AFiel {
+    public $fiel = 0;
+}
+
+class BFiel {
+    public $fiel = 1;
+}
+
+/**
+ * @kphp-template T $obj
+ * @kphp-return T
+ */
+function same(object $obj) {
+    return $obj;
+}
+
+function demoNestedTplInfer() {
+    $a = new AFiel;
+    $a1 = same($a);
+    $a2 = same($a1);
+    $a3 = same($a2);
+    $a1->fiel = 9;
+    echo $a->fiel;
+    echo $a1->fiel;
+    echo $a2->fiel;
+    echo $a3->fiel;
+    echo "\n";
+
+    $b = new BFiel;
+    same(same(same($b)))->fiel = 10;
+    echo same(same($b))->fiel;
+    echo "\n";
+}
+
+demoNestedTplInfer();
+
+class AStr {
+    function __toString() { return __CLASS__; }
+}
+class BStr {
+    function __toString() { return __CLASS__; }
+}
+
+class Stringer {
+    function myStr(object $i) {
+        echo $i, "\n";
+    }
+}
+
+$ss = new Stringer;
+$ss->myStr(new AStr);
+$ss->myStr(new BStr);
+


### PR DESCRIPTION
This PR brings some kind of support for the `object` keyword.
Like `callable`, it's not a real type, because there can't be "just any callable", likewise there can't be "just any object". Nevertheless, `object` keyword can be useful in various cases if is has special treatment.

## 1) `object` as a function parameter acts like `@kphp-template`
This:
```
function f(object $o) {
  $o->method();
}
```
Is now the same as
```
/** 
 * @kphp-template T
 * @kphp-param T $o
 */
function f($o) {
  $o->method();
}
```
Like `callable`, a standalone `object` implicitly converts a function into a template one.

## 2) `object` in `_functions.txt` means "any object"
For example, before this MR, `instanse_serialize()` was declared like this:
```
function instance_serialize($instance ::: any) ::: string | null;
```
Now, it's declared in this way:
```
function instance_serialize(object $instance) ::: string | null;
```
So, if passed not an instance, KPHP will fail on a compilation stage, not on gcc stage.

## 3) Better errors for using `callable`/`object` in a wrong way
For example, if one writes `/** @var callable[] */`, KPHP will give an error when applying this phpdoc. Before, it failed on gcc phase.

## 4) In future generics, `object` can be used as a "where" restriction
In a branch with generics, `function f(object $o)` will be converted to `function f<T:object>(T $o)`, which disallows passing primitives / arrays of objects / etc. to this function. The alternative syntax will also be available, since "object" is now a valid type hint.
```
/** 
 * @kphp-template T:object
 * @param T $o
 */
function f($o)
```