### PR TITLE
add DateTime class

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1510,11 +1510,14 @@ interface DateTimeInterface {
 
   /* Methods */
   public function format(string $format): string;
+  public function getTimestamp(): int;
 }
 
 class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
-  public function format(string $format): string;
   public static function getLastErrors(): array|false;
+  public function setTimestamp(int $timestamp): DateTime;
+  public function format(string $format): string;
+  public function getTimestamp(): int;
 }

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1492,7 +1492,27 @@ class DateTimeZone {
   public function getName(): string;
 }
 
-class DateTime {
+interface DateTimeInterface {
+  /* Constants */
+  const ATOM = "Y-m-d\TH:i:sP";
+  const COOKIE = "l, d-M-Y H:i:s T";
+  const ISO8601 = "Y-m-d\TH:i:sO";
+  const RFC822 = "D, d M y H:i:s O";
+  const RFC850 = "l, d-M-y H:i:s T";
+  const RFC1036 = "D, d M y H:i:s O";
+  const RFC1123 = "D, d M Y H:i:s O";
+  const RFC7231 = "D, d M Y H:i:s \G\M\T";
+  const RFC2822 = "D, d M Y H:i:s O";
+  const RFC3339 = "Y-m-d\TH:i:sP";
+  const RFC3339_EXTENDED = "Y-m-d\TH:i:s.vP";
+  const RSS = "D, d M Y H:i:s O";
+  const W3C = "Y-m-d\TH:i:sP";
+
+  /* Methods */
+  public function format(string $format): string;
+}
+
+class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
   public function format(string $format): string;

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1495,5 +1495,6 @@ class DateTimeZone {
 class DateTime {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
+  public function format(string $format): string;
   public static function getLastErrors(): array|false;
 }

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1485,3 +1485,15 @@ class JsonEncoder {
   /** @kphp-extern-func-info cpp_template_call */
   static function from_json_impl(string $encoder_tag, string $json, string $class_name) ::: instance<^3>;
 }
+
+class DateTimeZone {
+  /** @kphp-extern-func-info can_throw */
+  public function __construct(string $timezone);
+  public function getName(): string;
+}
+
+class DateTime {
+  /** @kphp-extern-func-info can_throw */
+  public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
+  public static function getLastErrors(): array|false;
+}

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1516,6 +1516,7 @@ interface DateTimeInterface {
 class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
+  public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): ?DateTime;
   public static function getLastErrors(): array|false;
   public function modify(string $modifier): ?DateTime;
   public function setDate(int $year, int $month, int $day): DateTime;

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1520,6 +1520,12 @@ class DateTime implements DateTimeInterface {
   public function modify(string $modifier): DateTime|false;
   public function setDate(int $year, int $month, int $day): DateTime;
   public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime;
+  public function setTime(
+      int $hour,
+      int $minute,
+      int $second = 0,
+      int $microsecond = 0
+  ): DateTime;
   public function setTimestamp(int $timestamp): DateTime;
   public function format(string $format): string;
   public function getTimestamp(): int;

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1519,6 +1519,7 @@ class DateTime implements DateTimeInterface {
   public static function getLastErrors(): array|false;
   public function modify(string $modifier): DateTime|false;
   public function setDate(int $year, int $month, int $day): DateTime;
+  public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime;
   public function setTimestamp(int $timestamp): DateTime;
   public function format(string $format): string;
   public function getTimestamp(): int;

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1517,7 +1517,7 @@ class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
   public static function getLastErrors(): array|false;
-  public function modify(string $modifier): DateTime|false;
+  public function modify(string $modifier): ?DateTime;
   public function setDate(int $year, int $month, int $day): DateTime;
   public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime;
   public function setTime(

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1510,6 +1510,7 @@ interface DateTimeInterface {
 
   /* Methods */
   public function format(string $format): string;
+  public function getOffset(): int;
   public function getTimestamp(): int;
 }
 
@@ -1529,5 +1530,6 @@ class DateTime implements DateTimeInterface {
   ): DateTime;
   public function setTimestamp(int $timestamp): DateTime;
   public function format(string $format): string;
+  public function getOffset(): int;
   public function getTimestamp(): int;
 }

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1518,6 +1518,7 @@ class DateTime implements DateTimeInterface {
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
   public static function getLastErrors(): array|false;
   public function modify(string $modifier): DateTime|false;
+  public function setDate(int $year, int $month, int $day): DateTime;
   public function setTimestamp(int $timestamp): DateTime;
   public function format(string $format): string;
   public function getTimestamp(): int;

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1517,6 +1517,7 @@ class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
   public static function getLastErrors(): array|false;
+  public function modify(string $modifier): DateTime|false;
   public function setTimestamp(int $timestamp): DateTime;
   public function format(string $format): string;
   public function getTimestamp(): int;

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -48,6 +48,15 @@ Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept {
   return php_timelib_date_get_last_errors();
 }
 
+class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &self, const string &modifier) noexcept {
+  auto [success, error_msg] = php_timelib_date_modify(self->time, modifier);
+  if (!success) {
+    php_warning("DateTime::modify(): %s", error_msg.c_str());
+    return {};
+  }
+  return self;
+}
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
   php_timelib_date_timestamp_set(self->time, timestamp);
   return self;

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -47,3 +47,7 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept {
   return php_timelib_date_get_last_errors();
 }
+
+string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept {
+  return php_timelib_date_format_localtime(format, self->time);
+}

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -57,6 +57,11 @@ class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &
   return self;
 }
 
+class_instance<C$DateTime> f$DateTime$$setDate(const class_instance<C$DateTime> &self, int64_t year, int64_t month, int64_t day) noexcept {
+  php_timelib_date_date_set(self->time, year, month, day);
+  return self;
+}
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
   php_timelib_date_timestamp_set(self->time, timestamp);
   return self;

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -1,0 +1,49 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/datetime-class.h"
+
+#include <cstring>
+
+#include "runtime/exception.h"
+#include "runtime/datetime.h"
+
+class_instance<C$DateTimeZone> f$DateTimeZone$$__construct(const class_instance<C$DateTimeZone> &self, const string &timezone) noexcept {
+  if (strcmp(PHP_TIMELIB_TZ_MOSCOW, timezone.c_str()) != 0 && strcmp(PHP_TIMELIB_TZ_GMT3, timezone.c_str()) != 0) {
+    string error_msg{"DateTimeZone::__construct(): Unknown or bad timezone "};
+    error_msg.append(1, '(').append(timezone).append(1, ')');
+    THROW_EXCEPTION(new_Exception(string{__FILE__}, __LINE__, error_msg));
+    return {};
+  }
+  self->timezone = timezone;
+  return self;
+}
+
+string f$DateTimeZone$$getName(const class_instance<C$DateTimeZone> &self) noexcept {
+  return self->timezone;
+}
+
+C$DateTime::~C$DateTime() {
+  php_timelib_date_remove(time);
+  time = nullptr;
+}
+
+const string NOW{"now", 3};
+
+class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTime> &self, const string &datetime,
+                                                   const class_instance<C$DateTimeZone> &timezone) noexcept {
+  auto [time, error_msg] = php_timelib_date_initialize(timezone.is_null() ? string{} : timezone->timezone, datetime);
+  if (!time) {
+    string error{"DateTime::__construct(): "};
+    error.append(error_msg);
+    THROW_EXCEPTION(new_Exception(string{__FILE__}, __LINE__, error));
+    return {};
+  }
+  self->time = time;
+  return self;
+}
+
+Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept {
+  return php_timelib_date_get_last_errors();
+}

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -48,6 +48,15 @@ Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept {
   return php_timelib_date_get_last_errors();
 }
 
+class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
+  php_timelib_date_timestamp_set(self->time, timestamp);
+  return self;
+}
+
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept {
   return php_timelib_date_format_localtime(format, self->time);
+}
+
+int64_t f$DateTime$$getTimestamp(const class_instance<C$DateTime> &self) noexcept {
+  return php_timelib_date_timestamp_get(self->time);
 }

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -94,6 +94,10 @@ string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &
   return php_timelib_date_format_localtime(format, self->time);
 }
 
+int64_t f$DateTime$$getOffset(const class_instance<C$DateTime> &self) noexcept {
+  return php_timelib_date_offset_get(self->time);
+}
+
 int64_t f$DateTime$$getTimestamp(const class_instance<C$DateTime> &self) noexcept {
   return php_timelib_date_timestamp_get(self->time);
 }

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -62,6 +62,11 @@ class_instance<C$DateTime> f$DateTime$$setDate(const class_instance<C$DateTime> 
   return self;
 }
 
+class_instance<C$DateTime> f$DateTime$$setISODate(const class_instance<C$DateTime> &self, int64_t year, int64_t week, int64_t dayOfWeek) noexcept {
+  php_timelib_date_isodate_set(self->time, year, week, dayOfWeek);
+  return self;
+}
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
   php_timelib_date_timestamp_set(self->time, timestamp);
   return self;

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -67,6 +67,12 @@ class_instance<C$DateTime> f$DateTime$$setISODate(const class_instance<C$DateTim
   return self;
 }
 
+class_instance<C$DateTime> f$DateTime$$setTime(const class_instance<C$DateTime> &self, int64_t hour, int64_t minute, int64_t second,
+                                               int64_t microsecond) noexcept {
+  php_date_time_set(self->time, hour, minute, second, microsecond);
+  return self;
+}
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
   php_timelib_date_timestamp_set(self->time, timestamp);
   return self;

--- a/runtime/datetime-class.cpp
+++ b/runtime/datetime-class.cpp
@@ -44,6 +44,18 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
   return self;
 }
 
+class_instance<C$DateTime> f$DateTime$$createFromFormat(const string &format, const string &datetime,
+                                                        const class_instance<C$DateTimeZone> &timezone) noexcept {
+  auto [time, _] = php_timelib_date_initialize(timezone.is_null() ? string{} : timezone->timezone, datetime, format.c_str());
+  if (!time) {
+    return {};
+  }
+  class_instance<C$DateTime> date_time;
+  date_time.alloc();
+  date_time->time = time;
+  return date_time;
+}
+
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept {
   return php_timelib_date_get_last_errors();
 }

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -48,4 +48,8 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
 
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;
 
+class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
+
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;
+
+int64_t f$DateTime$$getTimestamp(const class_instance<C$DateTime> &self) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -52,6 +52,8 @@ class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &
 
 class_instance<C$DateTime> f$DateTime$$setDate(const class_instance<C$DateTime> &self, int64_t year, int64_t month, int64_t day) noexcept;
 
+class_instance<C$DateTime> f$DateTime$$setISODate(const class_instance<C$DateTime> &self, int64_t year, int64_t week, int64_t dayOfWeek = 1) noexcept;
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -54,6 +54,9 @@ class_instance<C$DateTime> f$DateTime$$setDate(const class_instance<C$DateTime> 
 
 class_instance<C$DateTime> f$DateTime$$setISODate(const class_instance<C$DateTime> &self, int64_t year, int64_t week, int64_t dayOfWeek = 1) noexcept;
 
+class_instance<C$DateTime> f$DateTime$$setTime(const class_instance<C$DateTime> &self, int64_t hour, int64_t minute, int64_t second = 0,
+                                               int64_t microsecond = 0) noexcept;
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -1,0 +1,44 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/kphp_core.h"
+#include "runtime/refcountable_php_classes.h"
+#include "runtime/timelib_wrapper.h"
+
+struct C$DateTimeZone : public refcountable_php_classes<C$DateTimeZone> {
+  string timezone;
+
+  const char *get_class() const noexcept {
+    return R"(DateTimeZone)";
+  }
+
+  int get_hash() const noexcept {
+    return 219249843;
+  }
+};
+
+class_instance<C$DateTimeZone> f$DateTimeZone$$__construct(const class_instance<C$DateTimeZone> &self, const string &timezone) noexcept;
+string f$DateTimeZone$$getName(const class_instance<C$DateTimeZone> &self) noexcept;
+
+struct C$DateTime : public refcountable_php_classes<C$DateTime> {
+  timelib_time *time{nullptr};
+
+  const char *get_class() const noexcept {
+    return R"(DateTime)";
+  }
+
+  int get_hash() const noexcept {
+    return 2141635158;
+  }
+
+  ~C$DateTime();
+};
+
+extern const string NOW;
+class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTime> &self, const string &datetime = NOW,
+                                                   const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
+
+Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -48,6 +48,8 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
 
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;
 
+class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &self, const string &modifier) noexcept;
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -4,11 +4,14 @@
 
 #pragma once
 
+#include "runtime/dummy-visitor-methods.h"
 #include "runtime/kphp_core.h"
 #include "runtime/refcountable_php_classes.h"
 #include "runtime/timelib_wrapper.h"
 
-struct C$DateTimeZone : public refcountable_php_classes<C$DateTimeZone> {
+struct C$DateTimeZone : public refcountable_php_classes<C$DateTimeZone>, private DummyVisitorMethods {
+  using DummyVisitorMethods::accept;
+
   string timezone;
 
   const char *get_class() const noexcept {
@@ -23,7 +26,9 @@ struct C$DateTimeZone : public refcountable_php_classes<C$DateTimeZone> {
 class_instance<C$DateTimeZone> f$DateTimeZone$$__construct(const class_instance<C$DateTimeZone> &self, const string &timezone) noexcept;
 string f$DateTimeZone$$getName(const class_instance<C$DateTimeZone> &self) noexcept;
 
-struct C$DateTime : public refcountable_php_classes<C$DateTime> {
+struct C$DateTime : public refcountable_php_classes<C$DateTime>, private DummyVisitorMethods {
+  using DummyVisitorMethods::accept;
+
   timelib_time *time{nullptr};
 
   const char *get_class() const noexcept {
@@ -42,3 +47,5 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
                                                    const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;
+
+string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -50,6 +50,8 @@ Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;
 
 class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &self, const string &modifier) noexcept;
 
+class_instance<C$DateTime> f$DateTime$$setDate(const class_instance<C$DateTime> &self, int64_t year, int64_t month, int64_t day) noexcept;
+
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -46,6 +46,9 @@ extern const string NOW;
 class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTime> &self, const string &datetime = NOW,
                                                    const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
+class_instance<C$DateTime> f$DateTime$$createFromFormat(const string &format, const string &datetime,
+                                                        const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
+
 Optional<array<mixed>> f$DateTime$$getLastErrors() noexcept;
 
 class_instance<C$DateTime> f$DateTime$$modify(const class_instance<C$DateTime> &self, const string &modifier) noexcept;

--- a/runtime/datetime-class.h
+++ b/runtime/datetime-class.h
@@ -64,4 +64,6 @@ class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateT
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;
 
+int64_t f$DateTime$$getOffset(const class_instance<C$DateTime> &self) noexcept;
+
 int64_t f$DateTime$$getTimestamp(const class_instance<C$DateTime> &self) noexcept;

--- a/runtime/datetime.cpp
+++ b/runtime/datetime.cpp
@@ -31,12 +31,7 @@ static void set_default_timezone_id(const char *timezone_id) {
   default_timezone_id = timezone_id;
 }
 
-static const char *day_of_week_names_short[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-static const char *day_of_week_names_full[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
 static const char *suffix[] = {"st", "nd", "rd", "th"};
-static const char *month_names_short[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-static const char *month_names_full[] = {"January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November",
-                                         "December"};
 
 static time_t gmmktime(struct tm *tm) {
   char *tz = getenv("TZ");
@@ -53,10 +48,6 @@ static time_t gmmktime(struct tm *tm) {
   tzset();
 
   return result;
-}
-
-static inline int32_t is_leap(int32_t year) {
-  return ((year % 4 == 0) ^ (year % 100 == 0) ^ (year % 400 == 0));
 }
 
 bool f$checkdate(int64_t month, int64_t day, int64_t year) {
@@ -77,8 +68,8 @@ static inline int32_t fix_year(int32_t year) {
 void iso_week_number(int y, int doy, int weekday, int &iw, int &iy) {
   int y_leap, prev_y_leap, jan1weekday;
 
-  y_leap = is_leap(y);
-  prev_y_leap = is_leap(y - 1);
+  y_leap = timelib_is_leap_year(y);
+  prev_y_leap = timelib_is_leap_year(y - 1);
 
   jan1weekday = (weekday - (doy % 7) + 7) % 7;
 
@@ -144,13 +135,13 @@ static string date(const string &format, const tm &t, int64_t timestamp, bool lo
         SB << (char)(day % 10 + '0');
         break;
       case 'D':
-        SB << day_of_week_names_short[day_of_week];
+        SB << PHP_TIMELIB_DAY_SHORT_NAMES[day_of_week];
         break;
       case 'j':
         SB << day;
         break;
       case 'l':
-        SB << day_of_week_names_full[day_of_week];
+        SB << PHP_TIMELIB_DAY_FULL_NAMES[day_of_week];
         break;
       case 'N':
         SB << (day_of_week == 0 ? '7' : (char)(day_of_week + '0'));
@@ -189,14 +180,14 @@ static string date(const string &format, const tm &t, int64_t timestamp, bool lo
         SB << (char)('0' + iso_week % 10);
         break;
       case 'F':
-        SB << month_names_full[month - 1];
+        SB << PHP_TIMELIB_MON_FULL_NAMES[month - 1];
         break;
       case 'm':
         SB << (char)(month / 10 + '0');
         SB << (char)(month % 10 + '0');
         break;
       case 'M':
-        SB << month_names_short[month - 1];
+        SB << PHP_TIMELIB_MON_SHORT_NAMES[month - 1];
         break;
       case 'n':
         SB << month;
@@ -205,7 +196,7 @@ static string date(const string &format, const tm &t, int64_t timestamp, bool lo
         SB << php_timelib_days_in_month(month, year);
         break;
       case 'L':
-        SB << (int)is_leap(year);
+        SB << (int)timelib_is_leap_year(year);
         break;
       case 'o':
         iso_week_number(year, day_of_year, day_of_week, iso_week, iso_year);
@@ -317,12 +308,12 @@ static string date(const string &format, const tm &t, int64_t timestamp, bool lo
         }
         break;
       case 'r':
-        SB << day_of_week_names_short[day_of_week];
+        SB << PHP_TIMELIB_DAY_SHORT_NAMES[day_of_week];
         SB << ", ";
         SB << (char)(day / 10 + '0');
         SB << (char)(day % 10 + '0');
         SB << ' ';
-        SB << month_names_short[month - 1];
+        SB << PHP_TIMELIB_MON_SHORT_NAMES[month - 1];
         SB << ' ';
         SB << year;
         SB << ' ';
@@ -405,8 +396,8 @@ array<mixed> f$getdate(int64_t timestamp) {
   result.set_value(string("mon", 3), t.tm_mon + 1);
   result.set_value(string("year", 4), t.tm_year + 1900);
   result.set_value(string("yday", 4), t.tm_yday);
-  result.set_value(string("weekday", 7), string(day_of_week_names_full[t.tm_wday]));
-  result.set_value(string("month", 5), string(month_names_full[t.tm_mon]));
+  result.set_value(string("weekday", 7), string(PHP_TIMELIB_DAY_FULL_NAMES[t.tm_wday]));
+  result.set_value(string("month", 5), string(PHP_TIMELIB_MON_FULL_NAMES[t.tm_mon]));
   result.set_value(string("0", 1), timestamp);
 
   return result;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2281,6 +2281,7 @@ static void free_runtime_libs() {
   free_typed_rpc_lib();
   free_streams_lib();
   free_udp_lib();
+  free_timelib();
   OnKphpWarningCallback::get().reset();
 
   free_job_client_interface_lib();

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -46,6 +46,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         critical_section.cpp
         curl.cpp
         datetime.cpp
+        datetime-class.cpp
         exception.cpp
         files.cpp
         from-json-processor.cpp

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -631,3 +631,10 @@ std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &m
 
   return {true, {}};
 }
+
+void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d) {
+  t->y = y;
+  t->m = m;
+  t->d = d;
+  timelib_update_ts(t, nullptr);
+}

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -308,16 +308,7 @@ Optional<array<mixed>> php_timelib_date_get_last_errors() {
   return false;
 }
 
-static const char *const mon_full_names[] = {"January", "February", "March",     "April",   "May",      "June",
-                                             "July",    "August",   "September", "October", "November", "December"};
-
-static const char *const mon_short_names[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
-
-static const char *const day_full_names[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
-
-static const char *const day_short_names[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
-
-static const char *english_suffix(timelib_sll number) {
+constexpr const char *english_suffix(timelib_sll number) noexcept {
   if (number >= 10 && number <= 19) {
     return "th";
   } else {
@@ -332,15 +323,13 @@ static const char *english_suffix(timelib_sll number) {
   }
   return "th";
 }
-/* }}} */
 
-/* {{{ day of week helpers */
 static const char *php_date_full_day_name(timelib_sll y, timelib_sll m, timelib_sll d) {
   timelib_sll day_of_week = timelib_day_of_week(y, m, d);
   if (day_of_week < 0) {
     return "Unknown";
   }
-  return day_full_names[day_of_week];
+  return PHP_TIMELIB_DAY_FULL_NAMES[day_of_week];
 }
 
 static const char *php_date_short_day_name(timelib_sll y, timelib_sll m, timelib_sll d) {
@@ -348,10 +337,8 @@ static const char *php_date_short_day_name(timelib_sll y, timelib_sll m, timelib
   if (day_of_week < 0) {
     return "Unknown";
   }
-  return day_short_names[day_of_week];
+  return PHP_TIMELIB_DAY_SHORT_NAMES[day_of_week];
 }
-
-#define timelib_is_leap(y) ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
 
 using StaticBuf = std::array<char, 128>;
 
@@ -440,13 +427,13 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
 
       /* month */
       case 'F':
-        length = safe_snprintf(buffer, "%s", mon_full_names[t->m - 1]);
+        length = safe_snprintf(buffer, "%s", PHP_TIMELIB_MON_FULL_NAMES[t->m - 1]);
         break;
       case 'm':
         length = safe_snprintf(buffer, "%02d", static_cast<int>(t->m));
         break;
       case 'M':
-        length = safe_snprintf(buffer, "%s", mon_short_names[t->m - 1]);
+        length = safe_snprintf(buffer, "%s", PHP_TIMELIB_MON_SHORT_NAMES[t->m - 1]);
         break;
       case 'n':
         length = safe_snprintf(buffer, "%d", static_cast<int>(t->m));
@@ -457,7 +444,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
 
       /* year */
       case 'L':
-        length = safe_snprintf(buffer, "%d", timelib_is_leap((int)t->y));
+        length = safe_snprintf(buffer, "%d", timelib_is_leap_year(static_cast<int>(t->y)));
         break;
       case 'y':
         length = safe_snprintf(buffer, "%02d", static_cast<int>(t->y % 100));
@@ -537,8 +524,8 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         break;
       case 'r':
         length = safe_snprintf(buffer, "%3s, %02d %3s %04ld %02d:%02d:%02d %c%02d%02d", php_date_short_day_name(t->y, t->m, t->d), static_cast<int>(t->d),
-                               mon_short_names[t->m - 1], static_cast<int64_t>(t->y), static_cast<int>(t->h), static_cast<int>(t->i), static_cast<int>(t->s),
-                               localtime ? ((offset->offset < 0) ? '-' : '+') : '+', localtime ? abs(offset->offset / 3600) : 0,
+                               PHP_TIMELIB_MON_SHORT_NAMES[t->m - 1], static_cast<int64_t>(t->y), static_cast<int>(t->h), static_cast<int>(t->i),
+                               static_cast<int>(t->s), localtime ? ((offset->offset < 0) ? '-' : '+') : '+', localtime ? abs(offset->offset / 3600) : 0,
                                localtime ? abs((offset->offset % 3600) / 60) : 0);
         break;
       case 'U':

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -648,3 +648,11 @@ void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t
   t->have_relative = 1;
   timelib_update_ts(t, nullptr);
 }
+
+void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t ms) {
+  t->h = h;
+  t->i = i;
+  t->s = s;
+  t->us = ms;
+  timelib_update_ts(t, nullptr);
+}

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -264,11 +264,11 @@ std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_n
     ? timelib_parse_from_format(format, time_str.c_str(), time_str.size(), &err, timelib_builtin_db(), timelib_parse_tzfile)
     : timelib_strtotime(time_str_new.c_str(), time_str_new.size(), &err, timelib_builtin_db(), timelib_parse_tzfile);
 
-  /* update last errors and warnings */
+  // update last errors and warnings
   update_errors_warnings(err, script_guard);
 
   if (err && err->error_count) {
-    /* spit out the first library error message, at least */
+    // spit out the first library error message, at least
     timelib_time_dtor(t);
     return {nullptr, gen_parse_error_msg(*err, time_str)};
   }
@@ -387,7 +387,7 @@ static timelib_time_offset *create_time_offset(timelib_time *t, [[maybe_unused]]
     offset->offset = (t->z);
     offset->leap_secs = 0;
     offset->is_dst = 0;
-    offset->abbr = static_cast<char *>(timelib_malloc(9)); /* GMT±xxxx\0 */
+    offset->abbr = static_cast<char *>(timelib_malloc(9)); // GMT±xxxx\0
     // set upper bound to 99 just to ensure that 'hours_offset' fits in %02d
     auto hours_offset = std::min(abs(offset->offset / 3600), 99);
     snprintf(offset->abbr, 9, "GMT%c%02d%02d", (offset->offset < 0) ? '-' : '+', hours_offset, abs((offset->offset % 3600) / 60));
@@ -424,7 +424,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
   for (std::size_t i = 0; i < format.size(); ++i) {
     int rfc_colon = 0;
     switch (format[i]) {
-      /* day */
+      // day
       case 'd':
         length = safe_snprintf(buffer, "%02d", static_cast<int>(t->d));
         break;
@@ -450,23 +450,23 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         length = safe_snprintf(buffer, "%d", static_cast<int>(timelib_day_of_year(t->y, t->m, t->d)));
         break;
 
-      /* week */
+      // week
       case 'W':
         if (!weekYearSet) {
           timelib_isoweek_from_date(t->y, t->m, t->d, &isoweek, &isoyear);
           weekYearSet = 1;
         }
         length = safe_snprintf(buffer, "%02d", static_cast<int>(isoweek));
-        break; /* iso weeknr */
+        break; // iso weeknr
       case 'o':
         if (!weekYearSet) {
           timelib_isoweek_from_date(t->y, t->m, t->d, &isoweek, &isoyear);
           weekYearSet = 1;
         }
         length = safe_snprintf(buffer, "%ld", static_cast<int64_t>(isoyear));
-        break; /* iso year */
+        break; // iso year
 
-      /* month */
+      // month
       case 'F':
         length = safe_snprintf(buffer, "%s", PHP_TIMELIB_MON_FULL_NAMES[t->m - 1]);
         break;
@@ -483,7 +483,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         length = safe_snprintf(buffer, "%d", static_cast<int>(timelib_days_in_month(t->y, t->m)));
         break;
 
-      /* year */
+      // year
       case 'L':
         length = safe_snprintf(buffer, "%d", timelib_is_leap_year(static_cast<int>(t->y)));
         break;
@@ -494,7 +494,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         length = safe_snprintf(buffer, "%s%04lld", t->y < 0 ? "-" : "", abs(t->y));
         break;
 
-      /* time */
+      // time
       case 'a':
         length = safe_snprintf(buffer, "%s", t->h >= 12 ? "pm" : "am");
         break;
@@ -506,7 +506,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         if (retval < 0) {
           retval += 864000;
         }
-        /* Make sure to do this on a positive int to avoid rounding errors */
+        // Make sure to do this on a positive int to avoid rounding errors
         retval = (retval / 864) % 1000;
         length = safe_snprintf(buffer, "%03d", retval);
         break;
@@ -536,7 +536,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         length = safe_snprintf(buffer, "%03d", static_cast<int>(floor(t->us / 1000)));
         break;
 
-      /* timezone */
+      // timezone
       case 'I':
         length = safe_snprintf(buffer, "%d", localtime ? offset->is_dst : 0);
         break;
@@ -571,7 +571,7 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
         length = safe_snprintf(buffer, "%d", localtime ? offset->offset : 0);
         break;
 
-      /* full date/time */
+      // full date/time
       case 'c':
         length = safe_snprintf(buffer, "%04ld-%02d-%02dT%02d:%02d:%02d%c%02d:%02d", static_cast<int64_t>(t->y), static_cast<int>(t->m), static_cast<int>(t->d),
                                static_cast<int>(t->h), static_cast<int>(t->i), static_cast<int>(t->s), localtime ? ((offset->offset < 0) ? '-' : '+') : '+',
@@ -636,11 +636,11 @@ std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &m
   timelib_time *tmp_time = timelib_strtotime(modifier.c_str(), modifier.size(), &err, timelib_builtin_db(), timelib_parse_tzfile);
   vk::final_action tmp_time_deleter{[tmp_time] { timelib_time_dtor(tmp_time); }};
 
-  /* update last errors and warnings */
+  // update last errors and warnings
   update_errors_warnings(err, script_guard);
 
   if (err && err->error_count) {
-    /* spit out the first library error message, at least */
+    // spit out the first library error message, at least
     return {false, gen_parse_error_msg(*err, modifier)};
   }
 
@@ -648,21 +648,21 @@ std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &m
   t->have_relative = tmp_time->have_relative;
   t->sse_uptodate = 0;
 
-  if (tmp_time->y != -99999) {
+  if (tmp_time->y != TIMELIB_UNSET) {
     t->y = tmp_time->y;
   }
-  if (tmp_time->m != -99999) {
+  if (tmp_time->m != TIMELIB_UNSET) {
     t->m = tmp_time->m;
   }
-  if (tmp_time->d != -99999) {
+  if (tmp_time->d != TIMELIB_UNSET) {
     t->d = tmp_time->d;
   }
 
-  if (tmp_time->h != -99999) {
+  if (tmp_time->h != TIMELIB_UNSET) {
     t->h = tmp_time->h;
-    if (tmp_time->i != -99999) {
+    if (tmp_time->i != TIMELIB_UNSET) {
       t->i = tmp_time->i;
-      if (tmp_time->s != -99999) {
+      if (tmp_time->s != TIMELIB_UNSET) {
         t->s = tmp_time->s;
       } else {
         t->s = 0;
@@ -673,7 +673,7 @@ std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &m
     }
   }
 
-  if (tmp_time->us != -99999) {
+  if (tmp_time->us != TIMELIB_UNSET) {
     t->us = tmp_time->us;
   }
 

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -556,3 +556,20 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
 string php_timelib_date_format_localtime(const string &format, timelib_time *t) {
   return php_timelib_date_format(format, t, t->is_localtime);
 }
+
+void php_timelib_date_timestamp_set(timelib_time *t, int64_t timestamp) {
+  timelib_unixtime2local(t, static_cast<timelib_sll>(timestamp));
+  timelib_update_ts(t, nullptr);
+  t->us = 0;
+}
+
+int64_t php_timelib_date_timestamp_get(timelib_time *t) {
+  timelib_update_ts(t, nullptr);
+
+  int error = 0;
+  timelib_long timestamp = timelib_date_to_int(t, &error);
+  // the 'error' should be always 0 on x64 platform
+  php_assert(error == 0);
+
+  return timestamp;
+}

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -687,3 +687,23 @@ void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t
   t->us = ms;
   timelib_update_ts(t, nullptr);
 }
+
+int64_t php_timelib_date_offset_get(timelib_time *t) {
+  if (t->is_localtime) {
+    switch (t->zone_type) {
+      case TIMELIB_ZONETYPE_ID: {
+        timelib_time_offset *offset = timelib_get_time_zone_info(t->sse, t->tz_info);
+        int64_t offset_int = offset->offset;
+        timelib_time_offset_dtor(offset);
+        return offset_int;
+      }
+      case TIMELIB_ZONETYPE_OFFSET: {
+        return t->z;
+      }
+      case TIMELIB_ZONETYPE_ABBR: {
+        return t->z + (3600 * t->dst);
+      }
+    }
+  }
+  return 0;
+}

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -225,22 +225,14 @@ std::pair<int64_t, bool> php_timelib_strtotime(const string &tz_name, const stri
   return {ts, true};
 }
 
-struct DateGlobals {
-  char *default_timezone{nullptr};
-  char *timezone{nullptr};
-//  HashTable *tzcache{nullptr};
-  timelib_error_container *last_errors{nullptr};
-  int timezone_valid{0};
-};
-
-static DateGlobals date_globals;
+static timelib_error_container *last_errors_global = nullptr;
 
 static void update_errors_warnings(timelib_error_container *last_errors) {
-  if (date_globals.last_errors) {
-    timelib_error_container_dtor(date_globals.last_errors);
-    date_globals.last_errors = nullptr;
+  if (last_errors_global) {
+    timelib_error_container_dtor(last_errors_global);
+    last_errors_global = nullptr;
   }
-  date_globals.last_errors = last_errors;
+  last_errors_global = last_errors;
 }
 
 static string gen_parse_error_msg(const timelib_error_container &err, const string &str) {
@@ -309,8 +301,8 @@ void php_timelib_date_remove(timelib_time *t) {
 }
 
 Optional<array<mixed>> php_timelib_date_get_last_errors() {
-  if (date_globals.last_errors) {
-    return dump_errors(*date_globals.last_errors);
+  if (last_errors_global) {
+    return dump_errors(*last_errors_global);
   }
   return false;
 }

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -243,11 +243,14 @@ static void update_errors_warnings(timelib_error_container *last_errors) {
   date_globals.last_errors = last_errors;
 }
 
+static const string NOW{"now"};
+
 std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_name, const string &time_str, const char *format) {
+  const string &time_str_new = time_str.empty() ? NOW : time_str;
   timelib_error_container *err = nullptr;
   timelib_time *t = format
     ? timelib_parse_from_format(format, time_str.c_str(), time_str.size(), &err, timelib_builtin_db(), timelib_parse_tzfile)
-    : timelib_strtotime(time_str.c_str(), time_str.size(), &err, timelib_builtin_db(), timelib_parse_tzfile);
+    : timelib_strtotime(time_str_new.c_str(), time_str_new.size(), &err, timelib_builtin_db(), timelib_parse_tzfile);
 
   /* update last errors and warnings */
   update_errors_warnings(err);

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -285,7 +285,12 @@ std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_n
   timelib_unixtime2local(now, static_cast<timelib_sll>(sec));
   now->us = usec;
 
-  timelib_fill_holes(t, now, TIMELIB_NO_CLONE);
+  int options = TIMELIB_NO_CLONE;
+  if (format) {
+    options |= TIMELIB_OVERRIDE_TIME;
+  }
+
+  timelib_fill_holes(t, now, options);
   timelib_update_ts(t, tzi);
   timelib_update_from_sse(t);
 

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -388,7 +388,9 @@ static timelib_time_offset *create_time_offset(timelib_time *t, [[maybe_unused]]
     offset->leap_secs = 0;
     offset->is_dst = 0;
     offset->abbr = static_cast<char *>(timelib_malloc(9)); /* GMT±xxxx\0 */
-    snprintf(offset->abbr, 9, "GMT%c%02d%02d", (offset->offset < 0) ? '-' : '+', abs(offset->offset / 3600), abs((offset->offset % 3600) / 60));
+    // set upper bound to 99 just to ensure that 'hours_offset' fits in %02d
+    auto hours_offset = std::min(abs(offset->offset / 3600), 99);
+    snprintf(offset->abbr, 9, "GMT%c%02d%02d", (offset->offset < 0) ? '-' : '+', hours_offset, abs((offset->offset % 3600) / 60));
     return offset;
   }
   return timelib_get_time_zone_info(t->sse, t->tz_info);

--- a/runtime/timelib_wrapper.cpp
+++ b/runtime/timelib_wrapper.cpp
@@ -638,3 +638,13 @@ void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d)
   t->d = d;
   timelib_update_ts(t, nullptr);
 }
+
+void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d) {
+  t->y = y;
+  t->m = 1;
+  t->d = 1;
+  std::memset(&t->relative, 0, sizeof(t->relative));
+  t->relative.d = timelib_daynr_from_weeknr(y, w, d);
+  t->have_relative = 1;
+  timelib_update_ts(t, nullptr);
+}

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -39,3 +39,5 @@ constexpr bool timelib_is_leap_year(int32_t year) noexcept {
 
 string php_timelib_date_format(const string &format, timelib_time *t, bool localtime);
 string php_timelib_date_format_localtime(const string &format, timelib_time *t);
+void php_timelib_date_timestamp_set(timelib_time *t, int64_t timestamp);
+int64_t php_timelib_date_timestamp_get(timelib_time *t);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -5,9 +5,15 @@
 // php_timelib wraps the https://github.com/derickr/timelib library
 // which is used in PHP to implement several datetime lib functions.
 
-const char* const PHP_TIMELIB_TZ_MOSCOW = "Europe/Moscow";
-const char* const PHP_TIMELIB_TZ_GMT3 = "Etc/GMT-3";
-const char* const PHP_TIMELIB_TZ_GMT4 = "Etc/GMT-4";
+const char *const PHP_TIMELIB_TZ_MOSCOW = "Europe/Moscow";
+const char *const PHP_TIMELIB_TZ_GMT3 = "Etc/GMT-3";
+const char *const PHP_TIMELIB_TZ_GMT4 = "Etc/GMT-4";
+
+const char *const PHP_TIMELIB_MON_FULL_NAMES[] = {"January", "February", "March",     "April",   "May",      "June",
+                                                  "July",    "August",   "September", "October", "November", "December"};
+const char *const PHP_TIMELIB_MON_SHORT_NAMES[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
+const char *const PHP_TIMELIB_DAY_FULL_NAMES[] = {"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"};
+const char *const PHP_TIMELIB_DAY_SHORT_NAMES[] = {"Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"};
 
 void global_init_php_timelib();
 
@@ -26,5 +32,10 @@ using timelib_time = _timelib_time;
 std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_name, const string &time_str, const char *format = nullptr);
 void php_timelib_date_remove(timelib_time *t);
 Optional<array<mixed>> php_timelib_date_get_last_errors();
+
+constexpr bool timelib_is_leap_year(int32_t year) noexcept {
+  return (year % 4 == 0) && (year % 100 != 0 || year % 400 == 0);
+}
+
 string php_timelib_date_format(const string &format, timelib_time *t, bool localtime);
 string php_timelib_date_format_localtime(const string &format, timelib_time *t);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -26,6 +26,8 @@ array<mixed> php_timelib_date_parse_from_format(const string &format, const stri
 
 bool php_timelib_is_valid_date(int64_t month, int64_t day, int64_t year);
 
+void free_timelib();
+
 struct _timelib_time;
 using timelib_time = _timelib_time;
 

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -43,3 +43,5 @@ void php_timelib_date_timestamp_set(timelib_time *t, int64_t timestamp);
 int64_t php_timelib_date_timestamp_get(timelib_time *t);
 std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &modifier);
 void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d);
+void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d);
+

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -45,3 +45,4 @@ std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &m
 void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d);
 void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d);
 void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t ms);
+int64_t php_timelib_date_offset_get(timelib_time *t);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -19,3 +19,10 @@ array<mixed> php_timelib_date_parse(const string &time_str);
 array<mixed> php_timelib_date_parse_from_format(const string &format, const string &time_str);
 
 bool php_timelib_is_valid_date(int64_t month, int64_t day, int64_t year);
+
+struct _timelib_time;
+using timelib_time = _timelib_time;
+
+std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_name, const string &time_str, const char *format = nullptr);
+void php_timelib_date_remove(timelib_time *t);
+Optional<array<mixed>> php_timelib_date_get_last_errors();

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -42,3 +42,4 @@ string php_timelib_date_format_localtime(const string &format, timelib_time *t);
 void php_timelib_date_timestamp_set(timelib_time *t, int64_t timestamp);
 int64_t php_timelib_date_timestamp_get(timelib_time *t);
 std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &modifier);
+void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -41,3 +41,4 @@ string php_timelib_date_format(const string &format, timelib_time *t, bool local
 string php_timelib_date_format_localtime(const string &format, timelib_time *t);
 void php_timelib_date_timestamp_set(timelib_time *t, int64_t timestamp);
 int64_t php_timelib_date_timestamp_get(timelib_time *t);
+std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &modifier);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -26,3 +26,5 @@ using timelib_time = _timelib_time;
 std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_name, const string &time_str, const char *format = nullptr);
 void php_timelib_date_remove(timelib_time *t);
 Optional<array<mixed>> php_timelib_date_get_last_errors();
+string php_timelib_date_format(const string &format, timelib_time *t, bool localtime);
+string php_timelib_date_format_localtime(const string &format, timelib_time *t);

--- a/runtime/timelib_wrapper.h
+++ b/runtime/timelib_wrapper.h
@@ -44,4 +44,4 @@ int64_t php_timelib_date_timestamp_get(timelib_time *t);
 std::pair<bool, string> php_timelib_date_modify(timelib_time *t, const string &modifier);
 void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d);
 void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d);
-
+void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t ms);

--- a/tests/phpt/datetime/01_format.php
+++ b/tests/phpt/datetime/01_format.php
@@ -1,37 +1,63 @@
 @ok
 <?php
 
-$date = new DateTime("2005-07-14 22:30:41");
+function test_format_basic() {
+  $date = new DateTime("2005-07-14 22:30:41");
 
-// basic
-var_dump( $date->format( "F j, Y, g:i a") );
-var_dump( $date->format( "m.d.y") );
-var_dump( $date->format( "j, n, Y") );
-var_dump( $date->format( "Ymd") );
-var_dump( $date->format( 'h-i-s, j-m-y, it is w Day') );
-var_dump( $date->format( '\i\t \i\s \t\h\e jS \d\a\y.') );
-var_dump( $date->format( "D M j G:i:s T Y") );
-var_dump( $date->format( 'H:m:s \m \i\s\ \m\o\n\t\h') );
-var_dump( $date->format( "H:i:s") );
-var_dump( $date->format( "c") );
-var_dump( $date->format( "r") );
-var_dump( $date->format( "U") );
+  var_dump( $date->format( "F j, Y, g:i a") );
+  var_dump( $date->format( "m.d.y") );
+  var_dump( $date->format( "j, n, Y") );
+  var_dump( $date->format( "Ymd") );
+  var_dump( $date->format( 'h-i-s, j-m-y, it is w Day') );
+  var_dump( $date->format( '\i\t \i\s \t\h\e jS \d\a\y.') );
+  var_dump( $date->format( "D M j G:i:s T Y") );
+  var_dump( $date->format( 'H:m:s \m \i\s\ \m\o\n\t\h') );
+  var_dump( $date->format( "H:i:s") );
+  var_dump( $date->format( "c") );
+  var_dump( $date->format( "r") );
+  var_dump( $date->format( "U") );
+}
 
-// negative year
-$date2 = new DateTime("-2005-07-14 22:30:41");
-var_dump( $date2->format( "Y") );
-var_dump( $date2->format( "c") );
+function test_format_basic_predefined_constants() {
+  $date = new DateTime("2005-07-14 22:30:41");
 
-// leap year
-var_dump ((new DateTime("92-07-14"))->format( "L"));
-var_dump ((new DateTime("96-07-14"))->format( "L"));
-var_dump ((new DateTime("100-07-14"))->format( "L"));
-var_dump ((new DateTime("104-07-14"))->format( "L"));
-var_dump ((new DateTime("196-07-14"))->format( "L"));
-var_dump ((new DateTime("200-07-14"))->format( "L"));
-var_dump ((new DateTime("204-07-14"))->format( "L"));
-var_dump ((new DateTime("300-07-14"))->format( "L"));
-var_dump ((new DateTime("300-07-14"))->format( "L"));
-var_dump ((new DateTime("396-07-14"))->format( "L"));
-var_dump ((new DateTime("400-07-14"))->format( "L"));
-var_dump ((new DateTime("404-07-14"))->format( "L"));
+  var_dump( $date->format( DateTime::ATOM) ) ;
+  var_dump( $date->format( DateTime::COOKIE) ) ;
+  var_dump( $date->format( DateTime::ISO8601) ) ;
+  var_dump( $date->format( DateTime::RFC822) ) ;
+  var_dump( $date->format( DateTime::RFC850) ) ;
+  var_dump( $date->format( DateTime::RFC1036) ) ;
+  var_dump( $date->format( DateTime::RFC1123) ) ;
+  var_dump( $date->format( DateTime::RFC7231) ) ;
+  var_dump( $date->format( DateTime::RFC2822) ) ;
+  var_dump( $date->format( DateTime::RFC3339) ) ;
+  var_dump( $date->format( DateTime::RFC3339_EXTENDED) ) ;
+  var_dump( $date->format( DateTime::RSS) ) ;
+  var_dump( $date->format( DateTime::W3C) ) ;
+}
+
+function test_format_negative_year() {
+  $date2 = new DateTime("-2005-07-14 22:30:41");
+  var_dump( $date2->format( "Y") );
+  var_dump( $date2->format( "c") );
+}
+
+function test_format_leap_year() {
+  var_dump ((new DateTime("92-07-14"))->format( "L"));
+  var_dump ((new DateTime("96-07-14"))->format( "L"));
+  var_dump ((new DateTime("100-07-14"))->format( "L"));
+  var_dump ((new DateTime("104-07-14"))->format( "L"));
+  var_dump ((new DateTime("196-07-14"))->format( "L"));
+  var_dump ((new DateTime("200-07-14"))->format( "L"));
+  var_dump ((new DateTime("204-07-14"))->format( "L"));
+  var_dump ((new DateTime("300-07-14"))->format( "L"));
+  var_dump ((new DateTime("300-07-14"))->format( "L"));
+  var_dump ((new DateTime("396-07-14"))->format( "L"));
+  var_dump ((new DateTime("400-07-14"))->format( "L"));
+  var_dump ((new DateTime("404-07-14"))->format( "L"));
+}
+
+test_format_basic();
+test_format_basic_predefined_constants();
+test_format_negative_year();
+test_format_leap_year();

--- a/tests/phpt/datetime/01_format.php
+++ b/tests/phpt/datetime/01_format.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+
+$date = new DateTime("2005-07-14 22:30:41");
+
+var_dump( $date->format( "F j, Y, g:i a") );
+var_dump( $date->format( "m.d.y") );
+var_dump( $date->format( "j, n, Y") );
+var_dump( $date->format( "Ymd") );
+var_dump( $date->format( 'h-i-s, j-m-y, it is w Day') );
+var_dump( $date->format( '\i\t \i\s \t\h\e jS \d\a\y.') );
+var_dump( $date->format( "D M j G:i:s T Y") );
+var_dump( $date->format( 'H:m:s \m \i\s\ \m\o\n\t\h') );
+var_dump( $date->format( "H:i:s") );
+var_dump( $date->format( "c") );
+var_dump( $date->format( "r") );
+var_dump( $date->format( "U") );
+
+$date2 = new DateTime("-2005-07-14 22:30:41");
+var_dump( $date2->format( "Y") );
+var_dump( $date2->format( "c") );

--- a/tests/phpt/datetime/01_format.php
+++ b/tests/phpt/datetime/01_format.php
@@ -3,6 +3,7 @@
 
 $date = new DateTime("2005-07-14 22:30:41");
 
+// basic
 var_dump( $date->format( "F j, Y, g:i a") );
 var_dump( $date->format( "m.d.y") );
 var_dump( $date->format( "j, n, Y") );
@@ -16,6 +17,21 @@ var_dump( $date->format( "c") );
 var_dump( $date->format( "r") );
 var_dump( $date->format( "U") );
 
+// negative year
 $date2 = new DateTime("-2005-07-14 22:30:41");
 var_dump( $date2->format( "Y") );
 var_dump( $date2->format( "c") );
+
+// leap year
+var_dump ((new DateTime("92-07-14"))->format( "L"));
+var_dump ((new DateTime("96-07-14"))->format( "L"));
+var_dump ((new DateTime("100-07-14"))->format( "L"));
+var_dump ((new DateTime("104-07-14"))->format( "L"));
+var_dump ((new DateTime("196-07-14"))->format( "L"));
+var_dump ((new DateTime("200-07-14"))->format( "L"));
+var_dump ((new DateTime("204-07-14"))->format( "L"));
+var_dump ((new DateTime("300-07-14"))->format( "L"));
+var_dump ((new DateTime("300-07-14"))->format( "L"));
+var_dump ((new DateTime("396-07-14"))->format( "L"));
+var_dump ((new DateTime("400-07-14"))->format( "L"));
+var_dump ((new DateTime("404-07-14"))->format( "L"));

--- a/tests/phpt/datetime/02_create.php
+++ b/tests/phpt/datetime/02_create.php
@@ -1,0 +1,40 @@
+@ok
+<?php
+
+function test_constructor_valid_date() {
+  var_dump((new DateTime())->format('Y-m-d'));
+  var_dump((new DateTime(''))->format('Y-m-d'));
+  var_dump((new DateTime('now'))->format('Y-m-d'));
+
+  $dates = ['2000-01-01', '20000101 23:32:12', '2000-01-01 23:32:12',
+    '2000-01-01 233212', '2000-01-01 23:32', '2000-01-01 2332', '23:32:12', '23:32', '233212', '2332'];
+
+  foreach ($dates as $date) {
+    var_dump((new DateTime($date))->format("Y-m-d H:i:s"));
+    var_dump(DateTime::getLastErrors());
+  }
+}
+
+function test_constructor_invalid_date() {
+  $dates = ['foo', '200', '2000-01-01 23', '23:32 foo', "-x year"];
+
+  foreach ($dates as $date) {
+    try {
+      $date = new DateTime($date);
+      var_dump($date->format('Y-m-d'));
+    } catch (Exception $e) {
+     var_dump($e->getMessage());
+     var_dump(DateTime::getLastErrors());
+    }
+  }
+}
+
+
+function test_constructor_relative_date() {
+  $time = new \DateTime("-1 year");
+  echo $time->format('Y/m/d'), "\n";
+}
+
+test_constructor_valid_date();
+test_constructor_invalid_date();
+test_constructor_relative_date();

--- a/tests/phpt/datetime/02_create.php
+++ b/tests/phpt/datetime/02_create.php
@@ -35,6 +35,29 @@ function test_constructor_relative_date() {
   echo $time->format('Y/m/d'), "\n";
 }
 
+function test_constructor_tz_from_datetime() {
+  $dates = ['2010-01-28T15:00:00', '2010-01-28T15:00:00 Europe/Amsterdam', '2010-01-28T15:00:00 Pacific/Nauru',
+    '@946684800', '2010-01-28T15:00:00+0430', '2010-01-28T15:00:00 GMT-06:00', '2010-01-28T15:00:00 CEST',
+    '2010-01-28T15:00:00 BST', '2010-01-28T15:00:00 ACDT'];
+
+  foreach ($dates as $date) {
+    var_dump((new DateTime($date))->format("Y-m-d H:i:s e I O P T Z"));
+    var_dump(DateTime::getLastErrors());
+  }
+}
+
+function test_constructor_timezone_param() {
+  var_dump((new DateTime('2022-08-24 16:45:00'))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('2022-08-24 16:45:00', new DateTimeZone('Europe/Moscow')))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('2022-08-24 16:45:00', new DateTimeZone('Etc/GMT-3')))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('2022-08-24 16:45:00 Pacific/Nauru', new DateTimeZone('Etc/GMT-3')))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('2022-08-24 16:45:00 BST', new DateTimeZone('Europe/Moscow')))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('2022-08-24 16:45:00 GMT-06:00', new DateTimeZone('Europe/Moscow')))->format('Y-m-d H:i:s e I O P T Z U'));
+  var_dump((new DateTime('@946684800', new DateTimeZone('Etc/GMT-3')))->format('Y-m-d H:i:s e I O P T Z U'));
+}
+
 test_constructor_valid_date();
 test_constructor_invalid_date();
 test_constructor_relative_date();
+test_constructor_tz_from_datetime();
+test_constructor_timezone_param();

--- a/tests/phpt/datetime/03_set_timestamp.php
+++ b/tests/phpt/datetime/03_set_timestamp.php
@@ -1,0 +1,36 @@
+@ok
+<?php
+
+function test_set_timestamp() {
+  $date = new DateTime;
+
+  $date->setTimestamp(1171502725);
+  var_dump($date->format('U = Y-m-d H:i:s'));
+  var_dump($date->getTimestamp());
+
+  $date->setTimestamp(0);
+  var_dump($date->format('U = Y-m-d H:i:s'));
+  var_dump($date->getTimestamp());
+
+  $date->setTimestamp(PHP_INT_MAX);
+  var_dump($date->format('U = Y-m-d H:i:s'));
+  var_dump($date->getTimestamp());
+
+  $date->setTimestamp(PHP_INT_MIN);
+  var_dump($date->format('U = Y-m-d H:i:s'));
+  var_dump($date->getTimestamp());
+}
+
+function test_set_timestamp_return_object() {
+  $date = new DateTime;
+  var_dump($date->format('Y-m-d'));
+
+  $new_date = $date->setTimestamp(1171502725);
+  var_dump($new_date->format('U = Y-m-d H:i:s'));
+  var_dump($new_date->getTimestamp());
+  var_dump($date->format('U = Y-m-d H:i:s'));
+  var_dump($date->getTimestamp());
+}
+
+test_set_timestamp();
+test_set_timestamp_return_object();

--- a/tests/phpt/datetime/04_modify.php
+++ b/tests/phpt/datetime/04_modify.php
@@ -4,16 +4,20 @@
 function test_modify() {
   $datetime = new DateTime("2009-01-31 14:28:41");
 
-  $datetime->modify("+1 day");
+  $new_datetime = $datetime->modify("+1 day");
+  echo "After modification 1: " . $new_datetime->format("D, d M Y") . "\n";
   echo "After modification 1: " . $datetime->format("D, d M Y") . "\n";
 
-  $datetime->modify("+1 week 2 days 4 hours 2 seconds");
+  $new_datetime = $datetime->modify("+1 week 2 days 4 hours 2 seconds");
+  echo "After modification 2: " . $new_datetime->format("D, d M Y H:i:s") . "\n";
   echo "After modification 2: " . $datetime->format("D, d M Y H:i:s") . "\n";
 
-  $datetime->modify("next Thursday");
+  $new_datetime = $datetime->modify("next Thursday");
+  echo "After modification 3: " . $new_datetime->format("D, d M Y") . "\n";
   echo "After modification 3: " . $datetime->format("D, d M Y") . "\n";
 
-  $datetime->modify("last Sunday");
+  $new_datetime = $datetime->modify("last Sunday");
+  echo "After modification 4: " . $new_datetime->format("D, d M Y") . "\n";
   echo "After modification 4: " . $datetime->format("D, d M Y") . "\n";
 }
 

--- a/tests/phpt/datetime/04_modify.php
+++ b/tests/phpt/datetime/04_modify.php
@@ -1,0 +1,33 @@
+@ok
+<?php
+
+function test_modify() {
+  $datetime = new DateTime("2009-01-31 14:28:41");
+
+  $datetime->modify("+1 day");
+  echo "After modification 1: " . $datetime->format("D, d M Y") . "\n";
+
+  $datetime->modify("+1 week 2 days 4 hours 2 seconds");
+  echo "After modification 2: " . $datetime->format("D, d M Y H:i:s") . "\n";
+
+  $datetime->modify("next Thursday");
+  echo "After modification 3: " . $datetime->format("D, d M Y") . "\n";
+
+  $datetime->modify("last Sunday");
+  echo "After modification 4: " . $datetime->format("D, d M Y") . "\n";
+}
+
+function test_modify_shift_date() {
+  $date = new DateTime('2000-12-31');
+
+  // give 2001-01-31
+  $date->modify('+1 month');
+  echo $date->format('Y-m-d') . "\n";
+
+  // give 2001-03-03
+  $date->modify('+1 month');
+  echo $date->format('Y-m-d') . "\n";
+}
+
+test_modify();
+test_modify_shift_date();

--- a/tests/phpt/datetime/05_modify_wrong_modifier.php
+++ b/tests/phpt/datetime/05_modify_wrong_modifier.php
@@ -1,0 +1,10 @@
+@kphp_runtime_should_warn
+/DateTime::modify\(\): Failed to parse time string \(\+1 day \+four month\) at position 7 \(\+\): Unexpected character/
+<?php
+
+function test_modify_wrong_modifier() {
+  $date = new DateTime('2000-12-31');
+  $date->modify('+1 day +four month');
+}
+
+test_modify_wrong_modifier();

--- a/tests/phpt/datetime/05_modify_wrong_modifier.php
+++ b/tests/phpt/datetime/05_modify_wrong_modifier.php
@@ -4,7 +4,11 @@
 
 function test_modify_wrong_modifier() {
   $date = new DateTime('2000-12-31');
-  $date->modify('+1 day +four month');
+  $new_date = $date->modify('+1 day +four month');
+  var_dump((bool)$new_date);
+  var_dump((bool)$date);
+  echo $date->format("D, d M Y") . "\n";
+  var_dump(DateTime::getLastErrors());
 }
 
 test_modify_wrong_modifier();

--- a/tests/phpt/datetime/06_set_date.php
+++ b/tests/phpt/datetime/06_set_date.php
@@ -4,12 +4,13 @@
 function test_set_date() {
   $date = new DateTime("2009-01-30 19:34:10");
   echo $date->format(DATE_RFC2822) . "\n";
+
   $new_date = $date->setDate(2008, 02, 01);
   echo $date->format(DATE_RFC2822) . "\n";
   echo $new_date->format(DATE_RFC2822) . "\n";
 }
 
-function test_date_exceed_range() {
+function test_set_date_exceed_range() {
   $date = new DateTime();
   
   $date->setDate(2001, 2, 28);
@@ -22,5 +23,38 @@ function test_date_exceed_range() {
   echo $date->format('Y-m-d') . "\n";
 }
 
+function test_setiso_date() {
+  $date = new DateTime();
+
+  $new_date = $date->setISODate(2008, 2);
+  echo $date->format('Y-m-d') . "\n";
+  echo $new_date->format('Y-m-d') . "\n";
+
+  $date->setISODate(2008, 2, 7);
+  echo $date->format('Y-m-d') . "\n";
+}
+
+function test_setiso_date_exceed_range() {
+  $date = new DateTime();
+
+  $date->setISODate(2008, 2, 7);
+  echo $date->format('Y-m-d') . "\n";
+
+  $date->setISODate(2008, 2, 8);
+  echo $date->format('Y-m-d') . "\n";
+
+  $date->setISODate(2008, 53, 7);
+  echo $date->format('Y-m-d') . "\n";
+}
+
+function test_setiso_date_find_month() {
+  $date = new DateTime();
+  $newDate = $date->setISODate(2008, 14);
+  echo $newDate->format('n'), "\n";
+}
+
 test_set_date();
-test_date_exceed_range();
+test_set_date_exceed_range();
+test_setiso_date();
+test_setiso_date_exceed_range();
+test_setiso_date_find_month();

--- a/tests/phpt/datetime/06_set_date.php
+++ b/tests/phpt/datetime/06_set_date.php
@@ -1,0 +1,26 @@
+@ok
+<?php
+
+function test_set_date() {
+  $date = new DateTime("2009-01-30 19:34:10");
+  echo $date->format(DATE_RFC2822) . "\n";
+  $new_date = $date->setDate(2008, 02, 01);
+  echo $date->format(DATE_RFC2822) . "\n";
+  echo $new_date->format(DATE_RFC2822) . "\n";
+}
+
+function test_date_exceed_range() {
+  $date = new DateTime();
+  
+  $date->setDate(2001, 2, 28);
+  echo $date->format('Y-m-d') . "\n";
+  
+  $date->setDate(2001, 2, 29);
+  echo $date->format('Y-m-d') . "\n";
+  
+  $date->setDate(2001, 14, 3);
+  echo $date->format('Y-m-d') . "\n";
+}
+
+test_set_date();
+test_date_exceed_range();

--- a/tests/phpt/datetime/07_set_time.php
+++ b/tests/phpt/datetime/07_set_time.php
@@ -1,0 +1,32 @@
+@ok
+<?php
+
+function test_set_time() {
+  $date = new DateTime('2001-01-01');
+
+  $new_date = $date->setTime(14, 55);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+  echo $new_date->format('Y-m-d H:i:s') . "\n";
+
+  $date->setTime(14, 55, 24);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+}
+
+function test_set_time_exceed_range() {
+  $date = new DateTime('2001-01-01');
+
+  $date->setTime(14, 55, 24);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+
+  $date->setTime(14, 55, 65);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+
+  $date->setTime(14, 65, 24);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+
+  $date->setTime(25, 55, 24);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+}
+
+test_set_time();
+test_set_time_exceed_range();

--- a/tests/phpt/datetime/08_date_time_zone.php
+++ b/tests/phpt/datetime/08_date_time_zone.php
@@ -1,0 +1,19 @@
+@ok
+<?php
+
+function test_date_time_zone() {
+  $d = new DateTimeZone('Europe/Moscow');
+  echo $d->getName(), "\n";
+  $d = new DateTimeZone('Etc/GMT-3');
+  echo $d->getName(), "\n";
+
+  try {
+    $d = new DateTimeZone('Unknown');
+    echo $d->getName(), "\n";
+  } catch (Exception $e) {
+   var_dump($e->getMessage());
+   var_dump(DateTime::getLastErrors());
+  }
+}
+
+test_date_time_zone();

--- a/tests/phpt/datetime/09_create_from_format.php
+++ b/tests/phpt/datetime/09_create_from_format.php
@@ -97,8 +97,21 @@ function test_create_from_format_timezone_param() {
   echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
 }
 
+function test_implicit_current_time() {
+  // the $date has to contain current H-i-s, despite it's not provided
+  $date = DateTime::createFromFormat('Y-m-d', '2012-10-17');
+
+  $hours = (int)$date->format('H');
+  $minutes = (int)$date->format('i');
+  $seconds = (int)$date->format('s');
+
+  $sum = $hours + $minutes + $seconds;
+  var_dump($sum > 0);
+}
+
 test_create_from_format();
 test_create_from_format_errors();
 test_overflow_behaviour();
 test_create_from_format_tz_from_datetime();
 test_create_from_format_timezone_param();
+test_implicit_current_time();

--- a/tests/phpt/datetime/09_create_from_format.php
+++ b/tests/phpt/datetime/09_create_from_format.php
@@ -1,0 +1,104 @@
+@ok
+<?php
+
+function test_create_from_format() {
+  $format = 'Y-m-d';
+  $date = DateTime::createFromFormat($format, '2009-02-15');
+  echo "Format: $format; " . $date->format('Y-m-d') . "\n";
+
+  $format = 'd-m-Y';
+  $date = DateTime::createFromFormat($format, '15-02-2009');
+  echo "Format: $format; " . $date->format('Y-m-d') . "\n";
+
+  $format = 'Y-m-d H:i:s';
+  $date = DateTime::createFromFormat($format, '2009-02-15 15:16:17');
+  echo "Format: $format; " . $date->format('Y-m-d H:i:s') . "\n";
+
+  $format = 'Y-m-!d H:i:s';
+  $date = DateTime::createFromFormat($format, '2009-02-15 15:16:17');
+  echo "Format: $format; " . $date->format('Y-m-d H:i:s') . "\n";
+
+  $format = '!d';
+  $date = DateTime::createFromFormat($format, '15');
+  echo "Format: $format; " . $date->format('Y-m-d H:i:s') . "\n";
+
+  $format = 'i';
+  $date = DateTime::createFromFormat($format, '15');
+  echo "Format: $format; " . $date->format('Y-m-d H:i:s') . "\n";
+
+  $format = 'H\h i\m s\s';
+  $date = DateTime::createFromFormat($format, '23h 15m 03s');
+  echo "Format: $format; " . $date->format('H:i:s') . "\n";
+}
+
+function test_create_from_format_errors() {
+  $date = DateTime::createFromFormat('j-M-Y', '');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+
+  $date = DateTime::createFromFormat('', '15-Feb-2009');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+
+  $date = DateTime::createFromFormat('j-M-Y H', '15-Feb-2009');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+
+  $date = DateTime::createFromFormat('j-M-Y', '15-Feb-2009 23');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+
+  $date = DateTime::createFromFormat('j-M-Y', '15-Feb-hello');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+
+  $date = DateTime::createFromFormat('j-M-X', '15-Feb-2009');
+  var_dump((bool)$date);
+  var_dump(DateTime::getLastErrors());
+}
+
+function test_overflow_behaviour() {
+  echo DateTime::createFromFormat('Y-m-d H:i:s', '2021-17-35 16:60:97')->format(DateTime::RFC2822), "\n";
+  echo DateTime::createFromFormat(DateTime::RFC1123, 'Mon, 3 Aug 2020 25:00:00 +0000')->format(DateTime::RFC1123), "\n";
+}
+
+function test_create_from_format_tz_from_datetime() {
+  echo (DateTime::createFromFormat('Y-m-d H:i:s', '2010-01-28 15:25:10'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 Europe/Amsterdam'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 Pacific/Nauru'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('U', '946684800'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10+0430'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 GMT-06:00'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 CEST'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 BST'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+  echo (DateTime::createFromFormat('Y-m-d H:i:s e', '2010-01-28 15:25:10 ACDT'))->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+}
+
+function test_create_from_format_timezone_param() {
+  $date = DateTime::createFromFormat('Y-m-d H:i:s', '2022-08-24 16:45:00');
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('Y-m-d H:i:s', '2022-08-24 16:45:00', new DateTimeZone('Europe/Moscow'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('Y-m-d H:i:s', '2022-08-24 16:45:00', new DateTimeZone('Etc/GMT-3'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('Y-m-d H:i:s e', '2022-08-24 16:45:00 Pacific/Nauru', new DateTimeZone('Etc/GMT-3'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('Y-m-d H:i:s e', '2022-08-24 16:45:00 BST', new DateTimeZone('Europe/Moscow'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('Y-m-d H:i:s e', '2022-08-24 16:45:00 GMT-06:00', new DateTimeZone('Europe/Moscow'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+
+  $date = DateTime::createFromFormat('U', '946684800', new DateTimeZone('Etc/GMT-3'));
+  echo $date->format('Y-m-d H:i:s e I O P T Z U'), "\n";
+}
+
+test_create_from_format();
+test_create_from_format_errors();
+test_overflow_behaviour();
+test_create_from_format_tz_from_datetime();
+test_create_from_format_timezone_param();

--- a/tests/phpt/datetime/10_get_offset.php
+++ b/tests/phpt/datetime/10_get_offset.php
@@ -1,0 +1,33 @@
+@ok
+<?php
+
+function test_get_offset() {
+  $date = new DateTime('2008-06-21');
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('2008-06-21', new DateTimeZone('Europe/Moscow'));
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('2008-06-21', new DateTimeZone('Etc/GMT-3'));
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('2008-06-21 Pacific/Nauru');
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('2008-06-21 BST');
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('2008-06-21 GMT-06:00');
+  echo $date->getOffset(), "\n";
+
+  $date = new DateTime('@946684800');
+  echo $date->getOffset(), "\n";
+
+  $winter = new DateTime('2010-12-21 America/New_York');
+  echo $winter->getOffset(), "\n";
+
+  $summer = new DateTime('2008-06-21 America/New_York');
+  echo $summer->getOffset(), "\n";
+}
+
+test_get_offset();


### PR DESCRIPTION
This PR adds some functionality of php [DateTime](https://www.php.net/manual/en/class.datetime.php) class. Namelly, the following functions:

```

class DateTime {
  /** @kphp-extern-func-info can_throw */
  public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
  public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): ?DateTime;
  public static function getLastErrors(): array|false;
  public function modify(string $modifier): ?DateTime;
  public function setDate(int $year, int $month, int $day): DateTime;
  public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTime;
  public function setTime(
      int $hour,
      int $minute,
      int $second = 0,
      int $microsecond = 0
  ): DateTime;
  public function setTimestamp(int $timestamp): DateTime;
  public function format(string $format): string;
  public function getOffset(): int;
  public function getTimestamp(): int;
}
```