### PR TITLE
[runtime] preserve tl_flag value when resetting the timeout timer

### DIFF
--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -90,6 +90,8 @@ private:
 
   void on_request_timeout_error();
 
+  void assert_state(run_state_t expected);
+
 public:
 
   static PHPScriptBase *volatile current_script;


### PR DESCRIPTION
There are 2 situations when timeout timer is reset:

	1. When shutdown functions are being executed before
	   the timeout timer triggered

	2. When timeout timer already triggered and we're running
	   shutdown functions from the timeout context

For (2), we start from the SIGALRM handler and set `tl_flag` to `true`.
This meant that any attempt to do a TL RPC request would cause
a script to forcefully enter the timeout state.

We used `php_script_set_timeout` function to reset the timer in both
cases. It has a side effect of setting `tl_flag` to `false`.
This made it possible to enter the unexpected state when timeout
is already happened, but `tl_flag` is false instead of true.
While it could be useful to run TL RPC queries after the timeout
inside shutdown functions, we need to fix the worker `finish_time`
before that first, otherwise there are several things that can go wrong.

As a temporary fix, we keep the `tl_flag` value for both cases now.
Shutdown functions will still run after the timeout, but they will
bail out whenever they'll try to do a RPC query that goes through the `check_tl()`.
We may find a way to remove this restriction later.