### PR TITLE
Fix unexpected memory piece error

### DIFF
--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -247,7 +247,6 @@ public:
 
   void replace_malloc(bool is_malloc_replaced_before) noexcept {
     php_assert(is_malloc_replaced_before == is_malloc_replaced_);
-    CriticalSectionGuard critical_section;
 
     if (!is_malloc_replaced_before) {
       last_malloc_replacement_backtrace_size_ = fast_backtrace(last_malloc_replacement_backtrace_.data(), last_malloc_replacement_backtrace_.size());

--- a/runtime/allocator.h
+++ b/runtime/allocator.h
@@ -50,6 +50,7 @@ void script_allocator_free(void *p) noexcept;
 bool is_malloc_replaced() noexcept;
 void replace_malloc_with_script_allocator() noexcept;
 void rollback_malloc_replacement() noexcept;
+void report_wrong_malloc_replacement_error() noexcept;
 
 class MemoryReplacementGuard {
   bool force_enable_disable_;

--- a/runtime/kphp-backtrace.cpp
+++ b/runtime/kphp-backtrace.cpp
@@ -14,7 +14,7 @@
 
 std::forward_list<char **> KphpBacktrace::last_used_symbols_;
 
-KphpBacktrace::KphpBacktrace(void **raw_backtrace, int32_t size) noexcept {
+KphpBacktrace::KphpBacktrace(void *const *raw_backtrace, int32_t size) noexcept {
   dl::CriticalSectionGuard signal_critical_section;
   if ((symbols_begin_ = backtrace_symbols(raw_backtrace, size))) {
     symbols_end_ = symbols_begin_ + size;

--- a/runtime/kphp-backtrace.h
+++ b/runtime/kphp-backtrace.h
@@ -13,7 +13,7 @@
 
 class KphpBacktrace : vk::not_copyable {
 public:
-  KphpBacktrace(void **raw_backtrace, int32_t size) noexcept;
+  KphpBacktrace(void *const *raw_backtrace, int32_t size) noexcept;
 
   auto make_demangled_backtrace_range(bool full_trace = false) noexcept {
     return vk::make_transform_iterator_range(

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1039,6 +1039,11 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
         return 0;
       }
 
+      if (dl::is_malloc_replaced()) {
+        dl::rollback_malloc_replacement();
+        dl::report_wrong_malloc_replacement_error();
+      }
+
       tl_fetch_init_raw_message(raw);
 
       auto op_from_tl = tl_fetch_int();

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -201,6 +201,10 @@ void qmem_clear() {
 
   assert (state == st_inited);
 
+  if (dl::is_malloc_replaced()) {
+    dl::rollback_malloc_replacement();
+    dl::report_wrong_malloc_replacement_error();
+  }
   left.clear();
   used_mem = 0;
   for (int i = static_pages_n; i < pages_n; i++) {

--- a/server/server-log.cpp
+++ b/server/server-log.cpp
@@ -24,7 +24,7 @@ const char *level2str(ServerLog type) {
 }
 
 void write_log_server_impl(ServerLog type, const char *format, ...) noexcept {
-  std::array<char, 256> buffer{};
+  std::array<char, 2048> buffer{};
 
   va_list ap;
   va_start (ap, format);


### PR DESCRIPTION
Most likely, the key reason of the error - _malloc_ replacement isn't rolled back correctly sometimes.
In production it happens in 2 cases: at `qmem_clear` function on runtime environment freeing and at `rpcx_execute` on receiving   
RPC response. 
Now we force _malloc_ rollback in this 2 cases to fix the error itself and then report the critical error with the stacktrace of last _malloc_ replacement to be able to investigate it more precisely.

relates to `KPHP-1511`