### PR TITLE
[compiler] merge typedefed pointers with external pointers

### DIFF
--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -275,7 +275,10 @@ bool is_php2c_valid(VertexAdaptor<op_ffi_php2c_conv> conv, const FFIType *ffi_ty
   auto php_expr = conv->expr();
 
   if (ffi_type->is_cstring()) {
-    return conv->simple_dst && php_type->ptype() == tp_string;
+    // auto casting from PHP string to `const char*` is allowed in simple contexts
+    if (conv->simple_dst && php_type->ptype() == tp_string) {
+      return true;
+    }
   }
 
   switch (ffi_type->kind) {

--- a/runtime/ffi.h
+++ b/runtime/ffi.h
@@ -343,8 +343,14 @@ inline const void* ffi_php2c(const string &v, ffi_tag<const void*>) { return v.c
 template<class T>
 auto ffi_php2c(class_instance<C$FFI$CData<T>> v, ffi_tag<C$FFI$CData<T>>) { return v->c_value; }
 
+inline const char* ffi_php2c(CDataPtr<char> v, ffi_tag<const char*>) { return v.c_value; }
+inline const char* ffi_php2c(CDataPtr<const char> v, ffi_tag<const char*>) { return v.c_value; }
+
 template<class T>
 void *ffi_php2c(CDataPtr<T> v, ffi_tag<void*>) { return v.c_value; }
+
+template<class T>
+const void *ffi_php2c(CDataPtr<T> v, ffi_tag<const void*>) { return v.c_value; }
 
 template<class T>
 const void *ffi_php2c(CDataPtr<const T> v, ffi_tag<const void*>) { return v.c_value; }
@@ -354,6 +360,9 @@ T* ffi_php2c(CDataPtr<T> v, ffi_tag<C$FFI$CData<T*>>) { return v.c_value; }
 
 template<class T>
 const T* ffi_php2c(CDataPtr<T> v, ffi_tag<C$FFI$CData<const T*>>) { return v.c_value; }
+
+template<class T>
+const T* ffi_php2c(CDataPtr<const T> v, ffi_tag<C$FFI$CData<const T*>>) { return v.c_value; }
 
 // this is a special overloading for things like php2c(null);
 // note: we compile op_null as Optional<bool>{}

--- a/tests/python/tests/ffi/c/pointers.c
+++ b/tests/python/tests/ffi/c/pointers.c
@@ -27,6 +27,10 @@ int64_t read_int64(const int64_t *ptr) {
   return *ptr;
 }
 
+int64_t read_int64_from_void(const void *ptr) {
+  return *(const int64_t*)ptr;
+}
+
 int64_t* read_int64p(int64_t **ptr) {
   return *ptr;
 }
@@ -53,4 +57,15 @@ int void_strlen(const void *s) {
 
 void cstr_out_param(const char **out) {
   *out = "example result";
+}
+
+void set_void_ptr(void **dst, void *ptr) {
+  *dst = ptr;
+}
+
+int strlen_safe(const char *s) {
+  if (s == NULL) {
+    return 0;
+  }
+  return strlen(s);
 }

--- a/tests/python/tests/ffi/c/pointers.h
+++ b/tests/python/tests/ffi/c/pointers.h
@@ -3,6 +3,8 @@
 
 typedef struct SomeData { void *_opaque; } SomeData;
 
+typedef void *VoidPtr;
+
 // Declaring with void argument on purpose.
 SomeData *nullptr_data(void);
 
@@ -15,6 +17,7 @@ uint64_t voidptr_addr_value(void *ptr);
 
 void write_int64(int64_t *dst, int64_t value);
 int64_t read_int64(const int64_t *ptr);
+int64_t read_int64_from_void(const void *ptr);
 int64_t* read_int64p(int64_t **ptr);
 
 uint8_t bytes_array_get(uint8_t *arr, int offset);
@@ -24,4 +27,8 @@ void* ptr_to_void(void *ptr);
 const void* ptr_to_const_void(const void *ptr);
 int void_strlen(const void *s);
 
+void set_void_ptr(VoidPtr *dst, void *ptr);
+
 void cstr_out_param(const char **out);
+
+int strlen_safe(const char *s);

--- a/tests/python/tests/ffi/php/pointer/null_as_ptr.php
+++ b/tests/python/tests/ffi/php/pointer/null_as_ptr.php
@@ -17,7 +17,17 @@ function test2($ptr) {
   var_dump($lib->voidptr_addr_value($ptr) === 0);
 }
 
+function test3() {
+  $lib = FFI::scope('pointers');
+  var_dump($lib->strlen_safe(null));
+  $ptr1 = FFI::new('char *');
+  $ptr2 = FFI::new('const char*');
+  var_dump($lib->strlen_safe($ptr1));
+  var_dump($lib->strlen_safe($ptr2));
+}
+
 test();
 test2(null);
 $null_var = null;
 test2($null_var);
+test3();

--- a/tests/python/tests/ffi/php/pointer/ptr2.php
+++ b/tests/python/tests/ffi/php/pointer/ptr2.php
@@ -56,6 +56,16 @@ function test2() {
     var_dump($u64->cdata);
 }
 
+function test3() {
+  $lib = FFI::scope('pointers');
+  $i64 = $lib->new('int64_t');
+  $i64->cdata = 240;
+  $voidptr = $lib->new('VoidPtr');
+  $lib->set_void_ptr(FFI::addr($voidptr), FFI::addr($i64));
+  var_dump($lib->read_int64_from_void($voidptr));
+}
+
 test();
 test2();
 test_ptr2_out_param();
+test3();


### PR DESCRIPTION
Here is an example:

	typedef void *VoidPtr;
	void f(VoidPtr *x);

`x` type should be a pointer with elem type of `void` and `num`:

	Pointer{Elem: Void, Num: 2}

But before this patch, we generated this:

	Pointer{Elem: Pointer{Elem: Void, Num: 1}, Num: 1}

This caused the typechecker to treat these two as incompatible:

	VoidPtr* vs void**

This patch also includes a fix that makes all `T*` compatible with `const T*`.