### PR TITLE
fix a race leading to 'invalid ()-invocation of a non-lambda'

### DIFF
--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -431,32 +431,6 @@ public:
   }
 };
 
-// this is a hack preventing race condition and should be removed somewhen
-// (though it does not prevent it fully, but it happens noticeable more rarely)
-// see comment in MR for detailed description
-template <class PassT>
-void run_CalcAssumptionPass_safe(FunctionPtr function, PassT *pass) {
-  stage::StageInfo stage_backup_raw = *stage::get_stage_info_ptr();
-  pass->setup(function);
-  pass->on_start();
-
-  std::function<void(VertexPtr)> recurse = [&recurse, pass](VertexPtr vertex) {
-    stage::set_location(vertex->get_location());
-
-    pass->on_enter_vertex(vertex);
-    if (!pass->user_recursion(vertex)) {
-      for (VertexPtr i : *vertex) {
-        recurse(i);
-      }
-    }
-    pass->on_exit_vertex(vertex);
-  };
-
-  recurse(function->root);
-  pass->on_finish();
-  *stage::get_stage_info_ptr() = stage_backup_raw;
-}
-
 /*
  * A high-level function which deduces the type of $a inside f.
  * The results are cached per var_name; init on f is called during the first invocation.
@@ -496,7 +470,7 @@ static Assumption calc_assumption_for_var(FunctionPtr f, const std::string &var_
   }
 
   CalcAssumptionForVarPass pass(var_name, stop_at);
-  run_CalcAssumptionPass_safe(f, &pass);
+  run_function_pass(f, &pass);
 
   return f->get_assumption_for_var(var_name);
 }
@@ -733,7 +707,7 @@ Assumption assume_return_of_function(FunctionPtr f) {
     if (f->assumption_pass_status.compare_exchange_strong(expected, FunctionData::AssumptionStatus::processing_returns_in_body)) {
       f->assumption_processing_thread = std::this_thread::get_id();
       CalcAssumptionForReturnPass ret_pass;
-      run_CalcAssumptionPass_safe(f, &ret_pass);
+      run_function_pass(f, &ret_pass);
       f->assumption_pass_status = FunctionData::AssumptionStatus::done_returns_in_body;
     } else if (expected == FunctionData::AssumptionStatus::processing_returns_in_body) {
       while (f->assumption_pass_status == FunctionData::AssumptionStatus::processing_returns_in_body && f->assumption_processing_thread != std::this_thread::get_id()) {

--- a/compiler/compiler.cpp
+++ b/compiler/compiler.cpp
@@ -257,7 +257,7 @@ bool compiler_execute(CompilerSettings *settings) {
     >> PipeC<InstantiateGenericsAndLambdasF>{} >> use_nth_output_tag<0>{}
     >> PipeC<EarlyOptimizationF>{}
     >> SyncC<GenerateVirtualMethodsF>{}
-    >> PassC<ConvertInvokeToFuncCallPass>{}
+    >> PipeC<ConvertInvokeToFuncCallF>{}
     >> PassC<CheckFuncCallsAndVarargPass>{}
     >> PassC<InstantiateFFIOperationsPass>{}
     >> PipeC<CheckAbstractFunctionDefaults>{}

--- a/compiler/pipes/convert-invoke-to-func-call.h
+++ b/compiler/pipes/convert-invoke-to-func-call.h
@@ -8,6 +8,8 @@
 #include "compiler/function-pass.h"
 
 class ConvertInvokeToFuncCallPass final : public FunctionPassBase {
+  std::forward_list<FunctionPtr> nested_lambdas;
+
 public:
   std::string get_description() override {
     return "Convert invoke to func call";
@@ -20,6 +22,20 @@ public:
   VertexPtr on_exit_vertex(VertexPtr root) final;
 
   VertexPtr on_clone(VertexAdaptor<op_clone> v_clone);
+  VertexPtr on_func_call(VertexAdaptor<op_func_call> v_call);
   VertexPtr on_invoke_call(VertexAdaptor<op_invoke_call> v_invoke_call);
   VertexPtr on_callback_of_builtin(VertexAdaptor<op_callback_of_builtin> v_callback);
+
+  std::forward_list<FunctionPtr> &&flush_nested_lambdas() {
+    return std::move(nested_lambdas);
+  }
+};
+
+// this class is used in the compiler pipeline
+// it's needed to hold lambdas so they don't pass the pipeline before a containing function, see execute()
+class ConvertInvokeToFuncCallF {
+public:
+  void execute(FunctionPtr f, DataStream<FunctionPtr> &os);
+
+  static void execute_with_nested_lambdas(FunctionPtr f, DataStream<FunctionPtr> &os);
 };


### PR DESCRIPTION
Currently at VK.com, very-very rarely there is a compilation error "invalid ()-invocation of a non-lambda". This PR fixes the problem. The reason you can find in #443.

The solution is not to parallelize lambdas and outer functions when performing replacing `()` to `__invoke()`. Now, a lambda passes this pass only after a parent function does, within the same thread. It prevents traversing a parent function in parallel when calculating assumptions for it.