### PR TITLE
[vkext] fix TL RPC type name generating in case of 'Maybe long' in generic parameters

### DIFF
--- a/vkext/vk_zend.h
+++ b/vkext/vk_zend.h
@@ -177,7 +177,10 @@ static zend_always_inline zend_class_entry *vk_get_class(const char *class_name)
   zend_string *zend_str_class_name = zend_string_init(class_name, strlen(class_name), 0);
   zend_class_entry *res_class_entry = zend_lookup_class(zend_str_class_name);
   zend_string_release(zend_str_class_name);
-  assert(res_class_entry);
+  if (!res_class_entry) {
+    fprintf(stderr, "Class '%s' not found\n", class_name);
+    assert(res_class_entry);
+  }
   return res_class_entry;
 }
 

--- a/vkext/vkext-schema-memcache.cpp
+++ b/vkext/vkext-schema-memcache.cpp
@@ -417,8 +417,7 @@ int get_full_tree_type_name(char *dst, struct tl_tree_type *tree, const char *co
       // 1) Optional<T::PhpType> -- Maybe_T::PhpType
       // 2) T::PhpType          -- T::PhpType
       struct tl_tree_type *child = (struct tl_tree_type *)tree->children[0];
-      if (is_php_array(child->type) || cur_type->name == TL_INT || cur_type->name == TL_DOUBLE || cur_type->name == TL_FLOAT || cur_type->name == TL_STRING
-                                    || cur_type->name == TL_LONG) {
+      if (is_php_array(child->type) || vk::any_of_equal(child->type->name, TL_INT, TL_DOUBLE, TL_FLOAT, TL_STRING, TL_LONG)) {
         // php_field_type::t_int    || php_field_type::t_double
         // php_field_type::t_string || php_field_type::t_array
         dst += make_tl_class_name(dst, "", "maybe", "", '\0');


### PR DESCRIPTION
Fix bug on deserializing of types with `Maybe <primitive>` in generic parameters (something like `Pair (Maybe long) int`)

relates to `KPHP-1448`