### PR TITLE
[runtime] make shutdown funcs called even after a timeout

### DIFF
--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -14,6 +14,11 @@
 extern string_buffer *coub;//TODO static
 using shutdown_function_type = std::function<void()>;
 
+enum class shutdown_functions_status {
+  not_executed,
+  running,
+  running_from_timeout,
+};
 
 void f$ob_clean();
 
@@ -42,6 +47,12 @@ array<string> f$headers_list();
 void f$setcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);
 
 void f$setrawcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);
+
+void run_shutdown_functions_from_timeout();
+void run_shutdown_functions_from_script();
+
+int get_shutdown_functions_count();
+shutdown_functions_status get_shutdown_functions_status();
 
 void f$register_shutdown_function(const shutdown_function_type &f);
 

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -1050,6 +1050,10 @@ void finish_script(int exit_code __attribute__((unused))) {
   assert (0);
 }
 
+void reset_script_timeout() {
+  PHPScriptBase::current_script->reset_script_timeout();
+}
+
 double get_net_time() {
   return PHPScriptBase::current_script->get_net_time();
 }

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -305,6 +305,7 @@ int mc_connect_to(const char *host_name, int port);
 void mc_run_query(int host_num, const char *request, int request_len, int timeout_ms, int query_type, void (*callback)(const char *result, int result_len)) ubsan_supp("alignment");
 int db_proxy_connect();
 void db_run_query(int host_num, const char *request, int request_len, int timeout_ms, void (*callback)(const char *result, int result_len));
+void reset_script_timeout();
 double get_net_time();
 double get_script_time();
 int get_net_queries_count();

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <csetjmp>
+
 #include "common/dl-utils-lite.h"
 #include "common/sanitizer.h"
 
@@ -86,6 +88,8 @@ private:
 #endif
   int swapcontext_helper(ucontext_t_portable *oucp, const ucontext_t_portable *ucp);
 
+  void on_request_timeout_error();
+
 public:
 
   static PHPScriptBase *volatile current_script;
@@ -101,6 +105,8 @@ public:
   char *run_stack, *protected_end, *run_stack_end, *run_mem;
   size_t mem_size, stack_size;
   ucontext_t_portable run_context;
+
+  sigjmp_buf timeout_handler;
 
   script_t *run_main;
   php_query_data *data;
@@ -118,6 +124,8 @@ public:
   virtual ~PHPScriptBase();
 
   void init(script_t *script, php_query_data *data_to_set);
+
+  void asan_stack_unpoison();
 
   //in php script
   void pause();
@@ -137,6 +145,7 @@ public:
   void update_net_time();
   void update_script_time();
 
+  void reset_script_timeout();
   double get_net_time() const;
   double get_script_time();
   int get_net_queries_count() const;

--- a/tests/phpt/shutdown_functions/throw_error1.php
+++ b/tests/phpt/shutdown_functions/throw_error1.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/register_shutdown_callback should not throw exceptions/
+<?php
+
+/** @kphp-required */
+function throwing_func() {
+  throw new Exception('BAD');
+}
+
+register_shutdown_function('throwing_func');

--- a/tests/phpt/shutdown_functions/throw_error2.php
+++ b/tests/phpt/shutdown_functions/throw_error2.php
@@ -1,0 +1,7 @@
+@kphp_should_fail
+/register_shutdown_callback should not throw exceptions/
+<?php
+
+register_shutdown_function(function () {
+  throw new Exception('BAD');
+});

--- a/tests/phpt/shutdown_functions/throw_error3.php
+++ b/tests/phpt/shutdown_functions/throw_error3.php
@@ -1,0 +1,13 @@
+@kphp_should_fail
+/register_shutdown_callback should not throw exceptions/
+<?php
+
+function may_throw(bool $cond) {
+  if ($cond) {
+    throw new Exception('BAD');
+  }
+}
+
+register_shutdown_function(function () {
+  may_throw(false);
+});

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -1,0 +1,152 @@
+<?php
+
+class ServerException extends Exception {}
+
+function may_throw(bool $cond, string $msg) {
+  if ($cond) {
+    throw new Exception($msg);
+  }
+}
+
+/** @kphp-required */
+function shutdown_exception_warning() {
+  $msg = "running shutdown handler";
+  try {
+    // make KPHP generate exception-aware call that will check the
+    // CurException variable; it should be empty even if it had some
+    // exceptions before shutdown functions were executed
+    may_throw(false, "exception from shutdown handler");
+  } catch (Throwable $e) {
+    $msg = "unexpected exception in shutdown handler";
+  }
+  warning($msg);
+}
+
+/** @kphp-required */
+function shutdown_after_long_work() {
+  // unless the timer resets to 0 before this function is executed, it will not
+  // manage to finish successfully
+  do_sleep(0.75);
+  warning("shutdown function managed to finish");
+}
+
+/** @kphp-required */
+function shutdown_endless_loop() {
+  while (true) {}
+}
+
+/** @kphp-required */
+function shutdown_with_exit1() {
+  warning("running shutdown handler 1");
+  exit(0);
+}
+
+/** @kphp-required */
+function shutdown_with_exit2() {
+  warning("running shutdown handler 2");
+}
+
+/** @kphp-required */
+function shutdown_critical_error() {
+  warning("running shutdown handler critical errors");
+  critical_error("critical error from shutdown function");
+}
+
+/** @kphp-required */
+function shutdown_fork_wait() {
+  warning("before fork");
+  $resp_future = fork(forked_func(42));
+  warning("after fork");
+  while (!wait_concurrently($resp_future)) {}
+  warning("after wait");
+}
+
+function forked_func(int $i): int {
+  warning("before yield");
+  sched_yield_sleep(0.5); // wait net
+  warning("after yield");
+  return $i;
+}
+
+function do_sleep(float $seconds) {
+  usleep((int)(1000000 * $seconds));
+}
+
+function do_register_shutdown_function(string $fn) {
+  switch ($fn) {
+    case "shutdown_exception_warning":
+      register_shutdown_function("shutdown_exception_warning");
+      break;
+    case "shutdown_after_long_work":
+      register_shutdown_function("shutdown_after_long_work");
+      break;
+    case "shutdown_endless_loop":
+      register_shutdown_function("shutdown_endless_loop");
+      break;
+    case "shutdown_with_exit":
+      register_shutdown_function("shutdown_with_exit1");
+      register_shutdown_function("shutdown_with_exit2");
+      break;
+    case "shutdown_critical_error":
+      register_shutdown_function("shutdown_critical_error");
+      break;
+    case "shutdown_fork_wait":
+      register_shutdown_function("shutdown_fork_wait");
+      break;
+  }
+}
+
+function do_sigsegv() {
+  raise_sigsegv();
+}
+
+function do_exception(string $message, int $code) {
+  throw new ServerException($message, $code);
+}
+
+function do_stack_overflow(int $x): int {
+  $z = 10;
+  if ($x) {
+    $y = do_stack_overflow($x + 1);
+    $z = $y + 1;
+  }
+  $z += do_stack_overflow($x + $z);
+  return $z;
+}
+
+function do_long_work(int $duration) {
+  $s = time();
+  while(time() - $s <= $duration) {
+  }
+}
+
+function main() {
+  foreach (json_decode(file_get_contents('php://input')) as $action) {
+    switch ($action["op"]) {
+      case "sigsegv":
+        do_sigsegv();
+        break;
+      case "exception":
+        do_exception((string)$action["msg"], (int)$action["code"]);
+        break;
+      case "stack_overflow":
+        do_stack_overflow(1);
+        break;
+      case "long_work":
+        do_long_work((int)$action["duration"]);
+        break;
+      case "sleep":
+        do_sleep((float)$action["duration"]);
+        break;
+      case "register_shutdown_function":
+        do_register_shutdown_function((string)$action["msg"]);
+        break;
+      default:
+        echo "unknown operation";
+        return;
+    }
+  }
+  echo "ok";
+}
+
+main();

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions.py
@@ -1,0 +1,24 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestShutdownFunctions(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+
+    def test_fork_wait(self):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_fork_wait"},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.assertEqual(resp.status_code, 200)
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "env": "", "msg": "before fork", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "env": "", "msg": "after fork", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "env": "", "msg": "before yield", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "env": "", "msg": "after yield", "tags": {"uncaught": False}},
+                {"version": 0, "type": 2, "env": "", "msg": "after wait", "tags": {"uncaught": False}},
+            ],
+            timeout=5)

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
@@ -1,0 +1,21 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestShutdownFunctionsErrors(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+
+    def test_critical_error(self):
+        # with self.assertRaises(RuntimeError):
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_critical_error"},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler critical errors", "tags": {"uncaught": False}},
+                {"version": 0, "type": 1, "env": "", "msg": "critical error from shutdown function", "tags": {"uncaught": True}},
+            ])

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_exceptions.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_exceptions.py
@@ -1,0 +1,27 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestShutdownFunctionsExceptions(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+
+    def test_exception_shutdown_function(self):
+        # test that:
+        # 1. we execute shutdown functions after the "uncaught exception" critical error
+        # 2. that CurException is not visible inside shutdown functions
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_exception_warning"},
+                {"op": "exception", "msg": "hello", "code": 123},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[
+                {
+                    "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
+                    "msg": "Unhandled ServerException from index.php:\\d+; Error 123; Message: hello",
+                },
+                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler", "tags": {"uncaught": False}},
+            ])

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -1,0 +1,61 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.ignore_log_errors()
+        cls.kphp_server.update_options({
+            "--time-limit": 1
+        })
+
+    def test_timeout_reset_at_shutdown_function(self):
+        # test that the timeout timer resets, giving the shutdown functions a chance to complete
+        # if they're executed *before* the timeout but after a long-running script
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_after_long_work"},
+                {"op": "sleep", "duration": 0.75},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.assertEqual(resp.status_code, 200)
+        self.kphp_server.assert_json_log(
+            expect=[{"version": 0, "type": 2, "env": "", "msg": "shutdown function managed to finish", "tags": {"uncaught": False}}],
+            timeout=5)
+
+    def test_timeout_shutdown_exit(self):
+        # test that if we're doing an exit(0) in shutdown handler *after* the timeout
+        # that request will still end up in error state with 500 status code
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_with_exit"},
+                {"op": "long_work", "duration": 2}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[
+                {
+                    "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
+                    "msg": "Maximum execution time exceeded",
+                },
+                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler 1", "tags": {"uncaught": False}},
+            ],
+            timeout=5)
+
+    def test_timeout_after_timeout_at_shutdown_function(self):
+        # test that we do set up a second timeout for the shutdown functions
+        # that were executed *after* the (first) timeout
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_endless_loop"},
+                {"op": "long_work", "duration": 2}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_json_log(
+            expect=[{
+                "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
+                "msg": "Maximum execution time exceeded",
+            }],
+            timeout=5)


### PR DESCRIPTION
This is an alternative implementation that implements shutdown functions during the timeout in the script context.

See also: #517 

----

The most challenging part is that timeout is catched in a signal
handler of the running coroutine (run_context) which then
changes the state of the worker and switches the context to exit_context.
Running the shutdown handlers inside the run_context before switching it
is dangerous as arbitrary PHP code is not guaranteed to be safe for
the signal handling context.

If we run these shutdown handlers inside of the worker context,
we may suffer from the `exit()` calls done inside of the shutdown
functions that may cause us to attempt switching the context again
and entering a `finished` state instead of the `error` state we were in.

As a solution to this problem, we use a setjmp+longjmp to implement
our recovery from the `exit()` when running shutdown functions.

We only call shutdown handlers for timeout errors for now.
Executing shutdown handlers should not be a problem for some error
kinds, but some of them are more challenging (like memory limit errors).

Fixes #504