### PR TITLE
[runtime] make shutdown funcs called even after a timeout

### DIFF
--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -52,6 +52,8 @@ void f$fastcgi_finish_request(int64_t exit_code = 0);
 __attribute__((noreturn))
 void finish(int64_t exit_code, bool allow_forks_waiting);
 
+void run_shutdown_functions();
+
 __attribute__((noreturn))
 void f$exit(const mixed &v = 0);
 

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -601,6 +601,10 @@ void init_handlers() {
   dl_signal(SIGABRT, sigabrt_handler);
 }
 
+void php_script_run_shutdown_functions() {
+  run_shutdown_functions();
+}
+
 void php_script_finish(void *ptr) {
   ((PHPScriptBase *)ptr)->finish();
 }

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -56,6 +56,7 @@ extern long long query_stats_id;
 void dump_query_stats();
 
 void init_handlers();
+void php_script_run_shutdown_functions();
 void php_script_finish(void *ptr);
 void php_script_free(void *ptr);
 void php_script_clear(void *ptr);


### PR DESCRIPTION
The most challenging part is that timeout is catched in a signal
handler of the running coroutine (run_context) which then
changes the state of the worker and switches the context to exit_context.
Running the shutdown handlers inside the run_context before switching it
is dangerous as arbitrary PHP code is not guaranteed to be safe for
the signal handling context.

If we run these shutdown handlers inside of the worker context,
we may suffer from the `exit()` calls done inside of the shutdown
functions that may cause us to attempt switching the context again
and entering a `finished` state instead of the `error` state we were in.

As a solution to this problem, we use a setjmp+longjmp to implement
our recovery from the `exit()` when running shutdown functions.

We only call shutdown handlers for timeout errors for now.
Executing shutdown handlers should not be a problem for some error
kinds, but some of them are more challenging (like memory limit errors).

Fixes #504