### PR TITLE
print more info to stdout when running tests under GitHub actions

### DIFF
--- a/tests/python/lib/kphp_run_once.py
+++ b/tests/python/lib/kphp_run_once.py
@@ -79,7 +79,10 @@ class KphpRunOnce(KphpBuilder):
         self._php_stdout, php_stderr = self._wait_proc(php_proc)
 
         if php_stderr:
-            self._move_to_artifacts("php_stderr", php_proc.returncode, content=php_stderr)
+            if 'GITHUB_ACTIONS' in os.environ:
+                print("php_stderr: " + str(php_stderr))
+            else:
+                self._move_to_artifacts("php_stderr", php_proc.returncode, content=php_stderr)
 
         if not os.listdir(self._php_tmp_dir):
             shutil.rmtree(self._php_tmp_dir, ignore_errors=True)
@@ -131,5 +134,9 @@ class KphpRunOnce(KphpBuilder):
 
         with open(diff_artifact.file, 'wb') as f:
             subprocess.call(["diff", "--text", "-ud", php_stdout_file, kphp_server_stdout_file], stdout=f)
+            if 'GITHUB_ACTIONS' in os.environ:
+                # just open and read the file - it's easier than messing with popen, etc.
+                with open(diff_artifact.file, 'r') as f:
+                    print('diff: ' + f.read())
 
         return False


### PR DESCRIPTION
When running tests in GitHub actions, we can't normally download
the artifacts that would include PHP-vs-KPHP diff or other
useful output to debug what's going wrong.

We already have `GITHUB_ACTIONS` environment set to 1 when
running the tests there, so we can print relevant info to stdout
when running under GitHub actions.