### PR TITLE
[runtime] optimize `strtolower` and `strtoupper`

### DIFF
--- a/tests/phpt/string_functions/008_misc.php
+++ b/tests/phpt/string_functions/008_misc.php
@@ -1,0 +1,54 @@
+@ok
+<?php
+
+function extend_test_suite($tests) {
+  $all_tests = [];
+  foreach ($tests as $test) {
+    $all_tests[] = $test;
+    $all_tests[] = "  $test";
+    $all_tests[] = "$test  ";
+    $all_tests[] = "  $test  ";
+    $all_tests[] = "$test$test";
+    $all_tests[] = "$test _ $test";
+    $all_tests[] = "\x00$test";
+    $all_tests[] = "$test\x00$test\x00";
+  }
+  return $all_tests;
+}
+
+function test_strtolower_strtoupper() {
+  $tests = extend_test_suite([
+    '',
+    ' ',
+    'a',
+    'A',
+    '_',
+    'foo',
+    'foO',
+    'fOo',
+    'fOO',
+    'Foo',
+    'FoO',
+    'FOo',
+    'FOO',
+    'aAaA',
+    'AAAA',
+    'aaAa',
+    'Hello, World!',
+    'hello, world!',
+    'HELLO, WORLD!',
+    '93258324',
+    '&^@$%#^$@',
+  ]);
+  foreach ($tests as $test) {
+    var_dump(strtolower(strtolower($test)));
+    var_dump(strtolower($test));
+    var_dump(strtolower(strtoupper($test)));
+    var_dump(strtoupper($test));
+    var_dump(strtoupper(strtolower($test)));
+    var_dump(strtoupper(strtoupper($test)));
+  }
+}
+
+test_strtolower_strtoupper();
+


### PR DESCRIPTION
This change introduces two optimizations for the above mentioned functions:

1. If no characters need to be converted, return the argument as is. This is the best scenario, no allocations, no data copying. If there is such a character, save its offset (pos).

2. Use the char pos obtained at the first step and use `memcpy` to copy eveything before that pos, since we know that part doesn't need any case folding.

Benchmark results are provided below.

Execution time results:

    name                   old time/op    new time/op    delta
    Strtolower::1nop         42.2ns ± 3%    20.8ns ± 6%   -50.71%  (p=0.000 n=10+10)
    Strtolower::8nop         72.4ns ± 2%    28.7ns ± 2%   -60.36%  (p=0.000 n=10+10)
    Strtolower::32nop         182ns ± 1%      42ns ± 0%   -76.92%  (p=0.000 n=10+9)
    Strtolower::128nop        611ns ± 0%     136ns ± 1%   -77.69%  (p=0.000 n=9+10)
    Strtolower::1024nop      4.54µs ± 2%    0.76µs ± 1%   -83.27%  (p=0.000 n=10+10)
    Strtolower::1            41.3ns ± 2%    47.5ns ± 1%   +15.01%  (p=0.000 n=10+10)
    Strtolower::8mid         72.5ns ± 1%    71.6ns ± 2%    -1.21%  (p=0.018 n=10+8)
    Strtolower::32mid         187ns ± 3%     132ns ± 0%   -29.52%  (p=0.000 n=10+7)
    Strtolower::128mid        614ns ± 0%     387ns ± 1%   -36.88%  (p=0.000 n=9+10)
    Strtolower::1024mid      4.56µs ± 2%    2.72µs ± 0%   -40.40%  (p=0.000 n=10+9)
    Strtolower::8begin       73.4ns ± 2%    78.3ns ± 2%    +6.68%  (p=0.000 n=10+10)
    Strtolower::32begin       184ns ± 2%     186ns ± 0%      ~     (p=1.000 n=10+10)
    Strtolower::128begin      610ns ± 0%     616ns ± 0%    +1.12%  (p=0.000 n=9+8)
    Strtolower::1024begin    4.49µs ± 1%    4.51µs ± 0%    +0.54%  (p=0.000 n=9+8)
    Strtolower::8end         75.0ns ± 0%    58.0ns ± 0%   -22.67%  (p=0.000 n=6+9)
    Strtolower::32end         187ns ± 0%      72ns ± 0%   -61.50%  (p=0.000 n=6+9)
    Strtolower::128end        610ns ± 0%     174ns ± 2%   -71.48%  (p=0.000 n=9+10)
    Strtolower::1024end      4.50µs ± 1%    0.81µs ± 1%   -81.92%  (p=0.000 n=10+8)
    [Geo mean]                339ns          177ns        -47.72%

Allocations:

    name                   old alloc/op   new alloc/op   delta
    Strtolower::1nop          16.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
    Strtolower::8nop          24.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
    Strtolower::32nop         48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
    Strtolower::128nop         144B ± 0%        0B       -100.00%  (p=0.000 n=10+10)
    Strtolower::1024nop      1.04kB ± 0%    0.00kB       -100.00%  (p=0.000 n=10+10)
    Strtolower::1             16.0B ± 0%     16.0B ± 0%         ~  (all equal)
    Strtolower::8mid          24.0B ± 0%     24.0B ± 0%         ~  (all equal)
    Strtolower::32mid         48.0B ± 0%     48.0B ± 0%         ~  (all equal)
    Strtolower::128mid         144B ± 0%      144B ± 0%         ~  (all equal)
    Strtolower::1024mid      1.04kB ± 0%    1.04kB ± 0%         ~  (all equal)
    Strtolower::8begin        24.0B ± 0%     24.0B ± 0%         ~  (all equal)
    Strtolower::32begin       48.0B ± 0%     48.0B ± 0%         ~  (all equal)
    Strtolower::128begin       144B ± 0%      144B ± 0%         ~  (all equal)
    Strtolower::1024begin    1.04kB ± 0%    1.04kB ± 0%         ~  (all equal)
    Strtolower::8end          24.0B ± 0%     24.0B ± 0%         ~  (all equal)
    Strtolower::32end         48.0B ± 0%     48.0B ± 0%         ~  (all equal)
    Strtolower::128end         144B ± 0%      144B ± 0%         ~  (all equal)
    Strtolower::1024end      1.04kB ± 0%    1.04kB ± 0%         ~  (all equal)

* nop - the best case, string is returned "as is"
* begin - found char that needs to be converted in the beginning of the string
* mid - found char that needs to be converted in the middle of the string
* end - found char that needs to be converted in the ending of the string