### PR TITLE
add floating numbers in bcmod()

### DIFF
--- a/tests/phpt/dl/483_bcmath.php
+++ b/tests/phpt/dl/483_bcmath.php
@@ -198,6 +198,29 @@ function test_bcsqrt_scale($num) {
   bcscale(0);
 }
 
+function test_bcmod($nums) {
+  $count_outer = 0;
+
+  foreach ($nums as $divident) {
+    $divident = $count_outer++ % 2 ? -$divident : $divident;
+
+    $count_inner = 0;
+
+    foreach ($nums as $divisor) {
+      if ($divisor == 0) {
+        continue;
+      }
+
+      $divisor = $count_inner++ % 3 ? -$divisor : $divisor;
+      echo bcmod($divident, $divisor), "\n";
+
+      for ($i = 0; $i < 30; ++$i) {
+        echo bcmod($divident, $divisor, $i), "\n";
+      }
+    }
+  }
+}
+
 function gen_numbers($seed) {
   $res = [];
   foreach ([0.001, 0.01, 0.5, 3, 7, 10, 100, 1000, 10000, 100000, 1.0E+12] as $factor) {
@@ -230,3 +253,8 @@ test_bcsqrt(gen_numbers(M_LOG2E));
 test_bcsqrt(gen_numbers(M_SQRT2));
 test_bcsqrt(gen_numbers(M_LNPI));
 test_bcsqrt_scale(417.134576345);
+
+test_bcmod($low_nums);
+test_bcmod($mid_nums);
+test_bcmod($big_nums);
+test_bcmod($math_constants);

--- a/tests/phpt/dl/483_bcmod_warnings.php
+++ b/tests/phpt/dl/483_bcmod_warnings.php
@@ -1,0 +1,35 @@
+@kphp_runtime_should_warn
+/First parameter "9\.0E\-5" in function bcmod is not a number/
+/First parameter "1\.0E\+14" in function bcmod is not a number/
+/First parameter "abcd" in function bcmod is not a number/
+/Second parameter "9\.0E\-5" in function bcmod is not a number/
+/Second parameter "1\.0E\+14" in function bcmod is not a number/
+/Second parameter "abcd" in function bcmod is not a number/
+/Second parameter "" in function bcmod is not a number/
+/bcmod\(\): Division by zero/
+/bcmod\(\): Division by zero/
+/bcmod\(\): Division by zero/
+/bcmod\(\): Division by zero/
+/bcmod\(\): Division by zero/
+<?php
+
+function test_bcmod_bad_numbers() {
+  echo bcmod(9e-5, 2), "\n";
+  echo bcmod(1e+14, 2), "\n";
+  echo bcmod("abcd", 2), "\n";
+  echo bcmod(2, 9e-5), "\n";
+  echo bcmod(2, 1e+14), "\n";
+  echo bcmod(2, "abcd"), "\n";
+  echo bcmod(2, ""), "\n";
+}
+
+function test_bcmod_division_by_zero() {
+  echo bcmod(2, 0), "\n";
+  echo bcmod(2, 0.0), "\n";
+  echo bcmod(2, -0.0), "\n";
+  echo bcmod(2, +0.0), "\n";
+  echo bcmod(2, +00.00000), "\n";
+}
+
+test_bcmod_bad_numbers();
+test_bcmod_division_by_zero();


### PR DESCRIPTION
Add support of floating point arguments in `bcmod(string $num1, string $num2)`. Previously only integers were supported.