### PR TITLE
[runtime] fix string indexing (was broken during the refactoring)

### DIFF
--- a/runtime/mixed.inl
+++ b/runtime/mixed.inl
@@ -1360,7 +1360,7 @@ bool mixed::isset(int64_t int_key) const {
   if (unlikely (get_type() != type::ARRAY)) {
     if (get_type() == type::STRING) {
       int_key = as_string().get_correct_index(int_key);
-      return int_key < as_string().size();
+      return as_string().isset(int_key);
     }
 
     if (get_type() != type::NUL && (get_type() != type::BOOLEAN || as_bool())) {

--- a/runtime/regexp.cpp
+++ b/runtime/regexp.cpp
@@ -729,7 +729,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, bool all_
   pcre_last_error = 0;
 
   int64_t result = 0;
-  offset = subject.get_correct_index(offset);
+  offset = subject.get_correct_offset(offset);
   if (offset > subject.size()) {
     matches = array<mixed>();
     pcre_last_error = PCRE2_ERROR_BADOFFSET;
@@ -844,7 +844,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, int64_t f
 
   int64_t result = 0;
   auto empty_match = array<mixed>::create(string(), PCRE2_UNSET);
-  offset = subject.get_correct_index(offset);
+  offset = subject.get_correct_offset(offset);
   if (offset > subject.size()) {
     matches = array<mixed>();
     pcre_last_error = PCRE2_ERROR_BADOFFSET;

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -942,32 +942,40 @@ int64_t string::compare(const string &str) const {
   return res ? res : static_cast<int64_t>(my_size) - static_cast<int64_t>(str_size);
 }
 
-
-int64_t string::get_correct_index(int64_t index) const {
-  if (index < 0) {
-    index = index + size();
-    if (index < 0) {
-      index = 0;
-    }
-  }
-  return index;
+bool string::isset(int64_t index) const {
+  return index >= 0 && index < size();
 }
 
-int64_t string::get_correct_index_clamped(int64_t index) const {
-  if (index < 0) {
-    index = index + size();
-    if (index < 0) {
-      index = 0;
+
+int64_t string::get_correct_index(int64_t index) const {
+  return index >= 0 ? index : index + int64_t{size()};
+}
+
+int64_t string::get_correct_offset(int64_t offset) const {
+  if (offset < 0) {
+    offset = offset + size();
+    if (offset < 0) {
+      offset = 0;
     }
-  } else if (index > size()) {
-    index = size();
   }
-  return index;
+  return offset;
+}
+
+int64_t string::get_correct_offset_clamped(int64_t offset) const {
+  if (offset < 0) {
+    offset = offset + size();
+    if (offset < 0) {
+      offset = 0;
+    }
+  } else if (offset > size()) {
+    offset = size();
+  }
+  return offset;
 }
 
 const string string::get_value(int64_t int_key) const {
   const int64_t true_key = get_correct_index(int_key);
-  if (true_key >= size()) {
+  if (unlikely(!isset(true_key))) {
     return {};
   }
   return string(1, p[true_key]);

--- a/runtime/string_decl.inl
+++ b/runtime/string_decl.inl
@@ -176,8 +176,10 @@ public:
 
   inline int64_t compare(const string &str) const;
 
+  inline bool isset(int64_t index) const;
   inline int64_t get_correct_index(int64_t index) const;
-  inline int64_t get_correct_index_clamped(int64_t index) const;
+  inline int64_t get_correct_offset(int64_t index) const;
+  inline int64_t get_correct_offset_clamped(int64_t index) const;
   inline const string get_value(int64_t int_key) const;
   inline const string get_value(const string &string_key) const;
   inline const string get_value(const mixed &v) const;

--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -1843,11 +1843,11 @@ int64_t f$strnatcmp(const string &lhs, const string &rhs) {
 }
 
 int64_t f$strspn(const string &hayshack, const string &char_list, int64_t offset) noexcept {
-  return strspn(hayshack.c_str() + hayshack.get_correct_index_clamped(offset), char_list.c_str());
+  return strspn(hayshack.c_str() + hayshack.get_correct_offset_clamped(offset), char_list.c_str());
 }
 
 int64_t f$strcspn(const string &hayshack, const string &char_list, int64_t offset) noexcept {
-  return strcspn(hayshack.c_str() + hayshack.get_correct_index_clamped(offset), char_list.c_str());
+  return strcspn(hayshack.c_str() + hayshack.get_correct_offset_clamped(offset), char_list.c_str());
 }
 
 Optional<string> f$strpbrk(const string &haystack, const string &char_list) {
@@ -2329,7 +2329,7 @@ Optional<string> f$substr(const string &str, int64_t start, int64_t length) {
 //    php_warning("start is in part removed by length argument in substr function call");
     return false;
   }
-  start = str.get_correct_index(start);
+  start = str.get_correct_offset(start);
   if (length < 0) {
     length = (str_len - start) + length;
     if (length < 0) {
@@ -2345,7 +2345,7 @@ Optional<string> f$substr(const string &str, int64_t start, int64_t length) {
 }
 
 int64_t f$substr_count(const string &haystack, const string &needle, int64_t offset, int64_t length) {
-  offset = haystack.get_correct_index(offset);
+  offset = haystack.get_correct_offset(offset);
   if (offset >= haystack.size()) {
     return 0;
   }
@@ -2373,7 +2373,7 @@ string f$substr_replace(const string &str, const string &replacement, int64_t st
   int64_t str_len = str.size();
 
   // if $start is negative, count $start from the end of the string
-  start = str.get_correct_index_clamped(start);
+  start = str.get_correct_offset_clamped(start);
 
   // if $length is negative, set it to the length needed
   // needed to stop that many chars from the end of the string
@@ -2406,7 +2406,7 @@ Optional<int64_t> f$substr_compare(const string &main_str, const string &str, in
     return false;
   }
 
-  offset = str.get_correct_index(offset);
+  offset = main_str.get_correct_offset(offset);
 
   // > and >= signs depend on version of PHP7.2 and could vary unpredictably. We put `>` sign which corresponds to behaviour of PHP7.2.22
   if (offset > str_len) {


### PR DESCRIPTION
Most PHP functions wrap negative offset and make it 0 if it overflows the length.
Direct string indexing and `isset()` checks, hovewer, are not doing that.

Rename `get_correct_index` function into `get_correct_offset` to make this difference more obvious.

`get_correct_index` is reverted to its original form. It should not be used to calculate the offset.

Also added `string::isset` method to use that in both string internal implementation and inside mixed isset check for strings.