### PR TITLE
Add virtual_builtin methods for builtin classes

### DIFF
--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -67,6 +67,14 @@ public:
     return 0;
   }
 
+  virtual C$McMemcache* virtual_builtin_clone() const noexcept {
+    return new C$McMemcache{*this};
+  }
+
+  virtual size_t virtual_builtin_sizeof() const noexcept {
+    return sizeof(*this);
+  }
+
   array<host> hosts{array_size{1, 0, true}};
 };
 

--- a/runtime/tl/rpc_function.h
+++ b/runtime/tl/rpc_function.h
@@ -31,6 +31,9 @@ struct C$VK$TL$RpcFunction : abstract_refcountable_php_interface {
   virtual void accept(InstanceDeepCopyVisitor &) noexcept {}
   virtual void accept(InstanceDeepDestroyVisitor &) noexcept {}
 
+  virtual size_t virtual_builtin_sizeof() const noexcept { return 0; }
+  virtual C$VK$TL$RpcFunction *virtual_builtin_clone() const noexcept { return nullptr; }
+
   virtual ~C$VK$TL$RpcFunction() = default;
   virtual std::unique_ptr<tl_func_base> store() const = 0;
 };
@@ -46,6 +49,9 @@ struct C$VK$TL$RpcFunctionReturnResult : abstract_refcountable_php_interface {
   virtual void accept(InstanceReferencesCountingVisitor &) noexcept {}
   virtual void accept(InstanceDeepCopyVisitor &) noexcept {}
   virtual void accept(InstanceDeepDestroyVisitor &) noexcept {}
+
+  virtual size_t virtual_builtin_sizeof() const noexcept { return 0; }
+  virtual C$VK$TL$RpcFunctionReturnResult *virtual_builtin_clone() const noexcept { return nullptr; }
 
   virtual ~C$VK$TL$RpcFunctionReturnResult() = default;
 };
@@ -63,6 +69,9 @@ struct C$VK$TL$RpcResponse : abstract_refcountable_php_interface {
 
   virtual const char *get_class() const { return "VK\\TL\\RpcResponse"; }
   virtual int32_t get_hash() const { return static_cast<int32_t>(vk::std_hash(vk::string_view(C$VK$TL$RpcResponse::get_class()))); }
+
+  virtual size_t virtual_builtin_sizeof() const noexcept { return 0; }
+  virtual C$VK$TL$RpcResponse *virtual_builtin_clone() const noexcept { return nullptr; }
 
   virtual ~C$VK$TL$RpcResponse() = default;
 };


### PR DESCRIPTION
Add `virtual_builtin_sizeof` and `virtual_builtin_clone` for some builtin classes
Without them compiler crashes on gcc when trying to use such classes in job worker methods