### PR TITLE
[compiler] re-order class fields to reduce objects size

### DIFF
--- a/compiler/code-gen/declarations.h
+++ b/compiler/code-gen/declarations.h
@@ -121,6 +121,7 @@ struct ClassDeclaration : CodeGenRootCmd {
   static void compile_inner_methods(CodeGenerator &W, ClassPtr klass);
 
 private:
+  static void compile_fields(CodeGenerator &W, ClassPtr klass);
   static void compile_json_flatten_flag(CodeGenerator &W, ClassPtr klass);
   static void compile_has_wakeup_flag(CodeGenerator &W, ClassPtr klass);
   static void compile_get_class(CodeGenerator &W, ClassPtr klass);

--- a/tests/phpt/json/114_field_reorder.php
+++ b/tests/phpt/json/114_field_reorder.php
@@ -1,0 +1,46 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+class ExampleObject {
+  /** @var bool */
+  public $b1 = true;
+  /** @var bool */
+  public $b2 = false;
+  /** @var bool */
+  public $b3 = true;
+  /** @var bool */
+  public $b4 = false;
+  /** @var bool */
+  public $b5 = true;
+
+  /** @var int */
+  public $i1 = 1;
+  /** @var int */
+  public $i2 = 2;
+
+  /** @var bool */
+  public $b6 = false;
+  /** @var bool */
+  public $b7 = true;
+
+  /** @var ?bool */
+  public $opt_b1 = null;
+  /** @var ?bool */
+  public $opt_b2 = true;
+
+  /** @var ?int */
+  public $opt_i1 = 43;
+}
+
+function test(ExampleObject $e) {
+  $json = JsonEncoder::encode($e);
+  $e2 = JsonEncoder::decode($json, 'ExampleObject');
+  var_dump($json);
+  var_dump(to_array_debug($e));
+  var_dump(to_array_debug($e2));
+}
+
+$obj = new ExampleObject();
+test($obj);

--- a/tests/phpt/memory_usage/2_classes.php
+++ b/tests/phpt/memory_usage/2_classes.php
@@ -22,17 +22,16 @@ function test_empty_class() {
 
 function test_class_with_simple_fields() {
   class MyClass1 {
-    // counter 4 + unique index 4
-    public $x = 1; // 8
-    public $y = 1.0; // 8
-    public $z = true; // 1 // aligned to 8
-    public $u = "hello world"; // 8
-    public $w = [1, 2, 3]; // 8
-  } // total size = 48
+    public $x = 1;
+    public $y = 1.0;
+    public $z = true;
+    public $u = "hello world";
+    public $w = [1, 2, 3];
+  }
 
 #ifndef KPHP
-  var_dump(48);
-  var_dump(48);
+  var_dump(40);
+  var_dump(40);
   var_dump(0);
   return;
 #endif

--- a/tests/phpt/msgpack_serialize/112_field_reorder.php
+++ b/tests/phpt/msgpack_serialize/112_field_reorder.php
@@ -1,0 +1,89 @@
+@ok
+<?php
+
+require_once 'kphp_tester_include.php';
+
+/**
+ * @kphp-serializable
+ **/
+class ExampleObject {
+  /**
+   * @kphp-serialized-field 1
+   * @var bool
+   */
+  public $b1 = true;
+  /**
+   * @kphp-serialized-field 2
+   * @var bool
+   */
+  public $b2 = false;
+  /**
+   * @kphp-serialized-field 3
+   * @var bool
+   */
+  public $b3 = true;
+  /**
+   * @kphp-serialized-field 4
+   * @var bool
+   */
+  public $b4 = false;
+  /**
+   * @kphp-serialized-field 5
+   * @var bool
+   */
+  public $b5 = true;
+
+  /**
+   * @kphp-serialized-field 6
+   * @var int
+   */
+  public $i1 = 1;
+  /**
+   * @kphp-serialized-field 7
+   * @var int
+   */
+  public $i2 = 2;
+
+  /**
+   * @kphp-serialized-field 8
+   * @var bool
+   */
+  public $b6 = false;
+  /**
+   * @kphp-serialized-field 9
+   * @var bool
+   */
+  public $b7 = true;
+
+  /**
+   * @kphp-serialized-field 10
+   * @var ?bool
+   */
+  public $opt_b1 = null;
+  /**
+   * @kphp-serialized-field 11
+   * @var ?bool
+   */
+  public $opt_b2 = true;
+
+  /**
+   * @kphp-serialized-field 12
+   * @var ?int
+   */
+  public $opt_i1 = 43;
+}
+
+function test() {
+    $obj = new ExampleObject();
+    $serialized = instance_serialize($obj);
+    var_dump(base64_encode($serialized));
+    $deserialized = instance_deserialize($serialized, ExampleObject::class);
+    var_dump(to_array_debug($deserialized));
+    var_dump($deserialized->b1);
+    var_dump($deserialized->b2);
+    var_dump($deserialized->opt_i1);
+    var_dump($deserialized->opt_b1);
+    var_dump($deserialized->opt_b1);
+}
+
+test();


### PR DESCRIPTION
Some classes can benefit from fields reordering to occupy less space due to the unnecessary padding.

Suppose that we have a class like this:

```php
	class Example {
		public int $a;  // size=8
		public bool $b; // size=1
		public int $c;  // size=8
		public tuple(bool, bool, bool, bool) $d; // size=4
	}
```

It's layout in memory would look like this:

	[ 4 ] ref_cnt
	[ 4 ] ! padding
	[ 8 ] a
	[ 1 ] b
	[ 7 ] ! padding
	[ 8 ] c
	[ 4 ] d
	[ 4 ] ! padding (trailing padding due to struct alignment)

The total size would be 40.

With this patch, the compiler will re-arrange some fields to minimize the amount of padding we would get.

	[ 4 ] ref_cnt
	[ 4 ] d
	[ 8 ] a
	[ 8 ] c
	[ 1 ] b
	[ 7 ] ! padding (trailing padding due to struct alignment)

The result size will be 32.

The algorithm is quite simple:

1. Sort all fields by their size (take alignment into the account)
2. Fill the gap after the `ref_cnt` carefully, if possible
3. Output all remaining fields from the biggest to the smallest

Most of the time, this simple algorithm leads to the optimal layout. It's tested to never make objects bigger; although it may not always succeed in making them smaller (the size may remain identical).

The testing results on real world applications show that:

* About 13% of classes can be optimized (their size will be reduced)
* On average, this optimization reduces the size by 12-20%
* Depending on the code, this optimization reduces the memory usage by 6-12%