### PR TITLE
forbid unpacking an argument to a non-variadic param with implicit cast

### DIFF
--- a/compiler/pipes/check-func-calls-and-vararg.cpp
+++ b/compiler/pipes/check-func-calls-and-vararg.cpp
@@ -284,6 +284,8 @@ VertexPtr CheckFuncCallsAndVarargPass::on_func_call(VertexAdaptor<op_func_call> 
 
     if (call_arg->type() == op_varg) {
       kphp_error(f->has_variadic_param, "Unpacking an argument to a non-variadic param");
+    } else if (auto conv = call_arg.try_as<op_conv_array>(); conv && conv->expr()->type() == op_varg) {
+      kphp_error(f->has_variadic_param, "Unpacking an argument to a non-variadic param");
     }
   }
 

--- a/tests/phpt/variadic_args/112_unpack_non_variadic_fail.php
+++ b/tests/phpt/variadic_args/112_unpack_non_variadic_fail.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/Unpacking an argument to a non-variadic param/
+<?php
+
+function f($a ::: array) {
+}
+f(...[[1, 2]]);
+


### PR DESCRIPTION
Added a check that fails compilation with correct error message for such code:
```
function f($a ::: array) {
}
f(...[[1, 2]]);
```
instead of weird crash.