### PR TITLE
fix `substr` corner case with `start=length`

### DIFF
--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -2354,7 +2354,7 @@ Optional<string> f$substr(const string &str, int64_t start, int64_t length) {
     length = str_len;
   }
 
-  if (start >= str_len) {
+  if (start > str_len) {
 //    php_warning("start is after string end in substr function call");
     return false;
   }

--- a/tests/phpt/pk/011_substr.php
+++ b/tests/phpt/pk/011_substr.php
@@ -1,3 +1,4 @@
+@ok
 <?php
 
 $str = "abcde";


### PR DESCRIPTION
PHP returns empty string, `""`
KPHP returned `false`

The old test was passing due to the missing `@ok` tag.