### PR TITLE
[compiler] implement composer classmap autoloading

### DIFF
--- a/compiler/composer.h
+++ b/compiler/composer.h
@@ -22,15 +22,7 @@ public:
   // inverse of the `composer --no-dev` option
   void set_use_dev(bool v);
 
-  // load_file parses the "$pkg_root/composer.json" file and saves
-  // all relevant definitions inside loader;
-  // this method is not thread-safe and should be called only during the compiler init
-  void load_file(const std::string &pkg_root);
-
-  // load_root_file is like load_file, but should be only used
-  // for the main composer file;
-  // this method is not thread-safe and should be called only during the compiler init
-  void load_root_file(const std::string &pkg_root);
+  void load(const std::string &pkg_root);
 
   // psr4_lookup tries to find a filename that should contain
   // a class class_name; the lookup is based on the loaded
@@ -43,17 +35,31 @@ public:
     return filename == autoload_filename_;
   }
 
+  bool is_classmap_file(const std::string &filename) const noexcept;
+
   const std::vector<std::string> &get_files_to_require() const noexcept {
     return files_to_require_;
   }
 
 private:
+  // load_file parses the "$pkg_root/composer.json" file and saves
+  // all relevant definitions inside loader;
+  // this method is not thread-safe and should be called only during the compiler init
+  void load_file(const std::string &pkg_root);
+
+  // load_root_file is like load_file, but should be only used
+  // for the main composer file;
+  // this method is not thread-safe and should be called only during the compiler init
+  void load_root_file(const std::string &pkg_root);
+
   void load_file(const std::string &filename, bool root);
   std::string psr4_lookup_nocache(const std::string &class_name) const;
+  void scan_classmap(const std::string &filename);
 
   bool use_dev_;
   std::map<std::string, std::vector<std::string>, std::less<>> autoload_psr4_;
   std::unordered_set<std::string> deps_;
+  std::unordered_set<std::string> classmap_files_;
 
   std::string autoload_filename_;
   std::vector<std::string> files_to_require_;

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -41,7 +41,8 @@ void ClassData::set_name_and_src_name(const std::string &full_name) {
   std::string namespace_name = pos == std::string::npos ? "" : full_name.substr(0, pos);
   std::string class_name = pos == std::string::npos ? full_name : full_name.substr(pos + 1);
 
-  this->can_be_php_autoloaded = file_id && namespace_name == file_id->namespace_name && class_name == file_id->short_file_name;
+  this->can_be_php_autoloaded = file_id && ((namespace_name == file_id->namespace_name && class_name == file_id->short_file_name) ||
+                                            (G->get_composer_autoloader().is_classmap_file(file_id->file_name)));
   this->can_be_php_autoloaded |= this->is_builtin();
 
   this->is_lambda = vk::string_view{full_name}.starts_with("Lambda$") || vk::string_view{full_name}.starts_with("ITyped$");

--- a/tests/python/tests/composer/php/classmap/classmap_lib.php
+++ b/tests/python/tests/composer/php/classmap/classmap_lib.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ClassmapLib\Classes;
+
+class ClassmapClass1 {
+  public string $value = 'a';
+}
+
+class ClassmapClass2 {
+  public int $value = 51;
+}

--- a/tests/python/tests/composer/php/classmap/classmap_no_namespace.php
+++ b/tests/python/tests/composer/php/classmap/classmap_no_namespace.php
@@ -1,0 +1,7 @@
+<?php
+
+class ClassmapNoNamespace {
+  public function f() {
+    var_dump('f()');
+  }
+}

--- a/tests/python/tests/composer/php/classmap/dir/classmap.php
+++ b/tests/python/tests/composer/php/classmap/dir/classmap.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OtherClassmap;
+
+class OtherClassmapClass {
+  public function g() {
+    var_dump('g()');
+  }
+}

--- a/tests/python/tests/composer/php/composer.json
+++ b/tests/python/tests/composer/php/composer.json
@@ -27,7 +27,12 @@
                 "multi2/src/"
             ],
             "": "fallback"
-        }
+        },
+        "classmap": [
+            "classmap/classmap_lib.php",
+            "classmap/classmap_no_namespace.php",
+            "classmap/dir/"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/python/tests/composer/php/index.php
+++ b/tests/python/tests/composer/php/index.php
@@ -10,6 +10,7 @@ use VK\Feed\FeedTester; // available only when building with autoload-dev
 use MultiDir\MultiClass1; // from ./multi1
 use MultiDir\MultiClass2; // from ./multi2
 use Fallback1\Fallback2\FallbackClass; // from ./fallback
+use ClassmapLib\Classes\ClassmapClass1; // from ./classmap/classmap_lib.php
 
 class MyController extends Feed\Helpers\BaseController {}
 
@@ -18,6 +19,15 @@ new MultiClass1();
 new MultiClass2();
 new FallbackClass();
 new UtilsFallback(); // from ./packages/utils/utils-fallback/src
+
+$classmap_c1 = new ClassmapClass1();
+var_dump($classmap_c1->value);
+$classmap_c2 = new \ClassmapLib\Classes\ClassmapClass2();
+var_dump($classmap_c2->value);
+$classmap_c3 = new ClassmapNoNamespace();
+$classmap_c3->f();
+$classmap_c4 = new \OtherClassmap\OtherClassmapClass();
+$classmap_c4->g();
 
 $controller = new Controller();
 

--- a/tests/python/tests/composer/php/vendor/composer/ClassLoader.php
+++ b/tests/python/tests/composer/php/vendor/composer/ClassLoader.php
@@ -37,57 +37,130 @@ namespace Composer\Autoload;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * @author Jordi Boggiano <j.boggiano@seld.be>
- * @see    http://www.php-fig.org/psr/psr-0/
- * @see    http://www.php-fig.org/psr/psr-4/
+ * @see    https://www.php-fig.org/psr/psr-0/
+ * @see    https://www.php-fig.org/psr/psr-4/
  */
 class ClassLoader
 {
+    /** @var ?string */
+    private $vendorDir;
+
     // PSR-4
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<string, int>>
+     */
     private $prefixLengthsPsr4 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<int, string>>
+     */
     private $prefixDirsPsr4 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, string>
+     */
     private $fallbackDirsPsr4 = array();
 
     // PSR-0
+    /**
+     * @var array[]
+     * @psalm-var array<string, array<string, string[]>>
+     */
     private $prefixesPsr0 = array();
+    /**
+     * @var array[]
+     * @psalm-var array<string, string>
+     */
     private $fallbackDirsPsr0 = array();
 
+    /** @var bool */
     private $useIncludePath = false;
+
+    /**
+     * @var string[]
+     * @psalm-var array<string, string>
+     */
     private $classMap = array();
+
+    /** @var bool */
     private $classMapAuthoritative = false;
+
+    /**
+     * @var bool[]
+     * @psalm-var array<string, bool>
+     */
     private $missingClasses = array();
+
+    /** @var ?string */
     private $apcuPrefix;
 
+    /**
+     * @var self[]
+     */
+    private static $registeredLoaders = array();
+
+    /**
+     * @param ?string $vendorDir
+     */
+    public function __construct($vendorDir = null)
+    {
+        $this->vendorDir = $vendorDir;
+    }
+
+    /**
+     * @return string[]
+     */
     public function getPrefixes()
     {
         if (!empty($this->prefixesPsr0)) {
-            return call_user_func_array('array_merge', $this->prefixesPsr0);
+            return call_user_func_array('array_merge', array_values($this->prefixesPsr0));
         }
 
         return array();
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, array<int, string>>
+     */
     public function getPrefixesPsr4()
     {
         return $this->prefixDirsPsr4;
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, string>
+     */
     public function getFallbackDirs()
     {
         return $this->fallbackDirsPsr0;
     }
 
+    /**
+     * @return array[]
+     * @psalm-return array<string, string>
+     */
     public function getFallbackDirsPsr4()
     {
         return $this->fallbackDirsPsr4;
     }
 
+    /**
+     * @return string[] Array of classname => path
+     * @psalm-return array<string, string>
+     */
     public function getClassMap()
     {
         return $this->classMap;
     }
 
     /**
-     * @param array $classMap Class to filename map
+     * @param string[] $classMap Class to filename map
+     * @psalm-param array<string, string> $classMap
+     *
+     * @return void
      */
     public function addClassMap(array $classMap)
     {
@@ -102,9 +175,11 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix, either
      * appending or prepending to the ones previously set for this prefix.
      *
-     * @param string       $prefix  The prefix
-     * @param array|string $paths   The PSR-0 root directories
-     * @param bool         $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix
+     * @param string[]|string $paths   The PSR-0 root directories
+     * @param bool            $prepend Whether to prepend the directories
+     *
+     * @return void
      */
     public function add($prefix, $paths, $prepend = false)
     {
@@ -147,11 +222,13 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace, either
      * appending or prepending to the ones previously set for this namespace.
      *
-     * @param string       $prefix  The prefix/namespace, with trailing '\\'
-     * @param array|string $paths   The PSR-4 base directories
-     * @param bool         $prepend Whether to prepend the directories
+     * @param string          $prefix  The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths   The PSR-4 base directories
+     * @param bool            $prepend Whether to prepend the directories
      *
      * @throws \InvalidArgumentException
+     *
+     * @return void
      */
     public function addPsr4($prefix, $paths, $prepend = false)
     {
@@ -195,8 +272,10 @@ class ClassLoader
      * Registers a set of PSR-0 directories for a given prefix,
      * replacing any others previously set for this prefix.
      *
-     * @param string       $prefix The prefix
-     * @param array|string $paths  The PSR-0 base directories
+     * @param string          $prefix The prefix
+     * @param string[]|string $paths  The PSR-0 base directories
+     *
+     * @return void
      */
     public function set($prefix, $paths)
     {
@@ -211,10 +290,12 @@ class ClassLoader
      * Registers a set of PSR-4 directories for a given namespace,
      * replacing any others previously set for this namespace.
      *
-     * @param string       $prefix The prefix/namespace, with trailing '\\'
-     * @param array|string $paths  The PSR-4 base directories
+     * @param string          $prefix The prefix/namespace, with trailing '\\'
+     * @param string[]|string $paths  The PSR-4 base directories
      *
      * @throws \InvalidArgumentException
+     *
+     * @return void
      */
     public function setPsr4($prefix, $paths)
     {
@@ -234,6 +315,8 @@ class ClassLoader
      * Turns on searching the include path for class files.
      *
      * @param bool $useIncludePath
+     *
+     * @return void
      */
     public function setUseIncludePath($useIncludePath)
     {
@@ -256,6 +339,8 @@ class ClassLoader
      * that have not been registered with the class map.
      *
      * @param bool $classMapAuthoritative
+     *
+     * @return void
      */
     public function setClassMapAuthoritative($classMapAuthoritative)
     {
@@ -276,10 +361,12 @@ class ClassLoader
      * APCu prefix to use to cache found/not-found classes, if the extension is enabled.
      *
      * @param string|null $apcuPrefix
+     *
+     * @return void
      */
     public function setApcuPrefix($apcuPrefix)
     {
-        $this->apcuPrefix = function_exists('apcu_fetch') && ini_get('apc.enabled') ? $apcuPrefix : null;
+        $this->apcuPrefix = function_exists('apcu_fetch') && filter_var(ini_get('apc.enabled'), FILTER_VALIDATE_BOOLEAN) ? $apcuPrefix : null;
     }
 
     /**
@@ -296,25 +383,44 @@ class ClassLoader
      * Registers this instance as an autoloader.
      *
      * @param bool $prepend Whether to prepend the autoloader or not
+     *
+     * @return void
      */
     public function register($prepend = false)
     {
         spl_autoload_register(array($this, 'loadClass'), true, $prepend);
+
+        if (null === $this->vendorDir) {
+            return;
+        }
+
+        if ($prepend) {
+            self::$registeredLoaders = array($this->vendorDir => $this) + self::$registeredLoaders;
+        } else {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+            self::$registeredLoaders[$this->vendorDir] = $this;
+        }
     }
 
     /**
      * Unregisters this instance as an autoloader.
+     *
+     * @return void
      */
     public function unregister()
     {
         spl_autoload_unregister(array($this, 'loadClass'));
+
+        if (null !== $this->vendorDir) {
+            unset(self::$registeredLoaders[$this->vendorDir]);
+        }
     }
 
     /**
      * Loads the given class or interface.
      *
      * @param  string    $class The name of the class
-     * @return bool|null True if loaded, null otherwise
+     * @return true|null True if loaded, null otherwise
      */
     public function loadClass($class)
     {
@@ -323,6 +429,8 @@ class ClassLoader
 
             return true;
         }
+
+        return null;
     }
 
     /**
@@ -367,6 +475,21 @@ class ClassLoader
         return $file;
     }
 
+    /**
+     * Returns the currently registered loaders indexed by their corresponding vendor directories.
+     *
+     * @return self[]
+     */
+    public static function getRegisteredLoaders()
+    {
+        return self::$registeredLoaders;
+    }
+
+    /**
+     * @param  string       $class
+     * @param  string       $ext
+     * @return string|false
+     */
     private function findFileWithExtension($class, $ext)
     {
         // PSR-4 lookup
@@ -377,7 +500,7 @@ class ClassLoader
             $subPath = $class;
             while (false !== $lastPos = strrpos($subPath, '\\')) {
                 $subPath = substr($subPath, 0, $lastPos);
-                $search = $subPath.'\\';
+                $search = $subPath . '\\';
                 if (isset($this->prefixDirsPsr4[$search])) {
                     $pathEnd = DIRECTORY_SEPARATOR . substr($logicalPathPsr4, $lastPos + 1);
                     foreach ($this->prefixDirsPsr4[$search] as $dir) {
@@ -438,6 +561,10 @@ class ClassLoader
  * Scope isolated include.
  *
  * Prevents access to $this/self from included files.
+ *
+ * @param  string $file
+ * @return void
+ * @private
  */
 function includeFile($file)
 {

--- a/tests/python/tests/composer/php/vendor/composer/LICENSE
+++ b/tests/python/tests/composer/php/vendor/composer/LICENSE
@@ -1,56 +1,21 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
-Upstream-Name: Composer
-Upstream-Contact: Jordi Boggiano <j.boggiano@seld.be>
-Source: https://github.com/composer/composer
 
-Files: *
-Copyright: 2016, Nils Adermann <naderman@naderman.de>
-           2016, Jordi Boggiano <j.boggiano@seld.be>
-License: Expat
+Copyright (c) Nils Adermann, Jordi Boggiano
 
-Files: src/Composer/Util/TlsHelper.php
-Copyright: 2016, Nils Adermann <naderman@naderman.de>
-           2016, Jordi Boggiano <j.boggiano@seld.be>
-           2013, Evan Coury <me@evancoury.com>
-License: Expat and BSD-2-Clause
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
 
-License: BSD-2-Clause
- Redistribution and use in source and binary forms, with or without modification,
- are permitted provided that the following conditions are met:
- .
-     * Redistributions of source code must retain the above copyright notice,
-       this list of conditions and the following disclaimer.
- .
-     * Redistributions in binary form must reproduce the above copyright notice,
-       this list of conditions and the following disclaimer in the documentation
-       and/or other materials provided with the distribution.
- .
- THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
- ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-License: Expat
- Permission is hereby granted, free of charge, to any person obtaining a copy
- of this software and associated documentation files (the "Software"), to deal
- in the Software without restriction, including without limitation the rights
- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- copies of the Software, and to permit persons to whom the Software is furnished
- to do so, subject to the following conditions:
- .
- The above copyright notice and this permission notice shall be included in all
- copies or substantial portions of the Software.
- .
- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+

--- a/tests/python/tests/composer/php/vendor/composer/autoload_classmap.php
+++ b/tests/python/tests/composer/php/vendor/composer/autoload_classmap.php
@@ -6,4 +6,9 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'ClassmapLib\\Classes\\ClassmapClass1' => $baseDir . '/classmap/classmap_lib.php',
+    'ClassmapLib\\Classes\\ClassmapClass2' => $baseDir . '/classmap/classmap_lib.php',
+    'ClassmapNoNamespace' => $baseDir . '/classmap/classmap_no_namespace.php',
+    'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'OtherClassmap\\OtherClassmapClass' => $baseDir . '/classmap/dir/classmap.php',
 );

--- a/tests/python/tests/composer/php/vendor/composer/autoload_real.php
+++ b/tests/python/tests/composer/php/vendor/composer/autoload_real.php
@@ -13,6 +13,9 @@ class ComposerAutoloaderInit9539f736c30192217f7a8384c08769a6
         }
     }
 
+    /**
+     * @return \Composer\Autoload\ClassLoader
+     */
     public static function getLoader()
     {
         if (null !== self::$loader) {
@@ -20,12 +23,12 @@ class ComposerAutoloaderInit9539f736c30192217f7a8384c08769a6
         }
 
         spl_autoload_register(array('ComposerAutoloaderInit9539f736c30192217f7a8384c08769a6', 'loadClassLoader'), true, true);
-        self::$loader = $loader = new \Composer\Autoload\ClassLoader();
+        self::$loader = $loader = new \Composer\Autoload\ClassLoader(\dirname(\dirname(__FILE__)));
         spl_autoload_unregister(array('ComposerAutoloaderInit9539f736c30192217f7a8384c08769a6', 'loadClassLoader'));
 
         $useStaticLoader = PHP_VERSION_ID >= 50600 && !defined('HHVM_VERSION') && (!function_exists('zend_loader_file_encoded') || !zend_loader_file_encoded());
         if ($useStaticLoader) {
-            require_once __DIR__ . '/autoload_static.php';
+            require __DIR__ . '/autoload_static.php';
 
             call_user_func(\Composer\Autoload\ComposerStaticInit9539f736c30192217f7a8384c08769a6::getInitializer($loader));
         } else {

--- a/tests/python/tests/composer/php/vendor/composer/autoload_static.php
+++ b/tests/python/tests/composer/php/vendor/composer/autoload_static.php
@@ -50,12 +50,21 @@ class ComposerStaticInit9539f736c30192217f7a8384c08769a6
         1 => __DIR__ . '/..' . '/vk/utils/utils-fallback/src',
     );
 
+    public static $classMap = array (
+        'ClassmapLib\\Classes\\ClassmapClass1' => __DIR__ . '/../..' . '/classmap/classmap_lib.php',
+        'ClassmapLib\\Classes\\ClassmapClass2' => __DIR__ . '/../..' . '/classmap/classmap_lib.php',
+        'ClassmapNoNamespace' => __DIR__ . '/../..' . '/classmap/classmap_no_namespace.php',
+        'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'OtherClassmap\\OtherClassmapClass' => __DIR__ . '/../..' . '/classmap/dir/classmap.php',
+    );
+
     public static function getInitializer(ClassLoader $loader)
     {
         return \Closure::bind(function () use ($loader) {
             $loader->prefixLengthsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$prefixLengthsPsr4;
             $loader->prefixDirsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$prefixDirsPsr4;
             $loader->fallbackDirsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$fallbackDirsPsr4;
+            $loader->classMap = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$classMap;
 
         }, null, ClassLoader::class);
     }

--- a/tests/python/tests/composer/php/vendor/composer/installed.json
+++ b/tests/python/tests/composer/php/vendor/composer/installed.json
@@ -1,60 +1,73 @@
-[
-    {
-        "name": "vk/pkg1",
-        "version": "1.0.0",
-        "version_normalized": "1.0.0.0",
-        "dist": {
-            "type": "path",
-            "url": "./packages/pkg1",
-            "reference": "cad9181dd719b2300857994e3f139a3537295184",
-            "shasum": null
+{
+    "packages": [
+        {
+            "name": "vk/pkg1",
+            "version": "1.0.0",
+            "version_normalized": "1.0.0.0",
+            "dist": {
+                "type": "path",
+                "url": "./packages/pkg1",
+                "reference": "c815828c6fde4469dddb6f0df1057dc308af767d"
+            },
+            "require": {
+                "vk/pkg2": "1.0.0"
+            },
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "VK\\Common\\Pkg1\\": "src/"
+                }
+            },
+            "transport-options": {
+                "relative": true
+            },
+            "install-path": "../vk/pkg1"
         },
-        "require": {
-            "vk/pkg2": "1.0.0"
+        {
+            "name": "vk/pkg2",
+            "version": "1.0.0",
+            "version_normalized": "1.0.0.0",
+            "dist": {
+                "type": "path",
+                "url": "./packages/pkg2",
+                "reference": "e32549ec11d35c5d7deea3ffe72a35ca33456f23"
+            },
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "VK\\Common\\Pkg2\\": "src"
+                }
+            },
+            "transport-options": {
+                "relative": true
+            },
+            "install-path": "../vk/pkg2"
         },
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "VK\\Common\\Pkg1\\": "src/"
-            }
+        {
+            "name": "vk/utils",
+            "version": "1.0.0",
+            "version_normalized": "1.0.0.0",
+            "dist": {
+                "type": "path",
+                "url": "./packages/utils",
+                "reference": "0a222823e935ae31baddb76e6ab1801884ebc6c9"
+            },
+            "type": "library",
+            "installation-source": "dist",
+            "autoload": {
+                "psr-4": {
+                    "VK\\Utils\\": "src/",
+                    "": "utils-fallback/src/"
+                }
+            },
+            "transport-options": {
+                "relative": true
+            },
+            "install-path": "../vk/utils"
         }
-    },
-    {
-        "name": "vk/pkg2",
-        "version": "1.0.0",
-        "version_normalized": "1.0.0.0",
-        "dist": {
-            "type": "path",
-            "url": "./packages/pkg2",
-            "reference": "a4d1b73b856b267d687b5b6f9d4ab6ec1b884afe",
-            "shasum": null
-        },
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "VK\\Common\\Pkg2\\": "src"
-            }
-        }
-    },
-    {
-        "name": "vk/utils",
-        "version": "1.0.0",
-        "version_normalized": "1.0.0.0",
-        "dist": {
-            "type": "path",
-            "url": "./packages/utils",
-            "reference": "f08b32d3a2176e0de96c4e79383d1c950f39fc63",
-            "shasum": null
-        },
-        "type": "library",
-        "installation-source": "dist",
-        "autoload": {
-            "psr-4": {
-                "VK\\Utils\\": "src/",
-                "": "utils-fallback/src/"
-            }
-        }
-    }
-]
+    ],
+    "dev": true,
+    "dev-package-names": []
+}


### PR DESCRIPTION
`autoload.classmap` is another popular method of classes autoloading in composer.

Implementing this feature increases the number of composer packages that can be used by KPHP code.

Classmap works like this: for a given files list (dirs or regular files), collect all files with `.inc` and `.php` extension recursively and build autoloading maps for them. Unlike PSR4, classmap doesn't require any conventions. A file can have multiple classes, its name could be anything, namespaces can be arbitrary as well.

It's hard to implement this feature in KPHP without actually parsing the php files. As a compromise,
we're scanning the classmap folders and require all files found during the composer autoload file inclusion.

Fixes #49