### PR TITLE
add initial SPL ArrayIterator class support

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1367,6 +1367,13 @@ function set_migration_php8_warning ($mask ::: int) ::: void;
 
 function set_json_log_on_timeout_mode(bool $enabled) ::: void;
 
+// re-initialize given ArrayIterator with another array;
+// in KPHP it returns the same ArrayIterator that is ready to be used
+// in PHP (via polyfills) it returns a newly allocated object
+//
+// reset_array_iterator is a KPHP extension of ArrayIterator API
+function reset_array_iterator(ArrayIterator $iter, $array ::: mixed[]) : ArrayIterator;
+
 /**
  * ffi_memcpy_string implements FFI::memcpy for string-typed $src argument
  */

--- a/builtin-functions/spl.txt
+++ b/builtin-functions/spl.txt
@@ -24,3 +24,20 @@ class OverflowException extends RuntimeException {}
 class RangeException extends RuntimeException {}
 class UnderflowException extends RuntimeException {}
 class UnexpectedValueException extends RuntimeException {}
+
+// https://www.php.net/manual/en/class.arrayiterator.php
+// TODO: make it work with T[] arrays when generic classes are available.
+// For now, it only supports mixed[].
+final class ArrayIterator {
+    public function __construct($arr ::: mixed[]);
+
+    public function count(): int;
+
+    public function current(): mixed;
+
+    public function key(): mixed;
+
+    public function next(): void;
+
+    public function valid(): bool;
+}

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -21,6 +21,9 @@ prepend(KPHP_RUNTIME_JOB_WORKERS_SOURCES job-workers/
         processing-jobs.cpp
         server-functions.cpp)
 
+prepend(KPHP_RUNTIME_SPL_SOURCES spl/
+        array_iterator.cpp)
+
 prepend(KPHP_RUNTIME_PDO_SOURCES pdo/
         pdo.cpp
         pdo_statement.cpp
@@ -34,6 +37,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         ${KPHP_RUNTIME_MEMORY_RESOURCE_SOURCES}
         ${KPHP_RUNTIME_MSGPACK_SOURCES}
         ${KPHP_RUNTIME_JOB_WORKERS_SOURCES}
+        ${KPHP_RUNTIME_SPL_SOURCES}
         ${KPHP_RUNTIME_PDO_SOURCES}
         ${KPHP_RUNTIME_PDO_MYSQL_SOURCES}
         allocator.cpp

--- a/runtime/spl/array_iterator.cpp
+++ b/runtime/spl/array_iterator.cpp
@@ -1,0 +1,16 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/spl/array_iterator.h"
+
+void array_iterator_reset(const class_instance<C$ArrayIterator> &iter, const array<mixed> &arr) noexcept {
+  iter->arr = arr;
+  iter->it = const_begin(arr);
+  iter->end = const_end(arr);
+}
+
+class_instance<C$ArrayIterator> f$ArrayIterator$$__construct(class_instance<C$ArrayIterator> const &v$this, const array<mixed> &arr) noexcept {
+  array_iterator_reset(v$this, arr);
+  return v$this;
+}

--- a/runtime/spl/array_iterator.h
+++ b/runtime/spl/array_iterator.h
@@ -1,0 +1,62 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "common/algorithms/hashes.h"
+#include "common/wrappers/string_view.h"
+
+#include "runtime/dummy-visitor-methods.h"
+#include "runtime/kphp_core.h"
+#include "runtime/refcountable_php_classes.h"
+
+// C$ArrayIterator implements SPL ArrayIterator class.
+struct C$ArrayIterator : public refcountable_php_classes<C$ArrayIterator>, private DummyVisitorMethods {
+  // we store an array to keep a living reference to it while iterator is valid;
+  // also we may implement rewind() method later if we feel like it
+  array<mixed> arr;
+  array<mixed>::const_iterator it;
+  array<mixed>::const_iterator end;
+
+  const char *get_class() const noexcept {
+    return "ArrayIterator";
+  }
+
+  int32_t get_hash() const noexcept {
+    return static_cast<int32_t>(vk::std_hash(vk::string_view(get_class())));
+  }
+
+  using DummyVisitorMethods::accept;
+};
+
+void array_iterator_reset(class_instance<C$ArrayIterator> const &v$this, const array<mixed> &arr) noexcept;
+
+class_instance<C$ArrayIterator> f$ArrayIterator$$__construct(class_instance<C$ArrayIterator> const &v$this, const array<mixed> &arr) noexcept;
+
+inline bool f$ArrayIterator$$valid(class_instance<C$ArrayIterator> const &v$this) noexcept {
+  return v$this->it != v$this->end;
+}
+
+inline int64_t f$ArrayIterator$$count(class_instance<C$ArrayIterator> const &v$this) noexcept {
+  return v$this->arr.count();
+}
+
+inline mixed f$ArrayIterator$$current(class_instance<C$ArrayIterator> const &v$this) noexcept {
+  return v$this->it != v$this->end ? v$this->it.get_value() : Optional<bool>{};
+}
+
+inline mixed f$ArrayIterator$$key(class_instance<C$ArrayIterator> const &v$this) noexcept {
+  return v$this->it != v$this->end ? v$this->it.get_key() : Optional<bool>{};
+}
+
+inline void f$ArrayIterator$$next(class_instance<C$ArrayIterator> const &v$this) noexcept {
+  if (v$this->it != v$this->end) {
+    ++v$this->it;
+  }
+}
+
+inline class_instance<C$ArrayIterator> f$reset_array_iterator(const class_instance<C$ArrayIterator> &iter, const array<mixed> &arr) {
+  array_iterator_reset(iter, arr);
+  return iter;
+}

--- a/tests/phpt/spl/array_iterator.php
+++ b/tests/phpt/spl/array_iterator.php
@@ -1,0 +1,92 @@
+@ok
+<?php
+
+function test_empty_array_iterator() {
+  $it = new ArrayIterator([]);
+  var_dump($it->current());
+  var_dump($it->key());
+  var_dump($it->count());
+  var_dump($it->valid());
+  $it->next();
+  var_dump($it->current());
+  var_dump($it->key());
+  var_dump($it->count());
+  var_dump($it->valid());
+}
+
+function test_invalid_array_iterator() {
+  $it = new ArrayIterator([1]);
+  var_dump($it->valid());
+  $it->next();
+  var_dump($it->valid());
+  var_dump($it->key());
+  var_dump($it->current());
+
+  var_dump($it->valid());
+  $it->next();
+  $it->next();
+  var_dump($it->valid());
+  var_dump($it->key());
+  var_dump($it->current());
+}
+
+/** @param ArrayIterator $iter */
+function test1($iter) {
+  $i = 0;
+  while ($iter->valid()) {
+    var_dump("$i => " . json_encode($iter->current()) . '/' . $iter->key());
+    $iter->next();
+  }
+}
+
+/** @param ArrayIterator $iter */
+function test2($iter) {
+  if (!$iter->valid()) {
+    return;
+  }
+  for ($i = 0; $i < $iter->count(); $i++) {
+    var_dump("$i => " . json_encode($iter->current()) . '/' . $iter->key());
+    $iter->next();
+  }
+}
+
+$arrays = [
+  [],
+  [''],
+  [0],
+  [1, 2, 3],
+  ['a' => 1, 'b' => 2],
+  [5 => 1, 'x' => 53, 'b' => 'str', 0 => 42],
+  [10 => 'a', 2 => 'b'],
+  [[], []],
+  [[1], [2]],
+  ['a' => [1], 'b' => [2, 3]],
+];
+
+test_empty_array_iterator();
+test_invalid_array_iterator();
+
+foreach ($arrays as $a) {
+  test1(new ArrayIterator($a));
+  $iter = new ArrayIterator($a);
+  var_dump($iter->valid());
+  test1($iter);
+  var_dump($iter->valid());
+
+  $array_copy = $a;
+  $iter = new ArrayIterator($array_copy);
+  var_dump($iter->count());
+  if (count($array_copy) !== 0) {
+    array_pop($array_copy);
+  }
+  var_dump($iter->count());
+  test1($iter);
+  var_dump($iter->count());
+
+  $iter = new ArrayIterator($array_copy);
+  test2($iter);
+  test1($iter);
+  $iter = new ArrayIterator($array_copy);
+  test1($iter);
+  test2($iter);
+}


### PR DESCRIPTION
ArrayIterator provides a way to iterate the array without
using `foreach` statement or legacy `next()`/`current()` APIs.

In PHP it has almost identical performance to the above mentioned
pair of `next()`/`current()`.
In KPHP it works with minimal overhead when compared to a normal
`foreach` statement. This means that is can be used in lower
level components that need to iterate the array in unusual way.

Some performance comparison results:

	Direct1000         7065.0 ns/op   0 B/op      0 allocs/op
	ArrayIterator1000  8375.0 ns/op   0 B/op      0 allocs/op
	CopyKeys1000       40541.0 ns/op  16088 B/op  1 allocs/op
	Reslice1000        74655.0 ns/op  88088 B/op  1001 allocs/op

Direct - `foreach` array iteration.
ArrayIterator uses the newly introduced class.
CopyKeys uses `array_keys()` to iterate the array.
Reslice uses `array_slice()` to extract the array portion.

The 0 allocations are possible with KPHP function `reset_array_iterator`
that can be used to re-use the array iterator objects when possible.
This function is trivially polyfilled in PHP.

Until KPHP supports generic classes, this ArrayIterator only works
with `mixed[]` typed arrays.