### PR TITLE
[runtime] add fragmentation-related info to OOM error messages

### DIFF
--- a/runtime/memory_resource/monotonic_buffer_resource.cpp
+++ b/runtime/memory_resource/monotonic_buffer_resource.cpp
@@ -35,4 +35,32 @@ void monotonic_buffer::critical_dump(void *mem, size_t size) const noexcept {
     stats_.real_memory_used, stats_.max_real_memory_used);
 }
 
+void monotonic_buffer_resource::raise_oom(size_t size) const noexcept {
+  auto mem_pool_size = stats_.memory_limit;
+  size_t mem_available = mem_pool_size - stats_.memory_used;
+  if (mem_available < size) {
+    // to avoid the confusion, don't report this case as "high fragmentation";
+    // this is a genuine OOM case when user requested too much memory
+    php_out_of_memory_warning("Can't allocate %zu bytes (out of memory)", size);
+  } else {
+    // try to add some meaningful info to the OOM error message;
+    // buffer_free_space is a percentage of memory we have at our disposal
+    // if this value is high, then we have significant memory fragmentation issues;
+    // values below 0.1 are very good
+    auto fragmentation_rate = static_cast<double>(mem_available - size) / static_cast<double>(mem_pool_size);
+    auto buffer_free_space = static_cast<double>(mem_available) / static_cast<double>(mem_pool_size);
+    const char *fragmentation_hint = "low fragmentation";
+    if (fragmentation_rate >= 0.4) {
+      fragmentation_hint = "very high fragmentation";
+    } else if (fragmentation_rate >= 0.25) {
+      fragmentation_hint = "high fragmentation";
+    } else if (fragmentation_rate >= 0.1) {
+      fragmentation_hint = "normal fragmentation";
+    }
+    php_out_of_memory_warning("Can't allocate %zu bytes (%s, buffer free space: %.2f)", size, fragmentation_hint, buffer_free_space);
+  }
+
+  raise(SIGUSR2);
+}
+
 } // namespace memory_resource


### PR DESCRIPTION
This change adds some extra info to the OOM error messages to make fragmentation issues tracking easier.

The `buffer_free_space` measures how much memory the script buffer has left when the OOM happened. Ideally, this value should be low, like `0.1`, meaning there is only 10% memory left.

When calculating the fragmentation human-readable hint, we're taking the size of the allocation into the account.

Examples:
```
Warning: Can't allocate 524328 bytes (normal fragmentation, buffer free space: 0.70)
Warning: Can't allocate 72 bytes (low fragmentation, buffer free space: 0.02)
```