### PR TITLE
enable leak sanitizer

### DIFF
--- a/common/sanitizer.h
+++ b/common/sanitizer.h
@@ -16,11 +16,6 @@
 
 #if !defined(ASAN_ENABLED)
 # define ASAN_ENABLED 0
-#elif __GNUC__ >= 7
-// gcc prior 7 version didn't have __sanitizer_start[finish]_switch_fiber to control stack pointer during swapcontext
-// some functions(fast_backtrace) cause stack-buffer-overflow due to stack traversing out of frame, nevertheless it's ok for sanitizer
-// asan starts to produce false positive overflow due to swapcontext with c++ exceptions (if you have non-trivial destructors)
-# define ASAN7_ENABLED 1
 #endif
 
 #if defined(__clang__)

--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -822,7 +822,7 @@ Optional<string> file_file_get_contents(const string &name) {
   }
 
   struct stat stat_buf{};
-#if ASAN7_ENABLED && __GNUC__ == 10 && __GNUC_MINOR__ == 3
+#if ASAN_ENABLED && __GNUC__ == 10 && __GNUC_MINOR__ == 3
   ASAN_UNPOISON_MEMORY_REGION(&stat_buf, sizeof(stat_buf));
 #endif
   dl::enter_critical_section();//OK

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -4,6 +4,7 @@
 
 #include "server/php-runner.h"
 
+#include <array>
 #include <cassert>
 #include <cerrno>
 #include <cstdlib>
@@ -660,8 +661,11 @@ void check_stack_overflow() {
 
 //C interface
 void init_handlers() {
+  constexpr size_t SEGV_STACK_SIZE = MINSIGSTKSZ + 65536;
+  static std::array<char, SEGV_STACK_SIZE> buffer;
+
   stack_t segv_stack;
-  segv_stack.ss_sp = valloc(SEGV_STACK_SIZE);
+  segv_stack.ss_sp = buffer.data();
   segv_stack.ss_flags = 0;
   segv_stack.ss_size = SEGV_STACK_SIZE;
   sigaltstack(&segv_stack, nullptr);

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -106,7 +106,7 @@ PhpScript::PhpScript(size_t mem_sz, size_t stack_sz) noexcept
   : mem_size(mem_sz)
   , stack_size((stack_sz + getpagesize() - 1) / getpagesize() * getpagesize()) {
   // fprintf (stderr, "PHPScriptBase: constructor\n");
-  run_stack = static_cast<char *>(valloc(stack_size));
+  run_stack = static_cast<char *>(std::aligned_alloc(getpagesize(), stack_size));
   assert(mprotect(run_stack, getpagesize(), PROT_NONE) == 0);
   protected_end = run_stack + getpagesize();
   run_stack_end = run_stack + stack_size;

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -102,18 +102,17 @@ bool PhpScript::check_stack_overflow(char *x) noexcept {
   return left < (1 << 12);
 }
 
-PhpScript::PhpScript(size_t mem_size, size_t stack_size) noexcept :
-  mem_size(mem_size),
-  stack_size(stack_size)  {
-  //fprintf (stderr, "PHPScriptBase: constructor\n");
-  stack_size = getpagesize() + (stack_size + getpagesize() - 1) / getpagesize() * getpagesize();
-  run_stack = (char *)valloc(stack_size);
-  assert (mprotect(run_stack, getpagesize(), PROT_NONE) == 0);
+PhpScript::PhpScript(size_t mem_sz, size_t stack_sz) noexcept
+  : mem_size(mem_sz)
+  , stack_size((stack_sz + getpagesize() - 1) / getpagesize() * getpagesize()) {
+  // fprintf (stderr, "PHPScriptBase: constructor\n");
+  run_stack = static_cast<char *>(valloc(stack_size));
+  assert(mprotect(run_stack, getpagesize(), PROT_NONE) == 0);
   protected_end = run_stack + getpagesize();
   run_stack_end = run_stack + stack_size;
 
   run_mem = static_cast<char *>(mmap(nullptr, mem_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0));
-  //fprintf (stderr, "[%p -> %p] [%p -> %p]\n", run_stack, run_stack_end, run_mem, run_mem + mem_size);
+  // fprintf (stderr, "[%p -> %p] [%p -> %p]\n", run_stack, run_stack_end, run_mem, run_mem + mem_size);
 }
 
 PhpScript::~PhpScript() noexcept {

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -76,7 +76,7 @@ void PhpScript::error(const char *error_message, script_error_t error_type) noex
   current_script->error_message = error_message;
   current_script->error_type = error_type;
   stack_end = reinterpret_cast<char *>(exit_context.uc_stack.ss_sp) + exit_context.uc_stack.ss_size;
-#if ASAN7_ENABLED
+#if ASAN_ENABLED
   __sanitizer_finish_switch_fiber(nullptr, nullptr, nullptr);
   __sanitizer_start_switch_fiber(nullptr, exit_context.uc_stack.ss_sp, exit_context.uc_stack.ss_size);
 #endif
@@ -134,7 +134,7 @@ PhpScript::PhpScript(size_t mem_size, size_t stack_size) noexcept :
 }
 
 PhpScript::~PhpScript() noexcept {
-#if ASAN7_ENABLED
+#if ASAN_ENABLED
   if (fiber_is_started) {
     __sanitizer_finish_switch_fiber(nullptr, nullptr, nullptr);
   }
@@ -183,7 +183,7 @@ void PhpScript::init(script_t *script, php_query_data *data_to_set) noexcept {
 // if ASAN is disabled, this function does nothing
 // use this function right before doing a longjmp
 void PhpScript::asan_stack_unpoison() {
-#if ASAN7_ENABLED
+#if ASAN_ENABLED
   ASAN_UNPOISON_MEMORY_REGION(run_stack, stack_size);
 #endif
 }
@@ -213,7 +213,7 @@ void PhpScript::on_request_timeout_error() {
 
 int PhpScript::swapcontext_helper(ucontext_t_portable *oucp, const ucontext_t_portable *ucp) {
   stack_end = reinterpret_cast<char *>(ucp->uc_stack.ss_sp) + ucp->uc_stack.ss_size;
-#if ASAN7_ENABLED
+#if ASAN_ENABLED
   if (fiber_is_started) {
     __sanitizer_finish_switch_fiber(nullptr, nullptr, nullptr);
   }

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -103,25 +103,8 @@ bool PhpScript::check_stack_overflow(char *x) noexcept {
 }
 
 PhpScript::PhpScript(size_t mem_size, size_t stack_size) noexcept :
-  cur_timestamp(0),
-  net_time(0),
-  script_time(0),
-  queries_cnt(0),
-  long_queries_cnt(0),
-  state(run_state_t::empty),
-  error_message(nullptr),
-  error_type(script_error_t::no_error),
-  query(nullptr),
-  run_stack(nullptr),
-  protected_end(nullptr),
-  run_stack_end(nullptr),
-  run_mem(nullptr),
   mem_size(mem_size),
-  stack_size(stack_size),
-  run_context(),
-  run_main(nullptr),
-  data(nullptr),
-  res(nullptr) {
+  stack_size(stack_size)  {
   //fprintf (stderr, "PHPScriptBase: constructor\n");
   stack_size = getpagesize() + (stack_size + getpagesize() - 1) / getpagesize() * getpagesize();
   run_stack = (char *)valloc(stack_size);

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -64,8 +64,8 @@ void init_handlers();
  * It stores state of the script: current execution point, pointers to allocated script memory, stack for script context, etc.
  */
 class PhpScript {
-  double cur_timestamp, net_time, script_time;
-  int queries_cnt;
+  double cur_timestamp{0}, net_time{0}, script_time{0};
+  int queries_cnt{0};
   int long_queries_cnt{0};
 
 private:
@@ -79,26 +79,26 @@ private:
   void assert_state(run_state_t expected);
 
 public:
-
   static PhpScript *volatile current_script;
   static ucontext_t_portable exit_context;
   volatile static bool is_running;
   volatile static bool tl_flag;
   volatile static bool ml_flag;
 
-  run_state_t state;
-  const char *error_message;
-  script_error_t error_type;
-  php_query_base_t *query;
-  char *run_stack, *protected_end, *run_stack_end, *run_mem;
-  size_t mem_size, stack_size;
-  ucontext_t_portable run_context;
+  run_state_t state{run_state_t::empty};
+  const char *error_message{nullptr};
+  script_error_t error_type{script_error_t::no_error};
+  php_query_base_t *query{nullptr};
+  char *run_stack{nullptr}, *protected_end{nullptr}, *run_stack_end{nullptr}, *run_mem{nullptr};
+  const size_t mem_size{0};
+  const size_t stack_size{0};
+  ucontext_t_portable run_context{};
 
-  sigjmp_buf timeout_handler;
+  sigjmp_buf timeout_handler{};
 
-  script_t *run_main;
-  php_query_data *data;
-  script_result *res;
+  script_t *run_main{nullptr};
+  php_query_data *data{nullptr};
+  script_result *res{nullptr};
 
   static void script_context_entrypoint() noexcept;
   static void error(const char *error_message, script_error_t error_type) noexcept;

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -66,6 +66,7 @@ public:
   bool is_protected(const char *x) const noexcept;
   bool check_stack_overflow(const char *x) const noexcept;
   void asan_stack_unpoison() const noexcept;
+  void asan_stack_clear() const noexcept;
 
   char *get_stack_ptr() const noexcept { return run_stack_; }
   size_t get_stack_size() const noexcept { return stack_size_; }

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -103,7 +103,7 @@ public:
   static void script_context_entrypoint() noexcept;
   static void error(const char *error_message, script_error_t error_type) noexcept;
 
-  PhpScript(size_t mem_size, size_t stack_size) noexcept;
+  PhpScript(size_t mem_sz, size_t stack_sz) noexcept;
   ~PhpScript() noexcept;
 
   void check_tl() noexcept;

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -43,8 +43,6 @@ enum class script_error_t : uint8_t {
   errors_count
 };
 
-#define SEGV_STACK_SIZE (MINSIGSTKSZ + 65536)
-
 struct query_stats_t {
   long long q_id;
   const char *desc;

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -69,7 +69,7 @@ class PhpScript {
   int long_queries_cnt{0};
 
 private:
-#if ASAN7_ENABLED
+#if ASAN_ENABLED
   bool fiber_is_started = false;
 #endif
   int swapcontext_helper(ucontext_t_portable *oucp, const ucontext_t_portable *ucp);

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -87,9 +87,6 @@ class PhpScript {
   int long_queries_cnt{0};
 
 private:
-#if ASAN_ENABLED
-  bool fiber_is_started = false;
-#endif
   int swapcontext_helper(ucontext_t_portable *oucp, const ucontext_t_portable *ucp);
 
   void on_request_timeout_error();

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -58,10 +58,10 @@ void dump_query_stats();
 
 void init_handlers();
 
-class CoroutineStack : vk::not_copyable {
+class PhpScriptStack : vk::not_copyable {
 public:
-  explicit CoroutineStack(size_t stack_size) noexcept;
-  ~CoroutineStack() noexcept;
+  explicit PhpScriptStack(size_t stack_size) noexcept;
+  ~PhpScriptStack() noexcept;
 
   bool is_protected(const char *x) const noexcept;
   bool check_stack_overflow(const char *x) const noexcept;
@@ -107,7 +107,7 @@ public:
   php_query_base_t *query{nullptr};
   const size_t mem_size{0};
   char *run_mem{nullptr};
-  CoroutineStack coroutine_stack;
+  PhpScriptStack script_stack;
 
   ucontext_t_portable run_context{};
   sigjmp_buf timeout_handler{};

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -144,7 +144,7 @@ void PhpWorker::state_init_script() noexcept {
   script_t *script = get_script();
   dl_assert(script != nullptr, "failed to get script");
   if (php_script == nullptr) {
-    php_script = new PhpScript(max_memory, 8 << 20);;
+    php_script = new PhpScript(max_memory, 8 << 20);
   }
   php_script->init(script, data);
   php_script->set_timeout(timeout);


### PR DESCRIPTION
Leak sanitizer(lsan) by default run along with address sanitizer(asan), but in case of kphp lsan fails every time with error:
![image](https://user-images.githubusercontent.com/14000874/190575767-d7727425-7d24-463a-b3c5-d5fc825020ea.png)
There are 2 reason of that:
1) User code works within coroutine, whose stack memory is protected with `mprotect(run_stack, getpagesize(), PROT_NONE)` call. That makes lsan failed to examine stack memory.
2) __sanitizer_start_switch_fiber/__sanitizer_finish_switch_fiber sanitizer's hooks called incorrect. Quoting [comment](https://github.com/llvm-mirror/compiler-rt/blob/69445f095c22aac2388f939bedebf224a6efcdaf/include/sanitizer/common_interface_defs.h#L302) from sanitizer's source code:
> /// Before switching to a different stack, you must call
/// <c>__sanitizer_start_switch_fiber()</c> with a pointer to the bottom of the
/// destination stack and with its size. When code starts running on the new
/// stack, it must call <c>__sanitizer_finish_switch_fiber()</c> to finalize
/// the switch.

So, __sanitizer_finish_switch_fiber should be called at very start of coroutine, while in our code it called at the end. It's confirmed by internal [test](https://github.com/llvm/llvm-project/blob/main/compiler-rt/test/asan/TestCases/Linux/swapcontext_annotation.cpp) of sanitzers in llvm trunk.

Let's check how it works finally. Add artificial memory leak into our `echo` function, and call it:
```
// in c++
void f$echo(const string& s) {
  std::malloc(8); // <-- it is a leak
  print(s);
}

// in php
<?php
echo "hello\n";
```
The above script compiled with kphp and launched now produce next output:
 
![image](https://user-images.githubusercontent.com/14000874/190582759-492de93f-906c-42c1-9496-5a47665ee846.png)

Note, that for now I keep lsan disabled in our tests since they show some amount of leaks. I'm going to fix memory leaks and enable lsan in tests in separate patch.
