### PR TITLE
Downgrade warning `Can't send job: not enough shared messages` to notice

### DIFF
--- a/runtime/job-workers/client-functions.cpp
+++ b/runtime/job-workers/client-functions.cpp
@@ -43,7 +43,8 @@ JobMessageT *make_job_request_message(const class_instance<T> &instance) {
   auto &memory_manager = vk::singleton<job_workers::SharedMemoryManager>::get();
   auto *memory_request = memory_manager.acquire_shared_message<JobMessageT>();
   if (memory_request == nullptr) {
-    php_warning("Can't send job: not enough shared messages");
+    php_notice("Can't send job: not enough shared messages. "
+               "Most probably job workers are slowed and overloaded due to external factors: net/cpu lags, network queries slowdown etc.");
     return nullptr;
   }
 


### PR DESCRIPTION
Almost always this warning is the consequence of external factors: net/cpu lags, network queries slowdown etc.