### PR TITLE
add floating numbers in bcpow()

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -751,8 +751,8 @@ define('PHP_ROUND_HALF_ODD', 123423146);
 
 function bcscale ($scale ::: int) ::: void;
 function bcdiv ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;
-function bcmod ($lhs ::: string, $rhs ::: string, int $scale = PHP_INT_MIN) ::: string;
-function bcpow ($lhs ::: string, $rhs ::: string, int $scale = PHP_INT_MIN) ::: string;
+function bcmod ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;
+function bcpow ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;
 function bcadd ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;
 function bcsub ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;
 function bcmul ($lhs ::: string, $rhs ::: string, $scale ::: int = PHP_INT_MIN) ::: string;

--- a/tests/phpt/dl/483_bcmath.php
+++ b/tests/phpt/dl/483_bcmath.php
@@ -221,6 +221,24 @@ function test_bcmod($nums) {
   }
 }
 
+function test_bcpow($nums, $powers) {
+  foreach ($nums as $base) {
+    foreach ($powers as $power) {
+      echo bcpow($base, $power), "\n";
+      echo bcpow(-$base, $power), "\n";
+      echo bcpow($base, -$power), "\n";
+      echo bcpow(-$base, -$power), "\n";
+
+      for ($i = 0; $i < 20; ++$i) {
+        echo bcpow($base, $power, $i), "\n";
+        echo bcpow(-$base, $power, $i), "\n";
+        echo bcpow($base, -$power, $i), "\n";
+        echo bcpow(-$base, -$power, $i), "\n";
+      }
+    }
+  }
+}
+
 function gen_numbers($seed) {
   $res = [];
   foreach ([0.001, 0.01, 0.5, 3, 7, 10, 100, 1000, 10000, 100000, 1.0E+12] as $factor) {
@@ -258,3 +276,7 @@ test_bcmod($low_nums);
 test_bcmod($mid_nums);
 test_bcmod($big_nums);
 test_bcmod($math_constants);
+
+$powers = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 99, 100];
+test_bcpow($low_nums, $powers);
+test_bcpow($mid_nums, $powers);

--- a/tests/phpt/dl/483_bcpow_warnings.php
+++ b/tests/phpt/dl/483_bcpow_warnings.php
@@ -1,0 +1,39 @@
+@kphp_runtime_should_warn
+/First parameter "9\.0E\-5" in function bcpow is not a number/
+/First parameter "1\.0E\+14" in function bcpow is not a number/
+/First parameter "abcd" in function bcpow is not a number/
+/Second parameter "9\.0E\-5" in function bcpow is not a number/
+/Second parameter "1\.0E\+14" in function bcpow is not a number/
+/Second parameter "abcd" in function bcpow is not a number/
+/Second parameter "1000000000000000000" in function bcpow is larger than 1e18/
+/Second parameter "-1000000000000000000" in function bcpow is larger than 1e18/
+/bcpow\(\): non-zero scale "2\.23" in exponent/
+/bcpow\(\): non-zero scale "\-4\.0562" in exponent/
+/bcpow\(\): non-zero scale "\-0\.2" in exponent/
+/bcpow\(\): non-zero scale "0\.34" in exponent/
+<?php
+
+function test_bcpow_bad_args() {
+  echo bcpow(9e-5, 2), "\n";
+  echo bcpow(1e+14, 2), "\n";
+  echo bcpow("abcd", 2), "\n";
+  echo bcpow(2, 9e-5), "\n";
+  echo bcpow(2, 1e+14), "\n";
+  echo bcpow(2, "abcd"), "\n";
+}
+
+function test_bcpow_larger_than_1e18() {
+  echo bcpow(2, 1000000000000000000), "\n";
+  echo bcpow(2, -1000000000000000000), "\n";
+}
+
+function test_bcpow_fractional_exp() {
+  echo bcpow(2, 2.23), "\n";
+  echo bcpow(2, -4.0562), "\n";
+  echo bcpow(2, -0.2), "\n";
+  echo bcpow(2, 0.34), "\n";
+}
+
+test_bcpow_bad_args();
+test_bcpow_larger_than_1e18();
+test_bcpow_fractional_exp();

--- a/tests/phpt/dl/668_bcpow.php
+++ b/tests/phpt/dl/668_bcpow.php
@@ -1,4 +1,4 @@
-@ok K.O.T.
+@ok
 <?php
 
 echo bcpow (16, 7)."\n";
@@ -25,3 +25,44 @@ echo bcpow('-2', '3', 2), "\n";
 echo bcpow('-2', '3', 3), "\n";
 echo bcpow('-2', '3', 4), "\n";
 echo bcpow('-2', '3', 200), "\n";
+
+echo bcpow('abcd', '2'), "\n";
+echo bcpow('abcd', '2', 2), "\n";
+echo bcpow('2', 'abcd'), "\n";
+echo bcpow('2', 'abcd', 2), "\n";
+
+echo bcpow('2', '1.23'), "\n";
+echo bcpow('2', '-1.23'), "\n";
+echo bcpow('2', '0.952'), "\n";
+echo bcpow('2', '-0.952'), "\n";
+echo bcpow('2', '12.23'), "\n";
+echo bcpow('2', '-12.23'), "\n";
+echo bcpow('2', '934.023'), "\n";
+echo bcpow('2', '-934.023'), "\n";
+
+echo bcpow('2', '0'), "\n";
+echo bcpow('2', '0', 4), "\n";
+echo bcpow('2', '+0'), "\n";
+echo bcpow('2', '+0', 9), "\n";
+echo bcpow('2', '-0'), "\n";
+echo bcpow('2', '-0', 2), "\n";
+echo bcpow('2', '+0.0'), "\n";
+echo bcpow('2', '-0.0'), "\n";
+echo bcpow('2', '-0.0', 5), "\n";
+
+echo bcpow('0', '2'), "\n";
+echo bcpow('0', '2', 4), "\n";
+echo bcpow('+0', '2'), "\n";
+echo bcpow('+0', '2', 9), "\n";
+echo bcpow('-0', '2'), "\n";
+echo bcpow('-0', '2', 2), "\n";
+echo bcpow('+0.0', '2'), "\n";
+echo bcpow('-0.0', '2'), "\n";
+echo bcpow('-0.0', '2', 5), "\n";
+
+echo bcpow('', 2), "\n";
+echo bcpow('', 2, 5), "\n";
+echo bcpow(2, ''), "\n";
+echo bcpow(2, '', 5), "\n";
+echo bcpow('', ''), "\n";
+echo bcpow('', '', 5), "\n";


### PR DESCRIPTION
Add support of floating point arguments in `bcpow(string $base, string $exp)`, $exp argument are allowed to be negative.  Previously only integers and positive exponent were supported.