### PR TITLE
[compiler] optimize `op_append` with concat rhs

### DIFF
--- a/compiler/code-gen/naming.h
+++ b/compiler/code-gen/naming.h
@@ -201,9 +201,22 @@ struct FunctionClassName {
 
 struct VarName {
   VarPtr var;
+  vk::string_view name;
+
+  VarName() = default;
   explicit VarName(VarPtr var) : var(var) {}
+  explicit VarName(vk::string_view name) : name{name} {}
+
+  bool empty() const {
+    return !var && name.empty();
+  }
 
   void compile(CodeGenerator &W) const {
+    if (!name.empty()) {
+      W << name;
+      return;
+    }
+
     if (var->is_function_static_var()) {
       W << FunctionName(var->holder_func) << "$";
     }

--- a/tests/benchmarks/BenchmarkConcat.php
+++ b/tests/benchmarks/BenchmarkConcat.php
@@ -5,6 +5,17 @@ class BenchmarkConcat {
   private $s_short2 = 'world!';
   private $s_long = '';
   private $s_empty = '';
+  /** @var mixed[] */
+  private $short_str_parts = [
+    'string 1',
+    'another short string',
+    'https://github.com/VKCOM/kphp',
+    'Big Brother is Watching You',
+    'The choice for mankind lies between freedom and happiness and for the great bulk of mankind, happiness is better',
+    'Who controls the past controls the future',
+    'Who controls the present controls the past',
+    'Reality exists in the human mind, and nowhere else',
+  ];
 
   public function __construct() {
     $this->s_long = str_repeat('some text ', 100);
@@ -40,5 +51,73 @@ class BenchmarkConcat {
 
   public function benchmarkLongLong() {
     return $this->s_long . $this->s_long;
+  }
+
+  public function benchmarkAppend2() {
+    $s = 'abc';
+    $s .= $this->short_str_parts[0] . $this->short_str_parts[1];
+    return $s;
+  }
+
+  public function benchmarkAppend4() {
+    $s = 'abc';
+    $s .= $this->short_str_parts[0] . $this->short_str_parts[1] . $this->short_str_parts[2] . $this->short_str_parts[3];
+    return $s;
+  }
+
+  public function benchmarkAppend8() {
+    $s = 'abc';
+    $s .= $this->short_str_parts[0] .
+          $this->short_str_parts[1] .
+          $this->short_str_parts[2] .
+          $this->short_str_parts[3] .
+          $this->short_str_parts[4] .
+          $this->short_str_parts[5] .
+          $this->short_str_parts[6] .
+          $this->short_str_parts[7];
+    return $s;
+  }
+
+  public function benchmarkAppend4empty() {
+    $s = '';
+    $s .= $this->short_str_parts[0] . $this->short_str_parts[1] . $this->short_str_parts[2] . $this->short_str_parts[3];
+    return $s;
+  }
+
+  public function benchmarkAppend4accum() {
+    $s = 'abc';
+    for ($i = 0; $i < 4; $i++) {
+      $s .= $this->short_str_parts[0] . $this->short_str_parts[1] . $this->short_str_parts[2] . $this->short_str_parts[3];
+    }
+    return $s;
+  }
+
+  public function benchmarkAppend4complex() {
+    $a = ['abc'];
+    $a[0] .= $this->short_str_parts[0] . $this->short_str_parts[1] . $this->short_str_parts[2] . $this->short_str_parts[3];
+    return $a[0];
+  }
+
+  public function benchmarkAppend4optional() {
+    /** @var ?string $s */
+    $s = null;
+    $s .= $this->short_str_parts[0] . $this->short_str_parts[1] . $this->short_str_parts[2] . $this->short_str_parts[3];
+    return $s;
+  }
+
+  public function benchmarkAppend4InterpolatedString() {
+    $part = $this->short_str_parts[0];
+    $s = '';
+    $s .= "$part/$part/$part/$part";
+    $s .= "$part/$part/$part/$part";
+    return $s;
+  }
+
+  public function benchmarkAppend4InterpolatedInt() {
+    $part = 2432;
+    $s = '';
+    $s .= "$part/$part/$part/$part";
+    $s .= "$part/$part/$part/$part";
+    return $s;
   }
 }

--- a/tests/phpt/optimizations/010_str_concat.php
+++ b/tests/phpt/optimizations/010_str_concat.php
@@ -64,9 +64,189 @@ function modify9(&$s, $empty) {
   var_dump($s, $s2);
 }
 
+/**
+ * @param mixed $p1
+ * @param ?mixed $p4
+ */
+function appendref($ref, $p1, string $p2, ?string $p3, $p4) {
+  $ref .= $p1 . $p2 . $p3;
+  var_dump($ref);
+  $ref .= $p1 . $p2 . $p3 . $p4;
+  var_dump($ref);
+}
+
+/**
+ * @param mixed $p1
+ * @param ?mixed $p4
+ */
+function append_test($p1, string $p2, ?string $p3, $p4) {
+  $s = 'a';
+  $s .= $p1 . $p2 . $p3 . $p4;
+  var_dump($s);
+  $s .= $p1 . $p4;
+  var_dump($s);
+
+  /** @var ?string $optional_s */
+  $optional_s = 'a';
+  $optional_s .= $p1;
+  var_dump($optional_s);
+  $optional_s .= $p1 . $p2;
+  var_dump($optional_s);
+  $optional_s .= $p1 . $p2 . $p3 . $p4;
+  var_dump($optional_s);
+
+  /** @var string|false $orfalse_s */
+  $orfalse_s = false;
+  $orfalse_s .= $p1 . $p2 . $p3;
+  var_dump($orfalse_s);
+  $orfalse_s .= $p1 . $p2 . $p3 . $p4;
+  var_dump($orfalse_s);
+
+  /** @var string|null $ornull_s */
+  $ornull_s = null;
+  $ornull_s .= $p1 . $p2 . $p3;
+  var_dump($ornull_s);
+  $ornull_s .= $p1 . $p2 . $p3 . $p4;
+  var_dump($ornull_s);
+
+  $i = 535;
+  $i .= $p1 . $p2 . $p3;
+  var_dump($i);
+
+  /** @var mixed $s2 */
+  $s2 = 42;
+  if (true) {
+    $s2 = 'a';
+  }
+  $s2 .= $p1 . $p2 . $p3;
+  var_dump($s2);
+
+  if (true) {
+    $s3 = get_mixed();
+  }
+  if ($s3) {
+    $s3 .= "a" . $p2 . "b";
+    var_dump($s3);
+  }
+
+  $s4 = '';
+  if (true) {
+    $s4 = get_mixed();
+  }
+  if ($s4) {
+    $s4 .= $p1 . $p2 . $p4;
+    var_dump($s4);
+  }
+
+  if ($p1) {
+    $s5 .= "a" . $p1 . "b";
+    var_dump($s5);
+  }
+
+  $s6 = 'a';
+  $s6 .= $s6 . $s6;
+  var_dump($s6);
+  $s6 .= $s6 . $s6 . $s6 . $s6;
+  var_dump($s6);
+}
+
+function append_test2(string $x, string $y) {
+  $s = 545;
+  var_dump($s);
+  $s = $x . $y;
+  $s .= $x . $y;
+  var_dump($s);
+}
+
+/** @return mixed */
+function get_mixed() { return 'a'; }
+
+function append4arr($parts) {
+  $s = '';
+  $s .= $parts[0] . $parts[1] . $parts[2] . $parts[3];
+  var_dump($s);
+}
+
+function append4complex($parts) {
+  /** @var string[] $lhs */
+  $lhs = ['a'];
+  $lhs[0] .= $parts[0] . $parts[1] . $parts[2] . $parts[3];
+  var_dump($lhs);
+
+  $v = $parts[0];
+  /** @var string[] $arr */
+  $arr = [];
+  $arr['k'] = '';
+  $arr['k'] .= "<$v>";
+  var_dump($arr['k']);
+  $arr['k'] .= "<$v/$v>";
+  var_dump($arr['k']);
+  $arr['k'] .= "<$v/$v>" . $parts[0] . $parts[1];
+  var_dump($arr['k']);
+
+  $wrapper = new StringWrapper();
+  $wrapper->str = (string)$parts[0];
+  /** @var string[] $arr2 */
+  $arr2 = [];
+  $arr2['k'] = '';
+  $arr2['k'] .= "<$wrapper>";
+  var_dump($arr2);
+
+  $i = 32;
+  /** @var string[] $arr3 */
+  $arr3 = [];
+  $arr3['k'] .= "<$i>";
+  $arr3['k'] .= "<$i>" . ">$i<";
+  var_dump($arr3);
+}
+
+function append4complex2($parts) {
+  $lhs = new StringWrapper();
+  $lhs->str = 'fd';
+  $lhs->str .= $parts[0] . $parts[1] . $parts[2] . $parts[3];
+  var_dump($lhs->str);
+
+  $lhs2 = new StringWrapper2('example');
+  $lhs2->wrapper->str .= 'extra';
+  var_dump($lhs2->wrapper->str);
+  $lhs2->wrapper->str .= $parts[0] . $parts[1] . $parts[2];
+  var_dump($lhs2->wrapper->str);
+}
+
+function append_static($parts) {
+  static $static_s = '';
+  $static_s .= $parts[0] . $parts[1];
+  var_dump($static_s);
+  $static_s .= $parts[0] . $parts[1] . $parts[2] . $static_s;
+  var_dump($static_s);
+  return $static_s;
+}
+
+class StringWrapper {
+  public string $str = '';
+  public function __toString(): string {
+    return $this->str;
+  }
+}
+
+class StringWrapper2 {
+  public StringWrapper $wrapper;
+  public function __construct(string $s) {
+    $this->wrapper = new StringWrapper();
+    $this->wrapper->str = $s;
+  }
+}
+
 $empty = '';
 $conststr = 'hello global';
 $nonconst = modify1($empty);
+
+$str_parts = [
+  $conststr,
+  'hello world',
+  $empty,
+  $nonconst,
+];
 
 for ($i = 0; $i < 2; $i++) {
   modify1($empty);
@@ -83,4 +263,21 @@ for ($i = 0; $i < 2; $i++) {
 
   modify9($nonconst, $empty);
   modify9($nonconst, $empty);
+
+  append_test($nonconst, $empty, $empty, $str_parts[3]);
+  append_test($nonconst, (string)$nonconst, (string)$nonconst, (string)$nonconst);
+  append_test($str_parts[0], (string)$str_parts[1], (string)$str_parts[2], $str_parts[3]);
+  append_test2($empty, (string)$str_parts[0]);
+  append_test2((string)$str_parts[0], (string)$str_parts[1]);
+  append_test2((string)$str_parts[2], (string)$str_parts[3]);
+  append4arr($str_parts);
+  append4complex($str_parts);
+  append4complex2($str_parts);
+  var_dump(append_static($str_parts));
+
+  $s_ref = 'a';
+  appendref($s_ref, $str_parts[0], (string)$str_parts[1], (string)$str_parts[2], $str_parts[3]);
+  var_dump($s_ref);
+  appendref($s_ref, $str_parts[0], (string)$str_parts[1], (string)$str_parts[2], $str_parts[3]);
+  var_dump($s_ref);
 }


### PR DESCRIPTION
Instead of creating a tmp string for string_build on the rhs of append, append directly to the string:

```
$s .= $p1 . $p2 ...; // creates a tmp string for $p1 . $p2 ...
=>
$s->reserve(strlen($s) + strlen($p1) + strlen($p2) ...);
$s .= $p1;
$s .= $p2;
```

These patterns will be optimized:

	$s .= $p1 . $p2
	$s .= $p1 . $p2 . $p3
	...

Due to the fact that we compile `"<$x>"` as string build of `"<"`, `$x` and `">"`, these patterns will be optimized too:

	$s .= "<$x>";
	$s .= /* any string interpolation expr */
	...
	See Interpolated benchmark results

Since we rewrite some sprintf into a string build, these calls might benefit from this optimization too if it's append op with sprintf on the rhs.

Benchmark results:

    name                               old time/op    new time/op    delta
    Concat::Append2                       137ns ± 1%      98ns ± 1%  -28.09%  (p=0.000 n=14+15)
    Concat::Append4                       192ns ± 0%     162ns ± 3%  -15.38%  (p=0.000 n=11+15)
    Concat::Append8                       334ns ± 0%     276ns ± 0%  -17.46%  (p=0.000 n=15+14)
    Concat::Append4empty                  192ns ± 1%     141ns ± 1%  -26.38%  (p=0.000 n=13+15)
    Concat::Append4accum                  711ns ± 2%     552ns ± 1%  -22.39%  (p=0.000 n=15+14)
    Concat::Append4complex                247ns ± 1%     207ns ± 0%  -16.44%  (p=0.000 n=15+13)
    Concat::Append4optional               193ns ± 1%     161ns ± 0%  -16.64%  (p=0.000 n=14+15)
    Concat::Append4InterpolatedString     296ns ± 2%     186ns ± 0%  -37.08%  (p=0.000 n=15+9)
    Concat::Append4InterpolatedInt        249ns ± 1%     184ns ± 2%  -25.91%  (p=0.000 n=15+14)
    [Geo mean]                            253ns          194ns       -23.18%

    name                               old alloc/op   new alloc/op   delta
    Concat::Append2                       96.0B ± 0%     48.0B ± 0%  -50.00%  (p=0.000 n=15+15)
    Concat::Append4                        208B ± 0%      104B ± 0%  -50.00%  (p=0.000 n=15+15)
    Concat::Append8                        696B ± 0%      352B ± 0%  -49.43%  (p=0.000 n=15+15)
    Concat::Append4empty                   208B ± 0%      104B ± 0%  -50.00%  (p=0.000 n=15+15)
    Concat::Append4accum                 1.08kB ± 0%    0.66kB ± 0%  -38.52%  (p=0.000 n=15+15)
    Concat::Append4complex                 272B ± 0%      168B ± 0%  -38.24%  (p=0.000 n=15+15)
    Concat::Append4optional                208B ± 0%      104B ± 0%  -50.00%  (p=0.000 n=15+15)
    Concat::Append4InterpolatedString      232B ± 0%      136B ± 0%  -41.38%  (p=0.000 n=15+15)
    Concat::Append4InterpolatedInt         280B ± 0%      280B ± 0%        ~  (all equal)
    [Geo mean]                             283B           163B       -42.35%

    name                               old allocs/op  new allocs/op  delta
    Concat::Append2                        2.00 ± 0%      1.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append4                        2.00 ± 0%      1.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append8                        2.00 ± 0%      1.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append4empty                   2.00 ± 0%      1.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append4accum                   7.00 ± 0%      3.00 ± 0%  -57.14%  (p=0.000 n=15+15)
    Concat::Append4complex                 3.00 ± 0%      2.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append4optional                2.00 ± 0%      1.00 ± 0%        ~  (p=0.000 n=15+15)
    Concat::Append4InterpolatedString      4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=15+15)
    Concat::Append4InterpolatedInt         4.00 ± 0%      2.00 ± 0%  -50.00%  (p=0.000 n=15+15)
    [Geo mean]                             2.81           1.42       -49.25%