### PR TITLE
add support $rest_index param of getopt() 

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -375,7 +375,7 @@ function debug_backtrace() ::: string[][];
 function posix_getpid() ::: int;
 function posix_getuid() ::: int;
 function posix_getpwuid($uid ::: int) ::: mixed[] | false;
-function getopt ($options ::: string, $longopt ::: array = array()) ::: mixed[] | false;
+function getopt ($options ::: string, $longopt ::: array = array(), int &$rest_index = 0) ::: mixed[] | false;
 function gethostbynamel ($name ::: string) ::: string[] | false;
 function inet_pton ($address ::: string) ::: string | false;
 

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -375,7 +375,7 @@ function debug_backtrace() ::: string[][];
 function posix_getpid() ::: int;
 function posix_getuid() ::: int;
 function posix_getpwuid($uid ::: int) ::: mixed[] | false;
-function getopt ($options ::: string, $longopt ::: array = array(), int &$rest_index = 0) ::: mixed[] | false;
+function getopt ($options ::: string, $longopt ::: array = array(), ?int &$rest_index = null) ::: mixed[] | false;
 function gethostbynamel ($name ::: string) ::: string[] | false;
 function inet_pton ($address ::: string) ::: string | false;
 

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1304,12 +1304,12 @@ static bool parse_multipart(const char *post, int post_len, const string &bounda
 static char arg_vars_storage[sizeof(array<string>)];
 static array<string> *arg_vars = nullptr;
 
-int64_t &get_dummy_rest_index() noexcept {
-  static int64_t dummy_rest_index = 0;
+Optional<int64_t> &get_dummy_rest_index() noexcept {
+  static Optional<int64_t> dummy_rest_index;
   return dummy_rest_index;
 }
 
-Optional<array<mixed>> f$getopt(const string &options, array<string> longopts, int64_t &rest_index) {
+Optional<array<mixed>> f$getopt(const string &options, array<string> longopts, Optional<int64_t> &rest_index) {
   if (!arg_vars) {
     return false;
   }

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1304,21 +1304,26 @@ static bool parse_multipart(const char *post, int post_len, const string &bounda
 static char arg_vars_storage[sizeof(array<string>)];
 static array<string> *arg_vars = nullptr;
 
-Optional<array<mixed>> f$getopt(const string &options, array<string> longopts) {
+int64_t &get_dummy_rest_index() noexcept {
+  static int64_t dummy_rest_index = 0;
+  return dummy_rest_index;
+}
+
+Optional<array<mixed>> f$getopt(const string &options, array<string> longopts, int64_t &rest_index) {
   if (!arg_vars) {
     return false;
   }
-  string real_options = string("+");
+  string real_options{"+"};
   real_options.append(options);
   const char *php_argv[arg_vars->count()];
   int php_argc = 0;
-  for (array<string>::iterator iter = arg_vars->begin(); iter != arg_vars->end(); ++iter) {
+  for (auto iter : *arg_vars) {
     php_argv[php_argc++] = iter.get_value().c_str();
   }
 
   option real_longopts[longopts.count() + 1];
   int longopts_count = 0;
-  for (array<string>::iterator iter = longopts.begin(); iter != longopts.end(); ++iter) {
+  for (auto iter : longopts) {
     string opt = iter.get_value();
     string::size_type count = 0;
     while (count < opt.size() && opt[opt.size() - count - 1] == ':') {
@@ -1361,6 +1366,7 @@ Optional<array<mixed>> f$getopt(const string &options, array<string> longopts) {
       result.set_value(key, value);
     }
   }
+  rest_index = optind;
 
   return result;
 }

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -172,7 +172,8 @@ bool f$ini_set(const string &s, const string &value);
 
 Optional<string> f$ini_get(const string &s);
 
-Optional<array<mixed>> f$getopt(const string &options, array<string> longopts = array<string>());
+int64_t &get_dummy_rest_index() noexcept;
+Optional<array<mixed>> f$getopt(const string &options, array<string> longopts = {}, int64_t &rest_index = get_dummy_rest_index());
 
 void global_init_runtime_libs();
 void global_init_script_allocator();

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -172,8 +172,8 @@ bool f$ini_set(const string &s, const string &value);
 
 Optional<string> f$ini_get(const string &s);
 
-int64_t &get_dummy_rest_index() noexcept;
-Optional<array<mixed>> f$getopt(const string &options, array<string> longopts = {}, int64_t &rest_index = get_dummy_rest_index());
+Optional<int64_t> &get_dummy_rest_index() noexcept;
+Optional<array<mixed>> f$getopt(const string &options, array<string> longopts = {}, Optional<int64_t> &rest_index = get_dummy_rest_index());
 
 void global_init_runtime_libs();
 void global_init_script_allocator();

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -384,6 +384,10 @@ ext/standard/tests/general_functions/getopt.phpt
 ext/standard/tests/general_functions/getopt_002.phpt
 ext/standard/tests/general_functions/getopt_004.phpt
 ext/standard/tests/general_functions/getopt_005.phpt
+ext/standard/tests/general_functions/getopt_006.phpt
+ext/standard/tests/general_functions/getopt_007.phpt
+ext/standard/tests/general_functions/getopt_008.phpt
+ext/standard/tests/general_functions/getopt_009.phpt
 ext/standard/tests/general_functions/header_redirection_001.phpt
 ext/standard/tests/general_functions/header_redirection_002.phpt
 ext/standard/tests/general_functions/header_redirection_003.phpt


### PR DESCRIPTION
Added support for third  $rest_index param of [getopt()](https://www.php.net/manual/en/function.getopt.php) php function.