### PR TITLE
fix NUMA availability checking

### DIFF
--- a/server/numa-configuration.cpp
+++ b/server/numa-configuration.cpp
@@ -15,7 +15,7 @@ bool NumaConfiguration::add_numa_node([[maybe_unused]] int numa_node_id, [[maybe
 #if defined(__APPLE__)
   return false;
 #else
-  assert(numa_available() == 0);
+  assert(numa_available() >= 0);
 
   if (!inited) {
     total_cpus = numa_num_configured_cpus();
@@ -48,7 +48,7 @@ bool NumaConfiguration::add_numa_node([[maybe_unused]] int numa_node_id, [[maybe
 
 void NumaConfiguration::distribute_process([[maybe_unused]] int numa_node_id, [[maybe_unused]] const cpu_set_t &cpu_mask) const {
 #if !defined(__APPLE__)
-  assert(numa_available() == 0);
+  assert(numa_available() >= 0);
 
   int res = sched_setaffinity(0, sizeof(cpu_set_t), &cpu_mask);
   dl_passert(res != -1, "Can't bind worker to cpu");

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2062,7 +2062,7 @@ int main_args_handler(int i, const char *long_option) {
       kprintf("--%s option: NUMA is not available on macOS\n", long_option);
       return -1;
 #else
-      if (numa_available() != 0) {
+      if (numa_available() < 0) {
         kprintf("--%s option: NUMA is not available on the host\n", long_option);
         return -1;
       }
@@ -2101,7 +2101,7 @@ int main_args_handler(int i, const char *long_option) {
       kprintf("--%s option: NUMA is not available on macOS\n", long_option);
       return -1;
 #else
-      if (numa_available() != 0) {
+      if (numa_available() < 0) {
         kprintf("--%s option: NUMA is not available on the host\n", long_option);
         return -1;
       }


### PR DESCRIPTION
Use `numa_available() < 0` instead of `numa_available() != 0` to check that NUMA is not available

The fragment from documenetation:
```
Before any NUMA API functions can be used, the program must call numa_available(). When this function returns a
negative value, there is no NUMA policy support on the system. In this case, the behavior of all other NUMA API
functions is undefined and they should not be called. 
```