### PR TITLE
Fix @kphp-flatten optimization for array<double>

### DIFF
--- a/runtime/common_template_instantiations.cpp
+++ b/runtime/common_template_instantiations.cpp
@@ -6,9 +6,9 @@
 
 template class array<int64_t>;
 template class array<string>;
-template class array<double>;
-template class array<bool>;
 template class array<mixed>;
+//template class array<double>; // see the header for comments
+template class array<bool>;
 
 template class array<Optional<int64_t>>;
 template class array<Optional<string>>;

--- a/runtime/common_template_instantiations.h
+++ b/runtime/common_template_instantiations.h
@@ -11,7 +11,13 @@
 
 extern template class array<int64_t>;
 extern template class array<string>;
-extern template class array<double>;
+/*
+ * Commented out, because it breaks @kphp-flatten optimization.
+ * When array<double> is explicitly instantiated here it's compiled with -O3 instead of -Os.
+ * It spoils inlining of array<>::get_value functions called from @kphp-flatten annotated ML related functions:
+ * some strange `call` asm instructions are generated instead of normal inlining.
+ */
+// extern template class array<double>;
 extern template class array<bool>;
 extern template class array<mixed>;
 


### PR DESCRIPTION
https://github.com/VKCOM/kphp/pull/537 breaks `@kphp-flatten` optimization for `array<double>` in ML related functions.
As it's explicitly instantiated in runtime sources it's compiled with `-O3` instead of `-Os`.
It spoils inlining of `array<double>::get_value` functions called from `@kphp-flatten` annotated ML related functions:
some strange `call` asm instructions are generated instead of normal inlining.

This PR prevents `array<double>` from being instantiated in runtime sources and fix the problem explained above.