### PR TITLE
maintain RPC `engine.sleep` query via master port

### DIFF
--- a/common/tl-files/common.tl
+++ b/common/tl-files/common.tl
@@ -96,6 +96,7 @@ right {X:Type} {Y:Type} value:Y = Either X Y;
 @any @internal engine.setVerbosity verbosity:int = True;
 @any @internal engine.setVerbosityType type:string verbosity:int = True;
 @any @internal engine.sendSignal signal:int = True;
+@any @internal engine.sleep time_ms:int = Bool;
 
 @any engine.nop  = True;
 @read engine.readNop = True; // same as nop, but assumed as read in proxy
@@ -105,4 +106,3 @@ right {X:Type} {Y:Type} value:Y = Either X Y;
 @any engine.count = BoolStat;
 @any engine.pid = net.Pid;
 @any engine.version = String;
-

--- a/common/tl/constants/engine.h
+++ b/common/tl/constants/engine.h
@@ -20,6 +20,7 @@
 #define                                           TL_ENGINE_SEND_SIGNAL 0x1a7708a3U
 #define                                         TL_ENGINE_SET_VERBOSITY 0x9d980926U
 #define                                    TL_ENGINE_SET_VERBOSITY_TYPE 0x5388c0aeU
+#define                                                 TL_ENGINE_SLEEP 0x3d3bcd48U
 #define                                                  TL_ENGINE_STAT 0xefb3c36bU
 #define                                               TL_ENGINE_VERSION 0x1a2e06faU
 #define                                             TL_ENGINE_WRITE_NOP 0x58160af4U


### PR DESCRIPTION
It will be useful for tests that use RPC