### PR TITLE
[compiler] add hrtime() and microtime() specializations

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -349,12 +349,22 @@ function getdate ($timestamp ::: int = PHP_INT_MIN) ::: mixed[];
 function gmdate ($format ::: string, $timestamp ::: int = PHP_INT_MIN) ::: string;
 function gmmktime ($h ::: int = PHP_INT_MIN, $m ::: int = PHP_INT_MIN, $s ::: int = PHP_INT_MIN, $month ::: int = PHP_INT_MIN, $day ::: int = PHP_INT_MIN, $year ::: int = PHP_INT_MIN) ::: int;
 function localtime ($timestamp ::: int = PHP_INT_MIN, $is_associative ::: bool = false) ::: mixed[];
-function microtime ($get_as_float ::: bool = false) ::: mixed;//TODO
+function microtime ($get_as_float ::: bool = false) ::: mixed;
 function mktime ($h ::: int = PHP_INT_MIN, $m ::: int = PHP_INT_MIN, $s ::: int = PHP_INT_MIN, $month ::: int = PHP_INT_MIN, $day ::: int = PHP_INT_MIN, $year ::: int = PHP_INT_MIN) ::: int;
 function strftime ($format ::: string, $timestamp ::: int = PHP_INT_MIN) ::: string;
 function strtotime ($time ::: string, $timestamp ::: int = PHP_INT_MIN) ::: int | false;
 function time() ::: int;
-function hrtime (bool $as_number = false): mixed; // array|int
+function hrtime (bool $as_number = false): mixed; // int[]|int
+
+// microtime(false) specialization
+function microtime_string () : string;
+// microtime(true) specialization
+function microtime_float () : float;
+
+// hrtime(true) specialization
+function hrtime_int () : int;
+// hrtime(false) specialization
+function hrtime_array () : int[];
 
 function debug_backtrace() ::: string[][];
 function posix_getpid() ::: int;

--- a/compiler/pipes/check-func-calls-and-vararg.h
+++ b/compiler/pipes/check-func-calls-and-vararg.h
@@ -14,6 +14,8 @@ class CheckFuncCallsAndVarargPass final : public FunctionPassBase {
 
   VertexPtr create_CompileTimeLocation_call_arg(const Location &call_location);
 
+  VertexAdaptor<op_func_call> maybe_replace_extern_func_call(VertexAdaptor<op_func_call> call, FunctionPtr f_called);
+
 public:
   std::string get_description() override {
     return "Check func calls and vararg";

--- a/runtime/datetime.cpp
+++ b/runtime/datetime.cpp
@@ -512,6 +512,9 @@ mixed f$microtime(bool get_as_float) {
   }
 }
 
+double f$microtime_float() { return microtime(); }
+string f$microtime_string() { return microtime_string(); }
+
 int64_t f$mktime(int64_t h, int64_t m, int64_t s, int64_t month, int64_t day, int64_t year) {
   tm t;
   time_t timestamp_t = time(nullptr);
@@ -573,16 +576,27 @@ int64_t f$time() {
   return time(nullptr);
 }
 
-mixed f$hrtime(bool as_number) {
+int64_t hrtime_int() {
+  return std::chrono::steady_clock::now().time_since_epoch().count();
+}
+
+array<int64_t> hrtime_array() {
   auto since_epoch = std::chrono::steady_clock::now().time_since_epoch();
-  if (as_number) {
-    return since_epoch.count();
-  }
-  return array<mixed>::create(
+  return array<int64_t>::create(
     std::chrono::duration_cast<std::chrono::seconds>(since_epoch).count(),
     std::chrono::nanoseconds{since_epoch % std::chrono::seconds{1}}.count()
   );
 }
+
+mixed f$hrtime(bool as_number) {
+  if (as_number) {
+    return hrtime_int();
+  }
+  return hrtime_array();
+}
+
+array<int64_t> f$hrtime_array() { return hrtime_array(); }
+int64_t f$hrtime_int() { return hrtime_int(); }
 
 void init_datetime_lib() {
   dl::enter_critical_section();//OK

--- a/runtime/datetime.h
+++ b/runtime/datetime.h
@@ -32,6 +32,8 @@ double microtime_monotonic();
 double microtime();
 
 mixed f$microtime(bool get_as_float = false);
+string f$microtime_string();
+double f$microtime_float();
 
 int64_t f$mktime(int64_t h = std::numeric_limits<int64_t>::min(),
                  int64_t m = std::numeric_limits<int64_t>::min(),
@@ -47,5 +49,7 @@ Optional<int64_t> f$strtotime(const string &time_str, int64_t timestamp = std::n
 int64_t f$time();
 
 mixed f$hrtime(bool as_number = false);
+array<int64_t> f$hrtime_array();
+int64_t f$hrtime_int();
 
 void init_datetime_lib();

--- a/tests/phpt/func_specializations/hrtime.php
+++ b/tests/phpt/func_specializations/hrtime.php
@@ -1,0 +1,34 @@
+@ok
+<?php
+
+function ensure_int(int $x) {}
+
+/** @param int[] $x */
+function ensure_array($x) {}
+
+const HRTIME_AS_INT = true;
+const HRTIME_AS_ARRAY = false;
+
+function test() {
+  ensure_int(hrtime(true));
+  ensure_int(hrtime(HRTIME_AS_INT));
+  ensure_array(hrtime(false));
+  ensure_array(hrtime(HRTIME_AS_ARRAY));
+  ensure_array(hrtime());
+
+  $int_time = hrtime(true);
+  ensure_int($int_time);
+
+  $array_time = hrtime();
+  ensure_array($array_time);
+  $array_time = hrtime(false);
+  ensure_array($array_time);
+
+  $as_int = [false, true];
+  foreach ($as_int as $arg) {
+    $mixed_time = hrtime($arg);
+    var_dump(gettype($mixed_time));
+  }
+}
+
+test();

--- a/tests/phpt/func_specializations/hrtime_error1.php
+++ b/tests/phpt/func_specializations/hrtime_error1.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_array/
+<?php
+
+/** @param int[] $x */
+function ensure_array($x) {}
+
+function test() {
+  $as_int = true;
+  ensure_array(hrtime($as_int));
+}
+
+test();

--- a/tests/phpt/func_specializations/hrtime_error2.php
+++ b/tests/phpt/func_specializations/hrtime_error2.php
@@ -1,0 +1,12 @@
+@kphp_should_fail
+/pass int to argument \$x of ensure_array/
+<?php
+
+/** @param int[] $x */
+function ensure_array($x) {}
+
+function test() {
+  ensure_array(hrtime(true));
+}
+
+test();

--- a/tests/phpt/func_specializations/microtime.php
+++ b/tests/phpt/func_specializations/microtime.php
@@ -1,0 +1,33 @@
+@ok
+<?php
+
+function ensure_float(float $x) {}
+
+function ensure_string(string $x) {}
+
+const MICROTIME_AS_FLOAT = true;
+const MICROTIME_AS_STRING = false;
+
+function test() {
+  ensure_float(microtime(true));
+  ensure_float(microtime(MICROTIME_AS_FLOAT));
+  ensure_string(microtime(false));
+  ensure_string(microtime(MICROTIME_AS_STRING));
+  ensure_string(microtime());
+
+  $float_time = microtime(true);
+  ensure_float($float_time);
+
+  $string_time = microtime();
+  ensure_string($string_time);
+  $string_time = microtime(false);
+  ensure_string($string_time);
+
+  $as_float = [false, true];
+  foreach ($as_float as $arg) {
+    $mixed_time = microtime($arg);
+    var_dump(gettype($mixed_time));
+  }
+}
+
+test();

--- a/tests/phpt/func_specializations/microtime_error1.php
+++ b/tests/phpt/func_specializations/microtime_error1.php
@@ -1,0 +1,12 @@
+@kphp_should_fail
+/pass mixed to argument \$x of ensure_string/
+<?php
+
+function ensure_string(string $x) {}
+
+function test() {
+  $as_float = true;
+  ensure_string(microtime($as_float));
+}
+
+test();

--- a/tests/phpt/func_specializations/microtime_error2.php
+++ b/tests/phpt/func_specializations/microtime_error2.php
@@ -1,0 +1,11 @@
+@kphp_should_fail
+/pass float to argument \$x of ensure_string/
+<?php
+
+function ensure_string(string $x) {}
+
+function test() {
+  ensure_string(microtime(true));
+}
+
+test();


### PR DESCRIPTION
This is a port of #251 PR without more problematic regexp
function specializations and refactoring.
preg functions will be ported separately as they require
more unrelated changes to be applied.

In addition to microtime, this patch includes hrtime which
is now generally available as KPHP min PHP version is 7.4 now.

	microtime() -> microtime_string()
	microtime(false) -> microtime_string()
	microtime(true) -> microtime_float()

	hrtime() -> hrtime_array()
	hrtime(false) -> hrtime_array()
	hrtime(true) -> hrtime_int()

The main idea is to get less mixed-typed values in the code
that uses functions those return value type depends on its arguments.