### PR TITLE
[runtime] permit `$offset` argument of `preg_match_all`

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -406,7 +406,7 @@ define('PREG_SPLIT_DELIM_CAPTURE', 16);
 define('PREG_SPLIT_OFFSET_CAPTURE', 32);
 
 function preg_match ($regex ::: regexp, $subject ::: string, &$matches ::: mixed = TODO, $flags ::: int = 0, $offset ::: int = 0) ::: int | false;//TODO
-function preg_match_all ($regex ::: regexp, $subject ::: string, &$matches ::: mixed = TODO, $flags ::: int = 0) ::: int | false;//TODO
+function preg_match_all ($regex ::: regexp, $subject ::: string, &$matches ::: mixed = TODO, $flags ::: int = 0, $offset ::: int = 0) ::: int | false;//TODO
 function preg_replace ($regex ::: regexp, $replace_val, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: ^3|string|null|false;
 function preg_replace_callback ($regex ::: regexp, callable(string[] $x):string $callback, $subject, $limit ::: int = -1, &$replace_count ::: int = TODO) ::: ^3|string|null;
 function preg_quote ($str ::: string, $delimiter ::: string = '') ::: string;

--- a/runtime/regexp.h
+++ b/runtime/regexp.h
@@ -116,7 +116,7 @@ inline Optional<int64_t> f$preg_match_all(const regexp &regex, const string &sub
 
 inline Optional<int64_t> f$preg_match(const regexp &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
-inline Optional<int64_t> f$preg_match_all(const regexp &regex, const string &subject, mixed &matches, int64_t flags);
+inline Optional<int64_t> f$preg_match_all(const regexp &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
 inline Optional<int64_t> f$preg_match(const string &regex, const string &subject);
 
@@ -128,7 +128,7 @@ inline Optional<int64_t> f$preg_match_all(const string &regex, const string &sub
 
 inline Optional<int64_t> f$preg_match(const string &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
-inline Optional<int64_t> f$preg_match_all(const string &regex, const string &subject, mixed &matches, int64_t flags);
+inline Optional<int64_t> f$preg_match_all(const string &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
 inline Optional<int64_t> f$preg_match(const mixed &regex, const string &subject);
 
@@ -138,9 +138,9 @@ inline Optional<int64_t> f$preg_match(const mixed &regex, const string &subject,
 
 inline Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches);
 
-inline Optional<int64_t> f$preg_match(const mixed &regex, const string &subject, mixed &matches, int64_t flags);
+inline Optional<int64_t> f$preg_match(const mixed &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
-inline Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches, int64_t flags);
+inline Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset = 0);
 
 template<class T1, class T2, class T3, class = enable_if_t_is_optional<T3>>
 inline auto f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit = -1, int64_t &replace_count = preg_replace_count_dummy);
@@ -368,8 +368,8 @@ Optional<int64_t> f$preg_match(const regexp &regex, const string &subject, mixed
   return regex.match(subject, matches, flags, false, offset);
 }
 
-Optional<int64_t> f$preg_match_all(const regexp &regex, const string &subject, mixed &matches, int64_t flags) {
-  return regex.match(subject, matches, flags, true);
+Optional<int64_t> f$preg_match_all(const regexp &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset) {
+  return regex.match(subject, matches, flags, true, offset);
 }
 
 Optional<int64_t> f$preg_match(const string &regex, const string &subject) {
@@ -392,8 +392,8 @@ Optional<int64_t> f$preg_match(const string &regex, const string &subject, mixed
   return f$preg_match(regexp(regex), subject, matches, flags, offset);
 }
 
-Optional<int64_t> f$preg_match_all(const string &regex, const string &subject, mixed &matches, int64_t flags) {
-  return f$preg_match_all(regexp(regex), subject, matches, flags);
+Optional<int64_t> f$preg_match_all(const string &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset) {
+  return f$preg_match_all(regexp(regex), subject, matches, flags, offset);
 }
 
 Optional<int64_t> f$preg_match(const mixed &regex, const string &subject) {
@@ -412,12 +412,12 @@ Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mi
   return f$preg_match_all(regexp(regex.to_string()), subject, matches);
 }
 
-Optional<int64_t> f$preg_match(const mixed &regex, const string &subject, mixed &matches, int64_t flags) {
-  return f$preg_match(regexp(regex.to_string()), subject, matches, flags);
+Optional<int64_t> f$preg_match(const mixed &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset) {
+  return f$preg_match(regexp(regex.to_string()), subject, matches, flags, offset);
 }
 
-Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches, int64_t flags) {
-  return f$preg_match_all(regexp(regex.to_string()), subject, matches, flags);
+Optional<int64_t> f$preg_match_all(const mixed &regex, const string &subject, mixed &matches, int64_t flags, int64_t offset) {
+  return f$preg_match_all(regexp(regex.to_string()), subject, matches, flags, offset);
 }
 
 

--- a/tests/phpt/regexp/005_regexp_match2.php
+++ b/tests/phpt/regexp/005_regexp_match2.php
@@ -3,12 +3,20 @@
 
 // Tests for the preg_match and preg_match_all function overloading with 2 args (without $matches).
 
-function test_preg_match($re, $s) {
-  var_dump(["preg_match('$re', $s)" => preg_match($re, $s)]);
+function test_preg_match(string $re, $s, $offset) {
+  var_dump(["preg_match('$re', $s, _, 0, $offset)" => preg_match($re, $s, $m, 0, $offset)]);
+
+  /** @var mixed $mixed_re */
+  $mixed_re = $re;
+  var_dump(["preg_match((mixed)'$re', $s, _, 0, $offset)" => preg_match($mixed_re, $s, $m, 0, $offset)]);
 }
 
-function test_preg_match_all($re, $s) {
-  var_dump(["preg_match_all('$re', $s)" => preg_match_all($re, $s)]);
+function test_preg_match_all(string $re, $s, $offset) {
+  var_dump(["preg_match_all('$re', $s, _, 0, $offset)" => preg_match_all($re, $s, $m, 0, $offset)]);
+
+  /** @var mixed $mixed_re */
+  $mixed_re = $re;
+  var_dump(["preg_match_all((mixed)'$re', $s, _, 0, $offset)" => preg_match_all($mixed_re, $s, $m, 0, $offset)]);
 }
 
 $patterns = [
@@ -34,15 +42,21 @@ $inputs = [
   '123',
   '1 2',
   '12 34',
+  '   123921 821488123 4123',
+  '   123921 foo 4123',
   'foo',
   'foofoo',
   'foo foo',
   '<foo>foofoo',
 ];
 
-foreach ($patterns as $pattern) {
-  foreach ($inputs as $s) {
-    test_preg_match($pattern, $s);
-    test_preg_match_all($pattern, $s);
+$offsets = [0, 1, -1, 3, 10, -10, 100, -100];
+
+foreach ($offsets as $offset) {
+  foreach ($patterns as $pattern) {
+    foreach ($inputs as $s) {
+      test_preg_match($pattern, $s, $offset);
+      test_preg_match_all($pattern, $s, $offset);
+    }
   }
 }


### PR DESCRIPTION
Also add missing `$offset` parameter for mixed-typed pattern
parameter of `preg_match` function.

Fixes #546