### PR TITLE
[runtime] fix sigsegv in init_runtime_environment

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1718,8 +1718,6 @@ static void init_superglobals(const http_query_data &http_data, const rpc_query_
   v$_SERVER.set_value(string("argc"), v$argc);
 
   v$d$PHP_SAPI = php_sapi_name();
-
-  php_assert (dl::in_critical_section == 0);
 }
 
 static http_query_data empty_http_data;
@@ -2281,8 +2279,6 @@ static void init_runtime_libs() {
   init_string_buffer_lib(static_cast<int>(static_buffer_length_limit));
 
   init_interface_lib();
-
-  php_assert (dl::in_critical_section == 0);
 }
 
 static void free_interface_lib() {
@@ -2353,7 +2349,6 @@ void global_init_script_allocator() {
 }
 
 void init_runtime_environment(php_query_data *data, void *mem, size_t mem_size) {
-  dl::init_critical_section();
   dl::init_script_allocator(mem, mem_size);
   reset_global_interface_vars();
   init_runtime_libs();

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -435,8 +435,8 @@ void PhpScript::run() noexcept {
   assert (run_main->run != nullptr);
 
   dl::enter_critical_section();
-  init_runtime_environment(data, run_mem, mem_size);
   is_running = true;
+  init_runtime_environment(data, run_mem, mem_size);
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
     on_request_timeout_error(); // this call will not return (it changes the context)
   }

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -435,7 +435,9 @@ void PhpScript::run() noexcept {
     }
   }
   assert (run_main->run != nullptr);
-
+  if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point for initialising
+    perform_error_if_running("timeout exit\n", script_error_t::timeout);
+  }
   init_runtime_environment(data, run_mem, mem_size);
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
     on_request_timeout_error(); // this call will not return (it changes the context)

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -411,6 +411,9 @@ void PhpScript::query_answered() noexcept {
 }
 
 void PhpScript::run() noexcept {
+  if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point for initialising
+    perform_error_if_running("early timeout exit from script initialization\n", script_error_t::timeout); // this call will not return (it changes the context)
+  }
   is_running = true;
   check_tl();
 
@@ -436,9 +439,6 @@ void PhpScript::run() noexcept {
   }
   assert (run_main->run != nullptr);
 
-  if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point for initialising
-    perform_error_if_running("timeout exit\n", script_error_t::timeout); // this call will not return (it changes the context)
-  }
   init_runtime_environment(data, run_mem, mem_size);
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
     on_request_timeout_error(); // this call will not return (it changes the context)

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -181,7 +181,6 @@ void PhpScript::init(script_t *script, php_query_data *data_to_set) noexcept {
   queries_cnt = 0;
   long_queries_cnt = 0;
 
-  dl::init_critical_section();
   query_stats_id++;
   memset(&query_stats, 0, sizeof(query_stats));
 

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -435,6 +435,7 @@ void PhpScript::run() noexcept {
     }
   }
   assert (run_main->run != nullptr);
+
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point for initialising
     perform_error_if_running("timeout exit\n", script_error_t::timeout);
   }

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -438,7 +438,7 @@ void PhpScript::run() noexcept {
   init_runtime_environment(data, run_mem, mem_size);
   is_running = true;
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
-    on_request_timeout_error();                // this call will not return (it changes the context)
+    on_request_timeout_error(); // this call will not return (it changes the context)
   }
   dl::leave_critical_section();
   php_assert (dl::in_critical_section == 0); // To ensure that no critical section is left at the end of the initialization

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -437,7 +437,7 @@ void PhpScript::run() noexcept {
   assert (run_main->run != nullptr);
 
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point for initialising
-    perform_error_if_running("timeout exit\n", script_error_t::timeout);
+    perform_error_if_running("timeout exit\n", script_error_t::timeout); // this call will not return (it changes the context)
   }
   init_runtime_environment(data, run_mem, mem_size);
   if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -146,6 +146,7 @@ void PhpWorker::state_init_script() noexcept {
   if (php_script == nullptr) {
     php_script = new PhpScript(max_memory, 8 << 20);
   }
+  dl::init_critical_section();
   php_script->init(script, data);
   php_script->set_timeout(timeout);
   state = phpq_run;


### PR DESCRIPTION
# Fix SIGSEGV in sigalarm handler inside script initialization

What's the problem
-------------------------

In the code below the environment is initialized and the timeout recovery point is set. But what if sigalarm handler will work inside function init_runtime_environment or higher in the code? Jumping on a non-existent mark leads to `SIGSEGV`

```c++
  init_runtime_environment(data, run_mem, mem_size);
  if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
    on_request_timeout_error(); // this call will not return (it changes the context)
  }
```

Solution
-----------

Let's wrap it in critical section. Thanks to this we will ignore the timeout as well as other signals and process them after the recovery point is set.

```c++
 dl::enter_critical_section();
  is_running = true;
  init_runtime_environment(data, run_mem, mem_size);
  if (sigsetjmp(timeout_handler, true) != 0) { // set up a timeout recovery point
    on_request_timeout_error(); // this call will not return (it changes the context)
  }
  dl::leave_critical_section();
```

Also let's move check_tl call after init_runtime_environment because we need the  `is_running = true` inside `init_runtime_environment`