### PR TITLE
add function ignore_user_abort

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -139,6 +139,7 @@ function send_http_103_early_hints($headers ::: string[]) ::: void;
 function setcookie ($name ::: string, $value ::: string, $expire ::: int = 0, $path ::: string = '', $domain ::: string = '', $secure ::: bool = false, $http_only ::: bool = false) ::: void;
 function setrawcookie ($name ::: string, $value ::: string, $expire ::: int = 0, $path ::: string = '', $domain ::: string = '', $secure ::: bool = false, $http_only ::: bool = false) ::: void;
 function register_shutdown_function (callable():void $function) ::: void;
+function ignore_user_abort ($enable ::: ?bool = null) ::: int;
 /* // removed because it's not working now.
   function fastcgi_finish_request() ::: void;
 */

--- a/net/net-connections.h
+++ b/net/net-connections.h
@@ -218,6 +218,8 @@ struct connection {
   char in_buff[BUFF_SIZE];
   char out_buff[BUFF_SIZE];
   struct ucred credentials;
+  bool interrupted;
+  bool ignored;
 };
 typedef struct connection connection_t;
 

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -9,6 +9,7 @@
 #include "common/wrappers/string_view.h"
 
 #include "runtime/kphp_core.h"
+#include "runtime/optional.h"
 #include "server/php-query-data.h"
 
 extern string_buffer *coub;//TODO static
@@ -49,6 +50,8 @@ void f$send_http_103_early_hints(const array<string> & headers);
 void f$setcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);
 
 void f$setrawcookie(const string &name, const string &value, int64_t expire = 0, const string &path = string(), const string &domain = string(), bool secure = false, bool http_only = false);
+
+int64_t f$ignore_user_abort(Optional<bool> enable = Optional<bool>());
 
 void run_shutdown_functions_from_timeout();
 void run_shutdown_functions_from_script();

--- a/tests/python/lib/engine.py
+++ b/tests/python/lib/engine.py
@@ -294,13 +294,13 @@ class Engine:
 
         return (engine_stopped_properly, status)
 
-    def rpc_request(self, request):
+    def rpc_request(self, request, timeout=60):
         """
         Послать rpc запрос в движек
         :param request: Словарь с rpc запросом
         :return: Словарь с rpc ответом
         """
-        return send_rpc_request(request, self._rpc_port)
+        return send_rpc_request(request, self._rpc_port, timeout)
 
     def _assert_availability(self):
         _, status = os.waitpid(self._engine_process.pid, os.WNOHANG)

--- a/tests/python/lib/http_client.py
+++ b/tests/python/lib/http_client.py
@@ -22,11 +22,11 @@ class RawResponse:
             self.headers[k.decode()] = v.decode()
 
 
-def send_http_request(port, uri='/', method='GET', **kwargs):
+def send_http_request(port, uri='/', method='GET', timeout=30, **kwargs):
     session = requests.session()
     url = 'http://127.0.0.1:{}{}'.format(port, uri)
     print("\nSending HTTP request: [{}]".format(blue(url)))
-    r = session.request(method=method, url=url, timeout=30, **kwargs)
+    r = session.request(method=method, url=url, timeout=timeout, **kwargs)
     session.close()
     print("HTTP request debug:")
     print("=============================")

--- a/tests/python/lib/kphp_server.py
+++ b/tests/python/lib/kphp_server.py
@@ -68,7 +68,7 @@ class KphpServer(Engine):
         """
         return self._http_port
 
-    def http_request(self, uri='/', method='GET', http_port=None, **kwargs):
+    def http_request(self, uri='/', method='GET', http_port=None, timeout=30, **kwargs):
         """
         Послать запрос в kphp сервер
         :param http_port: порт в который посылать, если их несколько
@@ -77,7 +77,7 @@ class KphpServer(Engine):
         :param kwargs: дополнительные параметры, передаваемые в request
         :return: ответ на запрос
         """
-        return send_http_request(self._http_port if http_port is None else http_port, uri, method, **kwargs)
+        return send_http_request(self._http_port if http_port is None else http_port, uri, method, timeout, **kwargs)
 
     def http_post(self, uri='/', **kwargs):
         """

--- a/tests/python/lib/tl_client.py
+++ b/tests/python/lib/tl_client.py
@@ -28,7 +28,7 @@ def _tl_serialize_struct(request):
     return " ".join(encoded)
 
 
-def send_rpc_request(request, port):
+def send_rpc_request(request, port, timeout=60):
     tl_client_bin = search_tl_client()
     encoded_request = _tl_serialize_struct(request)
 
@@ -42,7 +42,7 @@ def send_rpc_request(request, port):
         stdin=subprocess.PIPE,
         stderr=subprocess.PIPE
     )
-    stdout_data, stderr_data = p.communicate(input=encoded_request.encode())
+    stdout_data, stderr_data = p.communicate(input=encoded_request.encode(), timeout=timeout)
     if stderr_data:
         raise RuntimeError("Can't send rpc request: " + stderr_data.decode())
     if p.returncode:

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -51,7 +51,6 @@ class RpcWorker implements I {
     }
 
     public function work() {
-        fwrite(STDERR, $this->port . "\n");
         $job = function() {
             $conn = new_rpc_connection('localhost', $this->port, 0, 5);
             $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
@@ -59,7 +58,9 @@ class RpcWorker implements I {
             $resp = rpc_tl_query_result_one($req_id);
             assert($resp['result']);
         };
-        $job();
+        for ($i = 0; $i < 3; ++$i) {
+            $job();
+        }
         fwrite(STDERR, "test_ignore_user_abort/finish_rpc_work_" . $_GET["level"] . "\n");
    }
 }

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -8,6 +8,65 @@ class A {
   public $b = "hello";
 }
 
+/**
+ * @kphp-required
+ */
+function shutdown_function() {
+    fwrite(STDERR, "shutdown_function was called\n");
+}
+
+function assert($flag) {
+    if ($flag !== true) {
+        critical_error("failed assert");
+    }
+}
+
+interface I {
+    public function work();
+}
+
+class ResumableWorker implements I {
+    public function work() {
+        $job = function() {
+                sched_yield_sleep(2);
+                return true;
+        };
+        $futures = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $futures[] = fork($job());
+        }
+        $responses = wait_multi($futures);
+        foreach ($responses as $resp) {
+            assert($resp);
+        }
+        fwrite(STDERR, "test_ignore_user_abort/finish_resumable_work\n");
+    }
+}
+
+class RpcWorker implements I {
+    protected int $port;
+
+    public function __construct(int $port) {
+        $this->port = $port;
+    }
+
+    public function work() {
+        fwrite(STDERR, $this->port . "\n");
+        $job = function() {
+            $conn = new_rpc_connection('localhost', $this->port, 0, 3);
+            $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
+                                                "time_ms" => 60]);
+            $resp = rpc_tl_query_result_one($req_id);
+            assert($resp['result']);
+        };
+        for ($i = 0; $i < 3; ++$i) {
+            $job();
+        }
+        fwrite(STDERR, "test_ignore_user_abort/finish_rpc_work\n");
+   }
+}
+
+
 if ($_SERVER["PHP_SELF"] === "/ini_get") {
   echo ini_get($_SERVER["QUERY_STRING"]);
 } else if (substr($_SERVER["PHP_SELF"], 0, 12) === "/test_limits") {
@@ -37,6 +96,48 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
   }
   file_put_contents("out.dat", $res === false ? "false" : $res);
   echo "OK";
+} else if ($_SERVER["PHP_SELF"] === "/test_ignore_user_abort") {
+    register_shutdown_function('shutdown_function');
+    /** @var I */
+    $worker = null;
+    switch($_GET["type"]) {
+     case "rpc":
+        $worker = new RpcWorker(intval($_GET["port"]));
+        break;
+     case "resumable":
+        $worker = new ResumableWorker;
+        break;
+     default:
+        echo "ERROR"; return;
+    }
+    switch($_GET["level"]) {
+     case "no_ignore":
+        $worker->work();
+        break;
+     case "ignore":
+        ignore_user_abort(true);
+        $worker->work();
+        fwrite(STDERR, "test_ignore_user_abort/finish_ignore\n");
+        ignore_user_abort(false);
+        break;
+     case "multi_ignore":
+        ignore_user_abort(true);
+        $worker->work();
+        $worker->work();
+        fwrite(STDERR, "test_ignore_user_abort/finish_multi_ignore\n");
+        ignore_user_abort(false);
+        break;
+     case "nested_ignore":
+        ignore_user_abort(true);
+        ignore_user_abort(true);
+        $worker->work();
+        ignore_user_abort(false);
+        fwrite(STDERR, "test_ignore_user_abort/finish_nested_ignore\n");
+        ignore_user_abort(false);
+     default:
+        echo "ERROR"; return;
+    }
+    echo "OK";
 } else if ($_SERVER["PHP_SELF"] === "/test_big_post_data") {
     $keys = array_keys($_POST);
     if ($keys) {

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -51,16 +51,11 @@ class RpcWorker implements I {
     }
 
     public function work() {
-        $job = function() {
-            $conn = new_rpc_connection('localhost', $this->port, 0, 5);
-            $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
-                                                "time_ms" => 60]);
-            $resp = rpc_tl_query_result_one($req_id);
-            assert($resp['result']);
-        };
-        for ($i = 0; $i < 3; ++$i) {
-            $job();
-        }
+        $conn = new_rpc_connection('localhost', $this->port, 0, 5);
+        $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
+                                                    "time_ms" => 120]);
+        $resp = rpc_tl_query_result_one($req_id);
+        assert($resp['result']);
         fwrite(STDERR, "test_ignore_user_abort/finish_rpc_work_" . $_GET["level"] . "\n");
    }
 }

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -39,7 +39,7 @@ class ResumableWorker implements I {
         foreach ($responses as $resp) {
             assert($resp);
         }
-        fwrite(STDERR, "test_ignore_user_abort/finish_resumable_work\n");
+        fwrite(STDERR, "test_ignore_user_abort/finish_resumable_work_" . $_GET["level"] . "\n");
     }
 }
 
@@ -53,16 +53,15 @@ class RpcWorker implements I {
     public function work() {
         fwrite(STDERR, $this->port . "\n");
         $job = function() {
-            $conn = new_rpc_connection('localhost', $this->port, 0, 3);
+            $conn = new_rpc_connection('localhost', $this->port, 0, 5);
             $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
                                                 "time_ms" => 60]);
             $resp = rpc_tl_query_result_one($req_id);
+            fwrite(STDERR, "" . var_export($resp, true) . "\n");
             assert($resp['result']);
         };
-        for ($i = 0; $i < 3; ++$i) {
-            $job();
-        }
-        fwrite(STDERR, "test_ignore_user_abort/finish_rpc_work\n");
+        $job();
+        fwrite(STDERR, "test_ignore_user_abort/finish_rpc_work_" . $_GET["level"] . "\n");
    }
 }
 
@@ -117,14 +116,14 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
      case "ignore":
         ignore_user_abort(true);
         $worker->work();
-        fwrite(STDERR, "test_ignore_user_abort/finish_ignore\n");
+        fwrite(STDERR, "test_ignore_user_abort/finish_ignore_" . $_GET["type"] . "\n");
         ignore_user_abort(false);
         break;
      case "multi_ignore":
         ignore_user_abort(true);
         $worker->work();
         $worker->work();
-        fwrite(STDERR, "test_ignore_user_abort/finish_multi_ignore\n");
+        fwrite(STDERR, "test_ignore_user_abort/finish_multi_ignore_" . $_GET["type"] . "\n");
         ignore_user_abort(false);
         break;
      case "nested_ignore":
@@ -132,7 +131,7 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
         ignore_user_abort(true);
         $worker->work();
         ignore_user_abort(false);
-        fwrite(STDERR, "test_ignore_user_abort/finish_nested_ignore\n");
+        fwrite(STDERR, "test_ignore_user_abort/finish_nested_ignore_" . $_GET["type"] . "\n");
         ignore_user_abort(false);
      default:
         echo "ERROR"; return;

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -57,7 +57,6 @@ class RpcWorker implements I {
             $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep",
                                                 "time_ms" => 60]);
             $resp = rpc_tl_query_result_one($req_id);
-            fwrite(STDERR, "" . var_export($resp, true) . "\n");
             assert($resp['result']);
         };
         $job();

--- a/tests/python/tests/http_server/test_ignore_user_abort.py
+++ b/tests/python/tests/http_server/test_ignore_user_abort.py
@@ -13,70 +13,70 @@ class TestIgnoreUserAbort(KphpServerAutoTestCase):
             pass
 
     def test_user_abort_rpc_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}' . format(str(self.kphp_server.master_port)))
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
         error = False
         try:
-            self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], "Can't find rpc_work end", timeout=5)
-        except RuntimeError as e:
+            self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "no_ignore"], timeout=2)
+        except Exception:
             error = True
         self.assertTrue(error)
-        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
 
     def test_user_abort_resumable_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=no_ignore')
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
         error = False
         try:
-            self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"], "Can't find resumable_work end", timeout=5)
-        except RuntimeError as e:
+            self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "no_ignore"], timeout=2)
+        except Exception:
             error = True
         self.assertTrue(error)
-        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
 
     def test_ignore_user_abort_rpc_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}' . format(str(self.kphp_server.master_port)))
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"], timeout=5)
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore_" + "rpc"], timeout=5)
         self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_ignore_user_abort_resumable_work(self):
         self._send_request(uri='/test_ignore_user_abort?type=resumable&level=ignore')
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"],  timeout=5)
-        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore_" + "resumable"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_nested_ignore_user_abort_rpc_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=nested_ignore&port={}' . format(str(self.kphp_server.master_port)))
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"],  timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"],  timeout=5)
-        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=nested_ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "nested_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore_" + "rpc"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_nested_ignore_user_abort_resumable_work(self):
         self._send_request(uri='/test_ignore_user_abort?type=resumable&level=nested_ignore')
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"],  timeout=5)
-        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "nested_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore_" + "resumable"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_multi_ignore_user_abort_rpc_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=multi_ignore')
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"],  timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore"],  timeout=5)
-        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=multi_ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "multi_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore_" + "rpc"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_multi_ignore_user_abort_resumable_work(self):
         self._send_request(uri='/test_ignore_user_abort?type=resumable&level=multi_ignore')
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore"],  timeout=5)
-        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "multi_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore_" + "resumable"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
     def test_idempotence_ignore_user_abort(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}' . format(str(self.kphp_server.master_port)))
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"], timeout=5)
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore_" + "rpc"], timeout=5)
         self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
 
         time.sleep(2)
 
         self._send_request(uri='/test_ignore_user_abort?type=resumable&level=nested_ignore')
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"], timeout=5)
-        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "nested_ignore"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore_" + "resumable"], timeout=5)
         self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)

--- a/tests/python/tests/http_server/test_ignore_user_abort.py
+++ b/tests/python/tests/http_server/test_ignore_user_abort.py
@@ -23,7 +23,7 @@ class TestIgnoreUserAbort(KphpServerAutoTestCase):
         self.assertTrue(error)
 
     def test_user_abort_resumable_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore')
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=no_ignore')
         self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
         error = False
         try:

--- a/tests/python/tests/http_server/test_ignore_user_abort.py
+++ b/tests/python/tests/http_server/test_ignore_user_abort.py
@@ -14,7 +14,7 @@ class TestIgnoreUserAbort(KphpServerAutoTestCase):
 
     def test_user_abort_rpc_work(self):
         self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}'.format(str(self.kphp_server.master_port)))
-        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=10)
         error = False
         try:
             self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work_" + "no_ignore"], timeout=2)
@@ -24,7 +24,7 @@ class TestIgnoreUserAbort(KphpServerAutoTestCase):
 
     def test_user_abort_resumable_work(self):
         self._send_request(uri='/test_ignore_user_abort?type=resumable&level=no_ignore')
-        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=10)
         error = False
         try:
             self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work_" + "no_ignore"], timeout=2)

--- a/tests/python/tests/http_server/test_ignore_user_abort.py
+++ b/tests/python/tests/http_server/test_ignore_user_abort.py
@@ -1,0 +1,82 @@
+import time
+import urllib
+import socket
+
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestIgnoreUserAbort(KphpServerAutoTestCase):
+    def _send_request(self, uri="/", timeout=0.05):
+        try:
+            self.kphp_server.http_request(uri=uri, timeout=timeout)
+        except Exception:
+            pass
+
+    def test_user_abort_rpc_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}' . format(str(self.kphp_server.master_port)))
+        error = False
+        try:
+            self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], "Can't find rpc_work end", timeout=5)
+        except RuntimeError as e:
+            error = True
+        self.assertTrue(error)
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
+
+    def test_user_abort_resumable_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=no_ignore')
+        error = False
+        try:
+            self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"], "Can't find resumable_work end", timeout=5)
+        except RuntimeError as e:
+            error = True
+        self.assertTrue(error)
+        self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
+
+    def test_ignore_user_abort_rpc_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}' . format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
+
+    def test_ignore_user_abort_resumable_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=ignore')
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"],  timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+
+    def test_nested_ignore_user_abort_rpc_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=nested_ignore&port={}' . format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"],  timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+
+    def test_nested_ignore_user_abort_resumable_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=nested_ignore')
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"],  timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+
+    def test_multi_ignore_user_abort_rpc_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=multi_ignore')
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore"],  timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+
+    def test_multi_ignore_user_abort_resumable_work(self):
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=multi_ignore')
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"],  timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_multi_ignore"],  timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"],  timeout=5)
+
+    def test_idempotence_ignore_user_abort(self):
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=ignore&port={}' . format(str(self.kphp_server.master_port)))
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_rpc_work"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_ignore"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)
+
+        time.sleep(2)
+
+        self._send_request(uri='/test_ignore_user_abort?type=resumable&level=nested_ignore')
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_resumable_work"], timeout=5)
+        self.kphp_server.assert_log(["test_ignore_user_abort/finish_nested_ignore"], timeout=5)
+        self.kphp_server.assert_log(["shutdown_function was called"], timeout=5)

--- a/tests/python/tests/http_server/test_ignore_user_abort.py
+++ b/tests/python/tests/http_server/test_ignore_user_abort.py
@@ -23,7 +23,7 @@ class TestIgnoreUserAbort(KphpServerAutoTestCase):
         self.assertTrue(error)
 
     def test_user_abort_resumable_work(self):
-        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore&port={}'.format(str(self.kphp_server.master_port)))
+        self._send_request(uri='/test_ignore_user_abort?type=rpc&level=no_ignore')
         self.kphp_server.assert_log(['Critical error during script execution: http connection close'], timeout=5)
         error = False
         try:


### PR DESCRIPTION
# Add a new function ignore_user_abort analogue from PHP

Introduction
---------------
**ignore_user_abort** — Set whether aborting should abort script execution. This implementation **matches the description** [here](https://www.php.net/manual/en/function.ignore-user-abort.php) with **one exception** unlike the implementation in PHP, the current version considers the **nesting level** and does not complete the script until it becomes zero

Description
---------------
```php
ignore_user_abort(?bool $enable = null): int
```

- **Parameter List**
Takes a flag **value** and sets it with the **appropriate** nesting level **change**. If the argument is **null**, then returns the current level **without changing** it

- **Return Values**
Return nesting level previous value


Usage
--------

```php
function important_work(...) {
    ignore_user_abort(true);
    ...
    ignore_user_abort(false);

// start critical section which will be executed regardless of the state of the connection
ignore_user_abort(true);
important_work(...);
// some other work to be carried out as rpc, resumable or function calls
ignore_user_abort(false);
// termination of the script if the connection was interrupted
```

Testing
---------
This pr also contains tests to check the correct operation of the server using this function