### PR TITLE
[compiler] add a special case for int64_t min value codegen

### DIFF
--- a/tests/phpt/phc/parsing/negative_literals.php
+++ b/tests/phpt/phc/parsing/negative_literals.php
@@ -27,6 +27,9 @@
   var_dump(- -9223372036854775807);
   var_dump(- - -9223372036854775807);
 
+  var_dump(PHP_INT_MIN);
+  var_dump(abs(PHP_INT_MIN + 1));
+
 #ifndef KPHP
   var_dump(-PHP_INT_MAX - 1);
   var_dump(-PHP_INT_MAX - 1);


### PR DESCRIPTION
Producing `-9223372036854775808_i64` literal will result in C++ compiler warning about integer overflow.

The recommended way to express min value is `(-9223372036854775807_i64 - 1_i64)`.