### PR TITLE
[runtime] fix length handling in `string::to_int(char*, uint32_t)`

### DIFF
--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -763,8 +763,9 @@ bool string::to_bool() const {
 }
 
 int64_t string::to_int(const char *s, size_type l) {
-  while (isspace(*s)) {
+  while (isspace(*s) && l > 0) {
     s++;
+    l--;
   }
 
   int64_t mul = 1, cur = 0;

--- a/tests/cpp/runtime/string-test.cpp
+++ b/tests/cpp/runtime/string-test.cpp
@@ -82,6 +82,49 @@ TEST(string_test, test_copy_and_make_not_shared) {
   ASSERT_EQ(str3.get_reference_counter(), 1);
 }
 
+TEST(string_test, test_to_int) {
+  struct TestCase {
+    std::string s;
+    string::size_type l;
+    int64_t want;
+  };
+  std::vector<TestCase> tests = {
+    {" ", 0, 0},
+    {" ", 1, 0},
+    {" -123", 1, 0},
+    {" -123", 2, 0},
+    {" -123", 3, -1},
+    {" -123", 4, -12},
+    {" -123", 5, -123},
+    {"  -123", 5, -12},
+    {"   -123", 5, -1},
+    {"    -123", 5, 0},
+    {"     -123", 5, 0},
+    {" +123", 1, 0},
+    {" +123", 2, 0},
+    {" +123", 3, 1},
+    {" +123", 4, 12},
+    {" +123", 5, 123},
+    {"  +123", 5, 12},
+    {"   +123", 5, 1},
+    {"    +123", 5, 0},
+    {"     +123", 5, 0},
+    {" 123 ", 1, 0},
+    {" 123 ", 2, 1},
+    {" 123 ", 3, 12},
+    {" 123 ", 4, 123},
+    {" 123 ", 5, 123},
+    {"  123 ", 5, 123},
+    {"   123 ", 5, 12},
+    {"    123 ", 5, 1},
+    {"     123 ", 5, 0},
+  };
+  for (const auto &test : tests) {
+    int64_t have = string::to_int(test.s.c_str(), test.l);
+    ASSERT_EQ(have, test.want) << "s=" << test.s << ", l=" << test.l;
+  }
+}
+
 TEST(string_test, test_hex_to_int) {
   for (size_t c = 0; c != 256; ++c) {
     if (vk::none_of_equal(c,


### PR DESCRIPTION
Suppose that we have this string: `" -123"`
And we're calling `to_int` with it's pointer and `l=3` Without this fix, it would consume the space without taking `l` into the account, so the result would be `-12` instead of `-1`.