### PR TITLE
striping indent of heredoc string

### DIFF
--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -36,6 +36,7 @@ std::string debugTokenName(TokenType t) {
     {tok_str, "tok_str"},
     {tok_str_begin, "tok_str_begin"},
     {tok_str_end, "tok_str_end"},
+    {tok_str_skip_indent, "tok_str_skip_indent"},
     {tok_expr_begin, "tok_expr_begin"},
     {tok_expr_end, "tok_expr_end"},
     {tok_var_name, "tok_var_name"},

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -14,6 +14,7 @@
 
 #include "common/algorithms/find.h"
 #include "common/smart_ptrs/singleton.h"
+#include "common/wrappers/fmt_format.h"
 
 #include "compiler/stage.h"
 #include "compiler/threading/thread-id.h"
@@ -124,6 +125,28 @@ bool LexerData::are_last_tokens(except_token_tag<token>, Args ...args) {
          are_last_tokens(args...);
 }
 
+vk::string_view LexerData::strip_whitespaces(std::size_t spaces_to_skip, vk::string_view source) noexcept {
+  kphp_assert(spaces_to_skip);
+  std::string val;
+  bool new_line = true;
+  std::size_t spaces_skipped = 0;
+  for (char c : source) {
+    if (new_line && c == ' ' && spaces_skipped < spaces_to_skip) {
+      ++spaces_skipped;
+      continue;
+    } else if (c == '\n') {
+      new_line = true;
+      spaces_skipped = 0;
+    } else {
+      stage::set_line(get_line_num());
+      kphp_error(spaces_skipped >= spaces_to_skip,
+                 fmt_format("Invalid body indentation level (expecting an indentation level of at least {})", spaces_to_skip));
+      new_line = false;
+    }
+    val.append(1, c);
+  }
+  return string_view_dup(val);
+}
 
 void LexerData::hack_last_tokens() {
   if (dont_hack_last_tokens) {
@@ -208,8 +231,12 @@ void LexerData::hack_last_tokens() {
   }
 
   if (are_last_tokens(tok_str_begin, tok_str, tok_str_end)) {
+    const std::size_t spaces_to_skip = tokens.back().str_val.size();
     tokens.pop_back();
     tokens.erase(std::prev(tokens.end(), 2));
+    if (spaces_to_skip) {
+      tokens.back().str_val = strip_whitespaces(spaces_to_skip, tokens.back().str_val);
+    }
     return;
   }
 
@@ -882,6 +909,9 @@ bool TokenLexerHeredocString::parse(LexerData *lexer_data) const {
     const char *t = s, *st = s;
     if (t[0] == '\n' || first) {
       t += t[0] == '\n';
+      const char *const spaces_start = t;
+      std::size_t spaces_count = 0;
+      for (; *t == ' '; ++spaces_count, ++t) {}
       if (!strncmp(t, tag.c_str(), tag.size())) {
         t += tag.size();
 
@@ -892,7 +922,7 @@ bool TokenLexerHeredocString::parse(LexerData *lexer_data) const {
         }
         if (t[0] == '\n' || t[0] == 0) {
           if (!single_quote) {
-            lexer_data->add_token((int)(t - st - semicolon), tok_str_end);
+            lexer_data->add_token((int)(t - st - semicolon), tok_str_end, spaces_start, spaces_start + spaces_count);
           } else {
             lexer_data->flush_str();
             lexer_data->pass_raw((int)(t - st - semicolon));;

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -47,7 +47,7 @@ struct LexerData : private vk::not_copyable {
   int get_line_num();
 
 private:
-  vk::string_view strip_whitespaces(std::size_t spaces_to_skip, vk::string_view source) noexcept;
+  vk::string_view strip_whitespaces(char space_char, std::size_t spaces_to_skip, vk::string_view source) noexcept;
 
   int line_num{0};
   const char *code{nullptr};

--- a/compiler/lexer.h
+++ b/compiler/lexer.h
@@ -47,6 +47,8 @@ struct LexerData : private vk::not_copyable {
   int get_line_num();
 
 private:
+  vk::string_view strip_whitespaces(std::size_t spaces_to_skip, vk::string_view source) noexcept;
+
   int line_num{0};
   const char *code{nullptr};
   const char *code_end{nullptr};

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -19,6 +19,7 @@ enum TokenType {
   tok_str,
   tok_str_begin,
   tok_str_end,
+  tok_str_skip_indent,
   tok_expr_begin,
   tok_expr_end,
   tok_var_name,

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -172,12 +172,18 @@ TEST(lexer_test, test_heredoc_string_skip_spaces) {
     {"<<<END\n a\nEND;", " a"},
     {"<<<END\n  a\nEND;", "  a"},
     {"<<<END\n  a\n\nEND;", "  a\n"},
-    // with indent
+    // with space indent
     {"<<<END\n a\n END;", "a"},
     {"<<<END\n  a\n END;", " a"},
     {"<<<END\n  a\n  END;", "a"},
     {"<<<END\n  a\n\n END;", " a\n"},
     {"<<<END\n  a\n\n  END;", "a\n"},
+    // with tab indent
+    {"<<<END\n\ta\n\tEND;", "a"},
+    {"<<<END\n\t\ta\n\tEND;", "\ta"},
+    {"<<<END\n\t\ta\n\t\tEND;", "a"},
+    {"<<<END\n\t\ta\n\n\tEND;", "\ta\n"},
+    {"<<<END\n\t\ta\n\n\t\tEND;", "a\n"},
     // few lanes
     {"<<<END\n a\n b\nEND;", " a\n b"},
     {"<<<END\n a\n b\n END;", "a\nb"},
@@ -189,14 +195,12 @@ TEST(lexer_test, test_heredoc_string_skip_spaces) {
     {"<<<END\n  a\n  \nEND;", "  a\n  "},
     {"<<<END\n  a\n  \n\nEND;", "  a\n  \n"},
     {"<<<END\n  a\n  \n \nEND;", "  a\n  \n "},
-
     {"<<<END\n  a\n \n END;", " a\n"},
     {"<<<END\n  a\n  \n END;", " a\n "},
     {"<<<END\n  a\n  \n\n END;", " a\n \n"},
     {"<<<END\n  a\n  \n \n END;", " a\n \n"},
     {"<<<END\n  a\n\n \n END;", " a\n\n"},
     {"<<<END\n   a\n \n   END;", "a\n"},
-
     {"<<<END\n  a\n \n  END;", "a\n"},
     {"<<<END\n  a\n  \n  END;", "a\n"},
     {"<<<END\n  a\n  \n\n  END;", "a\n\n"},

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -184,6 +184,12 @@ TEST(lexer_test, test_heredoc_string_skip_spaces) {
     {"<<<END\n\t\ta\n\t\tEND;", "a"},
     {"<<<END\n\t\ta\n\n\tEND;", "\ta\n"},
     {"<<<END\n\t\ta\n\n\t\tEND;", "a\n"},
+    // nowdoc
+    {"<<<'END'\n a\n END;", "a"},
+    {"<<<'END'\n  a\n END;", " a"},
+    {"<<<'END'\n  a\n  END;", "a"},
+    {"<<<'END'\n  a\n\n END;", " a\n"},
+    {"<<<'END'\n  a\n\n  END;", "a\n"},
     // few lanes
     {"<<<END\n a\n b\nEND;", " a\n b"},
     {"<<<END\n a\n b\n END;", "a\nb"},

--- a/tests/phpt/dl/1038_heredoc_strip_indent.php
+++ b/tests/phpt/dl/1038_heredoc_strip_indent.php
@@ -1,0 +1,40 @@
+@ok
+<?php
+
+echo <<<END
+  a
+END;
+
+echo <<<END
+  a
+ END;
+
+echo <<<END
+  a
+  END;
+
+echo <<<END
+  a
+ b
+END;
+
+echo <<<END
+  a
+ b
+ END;
+
+echo <<<END
+ a
+ b
+ END;
+
+echo <<<END
+  a
+  b
+  END;
+
+echo <<<END
+      a
+    b
+   c
+   END;

--- a/tests/phpt/dl/1038_heredoc_strip_indent.php
+++ b/tests/phpt/dl/1038_heredoc_strip_indent.php
@@ -1,6 +1,7 @@
 @ok
 <?php
 
+function strip_indent_space() {
 echo <<<END
   a
 END;
@@ -34,7 +35,61 @@ echo <<<END
   END;
 
 echo <<<END
+  	a
+  		b
+  END;
+
+echo <<<END
       a
     b
    c
    END;
+}
+
+function strip_indent_tabs() {
+echo <<<END
+		a
+END;
+
+echo <<<END
+		a
+	END;
+
+echo <<<END
+		a
+		END;
+
+echo <<<END
+		a
+	b
+END;
+
+echo <<<END
+		a
+	b
+	END;
+
+echo <<<END
+	a
+	b
+	END;
+
+echo <<<END
+		a
+		b
+		END;
+
+echo <<<END
+		 a
+		  b
+		END;
+
+echo <<<END
+						a
+				b
+			c
+			END;
+}
+
+strip_indent_space();
+strip_indent_tabs();

--- a/tests/phpt/dl/1038_heredoc_strip_indent.php
+++ b/tests/phpt/dl/1038_heredoc_strip_indent.php
@@ -1,7 +1,7 @@
 @ok
 <?php
 
-function strip_indent_space() {
+function test_strip_indent_space() {
 echo <<<END
   a
 END;
@@ -46,7 +46,7 @@ echo <<<END
    END;
 }
 
-function strip_indent_tabs() {
+function test_strip_indent_tabs() {
 echo <<<END
 		a
 END;
@@ -91,5 +91,51 @@ echo <<<END
 			END;
 }
 
-strip_indent_space();
-strip_indent_tabs();
+function test_strip_indent_nowdoc() {
+echo <<<'END'
+  a
+END;
+
+echo <<<'END'
+  a
+ END;
+
+echo <<<'END'
+  a
+  END;
+
+echo <<<'END'
+  a
+ b
+END;
+
+echo <<<'END'
+  a
+ b
+ END;
+
+echo <<<'END'
+ a
+ b
+ END;
+
+echo <<<'END'
+  a
+  b
+  END;
+
+echo <<<'END'
+  	a
+  		b
+  END;
+
+echo <<<'END'
+      a
+    b
+   c
+   END;
+}
+
+test_strip_indent_space();
+test_strip_indent_tabs();
+test_strip_indent_nowdoc();

--- a/tests/phpt/dl/1039_heredoc_invalid_indent.php
+++ b/tests/phpt/dl/1039_heredoc_invalid_indent.php
@@ -1,0 +1,25 @@
+@kphp_should_fail
+/Invalid body indentation level \(expecting an indentation level of at least 1\)/
+/Invalid body indentation level \(expecting an indentation level of at least 2\)/
+/Invalid body indentation level \(expecting an indentation level of at least 3\)/
+/Invalid body indentation level \(expecting an indentation level of at least 4\)/
+<?php
+
+echo <<<END
+a
+ END;
+
+echo <<<END
+ a
+  END;
+
+echo <<<END
+  b
+   a
+   END;
+
+echo <<<END
+    b
+   a
+    END;
+

--- a/tests/phpt/dl/1039_heredoc_invalid_indent.php
+++ b/tests/phpt/dl/1039_heredoc_invalid_indent.php
@@ -3,6 +3,13 @@
 /Invalid body indentation level \(expecting an indentation level of at least 2\)/
 /Invalid body indentation level \(expecting an indentation level of at least 3\)/
 /Invalid body indentation level \(expecting an indentation level of at least 4\)/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
+/Invalid indentation \- tabs and spaces cannot be mixed/
 <?php
 
 echo <<<END
@@ -22,4 +29,33 @@ echo <<<END
     b
    a
     END;
+
+// mix tabs and spaces below
+echo <<<END
+  a
+ 	END;
+
+echo <<<END
+  a
+	 END;
+
+echo <<<END
+	 a
+		END;
+
+echo <<<END
+ 	a
+		END;
+
+echo <<<END
+ 	a
+  END;
+
+echo <<<END
+	 a
+  END;
+
+echo <<<END
+		a
+  END;
 


### PR DESCRIPTION
Add support of php 7.3.0 striping indent of heredoc and nowdoc string feature: the closing identifier may be indented by space or tab, in which case the indentation will be stripped from all lines in the doc string.