### PR TITLE
add function to send 103 http code

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -135,6 +135,7 @@ function ob_get_level () ::: int;
 
 function header ($str ::: string, $replace ::: bool = true, $http_response_code ::: int = 0) ::: void;
 function headers_list () ::: string[];
+function send_http_103_early_hints($headers ::: string[]) ::: void;
 function setcookie ($name ::: string, $value ::: string, $expire ::: int = 0, $path ::: string = '', $domain ::: string = '', $secure ::: bool = false, $http_only ::: bool = false) ::: void;
 function setrawcookie ($name ::: string, $value ::: string, $expire ::: int = 0, $path ::: string = '', $domain ::: string = '', $secure ::: bool = false, $http_only ::: bool = false) ::: void;
 function register_shutdown_function (callable():void $function) ::: void;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -333,11 +333,11 @@ array<string> f$headers_list() {
 }
 
 void f$send_http_103_early_hints(const array<string> & headers) {
-  string header("HTTP/1.1 103 Early Hints\n");
+  string header("HTTP/1.1 103 Early Hints\r\n");
   for (const auto & h : headers) {
-    header.append(string(h.get_value()).append("\n"));
+    header.append(h.get_value().c_str()).append("\r\n");
   }
-  http_send_query(header.c_str(), header.size(), "\n", 1);
+  http_send_immediate_response(header.c_str(), header.size(), "\r\n", 2);
 }
 
 void f$setrawcookie(const string &name, const string &value, int64_t expire, const string &path, const string &domain, bool secure, bool http_only) {

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -332,6 +332,14 @@ array<string> f$headers_list() {
   return result;
 }
 
+void f$send_http_103_early_hints(const array<string> & headers) {
+  string header("HTTP/1.1 103 Early Hints\n");
+  for (const auto & h : headers) {
+    header.append(string(h.get_value()).append("\n"));
+  }
+  http_send_query(header.c_str(), header.size(), "\n", 1);
+}
+
 void f$setrawcookie(const string &name, const string &value, int64_t expire, const string &path, const string &domain, bool secure, bool http_only) {
   string date = f$gmdate(HTTP_DATE, expire);
 

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -44,6 +44,8 @@ void f$header(const string &str, bool replace = true, int64_t http_response_code
 
 array<string> f$headers_list();
 
+void f$send_http_103_early_hints(const array<string> & headers);
+
 void f$setcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);
 
 void f$setrawcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -957,15 +957,14 @@ void db_run_query(int host_num, const char *request, int request_len, int timeou
   }
 }
 
-void http_send_query(const char *headers, int headers_len, const char *body, int body_len) {
+void http_send_immediate_response(const char *headers, int headers_len, const char *body, int body_len) {
+  php_assert(active_worker != nullptr);
   if (active_worker->mode == http_worker) {
     write_out(&active_worker->conn->Out, headers, headers_len);
     write_out(&active_worker->conn->Out, body, body_len);
     flush_connection_output(active_worker->conn);
-  } else if (active_worker->mode == once_worker) {
-    write(1, headers, headers_len);
-    write(1, body, body_len);
-    fsync(1);
+  } else {
+    php_warning("Early hints available only from HTTP worker");
   }
 }
 

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -319,6 +319,7 @@ void job_set_result(int exit_code);
 
 void script_error();
 void finish_script(int exit_code);
+void http_send_query(const char *headers, int headers_len, const char *body, int body_len);
 int rpc_connect_to(const char *host_name, int port);
 slot_id_t rpc_send_query(int host_num, char *request, int request_len, int timeout_ms);
 void wait_net_events(int timeout_ms);

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -319,7 +319,7 @@ void job_set_result(int exit_code);
 
 void script_error();
 void finish_script(int exit_code);
-void http_send_query(const char *headers, int headers_len, const char *body, int body_len);
+void http_send_immediate_response(const char *headers, int headers_len, const char *body, int body_len);
 int rpc_connect_to(const char *host_name, int port);
 slot_id_t rpc_send_query(int host_num, char *request, int request_len, int timeout_ms);
 void wait_net_events(int timeout_ms);

--- a/tests/python/lib/http_client.py
+++ b/tests/python/lib/http_client.py
@@ -4,7 +4,7 @@ import socket
 
 from .colors import blue
 
-class _RawResponse:
+class RawResponse:
     def __init__(self, raw_bytes):
         self.raw_bytes = raw_bytes
         head, _, body = raw_bytes.partition(b"\r\n\r\n")
@@ -62,4 +62,4 @@ def send_http_request_raw(port, request):
     print(*response_bytes.splitlines(True), sep="\n")
     print("=============================")
 
-    return _RawResponse(response_bytes)
+    return RawResponse(response_bytes)

--- a/tests/python/lib/http_client.py
+++ b/tests/python/lib/http_client.py
@@ -4,6 +4,23 @@ import socket
 
 from .colors import blue
 
+class _RawResponse:
+    def __init__(self, raw_bytes):
+        self.raw_bytes = raw_bytes
+        head, _, body = raw_bytes.partition(b"\r\n\r\n")
+
+        first_line, _, headers_data = head.partition(b"\r\n")
+        self.method, _, status = first_line.partition(b' ')
+        status_code, _, status_line = status.partition(b' ')
+        self.status_code = int(status_code)
+        self.reason = status_line
+        self.headers = {}
+        self.content = body
+
+        for i in headers_data.splitlines():
+            k, v = i.split(b': ')
+            self.headers[k.decode()] = v.decode()
+
 
 def send_http_request(port, uri='/', method='GET', **kwargs):
     session = requests.session()
@@ -44,22 +61,5 @@ def send_http_request_raw(port, request):
     print("=============================")
     print(*response_bytes.splitlines(True), sep="\n")
     print("=============================")
-
-    class _RawResponse:
-        def __init__(self, raw_bytes):
-            self.raw_bytes = raw_bytes
-            head, _, body = raw_bytes.partition(b"\r\n\r\n")
-
-            first_line, _, headers_data = head.partition(b"\r\n")
-            self.method, _, status = first_line.partition(b' ')
-            status_code, _, status_line = status.partition(b' ')
-            self.status_code = int(status_code)
-            self.reason = status_line
-            self.headers = {}
-            self.content = body
-
-            for i in headers_data.splitlines():
-                k, v = i.split(b': ')
-                self.headers[k.decode()] = v.decode()
 
     return _RawResponse(response_bytes)

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -49,5 +49,9 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
 } else if ($_SERVER["PHP_SELF"] === "/pid") {
     echo "pid=" . posix_getpid();
 } else {
-  echo "Hello world!";
+    if ($_GET["hints"] === "yes") {
+        send_http_103_early_hints([]);
+        sleep(2);
+    }
+    echo "Hello world!";
 }

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -50,7 +50,7 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
     echo "pid=" . posix_getpid();
 } else {
     if ($_GET["hints"] === "yes") {
-        send_http_103_early_hints([]);
+        send_http_103_early_hints(["Content-Type: text/plain or application/json", "Link: </script.js>; rel=preload; as=script"]);
         sleep(2);
     }
     echo "Hello world!";


### PR DESCRIPTION
# Add support for HTTP Status Code 103 for Indicating Early Hints

Introduction
---------------
HTTP code 103 (Early hints) informational status code indicates to the client that the server is likely to send a final response with the header fields included in the informational response.

A client can speculatively evaluate the header fields included in a 103 (Early Hints) response while waiting for the final response. For example, a client might recognize a Link header field value containing the relation type "preload" and start fetching the target resource. However, these header fields only provide hints to the client; they do not replace the header fields on the final response.

More information [here](https://datatracker.ietf.org/doc/html/rfc8297)


Implementation
--------------------
Added new function `send_http_103_early_hints($headers ::: string[]) ::: void` that send HTTP 103 response with passed headers immediately **without buffering**.
Note that headers that have been set using the `header (...)` function **will not be sent** as hints.

Testing
---------
Also was developed a test that checks the correctness of sending a response by checking the code and timeout.


