### PR TITLE
support unpacking fixed-size arrays to positional arguments

### DIFF
--- a/compiler/pipes/deduce-implicit-types-and-casts.cpp
+++ b/compiler/pipes/deduce-implicit-types-and-casts.cpp
@@ -668,7 +668,7 @@ void DeduceImplicitTypesAndCastsPass::patch_call_arg_on_func_call(VertexAdaptor<
 
   // for cast params (::: in functions.txt or '@kphp-infer cast') we add conversions automatically (implicit casts),
   // unless the file from where we're calling this function is annotated with strict_types=1
-  if (param->is_cast_param && is_implicit_cast_allowed(current_function->file_id->is_strict_types, param_hint)) {
+  if (param->is_cast_param && is_implicit_cast_allowed(current_function->file_id->is_strict_types, param_hint) && call_arg->type() != op_varg) {
     call_arg = implicit_cast_call_arg_to_cast_param(call_arg, param_hint, param->var()->ref_flag);
     return;
   }

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -213,10 +213,10 @@ def run_fail_test(test: TestFile, runner):
     if runner.compile_with_kphp(test.env_vars):
         return TestResult.failed(test, runner.artifacts, "kphp build is ok, but it expected to fail")
 
-    if test.out_regexps or test.forbidden_regexps:
-        if not runner.kphp_build_stderr_artifact:
-            return TestResult.failed(test, runner.artifacts, "kphp build failed without stderr")
+    if not runner.kphp_build_stderr_artifact:
+        return TestResult.failed(test, runner.artifacts, "kphp build failed without stderr")
 
+    if test.out_regexps or test.forbidden_regexps:
         with open(runner.kphp_build_stderr_artifact.file) as f:
             stderr_log = f.read()
             for index, msg_regex in enumerate(test.out_regexps, start=1):

--- a/tests/phpt/array/026_array_is_list.php
+++ b/tests/phpt/array/026_array_is_list.php
@@ -1,4 +1,4 @@
-@ok php8
+@skip php8
 <?php
 
 var_dump(array_is_list([]));

--- a/tests/phpt/errors/007_method_params_n_variadic.php
+++ b/tests/phpt/errors/007_method_params_n_variadic.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-/Not enough arguments to supply a variadic call/
 /Too few arguments to function call, expected 2, have 0/
 /Too few arguments to function call, expected 4, have 2/
 /Too few arguments to function call, expected 2, have 0/

--- a/tests/phpt/variadic_args/012_php_doc_variadic.php
+++ b/tests/phpt/variadic_args/012_php_doc_variadic.php
@@ -66,9 +66,57 @@ function return_varg_doc($arg) {
   return $arg;
 }
 
+/**
+ * @param mixed[] $args
+ * @return mixed
+ */
+function minnz(...$args) {
+    var_dump($args);
+    $min = min($args);
+    return $min;
+}
+
+/**
+ * @return mixed
+ */
+function getResults() {
+    return [2, '1'];
+}
+
+function demo_with_mixed() {
+    $results = getResults();
+    $min = minnz(...$results);
+    var_dump($min);
+}
+
+
+/**
+ * @param mixed ...$args
+ */
+function takeArgsMixed(string $prefix, ...$args) {
+    var_dump($args);
+}
+
+/**
+ * @param string ...$args
+ */
+function takeArgsString(string $prefix, ...$args) {
+    var_dump($args);
+}
+
+function test_pass_different_types() {
+    $link = 'link';
+    takeArgsMixed('p', ...['app', $link]);
+    takeArgsString('p', ...['app', $link]);
+}
+
+
+
 get_int_args(1, 2, 3);
 get_array_args(["hello", "world"]);
 get_instance_args(new Stub, new Stub);
 get_interface_args(new StubImpl2, new StubImpl1);
 get_varg_in_phpdoc_but_array([1, 2]);
 var_dump(return_varg_doc(1));
+demo_with_mixed();
+test_pass_different_types();

--- a/tests/phpt/variadic_args/016_unpack_positional.php
+++ b/tests/phpt/variadic_args/016_unpack_positional.php
@@ -1,0 +1,63 @@
+@ok
+<?php
+
+function f(int $a, string $b, float $c = 0.0) {
+    echo "f: a $a b $b c $c\n";
+}
+
+class A {
+    const MIXED_13 = [13, 's13', 13.13];
+
+    function g(int $a, string $b, ...$rest) {
+        $n = count($rest);
+        $first = $n ? $rest[0] : '';
+        $last = $n ? $rest[$n-1] : '';
+        echo "g: a $a, b $b, rest $n $first..$last\n";
+    }
+}
+
+$zero = 0;
+f(1, 's1');
+f(...[2, 's2']);
+f(...[3, 's3', 3.3+$zero]);
+f(4, ...['s4']);
+f(5, ...['s5', 5.5]);
+f(6, 's6', ...[]);
+f(7, 's7', ...[7.7]);
+f(...[...[8, 's8'], ...[8.8]]);
+f(...[9], ...['s9']);
+f(...[], ...[10+0, 's10'.''], ...[], ...[10.10]);
+f(...[...[...[11, 's11']]]);
+f(...[12+0+$zero], ...[...[]], ...[...[...['s12']]]);
+f(...A::MIXED_13);
+// PHP does not allow positional arguments after unpacking (fails even in if(0)), but KPHP does
+// f(...[14], 's14', ...[14.14]);
+
+$a = new A;
+$a->g(...[1, 's1']);
+$a->g(...[2, 's2'], ...['x2', 'y2'], ...['z2']);
+$a->g(...[3, 's3', 'x3', 'y3']);
+$a->g(4, ...['s4', 'x4']);
+$f5 = 5;
+$y5 = 'y5';
+$w5 = 'w5';
+$a->g($f5, ...['s5', ...['x5', ...[$y5]]], ...['z5'], ...[], ...[$w5]);
+
+function callL(...$rest) {
+    $l = function(int $a, string $b, ...$rest) {
+        $n = count($rest);
+        $first = $n ? $rest[0] : '';
+        $last = $n ? $rest[$n-1] : '';
+        echo "l: a $a, b $b, rest $n $first..$last\n";
+    };
+    $l(...[10, 's10', ...$rest]);
+    $l(...[11, 's11'], ...$rest);
+    $l(...[12, 's12', 'p12'], ...$rest);
+    $l(13, ...['s13'], ...['p13'], ...$rest, ...['z14']);
+    $l(14, ...['s14'], ...['p14', ...$rest, 'z14']);
+}
+
+callL('x', 'y');
+
+// todo unpack constants ...A::CONST_ARR
+

--- a/tests/phpt/variadic_args/102_pass_less_arguments.php
+++ b/tests/phpt/variadic_args/102_pass_less_arguments.php
@@ -1,4 +1,5 @@
 @kphp_should_fail
+/It's prohibited to unpack non-fixed arrays where positional arguments expected/
 <?php
 
 function fun($x, ...$args) {

--- a/tests/phpt/variadic_args/111_bad_type_after_unpack.php
+++ b/tests/phpt/variadic_args/111_bad_type_after_unpack.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/pass int to argument \$s of f/
+<?php
+
+function f(string $s, int $i) {
+    echo $s, $i;
+}
+
+f(...[1, 2]);

--- a/tests/phpt/variadic_args/111_unpack_non_variadic_fail.php
+++ b/tests/phpt/variadic_args/111_unpack_non_variadic_fail.php
@@ -1,9 +1,0 @@
-@kphp_should_fail
-/Unpacking an argument to a non-variadic param/
-<?php
-
-function f($a, $b) {
-}
-
-f(1, ...[2]);
-

--- a/tests/phpt/variadic_args/112_bad_count_after_unpack.php
+++ b/tests/phpt/variadic_args/112_bad_count_after_unpack.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/Too many arguments to function call, expected 2, have 4/
+/Too many arguments to function call, expected 2, have 5/
+/Too few arguments to function call, expected 2, have 1/
+<?php
+
+function f(int $s, int $i) {
+    echo $s, $i;
+}
+
+f(...[1, 2, 3, 4]);
+f(...[1, 2, ...[3, 4]], ...[5]);
+
+
+function g($a, $b, $c = 0.0) {
+}
+
+g(...[1, ...[]]);

--- a/tests/phpt/variadic_args/112_unpack_non_variadic_fail.php
+++ b/tests/phpt/variadic_args/112_unpack_non_variadic_fail.php
@@ -1,8 +1,0 @@
-@kphp_should_fail
-/Unpacking an argument to a non-variadic param/
-<?php
-
-function f($a ::: array) {
-}
-f(...[[1, 2]]);
-

--- a/tests/phpt/variadic_args/113_unpack_to_cast.php
+++ b/tests/phpt/variadic_args/113_unpack_to_cast.php
@@ -1,0 +1,18 @@
+@kphp_should_fail
+/Invalid place for unpack, because param \$a is @kphp-infer cast/
+/Invalid place for unpack, because param \$s is @kphp-infer cast/
+/Invalid place for unpack, because param \$i is @kphp-infer cast/
+<?php
+
+function f($a ::: array) {
+}
+f(...[[1, 2]]);
+
+/**
+ * @kphp-infer cast
+ * @param string $s
+ * @param int $i
+ */
+function g($s, $i) {
+}
+g(...['s', 1]);


### PR DESCRIPTION
I've added a feature that can seem strange at first eye.
```php
function f($x, $y) { ... }

f(...[1, 2]);   // f(1,2)
f(3, ...[4]);   // f(3, 4)
f(...[], ...[5, ...[6, ...[]]], ...[]);  // f(5, 6)
```

This now works in KPHP too. It also works with default arguments and variadic arguments:
```php
function g($x, $y, ...$rest) {}

g(...[1, 2, 3, 4]);  // g(1, 2, [3,4])
g(5, ...[], ...[6, 7], ...[8]);  // g(5, 6, [7,8]);
```

This works only if arrays are fixed-size in compile-time. E.g., you can't call `f(...$some)` from the example above, only `f(...[$x,$y])`.

# What for?

It will be useful in the near future, with variadic generics. 
Using variadic generics, you'd be able to proxy any `...$args`. For example,
```
function h($x, $y, $z, $w = 0.0) { ... }

// assume this is a variadic generic from the future, $args are expanded at compile-time
function callHwithXeq0(...$args) {
    h(...[0, ...$args]);  // prepend 0
    h(...[...$args, 0]);  // append 0
}

callHwithXeq0(1, 2); // h(0, 1, 2)
callHwithXeq0(3, 4, 5.5); // h(0, 3, 4, 5.5)
```

After expanding the first call (with 2 arguments), we get `h(...[0, $args$1, $args$2])` which should be correctly mapped as `h(0, $args$1, $args$2)`.
This PR essentially does this stuff.