### PR TITLE
better handle functions that always throw/exit

### DIFF
--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -621,8 +621,8 @@ void CollectMainEdgesPass::on_finish() {
   if (current_function->is_extern()) {
     return;
   }
-  if (!have_returns) {
-    // hack to work well with functions which always throws
+  if (!have_returns && !current_function->return_typehint) {
+    // work well with functions which always throws
     create_type_assign(as_lvalue(current_function, -1), TypeData::get_type(tp_void));
   }
   call_on_var(current_function->local_var_ids);

--- a/tests/phpt/dl/1040_nohint_always_throw.php
+++ b/tests/phpt/dl/1040_nohint_always_throw.php
@@ -1,0 +1,23 @@
+@kphp_should_fail
+/\$i = getInt\(2\);/
+/Using result of void function getInt/
+/echo \$i, "\\n ";/
+/Using result of void expression/
+<?php
+
+function getVoid() {
+    throw new Exception();
+}
+
+function getInt(int $i) {
+    switch ($i) {
+    case 1: throw new Exception();
+    case 2: exit();
+    default: die();
+    }
+    return 1;
+}
+
+getVoid();
+$i = getInt(2);
+echo $i, "\n";

--- a/tests/phpt/exceptions/inheritance/29_throw_from_lambda3.php
+++ b/tests/phpt/exceptions/inheritance/29_throw_from_lambda3.php
@@ -6,7 +6,7 @@ class MyException2 extends MyException1 {}
 class MyException3 extends \Exception {}
 
 function test() {
-  $throw = function(Exception $e) {
+  $throw = function(Exception $e): int {
     throw $e;
   };
 

--- a/tests/phpt/phpdocs/030_hint_but_always_throw.php
+++ b/tests/phpt/phpdocs/030_hint_but_always_throw.php
@@ -1,0 +1,59 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+
+class A {
+    function aMethod() {}
+}
+
+function getVoid1() {
+    throw new Exception();
+}
+function getVoid2(): void {
+    throw new Exception();
+}
+
+function getInt1(): int {
+    throw new Exception();
+}
+function getInt2(): ?int {
+    if (rand())
+        throw new Exception();
+    throw new Exception();
+}
+
+function getA1(): A {
+    if (1) throw new Exception();
+    else throw new Exception();
+    return new A;
+}
+function getA2(): A {
+    if (1) throw new Exception();
+    else throw new Exception();
+}
+
+/** @return A[] */
+function getArr() {
+    switch (1) {
+        case 1: exit();
+        case 2: die();
+        default: throw new Exception(1);
+    }
+}
+
+function takeInt(int $arg) {}
+
+try {
+    getVoid1();
+    getVoid2();
+    takeInt(getInt1());
+    takeInt(not_null(getInt2()));
+    getA1()->aMethod();
+    getA2()->aMethod();
+    foreach (getArr() as $a)
+        $a->aMethod();
+}
+catch (Exception $ex) {
+    echo "ex caught, test ok, as it was compiled";
+}


### PR DESCRIPTION
With this MR, such code becomes valid:
```php
function getInt(): int {
  throw new Exception("todo");
}

$i = getInt();  // int, though getInt() never returns
```

Same for exit/die and more complex situations when a function never returns (e.g. all cases of a switch throw)