### PR TITLE
add php8 array_is_list function

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -299,6 +299,7 @@ function array_reserve_map_int_keys (&$a ::: array, $size ::: int) ::: void;
 function array_reserve_map_string_keys (&$a ::: array, $size ::: int) ::: void;
 function array_reserve_from (&$a ::: array, $base ::: array) ::: void;
 function array_is_vector ($a ::: array) ::: bool;
+function array_is_list ($a ::: array) ::: bool;
 
 function empty ($val ::: any) ::: bool;
 function count ($val ::: any) ::: int;

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -220,6 +220,8 @@ void f$array_reserve_from(array<T1> &a, const array<T2> &base);
 template<class T>
 bool f$array_is_vector(const array<T> &a);
 
+template<class T>
+bool f$array_is_list(const array<T> &a);
 
 array<mixed> f$range(const mixed &from, const mixed &to, int64_t step = 1);
 
@@ -1269,6 +1271,14 @@ void f$array_reserve_from(array<T1> &a, const array<T2> &base) {
 template<class T>
 bool f$array_is_vector(const array<T> &a) {
   return a.is_vector();
+}
+
+template<class T>
+bool f$array_is_list(const array<T> &a) {
+  // is_vector() is fast, but not enough;
+  // is_pseudo_vector() doesn't cover is_vector() case,
+  // so we need to call both of them to get the precise and PHP-compatible answer
+  return a.is_vector() || a.is_pseudo_vector();
 }
 
 

--- a/tests/phpt/array/026_array_is_list.php
+++ b/tests/phpt/array/026_array_is_list.php
@@ -1,0 +1,28 @@
+@ok php8
+<?php
+
+var_dump(array_is_list([]));
+var_dump(array_is_list([1, 2]));
+var_dump(array_is_list([1, 'x', 2]));
+var_dump(array_is_list(['a']));
+var_dump(array_is_list([[1], [2]]));
+var_dump(array_is_list([['a']]));
+var_dump(array_is_list([0 => 1, 1 => 2]));
+
+var_dump(array_is_list(['a' => 10]));
+var_dump(array_is_list([0 => 1, 1 => 2, 'a' => 10]));
+var_dump(array_is_list([1 => 2]));
+var_dump(array_is_list([1 => 'a', 0 => 'b']));
+
+$a = [1, 2, 3];
+unset($a[1]);
+$a[1] = 10;
+var_dump(array_is_list($a));
+
+$a2 = [];
+$a2[] = 1;
+var_dump(array_is_list($a2));
+$a2[] = 2;
+var_dump(array_is_list($a2));
+unset($a[0]);
+var_dump(array_is_list($a2));

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -107,5 +107,5 @@ def search_php_bin(php8_require=False):
     if sys.platform == "darwin":
         return shutil.which("php")
     if php8_require:
-        return shutil.which("php8.0")
+        return shutil.which("php8.1") or shutil.which("php8")
     return shutil.which("php7.4")


### PR DESCRIPTION
This function works like `array<>::is_pseudo_vector`,
but also includes a fast path for arrays that are real vectors.

In the end, it behaves like php8 `array_is_list` function,
hence it has the same name.

Refs #290