### PR TITLE
[tests] change default server option to one worker

### DIFF
--- a/tests/python/lib/kphp_server.py
+++ b/tests/python/lib/kphp_server.py
@@ -27,7 +27,7 @@ class KphpServer(Engine):
         self._options["--cluster-name"] = \
             "kphp_server_{}".format("".join(chr(ord('A') + int(c)) for c in str(self._http_port)))
         self._options["--disable-sql"] = True
-        self._options["--workers-num"] = 2
+        self._options["--workers-num"] = 1
         self._options["--allow-loopback"] = None
         self._json_log_file_read_fd = None
         self._json_logs = []

--- a/tests/python/tests/curl/test_curl.py
+++ b/tests/python/tests/curl/test_curl.py
@@ -4,6 +4,12 @@ from python.lib.testcase import KphpServerAutoTestCase
 class TestCurl(KphpServerAutoTestCase):
     maxDiff = 16 * 1024
 
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 2,
+        })
+
     def _curl_request(self, uri, return_transfer=1, post=None, headers=None):
         resp = self.kphp_server.http_post(
             uri="/test_curl",


### PR DESCRIPTION
**Test refactoring**
Changing the default number of workers for python tests for greater clarity