### PR TITLE
allow dirname() calls inside require_once()

### DIFF
--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -247,7 +247,7 @@ public:
     }
 
     if (auto require = root.try_as<op_require>()) {
-      std::string name = collect_string_concatenation(require->expr());
+      std::string name = collect_string_concatenation(require->expr(), true);
       kphp_error_act (!name.empty(), "Not a string in 'require' arguments", return root);
       if (is_composer_autoload(name)) {
         return require_composer_autoload(root);

--- a/tests/phpt/dl/1038_require_vs_dirname.php
+++ b/tests/phpt/dl/1038_require_vs_dirname.php
@@ -1,0 +1,5 @@
+@ok
+<?php
+require_once dirname(__FILE__) . '/include/foo.php';
+require dirname(__FILE__) . '/include/bar.php';
+require dirname(__FILE__) . '/include/bar.php';

--- a/tests/phpt/dl/1039_require_vs_dirname_fails.php
+++ b/tests/phpt/dl/1039_require_vs_dirname_fails.php
@@ -1,0 +1,6 @@
+@kphp_should_fail
+/call to 'dirname' must have one arg/
+/'dirname' has to be called with string type arg/
+<?php
+require_once dirname(__FILE__, 2) . '/include/foo.php';
+require_once dirname(123) . '/include/foo.php';

--- a/tests/phpt/dl/include/bar.php
+++ b/tests/phpt/dl/include/bar.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "hello from include/bar.php\n";

--- a/tests/phpt/dl/include/foo.php
+++ b/tests/phpt/dl/include/foo.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "hello from include/foo.php\n";


### PR DESCRIPTION
This PR adds support of `dirname()` calls inside `require_once()`, so that both next `require_once()` calls will be equals:
```<?php
require_once dirname(__FILE__) . '/filename.php';
require_once __DIR__ . '/filename.php';
```