### PR TITLE
WIP: [compiler] implement composer classmap autoloading

### DIFF
--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -240,7 +240,7 @@ add_executable(kphp2cpp ${KPHP_COMPILER_DIR}/kphp2cpp.cpp)
 target_include_directories(kphp2cpp PUBLIC ${KPHP_COMPILER_DIR})
 
 prepare_cross_platform_libs(COMPILER_LIBS yaml-cpp re2)
-set(COMPILER_LIBS vk::kphp2cpp_src vk::tlo_parsing_src vk::popular_common ${COMPILER_LIBS} fmt::fmt OpenSSL::Crypto pthread)
+set(COMPILER_LIBS -lstdc++fs vk::kphp2cpp_src vk::tlo_parsing_src vk::popular_common ${COMPILER_LIBS} fmt::fmt OpenSSL::Crypto pthread)
 
 target_link_libraries(kphp2cpp PRIVATE ${COMPILER_LIBS})
 target_link_options(kphp2cpp PRIVATE ${NO_PIE})

--- a/compiler/composer.h
+++ b/compiler/composer.h
@@ -48,6 +48,8 @@ public:
     return filename == autoload_filename_;
   }
 
+  bool is_classmap_file(const std::string &filename) const noexcept;
+
   const std::vector<std::string> &get_files_to_require() const noexcept {
     return files_to_require_;
   }
@@ -60,11 +62,14 @@ private:
 
   static std::string psr_lookup_nocache(const PsrMap &psr, const std::string &class_name, bool transform_underscore = false);
 
+  void scan_classmap(const std::string &filename);
+
   bool use_dev_;
   PsrMap autoload_psr4_;
   PsrMap autoload_psr0_;
   std::map<std::string, std::string> autoload_psr0_classmap_;
   std::unordered_set<std::string> deps_;
+  std::unordered_set<std::string> classmap_files_;
 
   std::string autoload_filename_;
   std::vector<std::string> files_to_require_;

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -42,7 +42,8 @@ void ClassData::set_name_and_src_name(const std::string &full_name) {
   std::string namespace_name = pos == std::string::npos ? "" : full_name.substr(0, pos);
   std::string class_name = pos == std::string::npos ? full_name : full_name.substr(pos + 1);
 
-  this->can_be_php_autoloaded = file_id && namespace_name == file_id->namespace_name && class_name == file_id->short_file_name;
+  this->can_be_php_autoloaded = file_id && ((namespace_name == file_id->namespace_name && class_name == file_id->short_file_name) ||
+                                            (G->get_composer_autoloader().is_classmap_file(file_id->file_name)));
   this->can_be_php_autoloaded |= this->is_builtin();
 
   this->is_lambda = vk::string_view{full_name}.starts_with("Lambda$") || vk::string_view{full_name}.starts_with("ITyped$");

--- a/tests/python/tests/composer/php/classmap/classmap_lib.php
+++ b/tests/python/tests/composer/php/classmap/classmap_lib.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ClassmapLib\Classes;
+
+class ClassmapClass1 {
+  public string $value = 'a';
+}
+
+class ClassmapClass2 {
+  public int $value = 51;
+}

--- a/tests/python/tests/composer/php/classmap/classmap_no_namespace.php
+++ b/tests/python/tests/composer/php/classmap/classmap_no_namespace.php
@@ -1,0 +1,7 @@
+<?php
+
+class ClassmapNoNamespace {
+  public function f() {
+    var_dump('f()');
+  }
+}

--- a/tests/python/tests/composer/php/classmap/dir/classmap.php
+++ b/tests/python/tests/composer/php/classmap/dir/classmap.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace OtherClassmap;
+
+class OtherClassmapClass {
+  public function g() {
+    var_dump('g()');
+  }
+}

--- a/tests/python/tests/composer/php/composer.json
+++ b/tests/python/tests/composer/php/composer.json
@@ -27,7 +27,12 @@
                 "multi2/src/"
             ],
             "": "fallback"
-        }
+        },
+        "classmap": [
+            "classmap/classmap_lib.php",
+            "classmap/classmap_no_namespace.php",
+            "classmap/dir/"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/tests/python/tests/composer/php/index.php
+++ b/tests/python/tests/composer/php/index.php
@@ -10,6 +10,7 @@ use VK\Feed\FeedTester; // available only when building with autoload-dev
 use MultiDir\MultiClass1; // from ./multi1
 use MultiDir\MultiClass2; // from ./multi2
 use Fallback1\Fallback2\FallbackClass; // from ./fallback
+use ClassmapLib\Classes\ClassmapClass1; // from ./classmap/classmap_lib.php
 
 class MyController extends Feed\Helpers\BaseController {}
 
@@ -18,6 +19,15 @@ new MultiClass1();
 new MultiClass2();
 new FallbackClass();
 new UtilsFallback(); // from ./packages/utils/utils-fallback/src
+
+$classmap_c1 = new ClassmapClass1();
+var_dump($classmap_c1->value);
+$classmap_c2 = new \ClassmapLib\Classes\ClassmapClass2();
+var_dump($classmap_c2->value);
+$classmap_c3 = new ClassmapNoNamespace();
+$classmap_c3->f();
+$classmap_c4 = new \OtherClassmap\OtherClassmapClass();
+$classmap_c4->g();
 
 $controller = new Controller();
 

--- a/tests/python/tests/composer/php/vendor/composer/autoload_classmap.php
+++ b/tests/python/tests/composer/php/vendor/composer/autoload_classmap.php
@@ -6,4 +6,9 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'ClassmapLib\\Classes\\ClassmapClass1' => $baseDir . '/classmap/classmap_lib.php',
+    'ClassmapLib\\Classes\\ClassmapClass2' => $baseDir . '/classmap/classmap_lib.php',
+    'ClassmapNoNamespace' => $baseDir . '/classmap/classmap_no_namespace.php',
+    'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'OtherClassmap\\OtherClassmapClass' => $baseDir . '/classmap/dir/classmap.php',
 );

--- a/tests/python/tests/composer/php/vendor/composer/autoload_static.php
+++ b/tests/python/tests/composer/php/vendor/composer/autoload_static.php
@@ -50,12 +50,21 @@ class ComposerStaticInit9539f736c30192217f7a8384c08769a6
         1 => __DIR__ . '/..' . '/vk/utils/utils-fallback/src',
     );
 
+    public static $classMap = array (
+        'ClassmapLib\\Classes\\ClassmapClass1' => __DIR__ . '/../..' . '/classmap/classmap_lib.php',
+        'ClassmapLib\\Classes\\ClassmapClass2' => __DIR__ . '/../..' . '/classmap/classmap_lib.php',
+        'ClassmapNoNamespace' => __DIR__ . '/../..' . '/classmap/classmap_no_namespace.php',
+        'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'OtherClassmap\\OtherClassmapClass' => __DIR__ . '/../..' . '/classmap/dir/classmap.php',
+    );
+
     public static function getInitializer(ClassLoader $loader)
     {
         return \Closure::bind(function () use ($loader) {
             $loader->prefixLengthsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$prefixLengthsPsr4;
             $loader->prefixDirsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$prefixDirsPsr4;
             $loader->fallbackDirsPsr4 = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$fallbackDirsPsr4;
+            $loader->classMap = ComposerStaticInit9539f736c30192217f7a8384c08769a6::$classMap;
 
         }, null, ClassLoader::class);
     }


### PR DESCRIPTION
`autoload.classmap` is another popular method of classes
autoloading in composer.

Implementing this feature increases the number of composer packages
that can be used by KPHP code.

Classmap works like this:
for a given files list (dirs or regular files),
collect all files with `.inc` and `.php` extension recursively and
build autoloading maps for them.

Unlike PSR4, classmap doesn't require any conventions.
A file can have multiple classes, its name could be anything,
namespaces can be arbitrary as well.

It's hard to implement this feature in KPHP without actually parsing the php files.
As a compromise, we're scanning the classmap folders and
require all files found during the composer autoload file inclusion.

Fixes #49