### PR TITLE
turn on memory leak sanitizer in tests

### DIFF
--- a/tests/phpt/timelib/strtotime.php
+++ b/tests/phpt/timelib/strtotime.php
@@ -91,3 +91,14 @@ foreach ($timezones as $tz) {
     $time += $i;
   }
 }
+
+function test_check_memory_leak() {
+  foreach (['UTC', 'BST', 'Europe/Amsterdam'] as $tz) {
+    $date = "2006:02:12 23:12:23 $tz";
+    strtotime($date);
+    date_parse($date);
+    date_parse_from_format('Y-m-d H:i:s', $date);
+  }
+}
+
+test_check_memory_leak();

--- a/tests/python/lib/engine.py
+++ b/tests/python/lib/engine.py
@@ -128,11 +128,16 @@ class Engine:
         self._log_file_write_fd = open(self._log_file, 'ab')
         self._log_file_read_fd = open(self._log_file, 'r')
         print("\nStarting engine: [{}]".format(cyan(" ".join(cmd))))
+
+        # some of engines are leaky
+        env = os.environ.copy()
+        env["ASAN_OPTIONS"] = "detect_leaks=0"
         self._engine_process = psutil.Popen(
             cmd,
             stdout=self._log_file_write_fd,
             stderr=subprocess.STDOUT,
-            cwd=self._working_dir
+            cwd=self._working_dir,
+            env=env
         )
 
         if os.waitpid(self._engine_process.pid, os.WNOHANG)[1] != 0:

--- a/tests/python/lib/kphp_builder.py
+++ b/tests/python/lib/kphp_builder.py
@@ -96,15 +96,15 @@ class KphpBuilder:
         shutil.rmtree(self._kphp_build_tmp_dir, ignore_errors=True)
 
     @staticmethod
-    def _prepare_sanitizer_env(working_directory, sanitizer_log_name):
+    def _prepare_sanitizer_env(working_directory, sanitizer_log_name, detect_leaks=1):
         tmp_sanitizer_file = os.path.join(working_directory, sanitizer_log_name)
         sanitizer_glob_mask = "{}.*".format(tmp_sanitizer_file)
         for old_sanitizer_file in glob.glob(sanitizer_glob_mask):
             os.remove(old_sanitizer_file)
 
         env = os.environ.copy()
-        env["ASAN_OPTIONS"] = "detect_leaks=0:allocator_may_return_null=1:log_path={}".format(tmp_sanitizer_file)
-        env["UBSAN_OPTIONS"] = "print_stacktrace=1:allow_addr2line=1:log_path={}".format(tmp_sanitizer_file)
+        env["ASAN_OPTIONS"] = f"detect_leaks={detect_leaks}:allocator_may_return_null=1:log_path={tmp_sanitizer_file}"
+        env["UBSAN_OPTIONS"] = f"print_stacktrace=1:allow_addr2line=1:log_path={tmp_sanitizer_file}"
         return env, sanitizer_glob_mask
 
     def _move_sanitizer_logs_to_artifacts(self, sanitizer_glob_mask, proc, sanitizer_log_name):
@@ -117,7 +117,7 @@ class KphpBuilder:
         os.makedirs(self._kphp_build_tmp_dir, exist_ok=True)
 
         sanitizer_log_name = "kphp_build_sanitizer_log"
-        env, sanitizer_glob_mask = self._prepare_sanitizer_env(self._kphp_build_tmp_dir, sanitizer_log_name)
+        env, sanitizer_glob_mask = self._prepare_sanitizer_env(self._kphp_build_tmp_dir, sanitizer_log_name, detect_leaks=0)
         if kphp_env:
             env.update(kphp_env)
         env.setdefault("KPHP_THREADS_COUNT", "3")

--- a/tests/python/lib/testcase.py
+++ b/tests/python/lib/testcase.py
@@ -208,8 +208,8 @@ class KphpServerAutoTestCase(BaseTestCase):
             os.link(cls.kphp_builder.kphp_runtime_bin, cls.kphp_server_bin)
 
         cls.sanitizer_pattern = os.path.join(cls.kphp_server_working_dir, "engine_sanitizer_log")
-        os.environ["ASAN_OPTIONS"] = "detect_leaks=0:log_path=" + cls.sanitizer_pattern
-        os.environ["UBSAN_OPTIONS"] = "print_stacktrace=1:allow_addr2line=1:log_path={}".format(cls.sanitizer_pattern)
+        os.environ["ASAN_OPTIONS"] = "log_path=" + cls.sanitizer_pattern
+        os.environ["UBSAN_OPTIONS"] = f"print_stacktrace=1:allow_addr2line=1:log_path={cls.sanitizer_pattern}"
         cls.kphp_server = KphpServer(
             engine_bin=cls.kphp_server_bin,
             working_dir=cls.kphp_server_working_dir

--- a/tests/python/lib/tl_client.py
+++ b/tests/python/lib/tl_client.py
@@ -36,11 +36,16 @@ def send_rpc_request(request, port, timeout=60):
     cmd = [tl_client_bin, "--stdin", "--json-encoded", "--port", str(port)]
     if not os.getuid():
         cmd += ["--user", "root", "--group", "root"]
+
+    # tlclient is leaky
+    env = os.environ.copy()
+    env["ASAN_OPTIONS"] = "detect_leaks=0"
     p = subprocess.Popen(
         cmd,
         stdout=subprocess.PIPE,
         stdin=subprocess.PIPE,
-        stderr=subprocess.PIPE
+        stderr=subprocess.PIPE,
+        env=env
     )
     stdout_data, stderr_data = p.communicate(input=encoded_request.encode(), timeout=timeout)
     if stderr_data:


### PR DESCRIPTION
This PR turns on memory leak sanitizer in tests. Also memory leaks have been fixed in timelib_wrapper.cpp and suppressed in regexp.cpp.