### PR TITLE
[vkext] Fix RPC TL `Maybe<array>` storing

### DIFF
--- a/vkext/rpc-tests/main.php
+++ b/vkext/rpc-tests/main.php
@@ -22,6 +22,7 @@ use VK\TL\memcache\Functions\memcache_get;
 use VK\TL\memcache\Functions\memcache_set;
 use VK\TL\memcache\Types\memcache_strvalue;
 use VK\TL\rpcProxy\Functions\rpcProxy_diagonal;
+use VK\TL\test\Functions\test_storeMaybeArray;
 use VK\TL\text\Functions\text_getExtraMask;
 use VK\TL\text\Functions\text_getSecret;
 use VK\TL\text\Functions\text_onlineFriendsId;
@@ -391,6 +392,29 @@ function test_rpc_invoke_req_extra_headers($key, $value, $ignore_result, $use_ac
   assertEq($value, $res["result"]["value"]);
 }
 
+function test_store_maybe_array() {
+  echo "##### test_store_maybe_array #####\n";
+  $data = new \VK\TL\test\Types\test_storeMaybeArrayData(
+    ["qwerty1 vector"],
+    ["qwerty1 tuple"],
+    ["hello" => "qwerty1 Dict"],
+    [123 => "qwerty1 IntDict"],
+    [123 => "qwerty1 LongDict"]);
+
+  $req = new test_storeMaybeArray($data);
+  $response = rpc_query_sync($req, MEMCACHE_PORT);
+  if ($response->isError()) {
+    var_dump(rpc_get_last_send_error());
+    assertFalse();
+  }
+  $ans = test_storeMaybeArray::result($response);
+  assertEq($data->vector, $ans->vector);
+  assertEq($data->tuple, $ans->tuple);
+  assertEq($data->dictionary, $ans->dictionary);
+  assertEq($data->int_key_dictionary, $ans->int_key_dictionary);
+  assertEq($data->long_key_dictionary, $ans->long_key_dictionary);
+}
+
 function main()
 {
   echo "@@@@@@ TESTS STARTED for PHP " . phpversion() . " @@@@@@\n";
@@ -429,6 +453,8 @@ function main()
   test_rpc_invoke_req_extra_headers("test1", "hello", false, true);
   test_rpc_invoke_req_extra_headers("test2", "hello", true, false);
   test_rpc_invoke_req_extra_headers("test3", "hello", true, true);
+
+  test_store_maybe_array();
 
   global $FailedAsserts;
   echo "@@@@@@ TESTS ENDED @@@@@@\n";

--- a/vkext/rpc-tests/memcache-rpc-tl-test.patch
+++ b/vkext/rpc-tests/memcache-rpc-tl-test.patch
@@ -1,5 +1,5 @@
 diff --git a/common/tl/schemas/memcache.tl b/common/tl/schemas/memcache.tl
-index 69ee471dd2..4d8e2882ae 100644
+index 69ee471dd2..7e92d3b373 100644
 --- a/common/tl/schemas/memcache.tl
 +++ b/common/tl/schemas/memcache.tl
 @@ -100,10 +100,10 @@ memcache.tokenHashMd5 hash:string = memcache.Token;
@@ -15,7 +15,7 @@ index 69ee471dd2..4d8e2882ae 100644
  @read memcache.getWildcardWithFlags prefix:string = Dictionary memcache.Value;
  
  // -1 for no expire, time before key is expired, false for no key
-@@ -127,3 +127,85 @@ memcache.tokenHashMd5 hash:string = memcache.Token;
+@@ -127,3 +127,103 @@ memcache.tokenHashMd5 hash:string = memcache.Token;
  @read @internal memcache.multiExists keys:%(Vector string) = Vector Bool;
  
  @readwrite memcache.compareAndDelete key:string expected_token:memcache.Token = memcache.CompareAndDeleteResult;
@@ -101,20 +101,39 @@ index 69ee471dd2..4d8e2882ae 100644
 +graph.retMaybeInt x: int = Maybe int;
 +@readwrite
 +graph.retMaybeVectorInt x: int len: int = Maybe (%Vector int);
++
++
++---types---
++
++test.storeMaybeArrayData
++  vector: (Maybe %(Vector string))
++  tuple: (Maybe %(Tuple string 1))
++  dictionary: (Maybe %(Dictionary string))
++  int_key_dictionary: (Maybe %(IntKeyDictionary string))
++  long_key_dictionary: (Maybe %(LongKeyDictionary string))
++= test.StoreMaybeArrayData;
++
++---functions---
++
++@readwrite
++test.storeMaybeArray
++  data: %test.storeMaybeArrayData
++= test.StoreMaybeArrayData;
 diff --git a/memcached/memcached-rpc.cpp b/memcached/memcached-rpc.cpp
-index f5e599c4ee..4003574eab 100644
+index f5e599c4ee..d787df4f08 100644
 --- a/memcached/memcached-rpc.cpp
 +++ b/memcached/memcached-rpc.cpp
-@@ -2,6 +2,8 @@
+@@ -2,6 +2,9 @@
  
  #include "auto/TL/constants/common.h"
  #include "auto/TL/constants/memcache.h"
 +#include "auto/TL/cpp-serializers/graph/all_functions.h"
 +#include "auto/TL/cpp-serializers/common/all_functions.h"
++#include "auto/TL/cpp-serializers/test/all_functions.h"
  #include "common/buffer-set.h"
  #include "common/precise-time.h"
  #include "common/rpc-error-codes.h"
-@@ -826,6 +828,85 @@ TL_DO_FUN_END
+@@ -826,6 +829,88 @@ TL_DO_FUN_END
  TL_PARSE_FUN(memcached_dump_all_lru_keys_to_log)
  TL_PARSE_FUN_END
  
@@ -196,15 +215,18 @@ index f5e599c4ee..4003574eab 100644
 +  e->tl_store_result(e->x);
 +TL_AUTOGEN_DO_FUN_END
 +
++TL_AUTOGEN_DO_FUN(test, storeMaybeArray)
++  e->tl_store_result(e->data);
++TL_AUTOGEN_DO_FUN_END
 +
  struct tl_act_extra *memcached_parse_function() {
    unsigned int op = tl_fetch_int();
    if (tl_fetch_error()) {
 diff --git a/memcached/memcached.mk b/memcached/memcached.mk
-index 35227ac23d..e35d5693d3 100644
+index 35227ac23d..8c53f64134 100644
 --- a/memcached/memcached.mk
 +++ b/memcached/memcached.mk
-@@ -4,8 +4,12 @@ $(foreach file, ${MEMCACHE_PARTS}, \
+@@ -4,8 +4,13 @@ $(foreach file, ${MEMCACHE_PARTS}, \
    $(eval $(call ObjWithFlagsCPP, ${OBJ}/memcached/memcached-with-times-$(file).o, memcached/memcached-$(file).cpp, -DWITH_MODIFICATION_TIME)) \
  )
  
@@ -213,6 +235,7 @@ index 35227ac23d..e35d5693d3 100644
 +MEMCACHE_AUTOGEN_TL_DEPS += ${TL_AUTOGEN_GRAPH_CXX}
 +MEMCACHE_AUTOGEN_TL_DEPS += ${TL_AUTOGEN_COMMON_CXX}
 +MEMCACHE_AUTOGEN_TL_DEPS += ${TL_AUTOGEN_SEARCH_CXX}
++MEMCACHE_AUTOGEN_TL_DEPS += ${TL_AUTOGEN_TEST_CXX}
 +
 +${EXE}/memcached-with-times: ${MEMCACHE_PARTS:%=${OBJ}/memcached/memcached-with-times-%.o} ${TL_ENGINE_OBJS} ${MEMCACHE_AUTOGEN_TL_DEPS}
 +${EXE}/memcached: ${MEMCACHE_PARTS:%=${OBJ}/memcached/memcached-%.o} ${TL_ENGINE_OBJS} ${MEMCACHE_AUTOGEN_TL_DEPS}

--- a/vkext/vkext-schema-memcache.cpp
+++ b/vkext/vkext-schema-memcache.cpp
@@ -1784,7 +1784,7 @@ void *tlcomb_store_type(void **IP, void **Data, zval **arr, struct tl_tree **var
 
   int n = -1;
   if (t->constructors_num > 1) {
-    if (t->name == TYPE_NAME_MAYBE && Z_TYPE_P(*arr) != IS_ARRAY) {
+    if (t->name == TYPE_NAME_MAYBE && typed_mode) {
       // hack for getting name of maybe constructor in typed mode
       const char *ctor_name;
       if (Z_TYPE_P(*arr) == IS_NULL) {

--- a/vkext/vkext.cpp
+++ b/vkext/vkext.cpp
@@ -1017,7 +1017,9 @@ PHP_FUNCTION (typed_rpc_tl_query) {
   ADD_CNT(total);
   START_TIMER(total);
   vkext_reset_error();
+  typed_mode = 1;
   vk_memcache_query(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  typed_mode = 0;
   tl_current_function_name = NULL;
   END_TIMER(total);
 }
@@ -1026,7 +1028,9 @@ PHP_FUNCTION (typed_rpc_tl_query_one) {
   ADD_CNT(total);
   START_TIMER(total);
   vkext_reset_error();
+  typed_mode = 1;
   vk_memcache_query1(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  typed_mode = 0;
   tl_current_function_name = NULL;
   END_TIMER(total);
 }


### PR DESCRIPTION
**The problem**
In typed serialization mode TL type `Maybe %(Vector string)` corresponds PHP type `string[]|null`.
But if you tried to store `["asdf", "asdf"]`, you would get the following error:
```
Unknown constructor asdf for type Maybe
```
So it mistakenly was expected to be like in untyped mode, i.e.: `["_" => "resultTrue", "result" => ["asdf", "asdf"]]`.

It happened because typed mode was determined by the condition like `type of serialized object is not array` in case of Maybe storing. But this condition is not hold in case of `Maybe<Vector>` or `Maybe<Tuple>`.

**Solution**
Let's use special `typed_mode` flag to distinguish typed and untyped storing mode. We will set it at every typed storing entrypoint and reset after that. 