### PR TITLE
[runtime] fix strcasecmp behavior

### DIFF
--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -1337,13 +1337,15 @@ string f$stripslashes(const string &str) {
 }
 
 int64_t f$strcasecmp(const string &lhs, const string &rhs) {
-  int n = min(lhs.size(), rhs.size()) + 1;
+  int n = min(lhs.size(), rhs.size());
   for (int i = 0; i < n; i++) {
     if (tolower(lhs[i]) != tolower(rhs[i])) {
       return tolower(lhs[i]) - tolower(rhs[i]);
     }
   }
-  return 0;
+  // TODO: for PHP8.2, use <=> operator instead:
+  //   return spaceship(static_cast<int64_t>(lhs.size()), static_cast<int64_t>(rhs.size()));
+  return static_cast<int64_t>(lhs.size()) - static_cast<int64_t>(rhs.size());
 }
 
 int64_t f$strcmp(const string &lhs, const string &rhs) {

--- a/tests/phpt/string_functions/008_misc.php
+++ b/tests/phpt/string_functions/008_misc.php
@@ -12,8 +12,33 @@ function extend_test_suite($tests) {
     $all_tests[] = "$test _ $test";
     $all_tests[] = "\x00$test";
     $all_tests[] = "$test\x00$test\x00";
+    $all_tests[] = "+$test";
+    $all_tests[] = "-$test";
+    if (strlen($test) > 2) {
+      $all_tests[] = substr($test, strlen($test) / 2);
+    }
   }
   return $all_tests;
+}
+
+function test_strcasecmp() {
+  $tests = extend_test_suite([
+    '',
+    ' ',
+    '_',
+    '134',
+    'foo',
+    'Foo',
+    'FOO',
+    'Hello, World!',
+    'Hello, World',
+  ]);
+
+  foreach ($tests as $s1) {
+    foreach ($tests as $s2) {
+      var_dump("'$s1' -vs- '$s2' " . strcasecmp($s1, $s2));
+    }
+  }
 }
 
 function test_strtolower_strtoupper() {
@@ -23,6 +48,8 @@ function test_strtolower_strtoupper() {
     'a',
     'A',
     '_',
+    '1242',
+    '+534',
     'foo',
     'foO',
     'fOo',
@@ -51,4 +78,4 @@ function test_strtolower_strtoupper() {
 }
 
 test_strtolower_strtoupper();
-
+test_strcasecmp();


### PR DESCRIPTION
Pre 8.2 behavior for different lengths is lenght delta. Previously, our version relied on `\0`, which is OK if you don't want to have exactly the same result values as PHP. Since it's such a minor optimization (if it actually optimizes anything), just follow what PHP does. This simplifies testing and reduces the risk that someone will use function result in some context where that difference matters.

See: https://github.com/php/php-src/blob/11491b63f800d150a00e9855f3a0a49e7bca50f7/Zend/zend_operators.c#L2608
For php8.2: https://github.com/php/php-src/blob/30ed8fb32da398f62bb08ebd59c607eeafc3621d/Zend/zend_operators.c#L3005