### PR TITLE
Fix JsonEncoder vs JsonWriter bind

### DIFF
--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -2038,6 +2038,11 @@ T array<T>::pop() {
 }
 
 template<class T>
+T &array<T>::back() {
+  return (--end()).get_value();
+}
+
+template<class T>
 T array<T>::shift() {
   if (count() == 0) {
     php_warning("Cannot use array_shift on empty array");

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -401,6 +401,7 @@ public:
 
 
   T pop();
+  T &back();
 
   T shift();
 

--- a/runtime/json-writer.h
+++ b/runtime/json-writer.h
@@ -6,7 +6,6 @@
 
 #include "runtime/kphp_core.h"
 
-#include <array>
 #include <string_view>
 
 namespace impl_ {
@@ -51,10 +50,7 @@ private:
     std::uint32_t values_count{0};
   };
 
-  constexpr static std::size_t MAX_DEPTH{64};
-  std::array<NestedLevel, MAX_DEPTH> stack_;
-  std::int64_t stack_top_{-1};
-
+  array<NestedLevel> stack_;
   string error_;
   std::size_t double_precision_{0};
   const bool pretty_print_{false};

--- a/tests/cpp/runtime/json-writer-test.cpp
+++ b/tests/cpp/runtime/json-writer-test.cpp
@@ -308,10 +308,17 @@ TEST(json_writer_error, brace_disbalance) {
 
 TEST(json_writer_error, stack_overflow) {
   JsonWriter writer;
-  for (std::size_t i = 0; i < 64; ++i) {
+  for (std::size_t i = 0; i < 128; ++i) {
     ASSERT_TRUE(writer.start_array());
   }
-  ASSERT_FALSE(writer.start_array());
+
+  // there is no stack overflow error anymore
   ASSERT_FALSE(writer.is_complete());
-  ASSERT_STREQ(writer.get_error().c_str(), "stack overflow, max depth level is 64");
+  ASSERT_TRUE(writer.get_error().empty());
+
+  for (std::size_t i = 0; i < 128; ++i) {
+    ASSERT_TRUE(writer.end_array());
+  }
+  ASSERT_TRUE(writer.is_complete());
+  ASSERT_TRUE(writer.get_error().empty());
 }

--- a/tests/phpt/json/3_nested_objects.php
+++ b/tests/phpt/json/3_nested_objects.php
@@ -181,7 +181,51 @@ function test_circular_dep() {
   var_dump(JsonEncoder::encode(new BCirc));
 }
 
+class ACirc2 {
+  /** @var BCirc2 */
+  public $b;
+}
 
+class BCirc2 {
+  /** @var ACirc2[] */
+  public $a;
+}
+
+function test_circular_dep2() {
+  $a = new ACirc2;
+  $b = new BCirc2;
+  $a->b = $b;
+  $b->a[] = $a;
+
+  var_dump(JsonEncoder::encode($a));
+  var_dump(JsonEncoder::getLastError());
+
+  var_dump(JsonEncoder::encode($b));
+  var_dump(JsonEncoder::getLastError());
+}
+
+class ACirc3 {
+  /** @var BCirc3[] */
+  public $b;
+}
+
+class BCirc3 {
+  /** @var ACirc3[] */
+  public $a;
+}
+
+function test_circular_dep3() {
+  $a = new ACirc3;
+  $b = new BCirc3;
+  $a->b[] = $b;
+  $b->a[] = $a;
+
+  var_dump(JsonEncoder::encode($a));
+  var_dump(JsonEncoder::getLastError());
+
+  var_dump(JsonEncoder::encode($b));
+  var_dump(JsonEncoder::getLastError());
+}
 
 test_decode_nested_types();
 test_decode_inheritance();
@@ -193,3 +237,5 @@ test_circular_reference();
 test_interface();
 test_interface_regress();
 test_circular_dep();
+test_circular_dep2();
+test_circular_dep3();


### PR DESCRIPTION
There is a bug occurred with deep nesting objects. Namely, it occurred when JsonWriter's internal stack limit is reached faster than depth level of JsonEncoder.
It is fixed by using dynamic container as JsonWriter stack, meaning that there is no stack limit further.