### PR TITLE
[compiler] better type inference for switch cond var

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1108,7 +1108,7 @@ void compile_switch_str(VertexAdaptor<op_switch> root, CodeGenerator &W) {
   W << temp_var_strval_of_condition << " = f$strval (" << root->condition() << ");" << NL;
   W << temp_var_matched_with_a_case << " = false;" << NL;
 
-  W << "switch (" << temp_var_strval_of_condition << ".as_string().hash()) " << BEGIN;
+  W << "switch (" << temp_var_strval_of_condition << ".hash()) " << BEGIN;
   for (const auto &one_case : cases) {
     if (one_case.is_default) {
       W << "default:" << NL;
@@ -1124,7 +1124,7 @@ void compile_switch_str(VertexAdaptor<op_switch> root, CodeGenerator &W) {
       }
       W << "if (!" << temp_var_matched_with_a_case << ") " << BEGIN;
       {
-        W << "if (!equals (" << temp_var_strval_of_condition << ".as_string(), " << one_case.expr << ")) " << BEGIN;
+        W << "if (!equals (" << temp_var_strval_of_condition << ", " << one_case.expr << ")) " << BEGIN;
 
         if (one_case.next) {
           W << "goto " << one_case.next->goto_name << ";" << NL;
@@ -1231,9 +1231,6 @@ void compile_switch_var(VertexAdaptor<op_switch> root, CodeGenerator &W) {
 
 void compile_switch(VertexAdaptor<op_switch> root, CodeGenerator &W) {
   kphp_assert(root->condition_on_switch()->type() == op_var && root->matched_with_one_case()->type() == op_var);
-  bool all_cases_are_ints = true;
-  int num_const_string_cases = 0;
-  int num_value_cases = 0;
   bool has_default = false;
 
   for (auto one_case : root->cases()) {
@@ -1242,22 +1239,11 @@ void compile_switch(VertexAdaptor<op_switch> root, CodeGenerator &W) {
       has_default = true;
       continue;
     }
-
-    auto val = GenTree::get_actual_value(one_case.as<op_case>()->expr());
-    all_cases_are_ints    &= is_const_int(val);
-    num_value_cases++;
-    if (auto as_string = val.try_as<op_string>()) {
-      // PHP would use a numerical comparison for strings that look like a number,
-      // we shouldn't rewrite these switches as a string-only switch
-      if (!php_is_numeric(as_string->str_val.data())) {
-        num_const_string_cases++;
-      }
-    }
   }
 
-  if (num_const_string_cases == num_value_cases) {
+  if (root->kind == SwitchKind::StringSwitch) {
     compile_switch_str(root, W);
-  } else if (all_cases_are_ints) {
+  } else if (root->kind == SwitchKind::IntSwitch) {
     compile_switch_int(root, W);
   } else {
     compile_switch_var(root, W);

--- a/compiler/vertex-desc.json
+++ b/compiler/vertex-desc.json
@@ -750,6 +750,11 @@
     "props": {
       "str": "switch"
     },
+    "extra_fields": {
+      "kind": {
+        "type": "SwitchKind"
+      }
+    },
     "ranges": {
       "cases": [
         3,

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -18,6 +18,13 @@ vertex_inner<Op> *raw_create_vertex_inner(int args_n);
 
 class TypeHint;
 
+enum class SwitchKind: uint8_t {
+  EmptySwitch,  // switch with no expr cases
+  IntSwitch,    // switch with int-only constexpr cases
+  StringSwitch, // switch with string-only constexpr
+  VarSwitch,    // switch with arbitrary (mixed) expr cases
+};
+
 enum class InstancePropAccessType: uint8_t {
   Default,        // normal instance prop access
   CData,          // accessing a FFI field through php2c level

--- a/tests/benchmarks/BenchmarkMultiSwitch.php
+++ b/tests/benchmarks/BenchmarkMultiSwitch.php
@@ -1,0 +1,65 @@
+<?php
+
+class BenchmarkMultiSwitch {
+  private $string_value = 'string';
+  private $int_value = 10;
+
+  public function benchmarkMultiString() {
+    $result = 0;
+    switch ($this->string_value) {
+    case 'hello':
+      $result += 1;
+      break;
+    case 'world':
+      $result += 2;
+      break;
+    case 'string':
+      $result += 3;
+      break;
+    }
+    switch ($this->string_value) {
+    case $this->getStringValue():
+      $result *= 10;
+      break;
+    case $this->getStringValue2():
+      $result *= 20;
+      break;
+    case 'hello':
+      $result *= 30;
+      break;
+    }
+    return $result;
+  }
+
+  public function benchmarkMultiInt() {
+    $result = 0;
+    switch ($this->int_value) {
+    case 54:
+      $result += 1;
+      break;
+    case 603:
+      $result += 2;
+      break;
+    case 10:
+      $result += 3;
+      break;
+    }
+    switch ($this->int_value) {
+    case $this->getIntValue():
+      $result *= 10;
+      break;
+    case ord('x'):
+      $result *= 20;
+      break;
+    case $this->int_value + 1:
+      $result *= 30;
+      break;
+    }
+    return $result;
+  }
+
+  private function getStringValue() { return $this->string_value; }
+  private function getStringValue2() { return 'ok'; }
+
+  private function getIntValue() { return $this->int_value; }
+}


### PR DESCRIPTION
Instead of producing a mixed-typed variable for every switch statement, try to find a more suitable type.

Most of the switches are optimized to int and string switches, so in those cases having non-mixed var is very beneficial.

Even for expr (var) switches we can get a measurable improvement if all cases and condition expr itself evaluate to some properly-typed value, like int or string.

Here is a non-compherensive list of why mixed-typed vars are not optimal:

* Expensive destructor, `mixed::~mixed` shows up in the CPU profiles
* The need to do `mixed::as_string()` many times inside optimized string switches
* mixed-typed overloadings are used in `eq2()` calls

The implementation used in this PR tries to avoid excessive work from the compiler. If it can be assumed to be a int/string switch, we won't do any extra work. For other switch statements we'll find an LCA type of condition expr and all expression cases results. It could still be mixed, but sometimes it's inferred to something like int and improves performance significantly.

	name                      old time/op  new time/op  delta
	MultiSwitch::MultiString  83.0ns ± 0%  59.3ns ± 1%  -28.55%  (p=0.000 n=8+10)
	MultiSwitch::MultiInt     23.3ns ± 3%   7.0ns ± 0%  -69.96%  (p=0.000 n=10+10)