### PR TITLE
[runtime] run shutdown handlers for null iface object method calls

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -164,6 +164,16 @@ function error_reporting ($e ::: int = TODO) ::: int;
 function warning ($message ::: string) ::: void;
 /** @kphp-no-return */
 function critical_error($message ::: string) ::: void;
+/**
+ * Raise a soft critical error.
+ * Unlike critical_error() this function will let the script to finish normally.
+ * In particular, the shutdown handlers will be executed.
+ *
+ * It will behave almost identically to critical_error() if -K runtime flag was used.
+ *
+ * @kphp-no-return
+ */
+function soft_critical_error($message ::: string) ::: void;
 /** @kphp-no-return */
 function exit($code = 0) ::: void;
 /** @kphp-no-return */

--- a/compiler/pipes/generate-virtual-methods.cpp
+++ b/compiler/pipes/generate-virtual-methods.cpp
@@ -55,8 +55,12 @@ VertexAdaptor<op_func_call> generate_critical_error_call(std::string msg) {
   auto msg_v = VertexAdaptor<op_string>::create();
   msg_v->str_val = std::move(msg);
 
+  // this error is bad, we can't continue the execution;
+  // but it's not bad enough to interrupt the normal script termination routine,
+  // so we emit a soft critical error instead of a harsh one;
+  // this way, shutdown handlers can be executed (#569)
   auto call_ce = VertexAdaptor<op_func_call>::create(msg_v);
-  call_ce->str_val = "critical_error";
+  call_ce->str_val = "soft_critical_error";
   call_ce->func_id = G->get_function(call_ce->str_val);
 
   return call_ce;

--- a/runtime/kphp_core.h
+++ b/runtime/kphp_core.h
@@ -464,6 +464,8 @@ inline int64_t f$error_reporting();
 
 inline void f$warning(const string &message);
 
+#define f$soft_critical_error(message) \
+  php_soft_critical_error("%s", (message).c_str())
 #define f$critical_error(message) \
   php_critical_error("%s", message.c_str());
 

--- a/runtime/php_assert.h
+++ b/runtime/php_assert.h
@@ -38,6 +38,11 @@ void raise_php_assert_signal__();
   }                                                  \
 } while(0)
 
+#define php_soft_critical_error(format, ...) do {                                                       \
+  php_error ("Critical error \"" format "\" in file %s on line %d", ##__VA_ARGS__, __FILE__, __LINE__); \
+  f$exit (1);                                                                                           \
+} while(0)
+
 #define php_critical_error(format, ...) do {                                                              \
   php_error ("Critical error \"" format "\" in file %s on line %d", ##__VA_ARGS__, __FILE__, __LINE__);   \
   raise_php_assert_signal__();                                                                            \

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -120,6 +120,18 @@ function do_long_work(int $duration) {
   }
 }
 
+interface Iface {
+  public function f();
+}
+
+class Impl implements Iface {
+  public function f() { var_dump(0); }
+}
+
+function do_null_interface_method_call(Iface $iface) {
+  $iface->f();
+}
+
 function main() {
   foreach (json_decode(file_get_contents('php://input')) as $action) {
     switch ($action["op"]) {
@@ -140,6 +152,11 @@ function main() {
         break;
       case "register_shutdown_function":
         do_register_shutdown_function((string)$action["msg"]);
+        break;
+      case "null_interface_method_call":
+        $impl = new Impl();
+        $impl = null;
+        do_null_interface_method_call($impl);
         break;
       default:
         echo "unknown operation";

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
@@ -6,8 +6,22 @@ class TestShutdownFunctionsErrors(KphpServerAutoTestCase):
     def extra_class_setup(cls):
         cls.kphp_server.ignore_log_errors()
 
+    def test_null_interface_method_call_error(self):
+        # See #569
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_exception_warning"},
+                {"op": "null_interface_method_call"},
+            ])
+        self.assertEqual(resp.status_code, 200)
+        self.kphp_server.assert_json_log(
+            expect=[
+                {"version": 0, "type": 1, "env": "", "msg": "call method\\(Iface::f\\) on null object", "tags": {"uncaught": True}},
+                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler", "tags": {"uncaught": False}},
+            ],
+            timeout=5)
+
     def test_critical_error(self):
-        # with self.assertRaises(RuntimeError):
         resp = self.kphp_server.http_post(
             json=[
                 {"op": "register_shutdown_function", "msg": "shutdown_critical_error"},


### PR DESCRIPTION
When null interface method is called, the script ends abnormally.
This disrupts the normal script termination process and shutdown
handlers will never be executed.

Since calling a method on a null object is not a fatal error inside
our runtime (we can still continue running some other KPHP code),
we can and should do something like a normal `f$exit(1)` and allow
the shutdown handlers to be executed.

To do that, a new runtime function is introduced: `soft_critical_error()`.
The only difference is that it calls `f$exit(1)` instead of doing
some signal raising business.

We may want to use this new function in other places, where recoverable
critical errors are preferred to the current criticals.
For now, it's only used in one place.

It's also debatable whether we should switch to non-fatal critical errors
in the future, so user-generated critical error do not bypass the
shutdown handlers (I'm not sure users expect that behavior anyway).

Fixes #569