### PR TITLE
add support of leading slash in context of constants and define/defined

### DIFF
--- a/compiler/compiler-core.cpp
+++ b/compiler/compiler-core.cpp
@@ -364,7 +364,12 @@ bool CompilerCore::register_define(DefinePtr def_id) {
   return true;
 }
 
-DefinePtr CompilerCore::get_define(const std::string &name) {
+DefinePtr CompilerCore::get_define(std::string_view name) {
+  // we don't support namespaces for constants yet, but we
+  // permit var_dump(\foo) syntax and interpret it as just var_dump(foo);
+  if (!name.empty() && name.front() == '\\') {
+    name.remove_prefix(1);
+  }
   return defines_ht.at(vk::std_hash(name))->data;
 }
 

--- a/compiler/compiler-core.h
+++ b/compiler/compiler-core.h
@@ -90,7 +90,7 @@ public:
   void set_memcache_class(ClassPtr klass);
 
   bool register_define(DefinePtr def_id);
-  DefinePtr get_define(const std::string &name);
+  DefinePtr get_define(std::string_view name);
 
   VarPtr create_var(const std::string &name, VarData::Type type);
   VarPtr get_global_var(const std::string &name, VarData::Type type, VertexPtr init_val, bool *is_new_inserted = nullptr);

--- a/compiler/lexer.cpp
+++ b/compiler/lexer.cpp
@@ -243,6 +243,17 @@ void LexerData::hack_last_tokens() {
   if (are_last_tokens(tok_function, tok_var_dump) || are_last_tokens(tok_function, tok_dbg_echo) || are_last_tokens(tok_function, tok_print) || are_last_tokens(tok_function, tok_echo)) {
     tokens.back() = {tok_func_name, tokens.back().str_val};
   }
+
+  // recognize leading slash for define/defined;
+  // similar logic has already implemented for regular functions
+  if (are_last_tokens(tok_func_name)) {
+    auto name = tokens.back().str_val;
+    if (name == "\\define") {
+      tokens.back() = {tok_define, name};
+    } else if (name == "\\defined") {
+      tokens.back() = {tok_defined, name};
+    }
+  }
 }
 
 void LexerData::set_dont_hack_last_tokens() {

--- a/tests/cpp/compiler/lexer-test.cpp
+++ b/tests/cpp/compiler/lexer-test.cpp
@@ -111,6 +111,11 @@ TEST(lexer_test, test_php_tokens) {
     {"[1]", {"tok_opbrk([)", "tok_int_const(1)", "tok_clbrk(])"}},
     {"array(1)", {"tok_array(array)", "tok_oppar(()", "tok_int_const(1)", "tok_clpar())"}},
 
+    {"define", {"tok_define(define)"}},
+    {"\\define", {"tok_define(\\define)"}},
+    {"defined", {"tok_defined(defined)"}},
+    {"\\defined", {"tok_defined(\\defined)"}},
+
     // combined tests
     {"echo \"{$x->y}\";", {"tok_echo(echo)", "tok_str_begin(\")", "tok_expr_begin({)", "tok_var_name($x)", "tok_arrow(->)", "tok_func_name(y)", "tok_expr_end(})", "tok_str_end(\")", "tok_semicolon(;)"}},
   };

--- a/tests/phpt/dl/1038_leading_slash_in_constants_defines.php
+++ b/tests/phpt/dl/1038_leading_slash_in_constants_defines.php
@@ -1,0 +1,8 @@
+@ok
+<?php
+
+define('foo', 23);
+var_dump(foo);
+var_dump(\foo);
+var_dump(defined('foo'));
+var_dump(defined('\foo'));

--- a/tests/phpt/dl/1038_leading_slash_in_constants_defines.php
+++ b/tests/phpt/dl/1038_leading_slash_in_constants_defines.php
@@ -6,3 +6,9 @@ var_dump(foo);
 var_dump(\foo);
 var_dump(defined('foo'));
 var_dump(defined('\foo'));
+
+\define('bar', 47);
+var_dump(bar);
+var_dump(\bar);
+var_dump(\defined('bar'));
+var_dump(\defined('\bar'));


### PR DESCRIPTION
Despite that we don't support namespaces yet, such code could be operated properly though:
```
var_dump(\PHP_EOL); // constants
\defined('foo'); // deidined
```