### PR TITLE
[compiler] move some helper methods from GenTree to VertexUtil

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -20,7 +20,7 @@
 #include "compiler/data/src-file.h"
 #include "compiler/data/lib-data.h"
 #include "compiler/data/var-data.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/public.h"
 #include "compiler/inferring/type-data.h"
 #include "compiler/tl-classes.h"
@@ -157,7 +157,7 @@ void FunctionParams::compile(CodeGenerator &W) const {
       case gen_out_style::txt: {
         declare_txt_param(W, var, type_gen);
         if (param->has_default_value() && param->default_value() && in_header) {
-          VertexPtr default_value = GenTree::get_actual_value(param->default_value());
+          VertexPtr default_value = VertexUtil::get_actual_value(param->default_value());
           kphp_assert(vk::any_of_equal(default_value->type(), op_int_const, op_float_const));
           W << " = " << default_value->get_string();
         }

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -8,7 +8,7 @@
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/vertex-compiler.h"
 #include "compiler/const-manipulations.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/type-data.h"
 
 void RawString::compile(CodeGenerator &W) const {
@@ -133,9 +133,9 @@ std::vector<int> compile_arrays_raw_representation(const std::vector<VarPtr> &co
 
     auto args_end = vertex->args().end();
     for (auto it = vertex->args().begin(); it != args_end; ++it) {
-      VertexPtr actual_vertex = GenTree::get_actual_value(*it);
+      VertexPtr actual_vertex = VertexUtil::get_actual_value(*it);
       if (auto double_arrow = actual_vertex.try_as<op_double_arrow>()) {
-        actual_vertex = GenTree::get_actual_value(double_arrow->value());
+        actual_vertex = VertexUtil::get_actual_value(double_arrow->value());
       }
       kphp_assert(vk::any_of_equal(vertex_inner_type->ptype(), tp_int, tp_float));
 

--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -188,6 +188,7 @@ prepend(KPHP_COMPILER_SOURCES ${KPHP_COMPILER_DIR}/
         compiler-settings.cpp
         function-colors.cpp
         gentree.cpp
+        vertex-util.cpp
         generics-reification.cpp
         index.cpp
         lambda-utils.cpp

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -13,7 +13,7 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/function-data.h"
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/type-data.h"
 #include "compiler/name-gen.h"
 #include "compiler/type-hint.h"
@@ -130,7 +130,7 @@ FunctionPtr ClassData::add_virt_clone() {
 }
 
 void ClassData::add_class_constant() {
-  members.add_constant("class", GenTree::generate_constant_field_class_value(get_self()), AccessModifiers::public_);
+  members.add_constant("class", VertexUtil::create_string_const(get_self()->name), AccessModifiers::public_);
 }
 
 void ClassData::create_constructor_with_parent_call(DataStream<FunctionPtr> &os) {
@@ -173,7 +173,7 @@ void ClassData::create_constructor(VertexAdaptor<op_function> func) {
   auto this_param = gen_param_this(func->get_location());
   func->param_list_ref() = VertexAdaptor<op_func_param_list>::create(this_param, func->param_list()->params());
 
-  GenTree::func_force_return(func, gen_vertex_this(func->location));
+  VertexUtil::func_force_return(func, gen_vertex_this(func->location));
 
   auto ctor_function = FunctionData::create_function(func_name, func, FunctionData::func_local);
   ctor_function->update_location_in_body();

--- a/compiler/inferring/expr-node.cpp
+++ b/compiler/inferring/expr-node.cpp
@@ -10,7 +10,7 @@
 #include "compiler/data/define-data.h"
 #include "compiler/data/function-data.h"
 #include "compiler/data/var-data.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/edge.h"
 #include "compiler/inferring/node-recalc.h"
 #include "compiler/type-hint.h"
@@ -115,17 +115,17 @@ void ExprNodeRecalc::recalc_push_back_return(VertexAdaptor<op_push_back_return> 
 }
 
 void ExprNodeRecalc::recalc_index(VertexAdaptor<op_index> index) {
-  bool is_const_int_index = index->has_key() && GenTree::get_actual_value(index->key())->type() == op_int_const;
+  bool is_const_int_index = index->has_key() && VertexUtil::get_actual_value(index->key())->type() == op_int_const;
   if (is_const_int_index) {
-    long int_index = parse_int_from_string(GenTree::get_actual_value(index->key()).as<op_int_const>());
+    long int_index = parse_int_from_string(VertexUtil::get_actual_value(index->key()).as<op_int_const>());
     MultiKey key({Key::int_key((int)int_index)});
     set_lca(index->array(), &key);
     return;
   }
 
-  bool is_const_string_index = index->has_key() && GenTree::get_actual_value(index->key())->type() == op_string;
+  bool is_const_string_index = index->has_key() && VertexUtil::get_actual_value(index->key())->type() == op_string;
   if (is_const_string_index) {
-    MultiKey key({Key::string_key(GenTree::get_actual_value(index->key())->get_string())});
+    MultiKey key({Key::string_key(VertexUtil::get_actual_value(index->key())->get_string())});
     set_lca(index->array(), &key);
     return;
   }
@@ -187,7 +187,7 @@ void ExprNodeRecalc::recalc_shape(VertexAdaptor<op_shape> shape) {
   recalc_ptype<tp_shape>();
   for (auto i: shape->args()) {
     auto double_arrow = i.as<op_double_arrow>();
-    const std::string &str_index = GenTree::get_actual_value(double_arrow->key())->get_string();
+    const std::string &str_index = VertexUtil::get_actual_value(double_arrow->key())->get_string();
     std::vector<Key> i_key_index{Key::string_key(str_index)};
     MultiKey key(i_key_index);
     set_lca_at(&key, double_arrow->value());
@@ -260,7 +260,7 @@ void ExprNodeRecalc::recalc_power(VertexAdaptor<op_pow> expr) {
   VertexPtr base = expr->lhs();
   add_dependency(as_rvalue(base));
   VertexPtr exponent = expr->rhs();
-  if (is_positive_constexpr_int(exponent)) {
+  if (VertexUtil::is_positive_constexpr_int(exponent)) {
     recalc_ptype<tp_int>();
     set_lca(drop_optional(as_rvalue(base)));
   } else {

--- a/compiler/inferring/ifi.cpp
+++ b/compiler/inferring/ifi.cpp
@@ -6,8 +6,8 @@
 
 #include "compiler/data/function-data.h"
 #include "compiler/data/var-data.h"
-#include "compiler/gentree.h"
 #include "compiler/vertex.h"
+#include "compiler/vertex-util.h"
 
 is_func_id_t get_ifi_id(VertexPtr v) {
   if (v->type() == op_unset) {
@@ -17,9 +17,9 @@ is_func_id_t get_ifi_id(VertexPtr v) {
     return ifi_isset;
   }
   if (v->type() == op_eq3) {
-    VertexPtr b = GenTree::get_actual_value(v.as<meta_op_binary>()->rhs());
+    VertexPtr b = VertexUtil::get_actual_value(v.as<meta_op_binary>()->rhs());
     if (b->type() == op_var || b->type() == op_index) {
-      b = GenTree::get_actual_value(v.as<meta_op_binary>()->lhs());
+      b = VertexUtil::get_actual_value(v.as<meta_op_binary>()->lhs());
     }
 
     if (b->type() == op_false) {                                // $var === false

--- a/compiler/inferring/restriction-stacktrace-finder.cpp
+++ b/compiler/inferring/restriction-stacktrace-finder.cpp
@@ -8,7 +8,6 @@
 #include "common/algorithms/string-algorithms.h"
 #include "common/termformat/termformat.h"
 
-#include "compiler/gentree.h"
 #include "compiler/data/src-file.h"
 #include "compiler/data/function-data.h"
 #include "compiler/inferring/edge.h"
@@ -17,6 +16,7 @@
 #include "compiler/inferring/var-node.h"
 #include "compiler/type-hint.h"
 #include "compiler/vertex.h"
+#include "compiler/vertex-util.h"
 
 /*
     This module finds a stacktrace to describe, why a type mismatch occurred.
@@ -67,7 +67,7 @@ int RestrictionStacktraceFinder::get_importance_of_reason(const tinf::Node *from
     return 0;
   }
 
-  VertexPtr expr = GenTree::get_actual_value(dynamic_cast<const tinf::ExprNode *>(to)->get_expr());
+  VertexPtr expr = VertexUtil::get_actual_value(dynamic_cast<const tinf::ExprNode *>(to)->get_expr());
   switch (expr->type()) {
     case op_var:
       return get_var_id_from_node(to) == get_var_id_from_node(from) ? 4 : 5;

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -5,7 +5,7 @@
 #include "compiler/type-hint.h"
 
 #include "compiler/data/function-data.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/public.h"
 
 // recalc_type_data_in_context_of_call() from type-hint.h for all ancestors
@@ -13,7 +13,7 @@
 
 
 void TypeHintArgRef::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
-  if (auto vertex = GenTree::get_call_arg_ref(arg_num, call)) {
+  if (auto vertex = VertexUtil::get_call_arg_ref(arg_num, call)) {
     dst->set_lca(vertex->tinf_node.get_type());
   }
 }
@@ -72,8 +72,8 @@ void TypeHintArgRefCallbackCall::recalc_type_data_in_context_of_call(TypeData *d
 }
 
 void TypeHintArgRefInstance::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
-  if (auto v = GenTree::get_call_arg_ref(arg_num, call)) {
-    if (const auto *class_name = GenTree::get_constexpr_string(v)) {
+  if (auto v = VertexUtil::get_call_arg_ref(arg_num, call)) {
+    if (const auto *class_name = VertexUtil::get_constexpr_string(v)) {
       if (auto klass = G->get_class(*class_name)) {
         dst->set_lca(klass->type_data);
         return;
@@ -151,8 +151,8 @@ void TypeHintFFIType::recalc_type_data_in_context_of_call(TypeData *dst, VertexP
 }
 
 void TypeHintFFIScopeArgRef::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
-  if (auto v = GenTree::get_call_arg_ref(arg_num, call)) {
-    if (const auto *arg_scope_name = GenTree::get_constexpr_string(v)) {
+  if (auto v = VertexUtil::get_call_arg_ref(arg_num, call)) {
+    if (const auto *arg_scope_name = VertexUtil::get_constexpr_string(v)) {
       dst->set_lca(G->get_class(FFIRoot::scope_class_name(*arg_scope_name))->type_data);
     }
   }

--- a/compiler/lambda-utils.cpp
+++ b/compiler/lambda-utils.cpp
@@ -13,6 +13,7 @@
 #include "compiler/type-hint.h"
 #include "compiler/utils/string-utils.h"
 #include "compiler/vertex.h"
+#include "compiler/vertex-util.h"
 
 /*
  * How do lambdas work.
@@ -438,7 +439,7 @@ void auto_capture_vars_from_body_in_arrow_lambda(FunctionPtr f_lambda) {
     return var_name != "this" &&      // $this is captured by another approach, in non-arrow lambdas also
            var_name.find("::") == std::string::npos &&
            var_name.find("$u") == std::string::npos &&   // not a superlocal var created in gentree
-           !GenTree::is_superglobal(var_name) &&
+           !VertexUtil::is_superglobal(var_name) &&
            !f_lambda->find_param_by_name(var_name) &&
            !f_lambda->find_use_by_name(var_name);
   };

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -13,7 +13,6 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/function-data.h"
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
 #include "compiler/lexer.h"
 #include "compiler/modulite-check-rules.h"
 #include "compiler/name-gen.h"

--- a/compiler/pipes/analyze-performance.cpp
+++ b/compiler/pipes/analyze-performance.cpp
@@ -11,7 +11,7 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/src-file.h"
 #include "compiler/inferring/public.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 
 namespace {
 
@@ -49,7 +49,7 @@ std::string get_description_for_help_impl(VertexPtr expr) {
   expr = remove_conv_wrap(expr);
   switch (expr->type()) {
     case op_var:
-      if (const auto *constexpr_str = GenTree::get_constexpr_string(expr)) {
+      if (const auto *constexpr_str = VertexUtil::get_constexpr_string(expr)) {
         std::string raw_str{constexpr_str->c_str(), std::min(constexpr_str->size(), size_t{36})};
         if (raw_str.size() < constexpr_str->size()) {
           raw_str.append("<...>");

--- a/compiler/pipes/cfg.cpp
+++ b/compiler/pipes/cfg.cpp
@@ -8,9 +8,10 @@
 #include <random>
 
 #include "compiler/data/function-data.h"
+#include "compiler/data/var-data.h"
+#include "compiler/compiler-core.h"
 #include "compiler/function-pass.h"
 #include "compiler/debug.h"
-#include "compiler/gentree.h"
 #include "compiler/inferring/ifi.h"
 #include "compiler/utils/idmap.h"
 

--- a/compiler/pipes/check-ub.cpp
+++ b/compiler/pipes/check-ub.cpp
@@ -6,7 +6,6 @@
 
 #include "compiler/compiler-core.h"
 #include "compiler/data/function-data.h"
-#include "compiler/gentree.h"
 
 /*
  * C++ undefined behaviour fixes.

--- a/compiler/pipes/collect-const-vars.cpp
+++ b/compiler/pipes/collect-const-vars.cpp
@@ -5,7 +5,9 @@
 #include "compiler/pipes/collect-const-vars.h"
 
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
+#include "compiler/data/var-data.h"
+#include "compiler/compiler-core.h"
 #include "compiler/name-gen.h"
 
 int CollectConstVarsPass::get_dependency_level(VertexPtr vertex) {
@@ -39,7 +41,7 @@ VertexPtr CollectConstVarsPass::on_enter_vertex(VertexPtr root) {
 
   if (root->const_type == cnst_const_val) {
     if (root->type() == op_conv_regexp) {
-      VertexPtr expr = GenTree::get_actual_value(root.as<op_conv_regexp>()->expr());
+      VertexPtr expr = VertexUtil::get_actual_value(root.as<op_conv_regexp>()->expr());
       if (vk::any_of_equal(expr->type(), op_string, op_concat, op_string_build)) {
         return create_const_variable(root, root->location);
       }

--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -9,7 +9,7 @@
 #include "compiler/data/src-file.h"
 #include "compiler/data/var-data.h"
 #include "compiler/function-pass.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/edge.h"
 #include "compiler/inferring/ifi.h"
 #include "compiler/inferring/public.h"
@@ -33,8 +33,8 @@ SwitchKind get_switch_kind(VertexAdaptor<op_switch> s) {
     }
 
     num_value_cases++;
-    auto val = GenTree::get_actual_value(one_case.as<op_case>()->expr());
-    if (is_const_int(val)) {
+    auto val = VertexUtil::get_actual_value(one_case.as<op_case>()->expr());
+    if (VertexUtil::is_const_int(val)) {
       num_const_int_cases++;
     } else if (auto as_string = val.try_as<op_string>()) {
       // PHP would use a numerical comparison for strings that look like a number,
@@ -69,7 +69,7 @@ RValue CollectMainEdgesPass::as_set_value(VertexPtr v) {
   if (vk::any_of_equal(v->type(), op_prefix_inc, op_prefix_dec, op_postfix_dec, op_postfix_inc)) {
     auto unary = v.as<meta_op_unary>();
     auto location = stage::get_location();
-    auto one = GenTree::create_int_const(1).set_location(location);
+    auto one = VertexUtil::create_int_const(1).set_location(location);
     auto res = VertexAdaptor<op_add>::create(unary->expr(), one).set_location(location);
     return as_rvalue(res);
   }
@@ -184,11 +184,11 @@ void CollectMainEdgesPass::create_edges_to_recalc_arg_ref(const TypeHint *type_h
     VertexPtr call_arg{nullptr};
 
     if (const auto *as_arg_ref = child->try_as<TypeHintArgRef>()) {
-      call_arg = GenTree::get_call_arg_ref(as_arg_ref->arg_num, func_call);
+      call_arg = VertexUtil::get_call_arg_ref(as_arg_ref->arg_num, func_call);
     } else if (const auto *as_arg_ref = child->try_as<TypeHintArgRefInstance>()) {
-      call_arg = GenTree::get_call_arg_ref(as_arg_ref->arg_num, func_call);
+      call_arg = VertexUtil::get_call_arg_ref(as_arg_ref->arg_num, func_call);
     } else if (const auto *as_arg_ref = child->try_as<TypeHintArgRefCallbackCall>()) {
-      call_arg = GenTree::get_call_arg_ref(as_arg_ref->arg_num, func_call);
+      call_arg = VertexUtil::get_call_arg_ref(as_arg_ref->arg_num, func_call);
     }
 
     if (call_arg) {

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -11,7 +11,6 @@
 #include "compiler/data/class-data.h"
 #include "compiler/data/src-file.h"
 #include "compiler/function-pass.h"
-#include "compiler/gentree.h"
 #include "compiler/lexer.h"
 #include "compiler/name-gen.h"
 #include "compiler/phpdoc.h"

--- a/compiler/pipes/convert-invoke-to-func-call.cpp
+++ b/compiler/pipes/convert-invoke-to-func-call.cpp
@@ -4,7 +4,6 @@
 
 #include "compiler/pipes/convert-invoke-to-func-call.h"
 
-#include "compiler/gentree.h"
 #include "compiler/name-gen.h"
 #include "compiler/type-hint.h"
 

--- a/compiler/pipes/convert-sprintf-calls.cpp
+++ b/compiler/pipes/convert-sprintf-calls.cpp
@@ -4,7 +4,7 @@
 
 #include "compiler/pipes/convert-sprintf-calls.h"
 
-#include <compiler/gentree.h>
+#include "compiler/vertex-util.h"
 #include <utility>
 
 struct FormatCallInfo {
@@ -90,7 +90,7 @@ VertexPtr ConvertSprintfCallsPass::on_exit_vertex(VertexPtr root) {
 VertexPtr ConvertSprintfCallsPass::convert_sprintf_call(VertexAdaptor<op_func_call> call) {
   const auto args = call->args();
   const auto format_arg_raw = args[0];
-  const auto *format_string = GenTree::get_constexpr_string(format_arg_raw);
+  const auto *format_string = VertexUtil::get_constexpr_string(format_arg_raw);
   if (format_string == nullptr) {
     return call;
   }

--- a/compiler/pipes/extract-resumable-calls.cpp
+++ b/compiler/pipes/extract-resumable-calls.cpp
@@ -5,7 +5,7 @@
 #include "compiler/pipes/extract-resumable-calls.h"
 
 #include "compiler/compiler-core.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/public.h"
 #include "compiler/name-gen.h"
 
@@ -108,8 +108,8 @@ VertexPtr ExtractResumableCallsPass::replace_set_ternary(VertexAdaptor<op_set_mo
   false_case_rhs = rhs_ternary->false_expr();
   false_case_rhs->val_ref_flag = rhs_ternary->val_ref_flag;
 
-  auto ternary_replacer = VertexAdaptor<op_if>::create(rhs_ternary->cond(), GenTree::embrace(set_true_case), GenTree::embrace(set_false_case));
-  return GenTree::embrace(ternary_replacer.set_rl_type(val_none).set_location(set_vertex));
+  auto ternary_replacer = VertexAdaptor<op_if>::create(rhs_ternary->cond(), VertexUtil::embrace(set_true_case), VertexUtil::embrace(set_false_case));
+  return VertexUtil::embrace(ternary_replacer.set_rl_type(val_none).set_location(set_vertex));
 }
 
 VertexPtr ExtractResumableCallsPass::replace_set_logical_operation(VertexAdaptor<op_set_modify> set_vertex, VertexAdaptor<meta_op_binary> operation) noexcept {
@@ -131,8 +131,8 @@ VertexPtr ExtractResumableCallsPass::replace_set_logical_operation(VertexAdaptor
       kphp_assert(0 && "unexpected type");
   }
 
-  auto check_lhs = VertexAdaptor<op_if>::create(temp_var.second, GenTree::embrace(set_if_lhs_true), GenTree::embrace(set_if_lhs_false));
-  return GenTree::embrace(check_lhs.set_rl_type(val_none).set_location(operation));
+  auto check_lhs = VertexAdaptor<op_if>::create(temp_var.second, VertexUtil::embrace(set_if_lhs_true), VertexUtil::embrace(set_if_lhs_false));
+  return VertexUtil::embrace(check_lhs.set_rl_type(val_none).set_location(operation));
 }
 
 VertexPtr ExtractResumableCallsPass::replace_resumable_expr_with_temp_var(VertexPtr *resumable_expr, VertexPtr expr_user) noexcept {

--- a/compiler/pipes/gen-tree-postprocess.cpp
+++ b/compiler/pipes/gen-tree-postprocess.cpp
@@ -8,7 +8,7 @@
 #include "compiler/data/class-data.h"
 #include "compiler/data/lib-data.h"
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 
 namespace {
 template <typename F>
@@ -67,7 +67,7 @@ VertexAdaptor<op_list> make_list_op(VertexAdaptor<op_set> assign) {
     }
 
     auto var = x;
-    auto key = GenTree::create_int_const(implicit_key);
+    auto key = VertexUtil::create_int_const(implicit_key);
     mappings.emplace_back(VertexAdaptor<op_list_keyval>::create(key, var));
   }
 
@@ -231,7 +231,7 @@ VertexPtr GenTreePostprocessPass::on_enter_vertex(VertexPtr root) {
 
 VertexPtr GenTreePostprocessPass::on_exit_vertex(VertexPtr root) {
   if (root->type() == op_var) {
-    if (GenTree::is_superglobal(root->get_string())) {
+    if (VertexUtil::is_superglobal(root->get_string())) {
       root->extra_type = op_ex_var_superglobal;
     }
   }
@@ -239,7 +239,7 @@ VertexPtr GenTreePostprocessPass::on_exit_vertex(VertexPtr root) {
   if (auto call = root.try_as<op_func_call>()) {
     if (!G->settings().profiler_level.get() && call->size() == 1 &&
         vk::any_of_equal(call->get_string(), "profiler_set_log_suffix", "profiler_set_function_label")) {
-      return VertexAdaptor<op_if>::create(VertexAdaptor<op_false>::create(), GenTree::embrace(call)).set_location_recursively(root);
+      return VertexAdaptor<op_if>::create(VertexAdaptor<op_false>::create(), VertexUtil::embrace(call)).set_location_recursively(root);
     }
   }
 

--- a/compiler/pipes/generate-virtual-methods.cpp
+++ b/compiler/pipes/generate-virtual-methods.cpp
@@ -11,6 +11,7 @@
 #include "compiler/data/function-data.h"
 #include "compiler/data/src-file.h"
 #include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/type-hint.h"
 
 // a "virtual method" is an instance method overridden in child classes (all methods of interfaces are virtual also)
@@ -267,7 +268,7 @@ void check_constructor_signature_compatibility(FunctionPtr interface_constructor
 }
 
 VertexAdaptor<op_case> gen_case_on_hash(ClassPtr derived, VertexAdaptor<op_seq> cmd) {
-  auto hash_of_derived = GenTree::create_int_const(derived->get_hash());
+  auto hash_of_derived = VertexUtil::create_int_const(derived->get_hash());
   return VertexAdaptor<op_case>::create(hash_of_derived, cmd);
 }
 
@@ -333,7 +334,7 @@ VertexPtr generate_default_value_of_type(const TypeHint *ret_type) {
       case tp_int:
       case tp_float:
       case tp_mixed:
-        return GenTree::create_int_const(0);
+        return VertexUtil::create_int_const(0);
       case tp_bool:
         return VertexAdaptor<op_false>::create();
       case tp_string:

--- a/compiler/pipes/instantiate-ffi-operations.cpp
+++ b/compiler/pipes/instantiate-ffi-operations.cpp
@@ -4,6 +4,7 @@
 
 #include "compiler/pipes/instantiate-ffi-operations.h"
 
+#include "compiler/vertex-util.h"
 #include "compiler/const-manipulations.h"
 #include "compiler/ffi/ffi_parser.h"
 #include "compiler/type-hint.h"
@@ -285,7 +286,7 @@ static VertexAdaptor<op_ffi_new> create_ffi_new(const InferResult &infer_result)
   } else if (const auto *ffi_type_hint = infer_result.type_hint->try_as<TypeHintFFIType>()) {
     if (ffi_type_hint->type->kind == FFITypeKind::Array && ffi_type_hint->type->num >= 0) {
       // a fixed-size array
-      size_expr = GenTree::create_int_const(ffi_type_hint->type->num);
+      size_expr = VertexUtil::create_int_const(ffi_type_hint->type->num);
     }
   }
   if (size_expr) {
@@ -528,7 +529,7 @@ VertexPtr InstantiateFFIOperationsPass::on_cdata_instance_prop(ClassPtr root_cla
 VertexPtr InstantiateFFIOperationsPass::on_scope_instance_prop(ClassPtr scope_class, VertexAdaptor<op_instance_prop> root) {
   auto enum_constant = scope_class->ffi_scope_mixin->enum_constants.find(root->get_string());
   if (enum_constant != scope_class->ffi_scope_mixin->enum_constants.end()) {
-    return GenTree::create_int_const(enum_constant->second);
+    return VertexUtil::create_int_const(enum_constant->second);
   }
 
   root->access_type = InstancePropAccessType::ExternVar;
@@ -630,7 +631,7 @@ VertexPtr InstantiateFFIOperationsPass::on_exit_vertex(VertexPtr root) {
         // so we inline the count result right away
         if (const auto *as_ffi = c2php->php_type->try_as<TypeHintFFIType>()) {
           if (as_ffi->type->kind == FFITypeKind::Array && as_ffi->type->num != -1) {
-            return GenTree::create_int_const(as_ffi->type->num);
+            return VertexUtil::create_int_const(as_ffi->type->num);
           }
         }
         call->args()[0] = c2php->expr();

--- a/compiler/pipes/instantiate-generics-and-lambdas.cpp
+++ b/compiler/pipes/instantiate-generics-and-lambdas.cpp
@@ -8,7 +8,7 @@
 #include "compiler/data/class-data.h"
 #include "compiler/data/function-data.h"
 #include "compiler/data/generics-mixins.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/lambda-utils.h"
 #include "compiler/phpdoc.h"
 #include "compiler/type-hint.h"
@@ -55,7 +55,7 @@ public:
         if (const auto *as_class_string = param->type_hint->try_as<TypeHintClassString>()) {
           const TypeHint *instT = instantiationTs->find(as_class_string->inner->try_as<TypeHintGenericT>()->nameT);
           if (instT && instT->try_as<TypeHintInstance>()) {
-            return GenTree::create_string_const(instT->try_as<TypeHintInstance>()->full_class_name);
+            return VertexUtil::create_string_const(instT->try_as<TypeHintInstance>()->full_class_name);
           }
         }
       }

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -9,7 +9,7 @@
 #include "common/algorithms/hashes.h"
 
 #include "compiler/data/class-data.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/inferring/public.h"
 
 namespace {
@@ -30,7 +30,7 @@ bool can_init_value_be_removed(VertexPtr init_value, const VarPtr &variable) {
 
   switch (init_type->ptype()) {
     case tp_string: {
-      const auto *init_string = GenTree::get_constexpr_string(init_value);
+      const auto *init_string = VertexUtil::get_constexpr_string(init_value);
       return init_string && init_string->empty();
     }
     case tp_array:

--- a/compiler/pipes/preprocess-exceptions.cpp
+++ b/compiler/pipes/preprocess-exceptions.cpp
@@ -5,7 +5,8 @@
 #include "compiler/pipes/preprocess-exceptions.h"
 
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
+#include "compiler/compiler-core.h"
 
 VertexPtr PreprocessExceptions::on_exit_vertex(VertexPtr root) {
   static const ClassPtr throwable_class = G->get_class("Throwable");
@@ -26,7 +27,7 @@ VertexPtr PreprocessExceptions::on_exit_vertex(VertexPtr root) {
   }
 
   auto call = root.try_as<op_func_call>();
-  if (!call || !is_constructor_call(call)) {
+  if (!call || !VertexUtil::is_constructor_call(call)) {
     return root;
   }
   auto alloc = call->args()[0].try_as<op_alloc>();
@@ -43,7 +44,7 @@ VertexPtr PreprocessExceptions::on_exit_vertex(VertexPtr root) {
   // 2) the result of codegeneration doesn't depend on username / project location
   auto file_arg = VertexAdaptor<op_string>::create().set_location(root->location);
   file_arg->set_string(root->location.get_file()->relative_file_name);
-  auto line_arg = GenTree::create_int_const(root->location.get_line());
+  auto line_arg = VertexUtil::create_int_const(root->location.get_line());
   auto new_call = VertexAdaptor<op_func_call>::create(call, file_arg, line_arg).set_location(root->location);
   new_call->func_id = G->get_function("_exception_set_location");
   new_call->auto_inserted = true;

--- a/compiler/pipes/register-ffi-scopes.cpp
+++ b/compiler/pipes/register-ffi-scopes.cpp
@@ -10,6 +10,7 @@
 #include "compiler/data/src-file.h"
 #include "compiler/data/ffi-data.h"
 #include "compiler/type-hint.h"
+#include "compiler/vertex-util.h"
 
 #include <fstream>
 
@@ -132,7 +133,7 @@ private:
   void add_enum_constant(const std::string &const_name, int const_value, ClassPtr scope_class) {
     auto fake_op_var = VertexAdaptor<op_var>::create();
     fake_op_var->str_val = const_name;
-    auto fake_def_val = GenTree::create_int_const(const_value);
+    auto fake_def_val = VertexUtil::create_int_const(const_value);
 
     // in PHP/KPHP, we access enum constants via an arrow: $cdef->CONST
     // so, make it be an instance field, not a static const; it'll pass all checks of fields existence

--- a/compiler/pipes/register-kphp-configuration.cpp
+++ b/compiler/pipes/register-kphp-configuration.cpp
@@ -9,7 +9,7 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/class-data.h"
 #include "compiler/data/function-data.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 
 void RegisterKphpConfiguration::execute(FunctionPtr function, DataStream<FunctionPtr> &unused_os __attribute__ ((unused))) {
   if (function->type == FunctionData::func_class_holder && function->class_id->name == configuration_class_name_) {
@@ -86,7 +86,7 @@ void RegisterKphpConfiguration::parse_palette_ruleset(VertexAdaptor<op_array> ar
 
 void RegisterKphpConfiguration::parse_palette_rule(VertexAdaptor<op_double_arrow> pair, function_palette::Palette &palette, function_palette::PaletteRuleset &add_to) {
   auto parse_rule_key_colors = [this, &palette](VertexPtr key) -> std::vector<function_palette::color_t> {
-    const auto *rule_string = GenTree::get_constexpr_string(key);
+    const auto *rule_string = VertexUtil::get_constexpr_string(key);
     auto color_names_strings = split(rule_string != nullptr ? *rule_string : "", ' ');
     kphp_error(!color_names_strings.empty(), fmt_format("{}::{} map keys must be non-empty constexpr strings",
                                                         configuration_class_name_, function_color_palette_name_));
@@ -97,7 +97,7 @@ void RegisterKphpConfiguration::parse_palette_rule(VertexAdaptor<op_double_arrow
   };
 
   auto parse_rule_value_error = [this](VertexPtr value) -> std::string {
-    const std::string *errtext_val = GenTree::get_constexpr_string(value);
+    const std::string *errtext_val = VertexUtil::get_constexpr_string(value);
     const auto ok_val = value.try_as<op_int_const>();
     kphp_error(errtext_val || (ok_val && ok_val->get_string() == "1"), fmt_format("{}::{} map values must be constexpr strings or number 1",
                                                                                   configuration_class_name_, function_color_palette_name_));
@@ -119,7 +119,7 @@ void RegisterKphpConfiguration::handle_constant_runtime_options(const ClassMembe
     auto opt_pair = opt.try_as<op_double_arrow>();
     kphp_error_return(opt_pair, fmt_format("{}::{} must be an associative map",
                                            configuration_class_name_, runtime_options_name_));
-    const auto *opt_key = GenTree::get_constexpr_string(opt_pair->key());
+    const auto *opt_key = VertexUtil::get_constexpr_string(opt_pair->key());
     kphp_error_return(opt_key, fmt_format("{}::{} map keys must be constexpr strings",
                                           configuration_class_name_, runtime_options_name_));
     if (*opt_key == confdata_blacklist_key_) {
@@ -144,7 +144,7 @@ void RegisterKphpConfiguration::handle_constant_runtime_options(const ClassMembe
 }
 
 void RegisterKphpConfiguration::generic_register_simple_option(VertexPtr value, vk::string_view opt_key) const noexcept {
-  const auto *opt_value = GenTree::get_constexpr_string(value);
+  const auto *opt_value = VertexUtil::get_constexpr_string(value);
   kphp_error_return(opt_value, fmt_format("{}::{} must be a constexpr string",
                                           configuration_class_name_, runtime_options_name_));
 
@@ -153,7 +153,7 @@ void RegisterKphpConfiguration::generic_register_simple_option(VertexPtr value, 
 }
 
 void RegisterKphpConfiguration::register_confdata_blacklist(VertexPtr value) const noexcept {
-  const auto *opt_value = GenTree::get_constexpr_string(value);
+  const auto *opt_value = VertexUtil::get_constexpr_string(value);
   kphp_error_return(opt_value, fmt_format("{}[{}] must be a constexpr string",
                                           runtime_options_name_, confdata_blacklist_key_));
 
@@ -170,7 +170,7 @@ void RegisterKphpConfiguration::register_confdata_predefined_wildcard(VertexPtr 
   kphp_error_return(wildcards, fmt_format("{}[{}] must be a constexpr array",
                                           runtime_options_name_, confdata_predefined_wildcard_key_));
   for (const auto &wildcard : wildcards->args()) {
-    const auto *wildcard_str_value = GenTree::get_constexpr_string(wildcard);
+    const auto *wildcard_str_value = VertexUtil::get_constexpr_string(wildcard);
     kphp_error_return(wildcard_str_value && !wildcard_str_value->empty(),
                       fmt_format("{}[{}][] must be non empty constexpr string",
                                  runtime_options_name_, confdata_predefined_wildcard_key_));
@@ -188,7 +188,7 @@ void RegisterKphpConfiguration::register_net_dc_mask(VertexPtr value) const noex
   kphp_error_return(dc_masks, fmt_format("{}[{}] must be a constexpr array",
                                          runtime_options_name_, net_dc_mask_key_));
   for (const auto &dc_mask_v : dc_masks->args()) {
-    const auto *index_ipv4_subnet = GenTree::get_constexpr_string(dc_mask_v);
+    const auto *index_ipv4_subnet = VertexUtil::get_constexpr_string(dc_mask_v);
     kphp_error_return(index_ipv4_subnet && !index_ipv4_subnet->empty(),
                       fmt_format("{}[{}][] must be non empty constexpr string",
                                  runtime_options_name_, net_dc_mask_key_));

--- a/compiler/pipes/register-variables.cpp
+++ b/compiler/pipes/register-variables.cpp
@@ -7,7 +7,6 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/class-data.h"
 #include "compiler/data/var-data.h"
-#include "compiler/gentree.h"
 #include "compiler/modulite-check-rules.h"
 #include "compiler/name-gen.h"
 #include "compiler/utils/string-utils.h"

--- a/compiler/pipes/resolve-self-static-parent.cpp
+++ b/compiler/pipes/resolve-self-static-parent.cpp
@@ -9,6 +9,7 @@
 #include "compiler/compiler-core.h"
 #include "compiler/data/class-data.h"
 #include "compiler/data/src-file.h"
+#include "compiler/vertex-util.h"
 #include "compiler/gentree.h"
 #include "compiler/name-gen.h"
 #include "compiler/phpdoc.h"
@@ -105,7 +106,7 @@ VertexPtr ResolveSelfStaticParentPass::on_enter_vertex(VertexPtr v) {
 
   } else if (auto as_instanceof = v.try_as<op_instanceof>()) {
     // ... instanceof XXX, the right was replaced by XXX::class
-    const std::string &instanceof_class = GenTree::get_actual_value(as_instanceof->rhs())->get_string();
+    const std::string &instanceof_class = VertexUtil::get_actual_value(as_instanceof->rhs())->get_string();
     auto pos = instanceof_class.find("::");
     kphp_assert(pos != std::string::npos);
 

--- a/compiler/pipes/split-switch.cpp
+++ b/compiler/pipes/split-switch.cpp
@@ -4,9 +4,10 @@
 
 #include "compiler/pipes/split-switch.h"
 
+#include "compiler/compiler-core.h"
 #include "compiler/data/src-file.h"
 #include "compiler/function-pass.h"
-#include "compiler/gentree.h"
+#include "compiler/vertex-util.h"
 #include "compiler/name-gen.h"
 
 class SplitSwitchPass final : public FunctionPassBase {
@@ -25,7 +26,7 @@ private:
       return goto_op;
     }
 
-    auto minus_one = GenTree::create_int_const(-1);
+    auto minus_one = VertexUtil::create_int_const(-1);
     auto state = VertexAdaptor<op_var>::create();
     state->str_val = state_name;
     auto expr = VertexAdaptor<op_set>::create(state, minus_one);
@@ -42,7 +43,7 @@ private:
     const std::string &state_name,
     int cycle_depth) {
     if (root->type() == op_return) {
-      auto one = GenTree::create_int_const(1);
+      auto one = VertexUtil::create_int_const(1);
       auto state = VertexAdaptor<op_var>::create();
       state->str_val = state_name;
       auto expr = VertexAdaptor<op_set>::create(state, one);
@@ -113,7 +114,7 @@ public:
       auto func_params = VertexAdaptor<op_func_param_list>::create(case_state_param);
       auto func = VertexAdaptor<op_function>::create(func_params, seq);
       func = prepare_switch_func(func, case_state_name, 1).as<op_function>();
-      GenTree::func_force_return(func, VertexAdaptor<op_null>::create());
+      VertexUtil::func_force_return(func, VertexAdaptor<op_null>::create());
 
       FunctionPtr switch_f = FunctionData::create_function(func_name, func, FunctionData::func_switch);
       new_functions.push_back(switch_f);
@@ -133,20 +134,20 @@ public:
       auto run_func = VertexAdaptor<op_set>::create(case_res, func_call);
 
 
-      auto zero = GenTree::create_int_const(0);
-      auto one = GenTree::create_int_const(1);
-      auto minus_one = GenTree::create_int_const(-1);
+      auto zero = VertexUtil::create_int_const(0);
+      auto one = VertexUtil::create_int_const(1);
+      auto minus_one = VertexUtil::create_int_const(-1);
 
       auto eq_one = VertexAdaptor<op_eq2>::create(case_state_1, one);
       auto eq_minus_one = VertexAdaptor<op_eq2>::create(case_state_2, minus_one);
 
       auto cmd_one = VertexAdaptor<op_return>::create(case_res_copy);
-      auto one_2 = GenTree::create_int_const(1);
+      auto one_2 = VertexUtil::create_int_const(1);
       auto cmd_minus_one = VertexAdaptor<op_break>::create(one_2);
 
       auto init = VertexAdaptor<op_set>::create(case_state_3, zero);
-      auto if_one = VertexAdaptor<op_if>::create(eq_one, GenTree::embrace(cmd_one));
-      auto if_minus_one = VertexAdaptor<op_if>::create(eq_minus_one, GenTree::embrace(cmd_minus_one));
+      auto if_one = VertexAdaptor<op_if>::create(eq_one, VertexUtil::embrace(cmd_one));
+      auto if_minus_one = VertexAdaptor<op_if>::create(eq_minus_one, VertexUtil::embrace(cmd_minus_one));
 
       auto new_seq = VertexAdaptor<op_seq>::create(init, run_func, if_one, if_minus_one);
       cs->back() = new_seq;

--- a/compiler/vertex-util.cpp
+++ b/compiler/vertex-util.cpp
@@ -1,0 +1,160 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/vertex-util.h"
+
+#include "common/algorithms/contains.h"
+#include "compiler/data/class-data.h"
+#include "compiler/data/var-data.h"
+#include <set>
+
+VertexPtr VertexUtil::get_actual_value(VertexPtr v) {
+  if (auto var = v.try_as<op_var>()) {
+    if (var->extra_type == op_ex_var_const && var->var_id) {
+      return var->var_id->init_val;
+    }
+  }
+  return v;
+}
+
+const std::string *VertexUtil::get_constexpr_string(VertexPtr v) {
+  v = VertexUtil::get_actual_value(v);
+  if (auto conv_vertex = v.try_as<op_conv_string>()) {
+    return get_constexpr_string(conv_vertex->expr());
+  }
+  if (auto str_vertex = v.try_as<op_string>()) {
+    return &str_vertex->get_string();
+  }
+  return nullptr;
+}
+
+VertexPtr VertexUtil::get_call_arg_ref(int arg_num, VertexPtr v_func_call) {
+  if (arg_num > 0) {
+    auto call_args = v_func_call.as<op_func_call>()->args();
+    return arg_num <= call_args.size() ? call_args[arg_num - 1] : VertexPtr{};
+  }
+  return {};
+}
+
+VertexPtr VertexUtil::create_int_const(int64_t number) {
+  auto int_v = VertexAdaptor<op_int_const>::create();
+  int_v->str_val = std::to_string(number);
+  return int_v;
+}
+
+VertexAdaptor<op_string> VertexUtil::create_string_const(const std::string &s) {
+  auto string_v = VertexAdaptor<op_string>::create();
+  string_v->set_string(s);
+  return string_v;
+}
+
+VertexAdaptor<op_seq> VertexUtil::embrace(VertexPtr v) {
+  if (auto seq = v.try_as<op_seq>()) {
+    return seq;
+  }
+  return VertexAdaptor<op_seq>::create(v).set_location(v);
+}
+
+void VertexUtil::func_force_return(VertexAdaptor<op_function> func, VertexPtr val) {
+  VertexPtr cmd = func->cmd();
+  assert (cmd->type() == op_seq);
+
+  VertexAdaptor<op_return> return_node;
+  if (val) {
+    return_node = VertexAdaptor<op_return>::create(val);
+  } else {
+    return_node = VertexAdaptor<op_return>::create();
+  }
+
+  std::vector<VertexPtr> next = cmd->get_next();
+  next.push_back(return_node);
+  func->cmd_ref() = VertexAdaptor<op_seq>::create(next);
+}
+
+bool VertexUtil::is_superglobal(const std::string &s) {
+  static std::set<std::string> names = {
+    "_SERVER",
+    "_GET",
+    "_POST",
+    "_FILES",
+    "_COOKIE",
+    "_REQUEST",
+    "_ENV"
+  };
+  return vk::contains(names, s);
+}
+
+bool VertexUtil::is_constructor_call(VertexAdaptor<op_func_call> call) {
+  return !call->args().empty() && call->str_val == ClassData::NAME_OF_CONSTRUCT;
+}
+
+bool VertexUtil::is_positive_constexpr_int(VertexPtr v) {
+  auto actual_value = get_actual_value(v).try_as<op_int_const>();
+  return actual_value && parse_int_from_string(actual_value) >= 0;
+}
+
+bool VertexUtil::is_const_int(VertexPtr root) {
+  switch (root->type()) {
+    case op_int_const:
+      return true;
+    case op_minus:
+    case op_plus:
+    case op_not:
+      return is_const_int(root.as<meta_op_unary>()->expr());
+    case op_add:
+    case op_mul:
+    case op_sub:
+    case op_div:
+    case op_and:
+    case op_or:
+    case op_xor:
+    case op_shl:
+    case op_shr:
+    case op_mod:
+    case op_pow:
+      return is_const_int(root.as<meta_op_binary>()->lhs()) && is_const_int(root.as<meta_op_binary>()->rhs());
+    default:
+      break;
+  }
+  return false;
+}
+
+VertexPtr VertexUtil::create_conv_to(PrimitiveType targetType, VertexPtr x) {
+  switch (targetType) {
+    case tp_int:
+      return VertexAdaptor<op_conv_int>::create(x).set_location(x);
+
+    case tp_bool:
+      return VertexAdaptor<op_conv_bool>::create(x).set_location(x);
+
+    case tp_string:
+      return VertexAdaptor<op_conv_string>::create(x).set_location(x);
+
+    case tp_float:
+      return VertexAdaptor<op_conv_float>::create(x).set_location(x);
+
+    case tp_array:
+      return VertexAdaptor<op_conv_array>::create(x).set_location(x);
+
+    case tp_regexp:
+      return VertexAdaptor<op_conv_regexp>::create(x).set_location(x);
+
+    case tp_mixed:
+      return VertexAdaptor<op_conv_mixed>::create(x).set_location(x);
+
+    default:
+      return x;
+  }
+}
+
+VertexAdaptor<meta_op_unary> VertexUtil::create_conv_to_lval(PrimitiveType targetType, VertexPtr x) {
+  switch (targetType) {
+    case tp_array : return VertexAdaptor<op_conv_array_l>::create(x).set_location(x);
+    case tp_int   : return VertexAdaptor<op_conv_int_l>::create(x).set_location(x);
+    case tp_string: return VertexAdaptor<op_conv_string_l>::create(x).set_location(x);
+    default:
+      return {};
+  }
+}
+

--- a/compiler/vertex-util.h
+++ b/compiler/vertex-util.h
@@ -1,0 +1,33 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "compiler/vertex.h"
+
+// This class contains helper methods that operate on various vertices.
+//
+// GenTree is mostly for parsing (tokens -> vertex tree),
+// VertexUtil is for the operations that are useful in most other parts of the compiler
+// and are not directly connected to parsing.
+class VertexUtil {
+public:
+  static VertexPtr get_actual_value(VertexPtr v);
+  static const std::string *get_constexpr_string(VertexPtr v);
+  static VertexPtr get_call_arg_ref(int arg_num, VertexPtr v_func_call);
+
+  static VertexPtr create_conv_to(PrimitiveType targetType, VertexPtr x);
+  static VertexAdaptor<meta_op_unary> create_conv_to_lval(PrimitiveType targetType, VertexPtr x);
+  static VertexPtr create_int_const(int64_t number);
+  static VertexAdaptor<op_string> create_string_const(const std::string &s);
+
+  static VertexAdaptor<op_seq> embrace(VertexPtr v);
+
+  static void func_force_return(VertexAdaptor<op_function> func, VertexPtr val = {});
+
+  static bool is_superglobal(const std::string &s);
+  static bool is_constructor_call(VertexAdaptor<op_func_call> call);
+  static bool is_positive_constexpr_int(VertexPtr v);
+  static bool is_const_int(VertexPtr root);
+};


### PR DESCRIPTION
Most of the time when some code includes "gentree.h" it only needs one or two methods like `get_actual_value` or `create_int_const`.

Since our parser code is already messy as it is, adding even more helpers is not very convenient as it makes gentree files even more bloated.

Moving helpers to another file/class gives these benefits:

1. Less code includes "gentree.h" => faster compilation
2. Less code inside gentree files => less complexity in the parser files
3. Easier to maintain helpers (files that contain them are smaller and simpler)
4. It's easier to refactor the parser and helpers separately
  4.1. We can separate AST generation like `create_int_const` and other ops if we want to
  4.2. GenTree can be treated as parser, not as "everything related to vertices + parsing + more"

This is only a first step.