### PR TITLE
[runtime] Remove hidden limit in fgets

### DIFF
--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <libgen.h>
 #include <sys/utsname.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #undef basename
@@ -719,7 +720,14 @@ static Optional<string> file_fgets(const Stream &stream, int64_t length) {
   }
 
   if (length < 0) {
-    length = 1024; // TODO remove limit
+    struct stat st{};
+    int fd = fileno(f);
+    fstat(fd, &st);
+    if (st.st_size > 0) {
+      length = st.st_size + 1;
+    } else {
+      return false;
+    }
   }
   if (length > string::max_size()) {
     php_warning("Parameter length in function fgetc is too large");

--- a/tests/phpt/dl/473_file.php
+++ b/tests/phpt/dl/473_file.php
@@ -87,6 +87,15 @@
   @var_dump (file_put_contents ('tmp', 'test'));
   var_dump (file_put_contents ($filename, "test-test-test"));
   var_dump (file_get_contents ($filename));
+  var_dump (file_put_contents ($filename, ''));
+  fclose($file);
+
+  $large_text = str_repeat("s", 3000);
+  var_dump (file_put_contents($filename, $large_text));
+  $file = fopen ($filename, 'r');
+  $large_line = fgets ($file);
+  var_dump (strlen ($large_line));
+  fclose ($file);
   unlink ($filename);
 
   @var_dump (realpath ("../dl/473-file.php"));


### PR DESCRIPTION
Remove hidden limit in function fgets when parameter is -1 and set it to size of file