### PR TITLE
detect incorrect encoding names for mb_functions

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1394,6 +1394,8 @@ function zstd_uncompress_dict(string $data, string $dict) ::: string | false;
 
 function set_migration_php8_warning ($mask ::: int) ::: void;
 
+function set_detect_incorrect_encoding_names_warning(bool $show) ::: void;
+
 function set_json_log_on_timeout_mode(bool $enabled) ::: void;
 
 // re-initialize given ArrayIterator with another array;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2327,6 +2327,7 @@ static void free_runtime_libs() {
   free_kphp_backtrace();
 
   free_migration_php8();
+  free_detect_incorrect_encoding_names();
 
   vk::singleton<JsonLogger>::get().reset_buffers();
 #ifdef PDO_DRIVER_MYSQL

--- a/runtime/mbstring.cpp
+++ b/runtime/mbstring.cpp
@@ -7,7 +7,31 @@
 #include "common/unicode/unicode-utils.h"
 #include "common/unicode/utf8-utils.h"
 
+bool is_detect_incorrect_encoding_names_warning = false;
+
+void f$set_detect_incorrect_encoding_names_warning(bool show) {
+  is_detect_incorrect_encoding_names_warning = show;
+}
+
+static void detect_incorrect_encoding_names(const string &encoding) {
+  const auto encoding_name = f$strtolower(encoding).c_str();
+
+  if (!strcmp(encoding_name, "cp1251") || !strcmp(encoding_name, "cp-1251") || !strcmp(encoding_name, "windows-1251")) {
+    return;
+  }
+
+  if (!strcmp(encoding_name, "utf8") || !strcmp(encoding_name, "utf-8")) {
+    return;
+  }
+
+  php_warning("Found unsupported \"%s\" encoding", encoding_name);
+}
+
 static int mb_detect_encoding(const string &encoding) {
+  if (is_detect_incorrect_encoding_names_warning) {
+    detect_incorrect_encoding_names(encoding);
+  }
+
   if (strstr(encoding.c_str(), "1251")) {
     return 1251;
   }

--- a/runtime/mbstring.h
+++ b/runtime/mbstring.h
@@ -26,3 +26,5 @@ Optional<int64_t> f$mb_stripos(const string &haystack, const string &needle, int
 string f$mb_substr(const string &str, int64_t start, const mixed &length = std::numeric_limits<int64_t>::max(), const string &encoding = CP1251);
 
 void f$set_detect_incorrect_encoding_names_warning(bool show);
+
+void free_detect_incorrect_encoding_names();

--- a/runtime/mbstring.h
+++ b/runtime/mbstring.h
@@ -24,3 +24,5 @@ Optional<int64_t> f$mb_strpos(const string &haystack, const string &needle, int6
 Optional<int64_t> f$mb_stripos(const string &haystack, const string &needle, int64_t offset = 0, const string &encoding = CP1251) noexcept;
 
 string f$mb_substr(const string &str, int64_t start, const mixed &length = std::numeric_limits<int64_t>::max(), const string &encoding = CP1251);
+
+void f$set_detect_incorrect_encoding_names_warning(bool show);


### PR DESCRIPTION
#### Table of behavioral differences in PHP / KPHP

| Name         | PHP | KPHP | Comment                                                                          |
|:-------------|:---:|:----:|:---------------------------------------------------------------------------------|
| cp1251       |  ✅  |  ✅   | It's okay, it accepts it as **windows-1251**                                     |
| utf-8        |  ✅  |  ✅   | It's okay, it accepts it as **UTF-8**                                            |
| utf8         |  ✅  |  ❌   | In KPHP error `encoding "utf8" doesn't supported"`, PHP accepts as **UTF-8**     |
| windows1251  |  ❌  |  ✅   | In PHP error `Invalid encoding "windows1251"`, KPHP accepts as **windows-1251**  |
| lol-1251-kek |  ❌  |  ✅   | In PHP error `Invalid encoding "lol-1251-kek"`, KPHP accepts as **windows-1251** |
| lol-8-kek    |  ❌  |  ✅   | In PHP error `Invalid encoding "lol-8-kek"`, KPHP accepts as **UTF-8**           |

#### Alias list in PHP

1. [windows-1251](https://github.com/php/php-src/blob/cebb8009c6bebd8af6c5cbdc803d632ae1252eeb/ext/mbstring/libmbfl/filters/mbfilter_singlebyte.c#L465)
2. [UTF-8](https://github.com/php/php-src/blob/cebb8009c6bebd8af6c5cbdc803d632ae1252eeb/ext/mbstring/libmbfl/filters/mbfilter_utf8.c#L55)

The changes will take place in several stages:
1. Search for incorrect encoding names (**we are here now**)
2. Replacement of encoding evaluation check