### PR TITLE
[runtime] add count=1 special case for `implode()` function

### DIFF
--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -297,6 +297,10 @@ inline void f$array_swap_int_keys(array<T> &a, int64_t idx1, int64_t idx2) noexc
 
 template<class T>
 string f$implode(const string &s, const array<T> &a) {
+  if (a.count() == 1) {
+    return f$strval(a.begin().get_value());
+  }
+
   string_buffer &SB = static_SB;
   SB.clean();
 

--- a/tests/benchmarks/BenchmarkImplode.php
+++ b/tests/benchmarks/BenchmarkImplode.php
@@ -1,0 +1,14 @@
+<?php
+
+class BenchmarkImplode {
+  private $parts1 = ['a single string'];
+  private $parts3 = ['first string', 'second string', 'third string'];
+
+  public function benchmarkImplode1() {
+    return implode(' ', $this->parts1);
+  }
+
+  public function benchmarkImplode3() {
+    return implode(' ', $this->parts3);
+  }
+}

--- a/tests/phpt/array/026_implode.php
+++ b/tests/phpt/array/026_implode.php
@@ -1,0 +1,72 @@
+@ok
+<?php
+
+function test() {
+  /** @var string[][] $string_parts */
+  $string_parts = [
+    [],
+    ['foo'],
+    [' ', 'foo'],
+    ['foo', ' ', 'bar'],
+  ];
+
+  /** @var int[][] $int_parts */
+  $int_parts = [
+    [],
+    [1],
+    [5324, -24],
+    [2394, 341, 0],
+  ];
+
+  /** @var mixed[][] $mixed_parts */
+  $mixed_parts = [
+    ['0'],
+    ['-53'],
+    ['3525', '53253'],
+  ];
+  foreach ($string_parts as $string_part) {
+    $mixed_parts[] = $string_part;
+  }
+  foreach ($int_parts as $int_part) {
+    $mixed_parts[] = $int_parts;
+  }
+
+  foreach ($string_parts as $string_part) {
+    var_dump(implode(', ', $string_part));
+    var_dump(implode(' ', $string_part));
+    var_dump(implode('', $string_part));
+  }
+  foreach ($int_parts as $int_part) {
+    var_dump(implode(', ', $int_part));
+    var_dump(implode(' ', $int_part));
+    var_dump(implode('', $int_part));
+  }
+  foreach ($mixed_parts as $mixed_part) {
+    var_dump(implode(', ', $mixed_part));
+    var_dump(implode(' ', $mixed_part));
+    var_dump(implode('', $mixed_part));
+  }
+
+  $str_arr = ['hello'];
+  $res = implode(' ', $str_arr);
+  var_dump($res);
+  $res[0] = 'x';
+  var_dump($res);
+  var_dump($str_arr[0]);
+
+  $str_arr2 = ['hello'];
+  $res2 = implode(' ', $str_arr2);
+  var_dump($res2);
+  $str_arr2[0][1] = 'x';
+  var_dump($res2);
+  var_dump($str_arr2[0]);
+
+  $str_arr3 = ['foo' => 'hello'];
+  $res3 = implode(' ', $str_arr3);
+  var_dump($res3);
+  $res3[2] = 'x';
+  var_dump($res3);
+  var_dump($str_arr3['foo']);
+}
+
+test();


### PR DESCRIPTION
Some stats from a real-world app:

    ~0.7% calls with count=0
    ~56%  calls with count=1
    ~43%  calls with count>1

The count=0 case can be optimized by returning the empty string right away, but since it's so rare, this change is not applied. Our allocator knows how to allocate an empty-sized string efficiently.

The count=1 case can be optimized by returning the sole array element. This may require a to_string conversion, so we're wrapping it in `f$strval`. Since this is a frequent case, this optimization will be applied.

This optimization is quite common in languages with immutable (or COW) strings:

    https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/strings/strings.go;l=435

Benchmark results:

    name               old time/op    new time/op    delta
    Implode::Implode1    58.0ns ± 0%    24.9ns ± 4%   -57.07%  (p=0.000 n=8+10)
    Implode::Implode3    84.1ns ± 3%    85.6ns ± 1%    +1.78%  (p=0.021 n=10+10)
    [Geo mean]           69.8ns         46.2ns        -33.90%

    name               old alloc/op   new alloc/op   delta
    Implode::Implode1     32.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
    Implode::Implode3     56.0B ± 0%     56.0B ± 0%         ~  (all equal)

    name               old allocs/op  new allocs/op  delta
    Implode::Implode1      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
    Implode::Implode3      1.00 ± 0%      1.00 ± 0%         ~  (all equal)

The case for count!=1 gets extra 2-3ns execution time due to the extra size check. The main benefit of this change is heap allocations reduction.