### PR TITLE
don't perform allocations in php_warning if script allocator is disabled

### DIFF
--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -26,10 +26,9 @@ memory_resource::Dealer &get_memory_dealer() noexcept {
   return dealer;
 }
 
-volatile bool script_allocator_enabled = false;
-
 } // namespace
 
+bool script_allocator_enabled = false;
 long long query_num = 0;
 
 memory_resource::unsynchronized_pool_resource &get_default_script_allocator() noexcept {

--- a/runtime/allocator.h
+++ b/runtime/allocator.h
@@ -17,6 +17,7 @@ class unsynchronized_pool_resource;
 
 namespace dl {
 
+extern bool script_allocator_enabled;
 extern long long query_num; // engine query number. query_num == 0 before first query
 
 memory_resource::unsynchronized_pool_resource &get_default_script_allocator() noexcept;

--- a/runtime/php_assert.cpp
+++ b/runtime/php_assert.cpp
@@ -123,7 +123,7 @@ static void php_warning_impl(bool out_of_memory, int error_type, char const *mes
     return;
   }
 
-  const bool allocations_allowed = !out_of_memory && !dl::in_critical_section;
+  const bool allocations_allowed = dl::script_allocator_enabled && !out_of_memory && !dl::in_critical_section;
   dl::enter_critical_section();//OK
 
   vsnprintf(buf, BUF_SIZE, message, args);


### PR DESCRIPTION
Before the fix, it led to endless recursion from here
https://github.com/VKCOM/kphp/blob/01582fa6c0904ef6566fcd326ffeb58c35a777d9/runtime/allocator.cpp#L105