### PR TITLE
add (boolean) and (integer) cast aliases

### DIFF
--- a/compiler/debug.cpp
+++ b/compiler/debug.cpp
@@ -165,6 +165,7 @@ std::string debugTokenName(TokenType t) {
     {tok_object, "tok_object"},
     {tok_callable, "tok_callable"},
     {tok_bool, "tok_bool"},
+    {tok_boolean, "tok_boolean"},
     {tok_void, "tok_void"},
     {tok_mixed, "tok_mixed"},
     {tok_conv_int, "tok_conv_int"},

--- a/compiler/keywords.gperf
+++ b/compiler/keywords.gperf
@@ -68,6 +68,7 @@ callable, tok_callable
 void, tok_void
 mixed, tok_mixed
 bool, tok_bool
+boolean, tok_boolean
 false, tok_false
 true, tok_true
 FALSE, tok_false

--- a/compiler/keywords.gperf
+++ b/compiler/keywords.gperf
@@ -60,6 +60,7 @@ __LINE__, tok_line_c
 __METHOD__, tok_method_c
 __NAMESPACE__, tok_namespace_c
 int, tok_int
+integer, tok_int
 float, tok_float
 double, tok_float
 string, tok_string

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -131,12 +131,13 @@ void LexerData::hack_last_tokens() {
   }
 
   TokenType casts[][2] = {
-    {tok_int,    tok_conv_int},
-    {tok_float,  tok_conv_float},
-    {tok_string, tok_conv_string},
-    {tok_array,  tok_conv_array},
-    {tok_object, tok_conv_object},
-    {tok_bool,   tok_conv_bool}
+    {tok_int,     tok_conv_int},
+    {tok_float,   tok_conv_float},
+    {tok_string,  tok_conv_string},
+    {tok_array,   tok_conv_array},
+    {tok_object,  tok_conv_object},
+    {tok_bool,    tok_conv_bool},
+    {tok_boolean, tok_conv_bool}
   };
 
   auto remove_last_tokens = [this](size_t cnt) {

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -331,8 +331,6 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
       cur_type = tok_int;
     } else if (cur_tok->str_val == "double") {
       cur_type = tok_float;
-    } else if (cur_tok->str_val == "boolean") {
-      cur_type = tok_bool;
     } else if (cur_tok->str_val == "\\tuple") {
       cur_type = tok_tuple;
     } else if (cur_tok->str_val == "\\shape") {
@@ -356,6 +354,8 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
       cur_tok++;
       return TypeHintPrimitive::create(tp_int);
     case tok_bool:
+      [[fallthrough]];
+    case tok_boolean:
       cur_tok++;
       return TypeHintPrimitive::create(tp_bool);
     case tok_float:

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -329,8 +329,6 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
   if (cur_type == tok_func_name) {
     if (cur_tok->str_val == "integer") {
       cur_type = tok_int;
-    } else if (cur_tok->str_val == "double") {
-      cur_type = tok_float;
     } else if (cur_tok->str_val == "\\tuple") {
       cur_type = tok_tuple;
     } else if (cur_tok->str_val == "\\shape") {

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -327,9 +327,7 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
   TokenType cur_type = cur_tok->type();
   // some type names inside phpdoc are not keywords/tokens, but they should be interpreted as such
   if (cur_type == tok_func_name) {
-    if (cur_tok->str_val == "integer") {
-      cur_type = tok_int;
-    } else if (cur_tok->str_val == "\\tuple") {
+    if (cur_tok->str_val == "\\tuple") {
       cur_type = tok_tuple;
     } else if (cur_tok->str_val == "\\shape") {
       cur_type = tok_shape;

--- a/compiler/token.h
+++ b/compiler/token.h
@@ -153,6 +153,7 @@ enum TokenType {
   tok_object,
   tok_callable,
   tok_bool,
+  tok_boolean,
   tok_void,
   tok_mixed,
 

--- a/tests/phpt/phc/parsing/primitive_casts.php
+++ b/tests/phpt/phc/parsing/primitive_casts.php
@@ -12,6 +12,17 @@ function test_int_casts() {
   var_dump ((int) true);
 }
 
+function test_integer_casts() {
+  var_dump ((integer) 1);
+  var_dump ((integer) 1.5);
+  var_dump ((integer) "12");
+  var_dump ((integer) "1.2");
+  var_dump ((integer) "hello");
+  var_dump ((integer) null);
+  var_dump ((integer) false);
+  var_dump ((integer) true);
+}
+
 function test_float_casts() {
   var_dump ((float) 1);
   var_dump ((float) 1.5);
@@ -86,6 +97,7 @@ function test_boolean_casts() {
 }
 
 test_int_casts();
+test_integer_casts();
 test_float_casts();
 test_double_casts();
 test_string_casts();

--- a/tests/phpt/phc/parsing/primitive_casts.php
+++ b/tests/phpt/phc/parsing/primitive_casts.php
@@ -57,8 +57,38 @@ function test_array_casts() {
   var_dump ((array) true);
 }
 
+function test_bool_casts() {
+  var_dump ((bool) 0);
+  var_dump ((bool) 1);
+  var_dump ((bool) 1.5);
+  var_dump ((bool) "");
+  var_dump ((bool) "12");
+  var_dump ((bool) "1.2");
+  var_dump ((bool) "hello");
+  var_dump ((bool) []);
+  var_dump ((bool) null);
+  var_dump ((bool) false);
+  var_dump ((bool) true);
+}
+
+function test_boolean_casts() {
+  var_dump ((boolean) 0);
+  var_dump ((boolean) 1);
+  var_dump ((boolean) 1.5);
+  var_dump ((boolean) "");
+  var_dump ((boolean) "12");
+  var_dump ((boolean) "1.2");
+  var_dump ((boolean) "hello");
+  var_dump ((boolean) []);
+  var_dump ((boolean) null);
+  var_dump ((boolean) false);
+  var_dump ((boolean) true);
+}
+
 test_int_casts();
 test_float_casts();
 test_double_casts();
 test_string_casts();
 test_array_casts();
+test_bool_casts();
+test_boolean_casts();

--- a/tests/phpt/phpdocs/105_bool_in_phpdoc.php
+++ b/tests/phpt/phpdocs/105_bool_in_phpdoc.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Do not use \|bool in phpdoc, use \|false instead\n\(if you really need bool, specify \|boolean\)/
+<?php
+
+/** @param string|bool $a */
+function foo($a) {
+  var_dump($a);
+}
+
+foo(false);

--- a/tests/phpt/phpdocs/106_boolean_in_phpdoc.php
+++ b/tests/phpt/phpdocs/106_boolean_in_phpdoc.php
@@ -1,0 +1,9 @@
+@ok
+<?php
+
+/** @param string|boolean $a */
+function foo($a) {
+  var_dump($a);
+}
+
+foo(false);


### PR DESCRIPTION
Add support of (boolean) and (integer) cast aliases. It makes possible to write such code:
```
(boolean) $var;
(integer) $var;
```