### PR TITLE
eliminate deprecated malloc hooks

### DIFF
--- a/common/macos-ports.cpp
+++ b/common/macos-ports.cpp
@@ -6,11 +6,6 @@
 
 #if defined(__APPLE__)
 
-void *(*__malloc_hook)(size_t size, const void *caller) = nullptr;
-void *(*__realloc_hook)(void *ptr, size_t size, const void *caller) = nullptr;
-void *(*__memalign_hook)(size_t alignment, size_t size, const void *caller) = nullptr;
-void (*__free_hook)(void *ptr, const void *caller) = nullptr;
-
 struct nothing {};
 nothing __start_run_scheduler_section;
 nothing __stop_run_scheduler_section;

--- a/common/macos-ports.h
+++ b/common/macos-ports.h
@@ -39,11 +39,6 @@
 
 extern char **environ;
 
-extern void *(*__malloc_hook)(size_t size, const void *caller);
-extern void *(*__realloc_hook)(void *ptr, size_t size, const void *caller);
-extern void *(*__memalign_hook)(size_t alignment, size_t size, const void *caller);
-extern void (*__free_hook)(void *ptr, const void *caller);
-
 struct ucred {
   pid_t pid;
   uid_t uid;

--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -287,7 +287,7 @@ MemoryReplacementGuard::~MemoryReplacementGuard() {
 
 extern "C" void *__libc_malloc(size_t size);
 extern "C" void *__libc_calloc(size_t nmemb, size_t size);
-extern "C" void *__libc_realloc(void *mem, std::size_t new_size);
+extern "C" void *__libc_realloc(void *mem, size_t new_size);
 extern "C" void __libc_free(void *mem);
 extern "C" void *__libc_memalign(size_t alignment, size_t size);
 
@@ -299,7 +299,7 @@ void *calloc(size_t nmemb, size_t size) {
   return dl::is_malloc_replaced() ? dl::script_allocator_calloc(nmemb, size) : __libc_calloc(nmemb, size);
 }
 
-void *realloc(void *mem, std::size_t new_size) {
+void *realloc(void *mem, size_t new_size) {
   return dl::is_malloc_replaced() ? dl::script_allocator_realloc(mem, new_size) : __libc_realloc(mem, new_size);
 }
 

--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -235,63 +235,39 @@ void script_allocator_free(void *mem) noexcept {
 
 namespace {
 
-class MallocHooksSwitcher : vk::not_copyable {
+class MallocStateHolder : vk::not_copyable {
 public:
-  static MallocHooksSwitcher &get() noexcept {
-    static MallocHooksSwitcher switcher;
-    return switcher;
+  static MallocStateHolder &get() noexcept {
+    static MallocStateHolder state;
+    return state;
   }
 
-  void switch_hooks(bool malloc_hooks_are_replaced_before) noexcept {
-    php_assert(malloc_hooks_are_replaced_before == malloc_hooks_are_replaced_);
-    CriticalSectionGuard critical_section;
-    std::swap(malloc_hook_, __malloc_hook);
-    std::swap(realloc_hook_, __realloc_hook);
-    std::swap(memalign_hook_, __memalign_hook);
-    std::swap(free_hook_, __free_hook);
-    malloc_hooks_are_replaced_ = !malloc_hooks_are_replaced_;
+  void replace_malloc(bool is_malloc_replaced_before) noexcept {
+    php_assert(is_malloc_replaced_before == is_malloc_replaced_);
+    is_malloc_replaced_ = !is_malloc_replaced_;
   }
 
-  bool are_malloc_hooks_replaced() const noexcept {
-    return malloc_hooks_are_replaced_;
+  bool is_malloc_replaced() const noexcept {
+    return is_malloc_replaced_;
   }
 
 private:
-  MallocHooksSwitcher() :
-    malloc_hook_{[](size_t size, const void *) {
-      return script_allocator_malloc(size);
-    }},
-    realloc_hook_{[](void *ptr, size_t size, const void *) {
-      return script_allocator_realloc(ptr, size);
-    }},
-    memalign_hook_{[](size_t alignment, size_t size, const void *) {
-      // script allocator gives addresses aligned to 8 bytes
-      php_assert(alignment <= 8);
-      return script_allocator_malloc(size);
-    }},
-    free_hook_{[](void *ptr, const void *) {
-      return script_allocator_free(ptr);
-    }} {}
-
-  decltype(__malloc_hook) malloc_hook_{nullptr};
-  decltype(__realloc_hook) realloc_hook_{nullptr};
-  decltype(__memalign_hook) memalign_hook_{nullptr};
-  decltype(__free_hook) free_hook_{nullptr};
-  bool malloc_hooks_are_replaced_{false};
+  MallocStateHolder() = default;
+  bool is_malloc_replaced_{false};
 };
 
 } // namespace
 
 bool is_malloc_replaced() noexcept {
-  return MallocHooksSwitcher::get().are_malloc_hooks_replaced();
+  return MallocStateHolder::get().is_malloc_replaced();
 }
 
 void replace_malloc_with_script_allocator() noexcept {
-  MallocHooksSwitcher::get().switch_hooks(false);
+  MallocStateHolder::get().replace_malloc(false);
 }
 
 void rollback_malloc_replacement() noexcept {
-  MallocHooksSwitcher::get().switch_hooks(true);
+  MallocStateHolder::get().replace_malloc(true);
 }
 
 MemoryReplacementGuard::MemoryReplacementGuard(memory_resource::unsynchronized_pool_resource &memory_resource, bool force_enable_disable) : force_enable_disable_(force_enable_disable) {
@@ -305,6 +281,48 @@ MemoryReplacementGuard::~MemoryReplacementGuard() {
 }
 
 } // namespace dl
+
+// sanitizers aren't happy with custom realization of malloc-like functions
+#if !ASAN_ENABLED and !defined(__APPLE__)
+
+extern "C" void *__libc_malloc(size_t size);
+extern "C" void *__libc_calloc(size_t nmemb, size_t size);
+extern "C" void *__libc_realloc(void *mem, std::size_t new_size);
+extern "C" void __libc_free(void *mem);
+extern "C" void *__libc_memalign(size_t alignment, size_t size);
+
+void *malloc(size_t size) {
+  return dl::is_malloc_replaced() ? dl::script_allocator_malloc(size) : __libc_malloc(size);
+}
+
+void *calloc(size_t nmemb, size_t size) {
+  return dl::is_malloc_replaced() ? dl::script_allocator_calloc(nmemb, size) : __libc_calloc(nmemb, size);
+}
+
+void *realloc(void *mem, std::size_t new_size) {
+  return dl::is_malloc_replaced() ? dl::script_allocator_realloc(mem, new_size) : __libc_realloc(mem, new_size);
+}
+
+void free(void *mem) {
+  return dl::is_malloc_replaced() ? dl::script_allocator_free(mem) : __libc_free(mem);
+}
+
+void *aligned_alloc(size_t alignment, size_t size) {
+  if (dl::is_malloc_replaced()) {
+    // script allocator gives addresses aligned to 8 bytes
+    php_assert(alignment <= 8);
+    return dl::script_allocator_malloc(size);
+  }
+  return __libc_memalign(alignment, size);
+}
+
+void *memalign(size_t alignment, size_t size) {
+  return aligned_alloc(alignment, size);
+}
+
+// put realization posix_memalign function here if you want to use it under script allocator
+
+#endif
 
 // replace global operators new and delete for linked C++ code
 void *operator new(size_t size) {

--- a/tests/cpp/runtime/_runtime-tests-env.cpp
+++ b/tests/cpp/runtime/_runtime-tests-env.cpp
@@ -11,11 +11,6 @@
 #include "server/php-engine-vars.h"
 #include "server/workers-control.h"
 
-// Используется в некоторых тестах, что бы обмануть clang и не дать ему выкинуть вызов std::malloc из кода
-void *alloc_no_inline(int x) {
-  return std::malloc(x);
-}
-
 class RuntimeTestsEnvironment final : public testing::Environment {
 public:
   ~RuntimeTestsEnvironment() final {}

--- a/tests/cpp/runtime/allocator-malloc-replacement-test.cpp
+++ b/tests/cpp/runtime/allocator-malloc-replacement-test.cpp
@@ -1,3 +1,4 @@
+#include <functional>
 #include <gtest/gtest.h>
 
 #include "common/sanitizer.h"
@@ -30,19 +31,20 @@ TEST(allocator_malloc_replacement_test, test_replacement_raii) {
   ASSERT_FALSE(dl::is_malloc_replaced());
 }
 
-void *alloc_no_inline(int x);
+using MallocFn = std::function<void *(std::size_t)>;
 
-TEST(allocator_malloc_replacement_test, test_replace_and_alloc) {
+static void do_malloc_fn_test(const MallocFn &malloc_fn) {
   ASSERT_FALSE(dl::is_malloc_replaced());
 
   const auto memory_stats_before = dl::get_script_memory_stats();
   {
     auto guard = make_malloc_replacement_with_script_allocator();
     ASSERT_TRUE(dl::is_malloc_replaced());
-    void *mem = alloc_no_inline(128);
+    void *mem = malloc_fn(128);
     ASSERT_TRUE(mem);
 #if !ASAN_ENABLED and !defined(__APPLE__)
-    // asan replaces malloc and hooks doens't work, on macos hooks doesn't work at all
+    // asan doesn't work with our custom mallocs;
+    // also custom malloc realization is platform specific and doesn't work on macos
     ASSERT_EQ(memory_stats_before.memory_used + 128 + 8, dl::get_script_memory_stats().memory_used);
 #endif
     std::free(mem);
@@ -52,8 +54,42 @@ TEST(allocator_malloc_replacement_test, test_replace_and_alloc) {
   ASSERT_FALSE(dl::is_malloc_replaced());
   ASSERT_EQ(memory_stats_before.memory_used, dl::get_script_memory_stats().memory_used);
 
-  void *mem = std::malloc(128);
+  void *mem = malloc_fn(128);
   ASSERT_TRUE(mem);
   ASSERT_EQ(memory_stats_before.memory_used, dl::get_script_memory_stats().memory_used);
   std::free(mem);
 }
+
+TEST(allocator_malloc_replacement_test, test_malloc) {
+  auto malloc_fn = [](std::size_t size) { return std::malloc(size); };
+  do_malloc_fn_test(malloc_fn);
+}
+
+TEST(allocator_malloc_replacement_test, test_calloc) {
+  auto malloc_fn = [](std::size_t size) { return std::calloc(1, size); };
+  do_malloc_fn_test(malloc_fn);
+}
+
+TEST(allocator_malloc_replacement_test, test_realloc) {
+  auto malloc_fn = [](std::size_t size) {
+    auto *mem = std::malloc(size);
+    return std::realloc(mem, size);
+  };
+  do_malloc_fn_test(malloc_fn);
+}
+
+TEST(allocator_malloc_replacement_test, aligned_alloc) {
+  auto malloc_fn = [](std::size_t size) { return std::aligned_alloc(8, size); };
+  do_malloc_fn_test(malloc_fn);
+}
+
+// macos lacks memalign
+#if !defined(__APPLE__)
+#include <malloc.h>
+
+TEST(allocator_malloc_replacement_test, test_memalign) {
+  auto malloc_fn = [](std::size_t size) { return memalign(8, size); };
+  do_malloc_fn_test(malloc_fn);
+}
+
+#endif


### PR DESCRIPTION
Get rid of deprecated [malloc hooks](https://man7.org/linux/man-pages/man3/malloc_hook.3.html). These hooks is removed from further versions of glibc making compilation of kphp unsuccessful under e.g. ubuntu 22.