### PR TITLE
[runtime] move 0xc0+0x80 utf8 to a separate method + add a comment

### DIFF
--- a/runtime/regexp.h
+++ b/runtime/regexp.h
@@ -71,6 +71,8 @@ private:
 
   void check_pattern_compilation_warning() const noexcept;
 
+  int64_t skip_utf8_subsequent_bytes(int64_t offset, const string &subject) const noexcept;
+
 public:
   regexp() = default;
 


### PR DESCRIPTION
Also used a while loop instead of `do while`.
The extra offset+1 is performed at the call site, since it
has nothing to do with utf8 subsequent bytes.

This is a part of many patches that we need to apply to make
regexp code at least a little bit more maintainable.