### PR TITLE
Suppress ASAN warning for g++ 10.3.0

### DIFF
--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -821,7 +821,10 @@ Optional<string> file_file_get_contents(const string &name) {
     offset = 0;
   }
 
-  struct stat stat_buf;
+  struct stat stat_buf{};
+#if ASAN7_ENABLED && __GNUC__ == 10 && __GNUC_MINOR__ == 3
+  ASAN_UNPOISON_MEMORY_REGION(&stat_buf, sizeof(stat_buf));
+#endif
   dl::enter_critical_section();//OK
   int file_fd = open_safe(name.c_str() + offset, O_RDONLY);
   if (file_fd < 0) {


### PR DESCRIPTION
To suppress error like this:
```
==14436==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f0c2e199118 at pc 0x0000008c7fbd bp 0x7f0c2e199070 sp 0x7f0c2e199060

READ of size 4 at 0x7f0c2e199118 thread T0
    #0 0x8c7fbc in file_file_get_contents(string const&) /home/kitten/kphp/runtime/files.cpp:837
    ...
```
Warning appeared after https://github.com/VKCOM/kphp/pull/537
Spent too much time to find out the key reason of the asan warning. Will be treated as false-positive.
