### PR TITLE
add stripcslashes function

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -629,6 +629,7 @@ function parse_str ($str ::: string, &$arr ::: mixed) ::: void; // TODO: why no 
 function ord ($c ::: string) ::: int;
 function strcasecmp ($str1 ::: string, $str2 ::: string) ::: int;
 function strcmp ($str1 ::: string, $str2 ::: string) ::: int;
+function stripcslashes ($str ::: string) ::: string;
 function stripslashes ($str ::: string) ::: string;
 function strip_tags ($str ::: string, $allow ::: string|string[] = "") ::: string;
 function strncmp ($str1 ::: string, $str2 ::: string, $len ::: int) ::: int;

--- a/runtime/string_functions.h
+++ b/runtime/string_functions.h
@@ -92,6 +92,8 @@ Optional<string> f$setlocale(int64_t category, const string &locale);
 
 string f$sprintf(const string &format, const array<mixed> &a);
 
+string f$stripcslashes(const string &str);
+
 string f$stripslashes(const string &str);
 
 int64_t f$strcasecmp(const string &lhs, const string &rhs);

--- a/tests/phpt/dl/429_addslashes.php
+++ b/tests/phpt/dl/429_addslashes.php
@@ -1,4 +1,4 @@
-@ok benchmark
+@ok
 <?php
   for ($i = 0; $i < 256; $i++)
     $s_full .= chr ($i);
@@ -11,16 +11,72 @@
   
   $s = str_repeat ($s_full, 100);
 
-//  for ($i = 0; $i < 10000; $i++) {
-//    $res = addcslashes ($s, " \n\r\t\v\0");
-//    $res = addcslashes ($s, "\0..\xff");
-//  }
-
-//  $s = str_repeat ("'\"\\a", 6400);
   $s = addslashes ($s).'\n\r\b\a\f\q\1\012\0\\\\\\';
 
-  for ($i = 0; $i < 10000; $i++) {
+  for ($i = 0; $i < 100; $i++) {
     $res = stripslashes ($s);
   }
 
   var_dump ($res);
+
+$tests = [
+  '',
+  '\H\e\l\l\o \W\or\l\d',
+  'Hello World\\r\\n',
+  '\\\Hello World',
+  '\x48\x65\x6c\x6c\x6f \x57\x6f\x72\x6c\x64',
+  '\x1\x2',
+  '\x11\x22',
+  '\x1\x22',
+  '\x11\x2',
+  '\xfff12',
+  '\xz12\x_112',
+  '\x',
+  '\xx',
+  '\\x',
+  '\x1',
+  '\xrr',
+  "\x\n",
+  '\\',
+  '\'',
+  "\\\"",
+  "\\",
+  "\\\\\"",
+  '\110\145\154\154\157 \127\157\162\154\144',
+  '\\a',
+  '\\b',
+  '\\f',
+  '\\t',
+  '\\v',
+  '\065\x64',
+  '\0',
+  '\1a\1',
+  '\11a\11',
+  '\1111',
+  '\9a',
+];
+
+$all_tests = [];
+foreach ($tests as $test) {
+  $all_tests[] = $test;
+  $all_tests[] = "$test$test";
+  $all_tests[] = "$test\n\\$test\\";
+  $all_tests[] = "$test ";
+  $all_tests[] = " $test";
+  $all_tests[] = "$test\x00";
+  $all_tests[] = "\x00$test";
+  $all_tests[] = "$test\x00$test";
+}
+
+foreach ($all_tests as $test) {
+  $res = stripcslashes($test);
+  var_dump($res);
+  $res2 = addcslashes($res, " \n\r\t\v\0");
+  var_dump(stripcslashes($res2));
+}
+
+var_dump(bin2hex(stripcslashes('\\a')));
+var_dump(bin2hex(stripcslashes('\\b')));
+var_dump(bin2hex(stripcslashes('\\f')));
+var_dump(bin2hex(stripcslashes('\\t')));
+var_dump(bin2hex(stripcslashes('\\v')));


### PR DESCRIPTION
We already have addcslashes, so having the opposite operation
does make sense. This function is useful when parsing string
literals with C-style escape sequences like `\n` etc.