### PR TITLE
[tl2php] generate `|null` for classes in PHP docs if needed

### DIFF
--- a/common/tl2php/gen-php-code.cpp
+++ b/common/tl2php/gen-php-code.cpp
@@ -587,7 +587,6 @@ struct ClassDefinition {
   friend std::ostream &operator<<(std::ostream &os, const ClassDefinition<Members...> &self) {
     os << "/**" << std::endl
        << " * @kphp-tl-class" << std::endl
-       << " * @kphp-infer" << std::endl
        << " */" << std::endl
        << (self.class_repr.is_interface ? "interface " : "class ") << self.class_repr.php_class_name;
     if (self.class_repr.parent) {

--- a/common/tl2php/php-classes.cpp
+++ b/common/tl2php/php-classes.cpp
@@ -22,7 +22,7 @@ void PhpClasses::load_from(const vk::tlo_parsing::tl_scheme &scheme, bool genera
 }
 
 bool is_or_null_possible(php_field_type internal_type) {
-  return vk::none_of_equal(internal_type, php_field_type::t_class, php_field_type::t_mixed, php_field_type::t_maybe);
+  return vk::none_of_equal(internal_type, php_field_type::t_mixed, php_field_type::t_maybe);
 }
 
 bool is_php_code_gen_allowed(const TlTypePhpRepresentation &type_repr) noexcept {


### PR DESCRIPTION
relates to `KPHP-1443`