### PR TITLE
fix a crash in OptimizationPass on indexing phpdoc leading to tp_Error

### DIFF
--- a/compiler/pipes/final-check.cpp
+++ b/compiler/pipes/final-check.cpp
@@ -901,6 +901,13 @@ void FinalCheckPass::on_function() {
     kphp_error(!return_type->or_false_flag(), fmt_format("Function returns void and false simultaneously"));
     kphp_error(!return_type->or_null_flag(), fmt_format("Function returns void and null simultaneously"));
   }
+  for (int i = 0; i < current_function->param_ids.size(); ++i) {
+    const TypeData *arg_type = tinf::get_type(current_function, i);
+    if (arg_type->get_real_ptype() == tp_any) {
+      stage::set_location(current_function->root->location);
+      raise_error_using_Unknown_type(current_function->get_params()[i].as<op_func_param>()->var());
+    }
+  }
 }
 
 void FinalCheckPass::raise_error_using_Unknown_type(VertexPtr v) {

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -76,7 +76,9 @@ void explicit_cast_array_type(VertexPtr &type_acceptor, const TypeData *required
       !is_implicit_array_conversion(existed_type, required_type)) {
     return;
   }
-  kphp_assert(vk::any_of_equal(required_type->get_real_ptype(), tp_array, tp_mixed));
+  if (!vk::any_of_equal(required_type->get_real_ptype(), tp_array, tp_mixed)) {
+    return;
+  }
   if (type_acceptor->extra_type == op_ex_var_const) {
     auto var_id = cast_const_array_type(type_acceptor, required_type);
     if (new_var_out) {

--- a/tests/phpt/phc/parsing/impure.php
+++ b/tests/phpt/phc/parsing/impure.php
@@ -1,9 +1,7 @@
 @ok
 <?php
+    /** @var int[] */
 	$x = array ();
-	/**
-	 * @kphp-required
-	 **/
 /**
  * @kphp-required
  * @param null $element1

--- a/tests/phpt/phpdocs/108_return_Unknown.php
+++ b/tests/phpt/phpdocs/108_return_Unknown.php
@@ -1,0 +1,36 @@
+@kphp_should_fail
+/Function wrongReturn1\(\) returns Unknown type/
+/Variable \$a has Unknown type/
+/\$a is any, can not get element/
+/Function wrongReturn2\(\) returns Unknown type/
+<?php
+
+class A {}
+
+/**
+ * @return A|int
+ */
+function wrongReturn1() {
+    $m = [];
+    for ($i = 0; $i < 1; ++$i)
+        $m[] = new A;
+    return $m;
+}
+
+/**
+ * @return A|null[]
+ */
+function wrongReturn2() {
+    $m = [];
+    for ($i = 0; $i < 1; ++$i)
+        $m[] = new A;
+    return $m;
+}
+
+$a = wrongReturn1();
+if ($a) {
+    echo $a[0];
+}
+
+$b = wrongReturn2();
+

--- a/tests/phpt/phpdocs/109_param_Unknown.php
+++ b/tests/phpt/phpdocs/109_param_Unknown.php
@@ -1,0 +1,12 @@
+@kphp_should_fail
+/function wrongParam1\(\$p\)/
+/Variable \$p has Unknown type/
+<?php
+
+class A {}
+
+/** @param A|int[] $p */
+function wrongParam1($p) {
+}
+
+wrongParam1([]);


### PR DESCRIPTION
Such a function previously crashed in `kphp_assert`:
```
/**
 * @return A|null[]
 */
function wrongReturn2() {
    $m = [];
    for ($i = 0; $i < 1; ++$i)
        $m[] = new A;
    return $m;
}
```
(notice an invalid `@return`)