### PR TITLE
add DateInterval

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1512,6 +1512,13 @@ class DateTimeZone {
   public function getName(): string;
 }
 
+class DateInterval {
+  /** @kphp-extern-func-info can_throw */
+  public function __construct(string $duration);
+  public static function createFromDateString(string $datetime): ?DateInterval;
+  public function format(string $format): string;
+}
+
 interface DateTimeInterface {
   /* Constants */
   const ATOM = "Y-m-d\TH:i:sP";

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1536,6 +1536,7 @@ interface DateTimeInterface {
   const W3C = "Y-m-d\TH:i:sP";
 
   /* Methods */
+  public function add(DateInterval $interval): DateTimeInterface;
   public function modify(string $modifier): ?DateTimeInterface;
   public function setDate(int $year, int $month, int $day): DateTimeInterface;
   public function setISODate(int $year, int $week, int $dayOfWeek = 1): DateTimeInterface;
@@ -1546,6 +1547,8 @@ interface DateTimeInterface {
       int $microsecond = 0
   ): DateTimeInterface;
   public function setTimestamp(int $timestamp): DateTimeInterface;
+  public function sub(DateInterval $interval): DateTimeInterface;
+  public function diff(DateTimeInterface $targetObject, bool $absolute = false): DateInterval;
   public function format(string $format): string;
   public function getOffset(): int;
   public function getTimestamp(): int;
@@ -1554,6 +1557,7 @@ interface DateTimeInterface {
 class DateTime implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
+  public function add(DateInterval $interval): DateTime;
   public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): ?DateTime;
   public static function createFromImmutable(DateTimeImmutable $object): DateTime;
   public static function getLastErrors(): array|false;
@@ -1567,6 +1571,8 @@ class DateTime implements DateTimeInterface {
       int $microsecond = 0
   ): DateTime;
   public function setTimestamp(int $timestamp): DateTime;
+  public function sub(DateInterval $interval): DateTime;
+  public function diff(DateTimeInterface $targetObject, bool $absolute = false): DateInterval;
   public function format(string $format): string;
   public function getOffset(): int;
   public function getTimestamp(): int;
@@ -1575,6 +1581,7 @@ class DateTime implements DateTimeInterface {
 class DateTimeImmutable implements DateTimeInterface {
   /** @kphp-extern-func-info can_throw */
   public function __construct(string $datetime = "now", ?DateTimeZone $timezone = null);
+  public function add(DateInterval $interval): DateTimeImmutable;
   public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): ?DateTimeImmutable;
   public static function createFromMutable(DateTime $object): DateTimeImmutable;
   public static function getLastErrors(): array|false;
@@ -1588,6 +1595,8 @@ class DateTimeImmutable implements DateTimeInterface {
       int $microsecond = 0
   ): DateTimeImmutable;
   public function setTimestamp(int $timestamp): DateTimeImmutable;
+  public function sub(DateInterval $interval): DateTimeImmutable;
+  public function diff(DateTimeInterface $targetObject, bool $absolute = false): DateInterval;
   public function format(string $format): string;
   public function getOffset(): int;
   public function getTimestamp(): int;

--- a/runtime/datetime/date_interval.cpp
+++ b/runtime/datetime/date_interval.cpp
@@ -1,0 +1,40 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/datetime/date_interval.h"
+
+#include "runtime/exception.h"
+
+C$DateInterval::~C$DateInterval() {
+  php_timelib_date_interval_remove(rel_time);
+  rel_time = nullptr;
+}
+
+class_instance<C$DateInterval> f$DateInterval$$__construct(const class_instance<C$DateInterval> &self, const string &duration) noexcept {
+  auto [rel_time, error_msg] = php_timelib_date_interval_initialize(duration);
+  if (!rel_time) {
+    string error{"DateInterval::__construct(): "};
+    error.append(error_msg);
+    THROW_EXCEPTION(new_Exception(string{__FILE__}, __LINE__, error));
+    return {};
+  }
+  self->rel_time = rel_time;
+  return self;
+}
+
+class_instance<C$DateInterval> f$DateInterval$$createFromDateString(const string &datetime) noexcept {
+  auto [rel_time, error_msg] = php_timelib_date_interval_create_from_date_string(datetime);
+  if (!rel_time) {
+    php_warning("DateInterval::createFromDateString(): %s", error_msg.c_str());
+    return {};
+  }
+  class_instance<C$DateInterval> date_interval;
+  date_interval.alloc();
+  date_interval->rel_time = rel_time;
+  return date_interval;
+}
+
+string f$DateInterval$$format(const class_instance<C$DateInterval> &self, const string &format) noexcept {
+  return php_timelib_date_interval_format(format, self->rel_time);
+}

--- a/runtime/datetime/date_interval.h
+++ b/runtime/datetime/date_interval.h
@@ -1,0 +1,31 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2022 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/datetime/timelib_wrapper.h"
+#include "runtime/dummy-visitor-methods.h"
+#include "runtime/refcountable_php_classes.h"
+
+struct C$DateInterval: public refcountable_php_classes<C$DateInterval>, private DummyVisitorMethods  {
+  using DummyVisitorMethods::accept;
+
+  timelib_rel_time *rel_time{nullptr};
+
+  const char *get_class() const  noexcept {
+    return R"(DateInterval)";
+  }
+
+  int get_hash() const  noexcept {
+    return -393296726;
+  }
+
+  ~C$DateInterval();
+};
+
+class_instance<C$DateInterval> f$DateInterval$$__construct(const class_instance<C$DateInterval> &self, const string &duration) noexcept;
+
+class_instance<C$DateInterval> f$DateInterval$$createFromDateString(const string &datetime) noexcept;
+
+string f$DateInterval$$format(const class_instance<C$DateInterval> &self, const string &format) noexcept;

--- a/runtime/datetime/datetime.cpp
+++ b/runtime/datetime/datetime.cpp
@@ -4,6 +4,7 @@
 
 #include "runtime/datetime/datetime.h"
 
+#include "runtime/datetime/date_interval.h"
 #include "runtime/datetime/datetime_immutable.h"
 #include "runtime/exception.h"
 
@@ -24,6 +25,11 @@ class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTi
     return {};
   }
   self->time = time;
+  return self;
+}
+
+class_instance<C$DateTime> f$DateTime$$add(const class_instance<C$DateTime> &self, const class_instance<C$DateInterval> &interval) noexcept {
+  self->time = php_timelib_date_add(self->time, interval->rel_time);
   return self;
 }
 
@@ -78,6 +84,24 @@ class_instance<C$DateTime> f$DateTime$$setTime(const class_instance<C$DateTime> 
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept {
   php_timelib_date_timestamp_set(self->time, timestamp);
   return self;
+}
+
+class_instance<C$DateTime> f$DateTime$$sub(const class_instance<C$DateTime> &self, const class_instance<C$DateInterval> &interval) noexcept {
+  auto [new_time, error_msg] = php_timelib_date_sub(self->time, interval->rel_time);
+  if (!new_time) {
+    php_warning("DateTime::sub(): %s", error_msg.data());
+    return self;
+  }
+  self->time = new_time;
+  return self;
+}
+
+class_instance<C$DateInterval> f$DateTime$$diff(const class_instance<C$DateTime> &self, const class_instance<C$DateTimeInterface> &target_object,
+                                                bool absolute) noexcept {
+  class_instance<C$DateInterval> interval;
+  interval.alloc();
+  interval->rel_time = php_timelib_date_diff(self->time, target_object.get()->time, absolute);
+  return interval;
 }
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept {

--- a/runtime/datetime/datetime.h
+++ b/runtime/datetime/datetime.h
@@ -10,6 +10,7 @@
 #include "runtime/kphp_core.h"
 #include "runtime/refcountable_php_classes.h"
 
+struct C$DateInterval;
 struct C$DateTimeImmutable;
 
 struct C$DateTime : public refcountable_polymorphic_php_classes<C$DateTimeInterface>, private DummyVisitorMethods {
@@ -30,6 +31,8 @@ extern const string NOW;
 class_instance<C$DateTime> f$DateTime$$__construct(const class_instance<C$DateTime> &self, const string &datetime = NOW,
                                                    const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
+class_instance<C$DateTime> f$DateTime$$add(const class_instance<C$DateTime> &self, const class_instance<C$DateInterval> &interval) noexcept;
+
 class_instance<C$DateTime> f$DateTime$$createFromFormat(const string &format, const string &datetime,
                                                         const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
@@ -47,6 +50,11 @@ class_instance<C$DateTime> f$DateTime$$setTime(const class_instance<C$DateTime> 
                                                int64_t microsecond = 0) noexcept;
 
 class_instance<C$DateTime> f$DateTime$$setTimestamp(const class_instance<C$DateTime> &self, int64_t timestamp) noexcept;
+
+class_instance<C$DateTime> f$DateTime$$sub(const class_instance<C$DateTime> &self, const class_instance<C$DateInterval> &interval) noexcept;
+
+class_instance<C$DateInterval> f$DateTime$$diff(const class_instance<C$DateTime> &self, const class_instance<C$DateTimeInterface> &target_object,
+                                                bool absolute = false) noexcept;
 
 string f$DateTime$$format(const class_instance<C$DateTime> &self, const string &format) noexcept;
 

--- a/runtime/datetime/datetime_immutable.h
+++ b/runtime/datetime/datetime_immutable.h
@@ -10,6 +10,7 @@
 #include "runtime/kphp_core.h"
 #include "runtime/refcountable_php_classes.h"
 
+struct C$DateInterval;
 struct C$DateTime;
 
 struct C$DateTimeImmutable : public refcountable_polymorphic_php_classes<C$DateTimeInterface>, private DummyVisitorMethods {
@@ -30,6 +31,9 @@ extern const string NOW;
 class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$__construct(const class_instance<C$DateTimeImmutable> &self, const string &datetime = NOW,
                                                                      const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
+class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$add(const class_instance<C$DateTimeImmutable> &self,
+                                                             const class_instance<C$DateInterval> &interval) noexcept;
+
 class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$createFromFormat(const string &format, const string &datetime,
                                                                           const class_instance<C$DateTimeZone> &timezone = Optional<bool>{}) noexcept;
 
@@ -49,6 +53,12 @@ class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$setTime(const class_ins
                                                                  int64_t second = 0, int64_t microsecond = 0) noexcept;
 
 class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$setTimestamp(const class_instance<C$DateTimeImmutable> &self, int64_t timestamp) noexcept;
+
+class_instance<C$DateTimeImmutable> f$DateTimeImmutable$$sub(const class_instance<C$DateTimeImmutable> &self,
+                                                             const class_instance<C$DateInterval> &interval) noexcept;
+
+class_instance<C$DateInterval> f$DateTimeImmutable$$diff(const class_instance<C$DateTimeImmutable> &self,
+                                                         const class_instance<C$DateTimeInterface> &target_object, bool absolute = false) noexcept;
 
 string f$DateTimeImmutable$$format(const class_instance<C$DateTimeImmutable> &self, const string &format) noexcept;
 

--- a/runtime/datetime/timelib_wrapper.cpp
+++ b/runtime/datetime/timelib_wrapper.cpp
@@ -760,3 +760,165 @@ int64_t php_timelib_date_offset_get(timelib_time *t) {
   }
   return 0;
 }
+
+std::pair<timelib_rel_time *, string> php_timelib_date_interval_initialize(const string &format) {
+  auto script_guard = make_malloc_replacement_with_script_allocator();
+
+  timelib_time *b = nullptr;
+  timelib_time *e = nullptr;
+  timelib_rel_time *p = nullptr;
+  int r = 0;
+  timelib_error_container *errors = nullptr;
+  timelib_strtointerval(format.c_str(), format.size(), &b, &e, &p, &r, &errors);
+  vk::final_action error_deleter{[errors]() { timelib_error_container_dtor(errors); }};
+  vk::final_action e_deleter{[e]() { free(e); }};
+  vk::final_action b_deleter{[b]() { free(b); }};
+
+  if (errors->error_count > 0) {
+    if (p) {
+      timelib_rel_time_dtor(p);
+    }
+    return {nullptr, string{"Unknown or bad format ("}.append(format).append(1, ')')};
+  }
+
+  if (p) {
+    return {p, {}};
+  }
+
+  if (b && e) {
+    timelib_update_ts(b, nullptr);
+    timelib_update_ts(e, nullptr);
+    return {timelib_diff(b, e), {}};
+  }
+
+  return {nullptr, string{"Failed to parse interval ("}.append(format).append(1, ')')};
+}
+
+void php_timelib_date_interval_remove(timelib_rel_time *t) {
+  if (t) {
+    auto script_guard = make_malloc_replacement_with_script_allocator();
+    timelib_rel_time_dtor(t);
+  }
+}
+
+std::pair<timelib_rel_time *, string> php_timelib_date_interval_create_from_date_string(const string &time_str) {
+  auto script_guard = make_malloc_replacement_with_script_allocator();
+
+  timelib_error_container *err = nullptr;
+  timelib_time *time = timelib_strtotime_leak_safe(time_str, &err);
+  vk::final_action time_deleter{[time] { timelib_time_dtor(time); }};
+  vk::final_action error_deleter{[err]() { timelib_error_container_dtor(err); }};
+
+  if (err->error_count > 0) {
+    string error_msg{"Unknown or bad format ("};
+    error_msg.append(time_str).append(1, ')').append(" at position ").append(err->error_messages[0].position);
+    error_msg.append(" (").append(1, err->error_messages[0].character ? err->error_messages[0].character : ' ').append("): ");
+    error_msg.append(err->error_messages[0].message);
+    return {nullptr, std::move(error_msg)};
+  }
+  return {timelib_rel_time_clone(&time->relative), {}};
+}
+
+string php_timelib_date_interval_format(const string &format, timelib_rel_time *t) {
+  // no need to use make_malloc_replacement_with_script_allocator() here since this function doesn't allocate heap memory
+  if (format.empty()) {
+    return {};
+  }
+
+  string_buffer &SB = static_SB_spare;
+  SB.clean();
+
+  // php implementation has 33 bytes buffer capacity, we have 128 bytes as well as php_timelib_date_format()
+  StaticBuf buffer{};
+  int length = 0;
+  bool have_format_spec = false;
+
+  for (std::size_t i = 0; i < format.size(); ++i) {
+    if (have_format_spec) {
+      switch (format[i]) {
+        case 'Y':
+          length = safe_snprintf(buffer, "%02d", static_cast<int>(t->y));
+          break;
+        case 'y':
+          length = safe_snprintf(buffer, "%d", static_cast<int>(t->y));
+          break;
+
+        case 'M':
+          length = safe_snprintf(buffer, "%02d", static_cast<int>(t->m));
+          break;
+        case 'm':
+          length = safe_snprintf(buffer, "%d", static_cast<int>(t->m));
+          break;
+
+        case 'D':
+          length = safe_snprintf(buffer, "%02d", static_cast<int>(t->d));
+          break;
+        case 'd':
+          length = safe_snprintf(buffer, "%d", static_cast<int>(t->d));
+          break;
+
+        case 'H':
+          length = safe_snprintf(buffer, "%02d", static_cast<int>(t->h));
+          break;
+        case 'h':
+          length = safe_snprintf(buffer, "%d", static_cast<int>(t->h));
+          break;
+
+        case 'I':
+          length = safe_snprintf(buffer, "%02d", static_cast<int>(t->i));
+          break;
+        case 'i':
+          length = safe_snprintf(buffer, "%d", static_cast<int>(t->i));
+          break;
+
+        case 'S':
+          length = safe_snprintf(buffer, "%02ld", static_cast<int64_t>(t->s));
+          break;
+        case 's':
+          length = safe_snprintf(buffer, "%ld", static_cast<int64_t>(t->s));
+          break;
+
+        case 'F':
+          length = safe_snprintf(buffer, "%06ld", static_cast<int64_t>(t->us));
+          break;
+        case 'f':
+          length = safe_snprintf(buffer, "%ld", static_cast<int64_t>(t->us));
+          break;
+
+        case 'a': {
+          if (static_cast<int>(t->days) != TIMELIB_UNSET) {
+            length = safe_snprintf(buffer, "%d", static_cast<int>(t->days));
+          } else {
+            length = safe_snprintf(buffer, "(unknown)");
+          }
+        } break;
+        case 'r':
+          length = safe_snprintf(buffer, "%s", t->invert ? "-" : "");
+          break;
+        case 'R':
+          length = safe_snprintf(buffer, "%c", t->invert ? '-' : '+');
+          break;
+
+        case '%':
+          length = safe_snprintf(buffer, "%%");
+          break;
+        default:
+          buffer[0] = '%';
+          buffer[1] = format[i];
+          buffer[2] = '\0';
+          length = 2;
+          break;
+      }
+      SB.append(buffer.data(), length);
+      have_format_spec = false;
+    } else {
+      if (format[i] == '%') {
+        have_format_spec = true;
+      } else {
+        SB << format[i];
+      }
+    }
+  }
+
+  return SB.str();
+}

--- a/runtime/datetime/timelib_wrapper.cpp
+++ b/runtime/datetime/timelib_wrapper.cpp
@@ -761,6 +761,39 @@ int64_t php_timelib_date_offset_get(timelib_time *t) {
   return 0;
 }
 
+timelib_time *php_timelib_date_add(timelib_time *t, timelib_rel_time *interval) {
+  auto script_guard = make_malloc_replacement_with_script_allocator();
+
+  timelib_time *new_time = timelib_add(t, interval);
+  timelib_time_dtor(t);
+  return new_time;
+}
+
+std::pair<timelib_time *, std::string_view> php_timelib_date_sub(timelib_time *t, timelib_rel_time *interval) {
+  auto script_guard = make_malloc_replacement_with_script_allocator();
+
+  if (interval->have_special_relative) {
+    return {nullptr, "Only non-special relative time specifications are supported for subtraction"};
+  }
+
+  timelib_time *new_time = timelib_sub(t, interval);
+  timelib_time_dtor(t);
+  return {new_time, {}};
+}
+
+timelib_rel_time *php_timelib_date_diff(timelib_time *time1, timelib_time *time2, bool absolute) {
+  auto script_guard = make_malloc_replacement_with_script_allocator();
+
+  timelib_update_ts(time1, nullptr);
+  timelib_update_ts(time2, nullptr);
+
+  timelib_rel_time *diff = timelib_diff(time1, time2);
+  if (absolute) {
+    diff->invert = 0;
+  }
+  return diff;
+}
+
 std::pair<timelib_rel_time *, string> php_timelib_date_interval_initialize(const string &format) {
   auto script_guard = make_malloc_replacement_with_script_allocator();
 

--- a/runtime/datetime/timelib_wrapper.h
+++ b/runtime/datetime/timelib_wrapper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "runtime/kphp_core.h"
 
 // php_timelib wraps the https://github.com/derickr/timelib library
@@ -52,6 +54,10 @@ void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d)
 void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d);
 void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t ms);
 int64_t php_timelib_date_offset_get(timelib_time *t);
+
+timelib_time *php_timelib_date_add(timelib_time *t, timelib_rel_time *interval);
+std::pair<timelib_time *, std::string_view> php_timelib_date_sub(timelib_time *t, timelib_rel_time *interval);
+timelib_rel_time *php_timelib_date_diff(timelib_time *time1, timelib_time *time2, bool absolute);
 
 std::pair<timelib_rel_time *, string> php_timelib_date_interval_initialize(const string &format);
 std::pair<timelib_rel_time *, string> php_timelib_date_interval_create_from_date_string(const string &time_str);

--- a/runtime/datetime/timelib_wrapper.h
+++ b/runtime/datetime/timelib_wrapper.h
@@ -31,6 +31,9 @@ void free_timelib();
 struct _timelib_time;
 using timelib_time = _timelib_time;
 
+struct _timelib_rel_time;
+using timelib_rel_time = _timelib_rel_time;
+
 std::pair<timelib_time *, string> php_timelib_date_initialize(const string &tz_name, const string &time_str, const char *format = nullptr);
 timelib_time *php_timelib_time_clone(timelib_time *t);
 void php_timelib_date_remove(timelib_time *t);
@@ -49,3 +52,8 @@ void php_timelib_date_date_set(timelib_time *t, int64_t y, int64_t m, int64_t d)
 void php_timelib_date_isodate_set(timelib_time *t, int64_t y, int64_t w, int64_t d);
 void php_date_time_set(timelib_time *t, int64_t h, int64_t i, int64_t s, int64_t ms);
 int64_t php_timelib_date_offset_get(timelib_time *t);
+
+std::pair<timelib_rel_time *, string> php_timelib_date_interval_initialize(const string &format);
+std::pair<timelib_rel_time *, string> php_timelib_date_interval_create_from_date_string(const string &time_str);
+void php_timelib_date_interval_remove(timelib_rel_time *t);
+string php_timelib_date_interval_format(const string &format, timelib_rel_time *t);

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -1,4 +1,5 @@
 prepend(KPHP_RUNTIME_DATETIME_SOURCES datetime/
+        date_interval.cpp
         datetime.cpp
         datetime_functions.cpp
         datetime_immutable.cpp

--- a/tests/phpt/datetime/12_create_interval.php
+++ b/tests/phpt/datetime/12_create_interval.php
@@ -1,0 +1,39 @@
+@ok
+<?php
+
+function test_constructor_date_interval() {
+  $durations = ['P1D', 'P2W', 'P3M', 'P4Y', 'P1Y1D', 'P1DT12H', 'PT3600S', 'P0001-12-04T10:05:55'];
+
+  foreach ($durations as $duration) {
+    $i = new DateInterval($duration);
+    echo $i->format('%y-%m-%d %h:%i:%s'), "\n";
+  }
+}
+
+function test_constructor_date_interval_range() {
+  $durations = ['2003-02-15T00:00:00Z/P2M', '2007-03-01T13:00:00Z/2008-05-11T15:30:00Z',
+    '2007-03-01T13:00:00Z/P1Y2M10DT2H30M', 'P1Y2M10DT2H30M/2008-05-11T15:30:00Z', 'R5/2008-03-02T13:00:00Z/P1Y2M10DT2H30M'];
+
+  foreach ($durations as $duration) {
+    $i = new DateInterval($duration);
+    echo $i->format('%y-%m-%d %h:%i:%s'), "\n";
+  }
+}
+
+function test_constructor_date_interval_invalid_duration() {
+  $intervals = ['', 'wat', '7', '7D', 'P4', 'P1L', 'P0001-12-0410:05:55', 'P0001-12-04T10:05'];
+
+  foreach ($intervals as $interval) {
+    try {
+      $i = new DateInterval($interval);
+      var_dump($i->format('%y-%m-%d'));
+    } catch (Exception $e) {
+     var_dump($e->getMessage());
+     var_dump(DateTime::getLastErrors());
+    }
+  }
+}
+
+test_constructor_date_interval();
+test_constructor_date_interval_range();
+test_constructor_date_interval_invalid_duration();

--- a/tests/phpt/datetime/13_create_interval_from_date_string.php
+++ b/tests/phpt/datetime/13_create_interval_from_date_string.php
@@ -1,0 +1,31 @@
+@ok
+<?php
+
+function test_create_interval_from_date_string() {
+  $datetimes = ['1 day', '2 weeks', '3 months', '4 years', '1 year + 1 day', '1 day + 12 hours', '3600 seconds'];
+
+  foreach ($datetimes as $datetime) {
+    $i = DateInterval::createFromDateString($datetime);
+    echo $i->format('%y-%m-%d %h:%i:%s'), "\n";
+  }
+}
+
+function test_parse_combinations() {
+  $i = DateInterval::createFromDateString('62 weeks + 1 day + 2 weeks + 2 hours + 70 minutes');
+  echo $i->format('%d %h %i'), "\n";
+
+  $i = DateInterval::createFromDateString('1 year - 10 days');
+  echo $i->format('%y %d'), "\n";
+}
+
+function test_special_relative_intervals() {
+  $i = DateInterval::createFromDateString('last day of next month');
+  echo $i->format('%d %h %i'), "\n";
+
+  $i = DateInterval::createFromDateString('last weekday');
+  echo $i->format('%d %h %i'), "\n";
+}
+
+test_create_interval_from_date_string();
+test_parse_combinations();
+test_special_relative_intervals();

--- a/tests/phpt/datetime/14_create_interval_wrong_date.php
+++ b/tests/phpt/datetime/14_create_interval_wrong_date.php
@@ -1,0 +1,13 @@
+@kphp_runtime_should_warn
+/DateInterval::createFromDateString\(\): Unknown or bad format \(\) at position 0 \( \): Empty string/
+/DateInterval::createFromDateString\(\): Unknown or bad format \(last what\) at position 0 \(l\): The timezone could not be found in the database/
+<?php
+
+function test_create_interval_wrong_date(string $datetime) {
+  $interval = DateInterval::createFromDateString($datetime);
+  var_dump((bool)$interval);
+  var_dump(DateTime::getLastErrors());
+}
+
+test_create_interval_wrong_date('');
+test_create_interval_wrong_date('last what');

--- a/tests/phpt/datetime/15_interval_format.php
+++ b/tests/phpt/datetime/15_interval_format.php
@@ -1,0 +1,12 @@
+@ok
+<?php
+
+function test_date_interval_format(string $duration) {
+  $interval = new DateInterval($duration);
+  echo $interval->format('%y-%m-%d %h:%i:%s'), "\n";
+  echo $interval->format(''), "\n";
+  echo $interval->format('%'), "\n";
+}
+
+test_date_interval_format('P2Y4DT6H8M');
+test_date_interval_format('P32D');

--- a/tests/phpt/datetime/16_add_sub_date_interval.php
+++ b/tests/phpt/datetime/16_add_sub_date_interval.php
@@ -1,0 +1,43 @@
+@ok
+<?php
+
+function test_add_date_interval(DateTimeInterface $date, DateInterval $interval) {
+  $newDate = $date->add($interval);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+  echo $newDate->format('Y-m-d H:i:s') . "\n";
+}
+
+function test_sub_date_interval(DateTimeInterface $date, DateInterval $interval) {
+  $newDate = $date->sub($interval);
+  echo $date->format('Y-m-d H:i:s') . "\n";
+  echo $newDate->format('Y-m-d H:i:s') . "\n";
+}
+
+function test_subs_months() {
+  $date = new DateTimeImmutable('2001-04-30');
+  $interval = new DateInterval('P1M');
+
+  $newDate1 = $date->sub($interval);
+  echo $newDate1->format('Y-m-d') . "\n";
+
+  $newDate2 = $newDate1->sub($interval);
+  echo $newDate2->format('Y-m-d') . "\n";
+}
+
+test_add_date_interval(new DateTime('2000-01-01'), new DateInterval('P10D'));
+test_add_date_interval(new DateTime('2000-01-01'), new DateInterval('PT10H30S'));
+test_add_date_interval(new DateTime('2000-01-01'), new DateInterval('P7Y5M4DT4H3M2S'));
+
+test_add_date_interval(new DateTimeImmutable('2000-01-01'), new DateInterval('P10D'));
+test_add_date_interval(new DateTimeImmutable('2000-01-01'), new DateInterval('PT10H30S'));
+test_add_date_interval(new DateTimeImmutable('2000-01-01'), new DateInterval('P7Y5M4DT4H3M2S'));
+
+test_sub_date_interval(new DateTime('2000-01-20'), new DateInterval('P10D'));
+test_sub_date_interval(new DateTime('2000-01-20'), new DateInterval('PT10H30S'));
+test_sub_date_interval(new DateTime('2000-01-20'), new DateInterval('P7Y5M4DT4H3M2S'));
+
+test_sub_date_interval(new DateTimeImmutable('2000-01-20'), new DateInterval('P10D'));
+test_sub_date_interval(new DateTimeImmutable('2000-01-20'), new DateInterval('PT10H30S'));
+test_sub_date_interval(new DateTimeImmutable('2000-01-20'), new DateInterval('P7Y5M4DT4H3M2S'));
+
+test_subs_months();

--- a/tests/phpt/datetime/17_sub_relative_interval_warning.php
+++ b/tests/phpt/datetime/17_sub_relative_interval_warning.php
@@ -1,0 +1,15 @@
+@kphp_runtime_should_warn
+/DateTime::sub\(\): Only non-special relative time specifications are supported for subtraction/
+/DateTimeImmutable::sub\(\): Only non-special relative time specifications are supported for subtraction/
+<?php
+
+function test_sub_relative_interval_warning(DateTimeInterface $date) {
+  $relative_interval = DateInterval::createFromDateString('third Tuesday of next month');
+  $new_date = $date->sub($relative_interval);
+
+  echo $date->format(DateTimeInterface::ISO8601), "\n";
+  echo $new_date->format(DateTimeInterface::ISO8601), "\n";
+}
+
+test_sub_relative_interval_warning(new DateTime('2010-03-07 13:21:38 UTC'));
+test_sub_relative_interval_warning(new DateTimeImmutable('2010-03-07 13:21:38 UTC'));

--- a/tests/phpt/datetime/18_diff_date_interval.php
+++ b/tests/phpt/datetime/18_diff_date_interval.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+
+function test_diff_date_interval(DateTimeInterface $origin, DateTimeInterface $target, bool $absolute = false) {
+  $interval = $origin->diff($target, $absolute);
+  echo $interval->format('%H:%I:%S (Full days: %R%a)'), "\n";
+  echo $origin->format(DateTimeInterface::ISO8601), "\n";
+  echo $target->format(DateTimeInterface::ISO8601), "\n";
+}
+
+test_diff_date_interval(new DateTime('2009-10-11'), new DateTime('2009-10-13'));
+test_diff_date_interval(new DateTime('2009-10-11'), new DateTime('2009-10-13'), true);
+test_diff_date_interval(new DateTime('2021-10-30 09:00:00 Europe/London'), new DateTime('2021-10-31 08:30:00 Europe/London'));
+test_diff_date_interval(new DateTimeImmutable('2009-10-11'), new DateTimeImmutable('2009-10-13'));
+test_diff_date_interval(new DateTimeImmutable('2009-10-11'), new DateTimeImmutable('2009-10-13'), true);
+test_diff_date_interval(new DateTimeImmutable('2021-10-30 09:00:00 Europe/London'), new DateTimeImmutable('2021-10-31 08:30:00 Europe/London'));
+
+test_diff_date_interval(new DateTime('2009-10-13'), new DateTime('2009-10-11'));
+test_diff_date_interval(new DateTime('2009-10-13'), new DateTime('2009-10-11'), true);
+test_diff_date_interval(new DateTimeImmutable('2009-10-13'), new DateTimeImmutable('2009-10-11'));
+test_diff_date_interval(new DateTimeImmutable('2009-10-13'), new DateTimeImmutable('2009-10-11'), true);


### PR DESCRIPTION
This PR is the last in `DateTime` - related family of patches. Previous was: [1](https://github.com/VKCOM/kphp/pull/598) and [2](https://github.com/VKCOM/kphp/pull/648). It adds `DateInterval` class and related functionality in `DateTime` and `DateTimeImmutable`, namely `add/sub/diff` methods. 