### PR TITLE
add support of alternative array syntax like array<int, string>

### DIFF
--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -394,7 +394,12 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
     case tok_array:
       cur_tok++;
       if (vk::any_of_equal(cur_tok->type(), tok_lt, tok_oppar)) {   // array<...>
-        return TypeHintArray::create(parse_nested_one_type_hint());
+        const auto &type_hints = parse_nested_type_hints();
+        if (type_hints.empty() || type_hints.size() > 2) {
+          throw std::runtime_error{"array<...> has to be parameterized with one type or two types at most"};
+        }
+        // just ignore array's key type if there is any
+        return TypeHintArray::create(type_hints.back());
       }
       return TypeHintArray::create_array_of_any();
     case tok_at: {      // @tl\...

--- a/tests/phpt/phpdocs/028_arrays_alternative_syntax.php
+++ b/tests/phpt/phpdocs/028_arrays_alternative_syntax.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+
+/** @param array<int> $a */
+function f1($a) {
+  var_dump($a);
+}
+
+/** @param array<int, int> $a */
+function f2($a) {
+  var_dump($a);
+}
+
+/** @param array<string, int> $a */
+function f3($a) {
+  var_dump($a);
+}
+
+f1([1, 2, 3]);
+f2([1, 2, 3]);
+f3([1, 2, 3]);

--- a/tests/phpt/phpdocs/029_arrays_alternative_syntax_errors.php
+++ b/tests/phpt/phpdocs/029_arrays_alternative_syntax_errors.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/array<\.\.\.> has to be parameterized with one type or two types at most/
+/array<\.\.\.> has to be parameterized with one type or two types at most/
+<?php
+
+/** @param array<bool, string, int> $a */
+function f1($a) {
+  var_dump($a);
+}
+
+/** @param array<> $a */
+function f2($a) {
+  var_dump($a);
+}
+
+f1([1, 2, 3]);
+f2([1, 2, 3]);


### PR DESCRIPTION
add support of alternative array syntax like array<int, string>, where key type will be just ignored.