### PR TITLE
skip PHP 8 compatibility checks for ksort

### DIFF
--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -1935,6 +1935,9 @@ void array<T>::ksort(const T1 &compare) {
     mutate_if_map_shared();
   }
 
+  const auto prev_show_migration_php8_warning = show_migration_php8_warning;
+  free_migration_php8();
+
   array<key_type> keys(array_size(n, 0, true));
   for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
     if (p->is_string_hash_entry(it)) {
@@ -1979,6 +1982,8 @@ void array<T>::ksort(const T1 &compare) {
   }
   prev->next = p->get_pointer(p->end());
   p->end()->prev = p->get_pointer(prev);
+
+  show_migration_php8_warning = prev_show_migration_php8_warning;
 }
 
 


### PR DESCRIPTION
For the `ksort` function, KPHP gives a warning that < will give different results for PHP 7 and 8, however `ksort` will work the same in PHP 7 and PHP 8 when KPHP gives a warning.

To allow developers to look for and fix other places, `ksort` is temporarily skipped for compatibility checking.