### PR TITLE
Improve cluster name

### DIFF
--- a/server/cluster-name.cpp
+++ b/server/cluster-name.cpp
@@ -2,11 +2,16 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-#include <algorithm>
-#include <cstring>
-#include <cctype>
-
 #include "server/cluster-name.h"
+
+#include <algorithm>
+
+#include <cctype>
+#include <cinttypes>
+#include <cstdio>
+#include <cstring>
+
+#include "common/crc32.h"
 
 ClusterName::ClusterName() {
   set_cluster_name("default");
@@ -14,7 +19,7 @@ ClusterName::ClusterName() {
 
 const char *ClusterName::set_cluster_name(const char *name) noexcept {
   // reserved for shmem, statsd, socket suffixes and prefixes
-  constexpr size_t reserved = 32;
+  constexpr size_t reserved = 42;
   const auto name_len = std::strlen(name);
   if (!name_len) {
     return "empty cluster name";
@@ -23,16 +28,31 @@ const char *ClusterName::set_cluster_name(const char *name) noexcept {
     return "too long cluster name";
   }
   std::copy(name, name + name_len + 1, cluster_name_.begin());
-  std::replace_copy_if(name, name + name_len + 1, socket_name_.begin(),
-                       [](char c) { return c && !std::isalpha(c); }, '_');
+  bool has_wrong_symbols = std::any_of(cluster_name_.begin(), cluster_name_.begin() + name_len, [](char c) {
+    return !std::isalnum(c) && c != '-' && c != '_';
+  });
+  if (has_wrong_symbols) {
+    return "Incorrect symbol in cluster name. Allowed symbols are: alpha-numerics, '-', '_'";
+  }
+
+  const char *socket_prefix = "kphp_master_fd_for_graceful_restart-";
+  auto socket_prefix_len = std::strlen(socket_prefix);
+  std::strcpy(socket_name_.data(), socket_prefix);
+  if (socket_prefix_len + name_len > MAX_SOCKET_NAME_LEN) {
+    // To allow cluster name longer than 107 symbols, we just take crc64 of it as the socket name
+    uint64_t crc = compute_crc64(name, name_len);
+    char hex_crc_str[sizeof(crc) * 2 + 1];
+    std::sprintf(hex_crc_str, "%16" PRIx64, crc);
+    std::strcat(socket_name_.data(), hex_crc_str);
+  } else {
+    std::strcat(socket_name_.data(), cluster_name_.data());
+  }
 
   std::strcpy(shmem_name_.data(), "/");
-  std::strcat(shmem_name_.data(), socket_name_.data());
+  std::strcat(shmem_name_.data(), cluster_name_.data());
   std::strcat(shmem_name_.data(), "_kphp_shm");
 
   std::strcpy(statsd_prefix_.data(), "kphp_stats.");
-  std::strcat(statsd_prefix_.data(), socket_name_.data());
-
-  std::strcat(socket_name_.data(), "_kphp_fd_transfer");
+  std::strcat(statsd_prefix_.data(), cluster_name_.data());
   return nullptr;
 }

--- a/server/cluster-name.h
+++ b/server/cluster-name.h
@@ -6,6 +6,8 @@
 
 #include <array>
 #include <climits>
+#include <sys/un.h>
+#include <type_traits>
 
 #include "common/mixin/not_copyable.h"
 #include "common/smart_ptrs/singleton.h"
@@ -20,12 +22,14 @@ public:
   const char *get_statsd_prefix() const noexcept { return statsd_prefix_.data(); }
 
 private:
+  static constexpr size_t MAX_SOCKET_NAME_LEN = sizeof(std::declval<sockaddr_un>().sun_path) - 1;
+
   ClusterName();
 
   friend class vk::singleton<ClusterName>;
 
   std::array<char, NAME_MAX> cluster_name_;
-  std::array<char, NAME_MAX> socket_name_;
+  std::array<char, MAX_SOCKET_NAME_LEN + 1> socket_name_;
   std::array<char, NAME_MAX> shmem_name_;
   std::array<char, NAME_MAX> statsd_prefix_;
 };

--- a/tests/cpp/server/cluster-name-test.cpp
+++ b/tests/cpp/server/cluster-name-test.cpp
@@ -8,7 +8,7 @@ TEST(cluster_name_test, test_usage) {
   ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("kphp_engine"), nullptr);
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "kphp_engine");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-kphp_engine");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-kphp_engine");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/kphp_engine_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.kphp_engine");
 }
@@ -16,7 +16,7 @@ TEST(cluster_name_test, test_usage) {
 TEST(cluster_name_test, test_long_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 
@@ -24,7 +24,7 @@ TEST(cluster_name_test, test_long_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(long_cluster_name.c_str()), "too long cluster name");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 
@@ -33,7 +33,7 @@ TEST(cluster_name_test, test_long_name) {
   uint64_t crc = compute_crc64(not_very_long_cluster_name.c_str(), not_very_long_cluster_name.length());
   char hex_crc_str[sizeof(crc) * 2 + 1];
   std::sprintf(hex_crc_str, "%16" PRIx64, crc);
-  std::string expected_socket_name = "kphp_master_fd_for_graceful_restart-" + std::string(hex_crc_str);
+  std::string expected_socket_name = "kphp_master_unix_socket_for_graceful_restart-" + std::string(hex_crc_str);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), not_very_long_cluster_name.c_str());
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), expected_socket_name.c_str());
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), ("/" + not_very_long_cluster_name + "_kphp_shm").c_str());
@@ -43,14 +43,14 @@ TEST(cluster_name_test, test_long_name) {
 TEST(cluster_name_test, test_empty_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(""), "empty cluster name");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 }
@@ -60,7 +60,7 @@ TEST(cluster_name_test, test_special_chars) {
                "Incorrect symbol in cluster name. Allowed symbols are: alpha-numerics, '-', '_'");
   ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("aB-12_0xD"), nullptr);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "aB-12_0xD");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-aB-12_0xD");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_unix_socket_for_graceful_restart-aB-12_0xD");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/aB-12_0xD_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.aB-12_0xD");
 }

--- a/tests/cpp/server/cluster-name-test.cpp
+++ b/tests/cpp/server/cluster-name-test.cpp
@@ -1,12 +1,14 @@
+#include <cinttypes>
 #include <gtest/gtest.h>
 
+#include "common/crc32.h"
 #include "server/cluster-name.h"
 
 TEST(cluster_name_test, test_usage) {
   ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("kphp_engine"), nullptr);
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "kphp_engine");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_engine_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-kphp_engine");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/kphp_engine_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.kphp_engine");
 }
@@ -14,7 +16,7 @@ TEST(cluster_name_test, test_usage) {
 TEST(cluster_name_test, test_long_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 
@@ -22,31 +24,43 @@ TEST(cluster_name_test, test_long_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(long_cluster_name.c_str()), "too long cluster name");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
+
+  const std::string not_very_long_cluster_name = "kphp" + std::string(128, '-') + "_engine";
+  ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name(not_very_long_cluster_name.c_str()), nullptr);
+  uint64_t crc = compute_crc64(not_very_long_cluster_name.c_str(), not_very_long_cluster_name.length());
+  char hex_crc_str[sizeof(crc) * 2 + 1];
+  std::sprintf(hex_crc_str, "%16" PRIx64, crc);
+  std::string expected_socket_name = "kphp_master_fd_for_graceful_restart-" + std::string(hex_crc_str);
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), not_very_long_cluster_name.c_str());
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), expected_socket_name.c_str());
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), ("/" + not_very_long_cluster_name + "_kphp_shm").c_str());
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), ("kphp_stats." + not_very_long_cluster_name).c_str());
 }
 
 TEST(cluster_name_test, test_empty_name) {
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("default"), nullptr);
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name(""), "empty cluster name");
 
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "default");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "default_kphp_fd_transfer");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-default");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/default_kphp_shm");
   ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.default");
 }
 
 TEST(cluster_name_test, test_special_chars) {
-  ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("a-b1c*d/e+f~g<h?i"), nullptr);
-
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "a-b1c*d/e+f~g<h?i");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "a_b_c_d_e_f_g_h_i_kphp_fd_transfer");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/a_b_c_d_e_f_g_h_i_kphp_shm");
-  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.a_b_c_d_e_f_g_h_i");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().set_cluster_name("a-b1c*d/e+f~g<h?i"),
+               "Incorrect symbol in cluster name. Allowed symbols are: alpha-numerics, '-', '_'");
+  ASSERT_EQ(vk::singleton<ClusterName>::get().set_cluster_name("aB-12_0xD"), nullptr);
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_cluster_name(), "aB-12_0xD");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_socket_name(), "kphp_master_fd_for_graceful_restart-aB-12_0xD");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_shmem_name(), "/aB-12_0xD_kphp_shm");
+  ASSERT_STREQ(vk::singleton<ClusterName>::get().get_statsd_prefix(), "kphp_stats.aB-12_0xD");
 }


### PR DESCRIPTION
This patch consists of the following improvements:
- Allow cluster name to contain digits and '-'
- Check cluster name for incorrect symbols on start instead of force quiet replacing them with '_'
- Handle the case when cluster name is longer than 108 bytes to be able to create `UNIX_SOCKET` for graceful restart. Before this patch, server just crashed when attempting to create such socket on graceful restart.