### PR TITLE
support `new $class` and `$class::method()` for compile-time known strings

### DIFF
--- a/builtin-functions/kphp_internal.txt
+++ b/builtin-functions/kphp_internal.txt
@@ -6,6 +6,22 @@
 
 function _exception_set_location($e, string $filename, int $line): ^1;
 
+// access fields and methods by class name stored in variable, e.g. `new $class_name` and `$class_name::something`
+// in gentree, such constructions are represented as func calls `_by_name_*($class_name, ...)`
+// they can be used in generics if $class_name is class-string<T>, replaced by `_by_name_*('T', ...)` on instantiation
+// later, such calls are replaced to `new T` and `T::something`, or produce a compilation error if left as variable
+// note, that `_by_name(...) += 5` is valid, since it's replaced to `T::$field += 5` long before rl calc
+// see GenTree::get_member_by_name_after_var() and replace-extern-func-calls.cpp
+
+// `new $c(...)` => `_by_name_construct($c, ...)`
+function _by_name_construct(string $class_name, ...$args) ::: instance<^1>;
+// `$c::method()` => `_by_name_call_method($c, 'method')`
+function _by_name_call_method(string $class_name, string $method_name, ...$args);
+// `$c::CONST` => `_by_name_get_const($c, 'CONST')`
+function _by_name_get_const(string $class_name, string $constant);
+// `$c::$field` => `_by_name_get_field($c, 'field')`
+function _by_name_get_field(string $class_name, string $field);
+
 // microtime(false) specialization
 function _microtime_string(): string;
 // microtime(true) specialization

--- a/compiler/class-assumptions.cpp
+++ b/compiler/class-assumptions.cpp
@@ -181,8 +181,8 @@ ClassPtr Assumption::extract_instance_from_type_hint(const TypeHint *a) {
   }
   // 'T::fieldName' — a syntax that's used in @return for generics
   if (const auto *as_field_ref = a->try_as<TypeHintRefToField>()) {
-    if (const auto *field = as_field_ref->resolve_field()) {
-      return extract_instance_from_type_hint(field->type_hint);
+    if (const TypeHint *field_type_hint = as_field_ref->resolve_field_type_hint()) {
+      return extract_instance_from_type_hint(field_type_hint);
     }
   }
   // 'T::methodName()' — a syntax that's used in @return for generics

--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -96,6 +96,7 @@ prepend(KPHP_COMPILER_CODEGEN_SOURCES code-gen/
         writer-data.cpp)
 
 prepend(KPHP_COMPILER_REWRITE_RULES_SOURCES rewrite-rules/
+        replace-extern-func-calls.cpp
         rules_runtime.cpp)
 
 prepend(KPHP_COMPILER_PIPES_SOURCES pipes/

--- a/compiler/generics-reification.cpp
+++ b/compiler/generics-reification.cpp
@@ -469,6 +469,7 @@ public:
     new_call->str_val = call->str_val;
     new_call->func_id = call->func_id;
     new_call->extra_type = call->extra_type;
+    new_call->auto_inserted = call->auto_inserted;
     return new_call;
   }
 };

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -89,8 +89,6 @@ public:
   VertexAdaptor<op_string> get_string();
   VertexAdaptor<op_string_build> get_string_build();
   VertexPtr get_def_value();
-  template<PrimitiveType ToT>
-  static VertexAdaptor<meta_op_unary> conv_to_lval(VertexPtr x);
   template<Operation Op, Operation EmptyOp, class FuncT, class ResultType = typename vk::function_traits<FuncT>::ResultType>
   VertexAdaptor<op_seq> get_multi_call(FuncT &&f, bool parenthesis = false);
   VertexAdaptor<op_return> get_return();
@@ -103,6 +101,8 @@ public:
   VertexAdaptor<op_do> get_do();
   VertexAdaptor<op_switch> get_switch();
   VertexAdaptor<op_shape> get_shape();
+  VertexPtr get_by_name_construct();
+  VertexPtr get_member_by_name_after_var(VertexAdaptor<op_var> v_before);
   VertexPtr get_phpdoc_inside_function();
   bool parse_cur_function_uses();
   static bool test_if_uses_and_arguments_intersect(const std::forward_list<VertexAdaptor<op_var>> &uses_list, const VertexRange &params);

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -835,9 +835,9 @@ const TypeHint *phpdoc_replace_genericTs_with_reified(const TypeHint *type_hint,
       return replacement ?: child;
     }
     if (const auto *as_field_ref = child->try_as<TypeHintRefToField>()) {
-      const auto *field = as_field_ref->resolve_field();
-      kphp_error(field, "Could not detect a field that :: points to in phpdoc white instantiating generics");
-      return field && field->type_hint ? field->type_hint : TypeHintPrimitive::create(tp_any);
+      const TypeHint *field_type_hint = as_field_ref->resolve_field_type_hint();
+      kphp_error(field_type_hint, "Could not detect a field that :: points to in phpdoc white instantiating generics");
+      return field_type_hint ?: TypeHintPrimitive::create(tp_any);
     }
     if (const auto *as_field_ref = child->try_as<TypeHintRefToMethod>()) {
       FunctionPtr method = as_field_ref->resolve_method();

--- a/compiler/pipes/check-func-calls-and-vararg.h
+++ b/compiler/pipes/check-func-calls-and-vararg.h
@@ -9,13 +9,9 @@
 
 class CheckFuncCallsAndVarargPass final : public FunctionPassBase {
   VertexAdaptor<op_func_call> process_varargs(VertexAdaptor<op_func_call> call, FunctionPtr f_called);
+
   VertexPtr maybe_autofill_missing_call_arg(VertexAdaptor<op_func_call> call, FunctionPtr f_called, VertexAdaptor<op_func_param> param);
-  VertexAdaptor<op_func_call> add_call_arg(VertexPtr to_add, VertexAdaptor<op_func_call> call, bool prepend);
-
   VertexPtr create_CompileTimeLocation_call_arg(const Location &call_location);
-
-  VertexPtr maybe_replace_extern_func_call(VertexAdaptor<op_func_call> call, FunctionPtr f_called);
-  bool is_class_JsonEncoder_or_child(ClassPtr class_id);
 
 public:
   std::string get_description() override {

--- a/compiler/pipes/inline-defines-usages.cpp
+++ b/compiler/pipes/inline-defines-usages.cpp
@@ -58,7 +58,7 @@ VertexPtr InlineDefinesUsagesPass::on_enter_vertex(VertexPtr root) {
     } else {
       if (def->class_id) {
         auto access_class = def->class_id;
-        check_access(class_id, lambda_class_id, FieldModifiers{def->access}, access_class, "const", def->name);
+        check_access(class_id, lambda_class_id, FieldModifiers{def->access}, access_class, "const", def->as_human_readable());
       }
       root = def->val.clone().set_location_recursively(root);
     }

--- a/compiler/pipes/instantiate-generics-and-lambdas.cpp
+++ b/compiler/pipes/instantiate-generics-and-lambdas.cpp
@@ -27,7 +27,7 @@ class InstantiateGenericFunctionPass final : public FunctionPassBase {
   const GenericsInstantiationMixin *instantiationTs;
 
 public:
-  InstantiateGenericFunctionPass(FunctionPtr generic_function, GenericsInstantiationMixin *instantiationTs)
+  InstantiateGenericFunctionPass(FunctionPtr generic_function, const GenericsInstantiationMixin *instantiationTs)
     : generic_function(generic_function)
     , instantiationTs(instantiationTs) {
   }
@@ -61,7 +61,8 @@ public:
       }
 
     } else if (auto as_op_lambda = root.try_as<op_lambda>()) {
-      run_function_pass(as_op_lambda->func_id, this);
+      InstantiateGenericFunctionPass pass(generic_function, instantiationTs);
+      run_function_pass(as_op_lambda->func_id, &pass);
     }
 
     return root;

--- a/compiler/pipes/preprocess-exceptions.cpp
+++ b/compiler/pipes/preprocess-exceptions.cpp
@@ -27,7 +27,7 @@ VertexPtr PreprocessExceptions::on_exit_vertex(VertexPtr root) {
   }
 
   auto call = root.try_as<op_func_call>();
-  if (!call || !VertexUtil::is_constructor_call(call)) {
+  if (!call || call->extra_type != op_ex_constructor_call) {
     return root;
   }
   auto alloc = call->args()[0].try_as<op_alloc>();

--- a/compiler/rewrite-rules/replace-extern-func-calls.cpp
+++ b/compiler/rewrite-rules/replace-extern-func-calls.cpp
@@ -1,0 +1,235 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "compiler/rewrite-rules/replace-extern-func-calls.h"
+#include "compiler/pipes/check-access-modifiers.h"
+
+#include <vector>
+
+#include "compiler/compiler-core.h"
+#include "compiler/data/class-data.h"
+#include "compiler/data/define-data.h"
+#include "compiler/data/kphp-json-tags.h"
+#include "compiler/data/function-data.h"
+#include "compiler/vertex-util.h"
+
+/*
+ * Sometimes, we want to replace f(...) with f'(...)
+ * as f' better coincides with C++ implementation and/or C++ templates (f is extern).
+ *
+ * For instance, `JsonEncoder::encode()` and all inheritors' calls are replaced
+ * (not to carry auto-generated inheritors body, as they are generated wrong anyway, cause JsonEncoder is built-in).
+ *
+ * For instance, `new $class` in PHP is stored as `_by_name_construct($class)` in AST, and here
+ * this call is replaced with `new T` where T=assumption($class) for compile-time known variables.
+ *
+ * Note, that this file contains manually written (hardcoded) replacements that can't be expressed by DSL.
+ * Replacements like `microtime(true)` => `_microtime_float()` are not listed here:
+ * such simple replacements are expressed in early_opt.rules in a DSL manner, see EarlyOptimizationF.
+ */
+
+static bool is_class_JsonEncoder_or_child(ClassPtr class_id) {
+  ClassPtr klass_JsonEncoder = G->get_class("JsonEncoder");
+  if (klass_JsonEncoder && klass_JsonEncoder->is_parent_of(class_id)) {
+    // when a class is first time detected as json encoder, parse and validate all constants, and store them
+    if (!class_id->kphp_json_tags) {
+      class_id->kphp_json_tags = kphp_json::convert_encoder_constants_to_tags(class_id);
+    }
+    return true;
+  }
+  return false;
+}
+
+// `new $c(...)` is stored as `_by_name_construct($c, ...)` in AST
+// here we replace `_by_name_construct('A', ...args)` => `A::__construct(op_alloc, ...args)`
+static VertexPtr replace_by_name_construct(VertexAdaptor<op_func_call> call) {
+  const std::string *class_name = VertexUtil::get_constexpr_string(call->args()[0]);
+  kphp_error_act(class_name, "Syntax 'new $class_name' works only if $class_name is compile-time known.\nIt can be achieved via generics and class-string<T>, for example.", return call);
+
+  ClassPtr klass = G->get_class(*class_name);
+  kphp_assert(klass);
+
+  FunctionPtr m_ctor = klass->construct_function;
+  if (!m_ctor) {
+    kphp_error(0, fmt_format("Syntax 'new $class_name' not resolved: __construct() not found in {}", klass->as_human_readable()));
+    return call;
+  }
+
+  auto v_alloc = VertexAdaptor<op_alloc>::create().set_location(call);
+  v_alloc->allocated_class_name = *class_name;
+  v_alloc->allocated_class = klass;
+
+  std::vector<VertexPtr> ctor_args;
+  ctor_args.reserve(call->size());
+  ctor_args.emplace_back(v_alloc);
+  for (int i = 1; i < call->size(); ++i) {
+    ctor_args.emplace_back(call->args()[i]);
+  }
+
+  auto ctor_call = VertexAdaptor<op_func_call>::create(ctor_args).set_location(call);
+  ctor_call->extra_type = op_ex_constructor_call;
+  ctor_call->func_id = m_ctor;
+  return ctor_call;
+}
+
+// `$c::method()` is stored as `_by_name_call_method($c, 'method')` in AST
+// here we replace `_by_name_call_method('A', 'method', ...args)` => `A::method(...args)`
+static VertexPtr replace_by_name_call_method(VertexAdaptor<op_func_call> call) {
+  const std::string *class_name = VertexUtil::get_constexpr_string(call->args()[0]);
+  const std::string *method_name = VertexUtil::get_constexpr_string(call->args()[1]);
+  kphp_error_act(class_name, "Syntax '$class_name::method()' works only if $class_name is compile-time known.\nIt can be achieved via generics and class-string<T>, for example.", return call);
+
+  ClassPtr klass = G->get_class(*class_name);
+  kphp_assert(klass && method_name);
+
+  const auto *m_method = klass->members.get_static_method(*method_name);
+  if (!m_method) {
+    const auto *instance_method_m = klass->get_instance_method(*method_name);
+    kphp_error(!instance_method_m, fmt_format("Syntax '$class_name::method()' works only for static methods, but {} is an instance method", instance_method_m->function->as_human_readable()));
+    kphp_error( instance_method_m, fmt_format("Syntax '$class_name::method()' not resolved: method {} not found in class {}", *method_name, klass->as_human_readable()));
+    return call;
+  }
+  FunctionPtr method = m_method->function;
+  kphp_error(method->is_required, fmt_format("Add @kphp-required over {}, because it's used only from a '$class_name::method()' syntax", method->as_human_readable()));
+
+  std::vector<VertexPtr> method_args;
+  method_args.reserve(call->size() - 2);
+  for (int i = 2; i < call->size(); ++i) {
+    method_args.emplace_back(call->args()[i]);
+  }
+
+  auto m_call = VertexAdaptor<op_func_call>::create(method_args).set_location(call);
+  m_call->str_val = method->name;
+  m_call->func_id = method;
+  return m_call;
+}
+
+// `$c::CONST` is stored as `_by_name_get_const($c, 'CONST')` in AST
+// here we replace `_by_name_get_const('A', 'const')` => `A::CONST (value of)`
+static VertexPtr replace_by_name_get_const(FunctionPtr current_function, VertexAdaptor<op_func_call> call) {
+  const std::string *class_name = VertexUtil::get_constexpr_string(call->args()[0]);
+  const std::string *const_name = VertexUtil::get_constexpr_string(call->args()[1]);
+  kphp_error_act(class_name, "Syntax '$class_name::CONST' works only if $class_name is compile-time known.\nIt can be achieved via generics and class-string<T>, for example.", return call);
+
+  ClassPtr klass = G->get_class(*class_name);
+  kphp_assert(klass && const_name);
+
+  const auto *m_const = klass->get_constant(*const_name);
+  if (!m_const) {
+    kphp_error(0, fmt_format("Syntax '$class_name::CONST' not resolved: const {} not found in class {}", *const_name, klass->as_human_readable()));
+    return call;
+  }
+  DefinePtr define = G->get_define(m_const->define_name);
+
+  // for constants, check access modifiers right here (for other constants it was also done before)
+  // (for other methods/fields, it will automatically be done later, constants are exceptions due to inlining
+  ClassPtr lambda_class_id = current_function->get_this_or_topmost_if_lambda()->class_id;
+  check_access(current_function->class_id, lambda_class_id, FieldModifiers{define->access}, define->class_id, "const", define->as_human_readable());
+
+  return define->val.clone().set_location_recursively(call);
+}
+
+// `$c::$field` is stored as `_by_name_get_field($c, 'field')` in AST
+// here we replace `_by_name_get_field('A', 'field')` => `A::$field`
+static VertexPtr replace_by_name_get_field(VertexAdaptor<op_func_call> call) {
+  const std::string *class_name = VertexUtil::get_constexpr_string(call->args()[0]);
+  const std::string *field_name = VertexUtil::get_constexpr_string(call->args()[1]);
+  kphp_error_act(class_name, "Syntax '$class_name::$field' works only if $class_name is compile-time known.\nIt can be achieved via generics and class-string<T>, for example.", return call);
+
+  ClassPtr klass = G->get_class(*class_name);
+  kphp_assert(klass && field_name);
+
+  const auto *m_field = klass->get_static_field(*field_name);
+  if (!m_field) {
+    const auto *instance_field_m = klass->get_instance_field(*field_name);
+    kphp_error(!instance_field_m, fmt_format("Syntax '$class_name::$field' works only for static fields, but {} is an instance field", instance_field_m->var->as_human_readable()));
+    kphp_error( instance_field_m, fmt_format("Syntax '$class_name::$field' not resolved: field ${} not found in class {}", *field_name, klass->as_human_readable()));
+    return call;
+  }
+  VarPtr field = m_field->var;
+
+  auto f_get = VertexAdaptor<op_var>::create().set_location(call);
+  f_get->str_val = field->name;
+  return f_get;
+}
+
+// `JsonEncoderOrChild::decode($json, $class_name)` => `JsonEncoder::from_json_impl('JsonEncoderOrChild', $json, $class_name)`
+static VertexPtr replace_JsonEncoder_decode(VertexAdaptor<op_func_call> call) {
+  auto v_encoder_name = VertexAdaptor<op_string>::create().set_location(call->location);
+  v_encoder_name->str_val = call->func_id->class_id->name;
+  call->str_val = "JsonEncoder$$from_json_impl";
+  call->func_id = G->get_function(call->str_val);
+  return VertexUtil::add_call_arg(v_encoder_name, call, true);
+}
+
+// `JsonEncoderOrChild::encode($instance)` => `JsonEncoder::to_json_impl('JsonEncoderOrChild', $instance)`
+static VertexPtr replace_JsonEncoder_encode(VertexAdaptor<op_func_call> call) {
+  auto v_encoder_name = VertexAdaptor<op_string>::create().set_location(call->location);
+  v_encoder_name->str_val = call->func_id->class_id->name;
+  call->str_val = "JsonEncoder$$to_json_impl";
+  call->func_id = G->get_function(call->str_val);
+  return VertexUtil::add_call_arg(v_encoder_name, call, true);
+}
+
+// `JsonEncoderOrChild::getLastError()` => `JsonEncoder::getLastError()`
+static VertexPtr replace_JsonEncoder_getLastError(VertexAdaptor<op_func_call> call) {
+  call->str_val = "JsonEncoder$$getLastError";
+  call->func_id = G->get_function(call->str_val);
+  return call;
+}
+
+// `classof(expr)` => `assumption(expr)::class`
+static VertexPtr replace_classof(FunctionPtr current_function, VertexAdaptor<op_func_call> call) {
+  ClassPtr klassT = assume_class_of_expr(current_function, call->args()[0], call).try_as_class();
+  kphp_error_act(klassT, "classof() used for non-instance", return call);
+  auto v_class_name = VertexAdaptor<op_string>::create();
+  v_class_name->str_val = klassT->name;
+  return v_class_name;
+}
+
+
+// it's the main (exported) function
+// see comment at the top of the file
+VertexPtr maybe_replace_extern_func_call(FunctionPtr current_function, VertexAdaptor<op_func_call> call) {
+  FunctionPtr f_called = call->func_id;
+  const std::string &f_name = f_called->name;
+  int n_args = call->size();
+
+  // new $c, $c::method(), $c::CONST, $c::$FIELD
+  // see GenTree::get_member_by_name_after_var()
+  if (f_name == "_by_name_construct") {
+    return replace_by_name_construct(call);
+  }
+  if (f_name == "_by_name_call_method") {
+    return replace_by_name_call_method(call);
+  }
+  if (f_name == "_by_name_get_const") {
+    return replace_by_name_get_const(current_function, call);
+  }
+  if (f_name == "_by_name_get_field") {
+    return replace_by_name_get_field(call);
+  }
+
+  // JsonEncoder::encode(), MyJsonEncoder::decode(), and similar
+  if (f_called->modifiers.is_static() && f_called->class_id) {
+    vk::string_view local_name = f_called->local_name();
+
+    if (local_name == "decode" && is_class_JsonEncoder_or_child(f_called->class_id) && n_args >= 2) {
+      return replace_JsonEncoder_decode(call.clone());
+    }
+    if (local_name == "encode" && is_class_JsonEncoder_or_child(f_called->class_id) && n_args >= 1) {
+      return replace_JsonEncoder_encode(call.clone());
+    }
+    if (local_name == "getLastError" && is_class_JsonEncoder_or_child(f_called->class_id) && n_args == 0) {
+      return replace_JsonEncoder_getLastError(call.clone());
+    }
+  }
+
+  // classof($expr)
+  if (f_name == "classof" && n_args == 1) {
+    return replace_classof(current_function, call);
+  }
+
+  return call;
+}

--- a/compiler/rewrite-rules/replace-extern-func-calls.h
+++ b/compiler/rewrite-rules/replace-extern-func-calls.h
@@ -1,0 +1,11 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "compiler/data/data_ptr.h"
+#include "compiler/vertex.h"
+
+// maybe, replace f(...) with f'(...); see comments in cpp file
+VertexPtr maybe_replace_extern_func_call(FunctionPtr current_function, VertexAdaptor<op_func_call> call);

--- a/compiler/type-hint.h
+++ b/compiler/type-hint.h
@@ -197,7 +197,7 @@ public:
   const TypeHint *replace_children_custom(const ReplacerCallbackT &callback) const final;
   void recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr func_call) const final;
 
-  const ClassMemberInstanceField *resolve_field() const;
+  const TypeHint *resolve_field_type_hint() const;
 };
 
 /**

--- a/compiler/vertex-util.cpp
+++ b/compiler/vertex-util.cpp
@@ -39,6 +39,25 @@ VertexPtr VertexUtil::get_call_arg_ref(int arg_num, VertexPtr v_func_call) {
   return {};
 }
 
+VertexAdaptor<op_func_call> VertexUtil::add_call_arg(VertexPtr to_add, VertexAdaptor<op_func_call> call, bool prepend) {
+  std::vector<VertexPtr> new_args;
+  new_args.reserve(call->args().size() + 1);
+  if (prepend) {
+    new_args.emplace_back(to_add);
+  }
+  for (auto arg : call->args()) {
+    new_args.emplace_back(arg);
+  }
+  if (!prepend) {
+    new_args.emplace_back(to_add);
+  }
+
+  auto new_call = VertexAdaptor<op_func_call>::create(new_args).set_location(call->location);
+  new_call->str_val = call->str_val;
+  new_call->func_id = call->func_id;
+  return new_call;
+}
+
 VertexPtr VertexUtil::create_int_const(int64_t number) {
   auto int_v = VertexAdaptor<op_int_const>::create();
   int_v->str_val = std::to_string(number);
@@ -98,10 +117,6 @@ bool VertexUtil::is_superglobal(const std::string &s) {
     "_ENV"
   };
   return vk::contains(names, s);
-}
-
-bool VertexUtil::is_constructor_call(VertexAdaptor<op_func_call> call) {
-  return !call->args().empty() && call->str_val == ClassData::NAME_OF_CONSTRUCT;
 }
 
 bool VertexUtil::is_positive_constexpr_int(VertexPtr v) {

--- a/compiler/vertex-util.h
+++ b/compiler/vertex-util.h
@@ -16,6 +16,7 @@ public:
   static VertexPtr get_actual_value(VertexPtr v);
   static const std::string *get_constexpr_string(VertexPtr v);
   static VertexPtr get_call_arg_ref(int arg_num, VertexPtr v_func_call);
+  static VertexAdaptor<op_func_call> add_call_arg(VertexPtr to_add, VertexAdaptor<op_func_call> call, bool prepend);
 
   static VertexPtr create_conv_to(PrimitiveType targetType, VertexPtr x);
   static VertexAdaptor<meta_op_unary> create_conv_to_lval(PrimitiveType targetType, VertexPtr x);
@@ -35,7 +36,6 @@ public:
   static void func_force_return(VertexAdaptor<op_function> func, VertexPtr val = {});
 
   static bool is_superglobal(const std::string &s);
-  static bool is_constructor_call(VertexAdaptor<op_func_call> call);
   static bool is_positive_constexpr_int(VertexPtr v);
   static bool is_const_int(VertexPtr root);
 };

--- a/docs/kphp-language/howto-by-kphp/call-function-by-name.md
+++ b/docs/kphp-language/howto-by-kphp/call-function-by-name.md
@@ -7,13 +7,13 @@ sort: 1
 An ability to call a function/method by name does not exist in compiled languages. 
 But it exists in plain PHP and is essential in various routing/ORMs and so on.
 
-KPHP **does not support** calling by name, just as any other compiled language. 
+KPHP **does not support** calling by a dynamic name, just like any other compiled language.   
 How to achieve the same result?
 
 
 ## How is it done in plain PHP?
 
-In PHP you just call any function by name / any method by name / create a class by name:
+In PHP, you just call any function by name / any method by name / create a class by name:
 
 ```php
 $f_name = "...";
@@ -35,7 +35,8 @@ This is prohibited in KPHP. All calls, all property access — everything must b
 
 ## How to achieve this in KPHP?
 
-Think of KPHP as of any other compiled language. Nothing better than *switch-case* is generally unavailable.
+Think of KPHP as of any other compiled language. 
+For dynamic variables, nothing better than *switch-case* actually exists.
 
 And this is OK, this is not a drawback. 
 Static call graph makes your code predictable and understandable, you always see all available methods reached out from here.
@@ -51,6 +52,30 @@ case "logout":
   break; 
 }
 ```
+
+
+## Compile-time known strings and generics
+
+If `$class_name` is compile-time known, you are able to create it via `new $class_name` or call like `$class_name::method()`:
+
+```php
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function demo($class_name) {
+  $obj = new $class_name;         // ok
+  $obj->afterCreated();
+  $class_name::staticMethod();    // also ok
+}
+
+demo(A::class);     // actually, demo<A>('A')
+demo(B::class);     // actually, demo<B>('B')
+```
+
+It works **only for compile-time known variables**, in [generic functions](../static-type-system/generic-functions.md). It can work, because everything is still statically resolved.
+
+Probably, when you are searching for a way to "create any class" or "call any function", that "any" comes from an input. Hence, generics will not fit your needs.
 
 
 ## If so, how do I perform request routing?

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -323,7 +323,9 @@ def run_test(use_nocc, cxx_name, test: TestFile):
     runner = test.make_kphp_once_runner(use_nocc, cxx_name)
     runner.remove_artifacts_dir()
 
-    if test.is_kphp_should_fail():
+    if test.is_php8() and runner._php_bin is None:      # if php8 doesn't exist on a machine
+        test_result = TestResult.skipped(test)
+    elif test.is_kphp_should_fail():
         test_result = run_fail_test(test, runner)
     elif test.is_kphp_should_warn():
         test_result = run_warn_test(test, runner)

--- a/tests/phpt/by_name/01_by_name_construct.php
+++ b/tests/phpt/by_name/01_by_name_construct.php
@@ -1,0 +1,131 @@
+@ok
+<?php
+
+class NoCtor {
+    function nMethod() { echo "NoCtor\n";}
+}
+
+class EmtpyCtor {
+    private int $idx;
+    private static $count = 0;
+
+    function __construct() { $this->idx = ++self::$count; }
+
+    function eMethod() { echo "EmtpyCtor {$this->idx}\n";}
+
+    function getSelf(): self { return $this; }
+
+    /** @kphp-required */
+    static function getFieldInst(): A { return static::$inst; }
+
+    static function createAInstance(int $value) { return new A($value); }
+}
+
+class A {
+    public int $value;
+
+    function __construct(int $value) { $this->value = $value; }
+
+    function aMethod() { echo "A value = {$this->value}\n"; }
+
+    function getSelf(): self { return $this; }
+}
+
+class B {
+    public A $a;
+    private ?int $marker = null;
+
+    function __construct(A $a, ?int $marker = null) { $this->a = $a; $this->marker = $marker; }
+
+    function bMethod() { echo "B with a->value = {$this->a->value} marker = {$this->marker}\n"; }
+}
+
+class Joiner {
+    function __construct(A $a, B $b) {
+        echo "construct Joiner: a {$a->value}, b {$b->a->value}\n";
+    }
+
+    function jMethod() { }
+}
+
+class Str3 {
+    public string $concat;
+    function __construct(string $a, string $b = '', string $c = '') {
+        $this->concat = "$a$b$c";
+    }
+    function printMe() {
+        echo "Str3: $this->concat\n";
+    }
+}
+
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ * @return T
+ */
+function createTWithNoArg($c) {
+    return new $c;
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ * @return T
+ */
+function createTWithInt($c) {
+    return (new $c(1))->getSelf()->getSelf();
+}
+
+/**
+ * @kphp-generic T, TArg
+ * @param class-string<T> $c
+ * @param TArg $arg
+ * @return T
+ */
+function createTWithAnySingleArg($c, $arg) {
+    return new $c($arg);
+}
+
+/**
+ * @kphp-generic T, ...TArg
+ * @param class-string<T> $c
+ * @param TArg ...$args
+ * @return T
+ */
+function createTWithAnyArgs($c, ...$args) {
+    return new $c(...$args);
+}
+
+/**
+ * @kphp-generic T, ...TArg
+ * @param class-string<T> $c
+ * @param TArg ...$strings
+ */
+function createPrependingStrAndPrint($c, ...$strings): void {
+    $o = new $c(...['a', ...$strings]);
+    $o->printMe();
+}
+
+
+createTWithNoArg(EmtpyCtor::class)->eMethod();
+createTWithNoArg(EmtpyCtor::class)->eMethod();
+createTWithNoArg(NoCtor::class)->nMethod();
+
+$a = createTWithInt(A::class);
+$a->aMethod();
+
+createTWithAnySingleArg(A::class, 10)->aMethod();
+createTWithAnySingleArg(B::class, new A(11))->bMethod();
+
+createTWithAnyArgs(A::class, 20)->aMethod();
+createTWithAnyArgs(B::class, new A(21))->bMethod();
+createTWithAnyArgs(B::class, new A(22), -22)->bMethod();
+
+createTWithAnyArgs(Joiner::class, new A(71), new B(new A(72)))->jMethod();
+createTWithAnyArgs(Joiner::class, new A(81), new B(new A(82)))->jMethod();
+
+createPrependingStrAndPrint(Str3::class);
+createPrependingStrAndPrint(Str3::class, 'b');
+createPrependingStrAndPrint(Str3::class, 'b', 'c');

--- a/tests/phpt/by_name/02_by_name_call.php
+++ b/tests/phpt/by_name/02_by_name_call.php
@@ -1,0 +1,78 @@
+@ok
+<?php
+
+class HasSomeFields {
+    /** @var B */
+    public static $inst;
+
+    /** @kphp-required */
+    static public function getFieldInst(): B { return self::$inst; }
+}
+
+class EmtpyCtor {
+    private int $idx;
+    private static $count = 0;
+
+    /** @var A */
+    public static $inst;
+
+    function __construct() { $this->idx = ++self::$count; }
+
+    /** @kphp-required */
+    static function sm(int $x = null, int $y = null) { echo "EmtpyCtor::sm($x,$y)\n"; }
+
+    /** @kphp-required */
+    static function getFieldInst(): A { return static::$inst; }
+
+    static function createAInstance(int $value) { return new A($value); }
+}
+
+class A extends HasSomeFields {
+    public int $value;
+
+    function __construct(int $value) { $this->value = $value; }
+
+    static function sm() { echo "A::sm()\n"; }
+
+    function getInfoStr() { return "this is A value=$this->value"; }
+}
+
+class B {
+    public A $a;
+    private ?int $marker = null;
+
+    function __construct(A $a, ?int $marker = null) { $this->a = $a; $this->marker = $marker; }
+
+    function getInfoStr() { return "this is B marker={$this->marker}"; }
+}
+
+
+A::$inst = new B(new A(0), 111);
+EmtpyCtor::$inst = new A(111);
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T::sm()
+ */
+function callSmNoArg($cn) {
+    return $cn::sm();
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ */
+function callGetInstAndItsMethod($cn) {
+    /** @var T::getFieldInst() */
+    $inst = $cn::getFieldInst();
+    echo "getFieldInst() of $cn returned ", get_class($inst), ": ", $inst->getInfoStr(), "\n";
+}
+
+
+callSmNoArg(EmtpyCtor::class);
+
+callGetInstAndItsMethod(EmtpyCtor::class);
+callGetInstAndItsMethod(HasSomeFields::class);
+

--- a/tests/phpt/by_name/03_by_name_get_const.php
+++ b/tests/phpt/by_name/03_by_name_get_const.php
@@ -1,0 +1,36 @@
+@ok
+<?php
+
+class HasSomeFields {
+    const ONE = 1;
+    const INT_DOUBLE_ARR = [[0], [1]];
+}
+
+class EmtpyCtor {
+    // some consts of HasSomeFields
+    const ONE = 2;
+    const INT_DOUBLE_ARR = [[1], [2+3*2+self::ONE, self::ONE+HasSomeFields::INT_DOUBLE_ARR[0][0]]];
+
+    function __construct() { }
+}
+
+class A extends HasSomeFields {
+    public int $value;
+
+    function __construct(int $value) { $this->value = $value; }
+}
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function printSomeConstants($c) {
+    echo $c, '::ONE = ', $c::ONE, ', ARR[1][0] = ', $c::INT_DOUBLE_ARR[1][0], ', c=', count($c::INT_DOUBLE_ARR[1]), "\n";
+}
+
+
+printSomeConstants(EmtpyCtor::class);
+printSomeConstants(HasSomeFields::class);
+printSomeConstants(A::class);
+

--- a/tests/phpt/by_name/04_by_name_get_field.php
+++ b/tests/phpt/by_name/04_by_name_get_field.php
@@ -1,0 +1,114 @@
+@ok
+<?php
+
+class HasSomeFields {
+    public static $hello = 0;
+    public static $f_arr = [0, 1];
+    /** @var B */
+    public static $inst;
+
+    static public function testFieldArr() {
+        testFieldArr(static::class);
+    }
+}
+
+class EmtpyCtor {
+    private int $idx;
+    private static $count = 0;
+
+    // same fields as HasSomeFields
+    public static $hello = 1;
+    public static $f_arr = ['1', '2'];
+    /** @var A */
+    public static $inst;
+
+    function __construct() { $this->idx = ++self::$count; }
+
+    function eMethod() { echo "EmtpyCtor {$this->idx}\n";}
+
+    function getSelf(): self { return $this; }
+
+    /** @kphp-required */
+    static function sm(int $x = null, int $y = null) { echo "EmtpyCtor::sm($x,$y)\n"; }
+}
+
+class A extends HasSomeFields {
+    public int $value;
+
+    function __construct(int $value) { $this->value = $value; }
+
+    function getInfoStr() { return "this is A value=$this->value"; }
+}
+
+class B {
+    public A $a;
+    private ?int $marker = null;
+
+    function __construct(A $a, ?int $marker = null) { $this->a = $a; $this->marker = $marker; }
+
+    function getInfoStr() { return "this is B marker={$this->marker}"; }
+}
+
+
+A::$inst = new B(new A(0), 111);
+EmtpyCtor::$inst = new A(111);
+
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ */
+function printFieldHello($cn) {
+    echo "hello of ", $cn, " = ", $cn::$hello, "\n";
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ */
+function incFieldHello($cn) {
+    $add_5 = function(int &$int) { $int += 5; };
+    $cn::$hello++;
+    $cn::$hello += 5;
+    $add_5($cn::$hello);
+    ++$cn::$hello;
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $klass
+ */
+function testFieldArr($klass) {
+    $klass::$f_arr[1] += 2;
+    $klass::$f_arr[] = [$klass::$f_arr[0]][0];
+    echo 'f_arr of ', $klass, ': ', 'n=', count($klass::$f_arr), ', [1]=', $klass::$f_arr[1], "\n";
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $klass
+ */
+function testFieldInst($klass) {
+    /** @var T::inst */
+    $inst = $klass::$inst;
+    echo "inst of ", $klass, ": ", $inst->getInfoStr(), "\n";
+}
+
+
+printFieldHello(EmtpyCtor::class);
+incFieldHello(EmtpyCtor::class);
+printFieldHello(EmtpyCtor::class);
+
+printFieldHello(A::class);
+incFieldHello(A::class);
+printFieldHello(A::class);
+printFieldHello(HasSomeFields::class);
+
+testFieldArr(EmtpyCtor::class);
+HasSomeFields::testFieldArr();
+A::testFieldArr();
+
+testFieldInst(A::class);
+testFieldInst(EmtpyCtor::class);
+

--- a/tests/phpt/by_name/100_by_name_non_constexpr.php
+++ b/tests/phpt/by_name/100_by_name_non_constexpr.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/Syntax 'new \$class_name' works only if \$class_name is compile-time known/
+/Syntax '\$class_name::method\(\)' works only if \$class_name is compile-time known/
+/Syntax '\$class_name::CONST' works only if \$class_name is compile-time known/
+/Syntax '\$class_name::\$field' works only if \$class_name is compile-time known/
+<?php
+
+class A {}
+
+$class_name = 'A';
+new $class_name;
+$class_name::hello();
+$class_name::A;
+$class_name::$bo;

--- a/tests/phpt/by_name/101_call_all_dynamic.php
+++ b/tests/phpt/by_name/101_call_all_dynamic.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Syntax '\$class_name::\$method_name\(\)' is invalid in KPHP/
+<?php
+
+class A {}
+
+$class_name = 'A';
+$method = 'mm';
+$class_name::$method(10);
+

--- a/tests/phpt/by_name/102_get_unresolved.php
+++ b/tests/phpt/by_name/102_get_unresolved.php
@@ -1,0 +1,44 @@
+@kphp_should_fail
+/Syntax 'new \$class_name' not resolved: __construct\(\) not found in I/
+/Syntax '\$class_name::method\(\)' not resolved: method unexistingSm not found in class A/
+/Syntax '\$class_name::method\(\)' works only for static methods, but A::im is an instance method/
+/Syntax '\$class_name::CONST' not resolved: const UNEXISTING_CONST not found in class A/
+/Syntax '\$class_name::\$field' not resolved: field \$unexisting_field not found in class A/
+/Syntax '\$class_name::\$field' works only for static fields, but A::\$idx is an instance field/
+<?php
+
+interface I {}
+class A implements I {
+    public int $idx = 0;
+    function im() {}
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gCtor($c) { new $c; }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gCallMethod($c) { $c::unexistingSm(); $c::im(); }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gGetConst($c) { echo $c::UNEXISTING_CONST[0]; }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gGetField($c) { $c::$unexisting_field += $c::$idx; }
+
+
+gCtor(I::class);
+gCallMethod(A::class);
+gGetConst(A::class);
+gGetField(A::class);

--- a/tests/phpt/by_name/103_by_name_private_1.php
+++ b/tests/phpt/by_name/103_by_name_private_1.php
@@ -1,0 +1,34 @@
+@kphp_should_fail
+/Can't access private static field count/
+/Can't access private static method A::sm/
+/Can't access private method A::__construct/
+<?php
+
+class A {
+    private static $count = 0;
+    private function __construct() {}
+    /** @kphp-required */
+    private static function sm() { echo 'sm'; }
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gCtor($c) { new $c; }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gCallMethod($c) { $c::sm(); }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gGetField($c) { $c::$count++; }
+
+gCtor(A::class);
+gCallMethod(A::class);
+gGetField(A::class);

--- a/tests/phpt/by_name/103_by_name_private_2.php
+++ b/tests/phpt/by_name/103_by_name_private_2.php
@@ -1,0 +1,21 @@
+@kphp_should_fail
+/Can't access private const A::ONE/
+<?php
+
+class A {
+    private const ONE = 1;
+    private static $count = 0;
+    private function __construct() {}
+    /** @kphp-required */
+    private static function sm() { echo 'sm'; }
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $c
+ */
+function gGetConst($c) { echo $c::ONE; }
+
+
+// exposed as a separate test, because constants inlining is done way before checking other access modifiers
+gGetConst(A::class);

--- a/tests/phpt/by_name/104_invalid_syntax_colons.php
+++ b/tests/phpt/by_name/104_invalid_syntax_colons.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Unrecognized syntax after '\$cn::'/
+<?php
+
+function f() {
+    $cn = 'A';
+    $cn::[0];
+}
+
+f();

--- a/tests/phpt/by_name/105_direct_by_name_call.php
+++ b/tests/phpt/by_name/105_direct_by_name_call.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Called internal function _by_name_call_method\(\)/
+/Called internal function _by_name_construct\(\)/
+<?php
+
+class A {  /** @kphp-required */ static function method(){} }
+
+_by_name_call_method('A', 'method');
+_by_name_construct();
+

--- a/tests/phpt/by_name/106_by_name_wrong_args.php
+++ b/tests/phpt/by_name/106_by_name_wrong_args.php
@@ -1,0 +1,20 @@
+@kphp_should_fail
+/in callByName<A>/
+/\$class_name::sf\(\);/
+/Too few arguments in call to A::sf\(\), expected 1, have 0/
+<?php
+
+class A {
+    static function sf(int $a) {}
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function callByName(string $class_name) {
+    $class_name::sf();
+}
+
+callByName('A');
+

--- a/tests/phpt/by_name/107_by_name_wrong_tinf.php
+++ b/tests/phpt/by_name/107_by_name_wrong_tinf.php
@@ -1,0 +1,33 @@
+@kphp_should_fail
+KPHP_SHOW_ALL_TYPE_ERRORS=1
+/in callByName<A>/
+/pass string to argument \$a of A::sf/
+/in assignByName<A>/
+/assign string to A::\$SIZE/
+<?php
+
+class A {
+    static public int $SIZE = 0;
+
+    /** @kphp-required */
+    static function sf(int $a) {}
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function callByName(string $class_name) {
+    $class_name::sf('s');
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function assignByName(string $class_name) {
+    $class_name::$SIZE = 's';
+}
+
+callByName('A');
+assignByName('A');

--- a/tests/phpt/errors/006_method_params_n.php
+++ b/tests/phpt/errors/006_method_params_n.php
@@ -1,11 +1,11 @@
 @kphp_should_fail
-/Too few arguments to function call, expected 1, have 0/
-/Too few arguments to function call, expected 3, have 1/
-/Too few arguments to function call, expected 1, have 0/
-/Too many arguments to function call, expected 0, have 3/
-/Too many arguments to function call, expected 1, have 2/
-/Too many arguments to function call, expected 4, have 5/
-/Too many arguments to function call, expected 0, have 2/
+/Too few arguments in call to Test::f_min1_max1\(\), expected 1, have 0/
+/Too few arguments in call to Test::f_min3_max4\(\), expected 3, have 1/
+/Too few arguments in call to Test::sf_min1_max1\(\), expected 1, have 0/
+/Too many arguments in call to Test::f_min0_max0\(\), expected 0, have 3/
+/Too many arguments in call to Test::f_min1_max1\(\), expected 1, have 2/
+/Too many arguments in call to Test::f_min3_max4\(\), expected 4, have 5/
+/Too many arguments in call to Test::sf_min0_max0\(\), expected 0, have 2/
 <?php
 
 class Test {

--- a/tests/phpt/errors/007_method_params_n_variadic.php
+++ b/tests/phpt/errors/007_method_params_n_variadic.php
@@ -1,8 +1,8 @@
 @kphp_should_fail
-/Too few arguments to function call, expected 2, have 0/
-/Too few arguments to function call, expected 4, have 2/
-/Too few arguments to function call, expected 2, have 0/
-/Too few arguments to function call, expected 5, have 1/
+/Too few arguments in call to Test::f_min1_maxn\(\), expected 2, have 0/
+/Too few arguments in call to Test::f_min3_maxn\(\), expected 4, have 2/
+/Too few arguments in call to Test::sf_min1_maxn\(\), expected 2, have 0/
+/Too few arguments in call to Test::sf_min4_maxn\(\), expected 5, have 1/
 <?php
 
 // as variadic functions are preprocessed, error is given

--- a/tests/phpt/exceptions/18_set_location_error.php
+++ b/tests/phpt/exceptions/18_set_location_error.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Called internal _exception_set_location function/
+/Called internal function _exception_set_location\(\)/
 <?php
 
 _exception_set_location(null, '', 10);

--- a/tests/phpt/ffi/typing/012_func_call_argcount_error.php
+++ b/tests/phpt/ffi/typing/012_func_call_argcount_error.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Too many arguments to function call, expected 0, have 2/
+/Too many arguments in call to scope\\example::f\(\), expected 0, have 2/
 <?php
 
 $cdef = FFI::cdef('

--- a/tests/phpt/ffi/typing/013_func_call_argcount_error2.php
+++ b/tests/phpt/ffi/typing/013_func_call_argcount_error2.php
@@ -1,5 +1,5 @@
 @kphp_should_fail
-/Too few arguments to function call, expected 2, have 1/
+/Too few arguments in call to scope\\example::f\(\), expected 2, have 1/
 <?php
 
 $cdef = FFI::cdef('

--- a/tests/phpt/generics/129_bad_variadic_1.php
+++ b/tests/phpt/generics/129_bad_variadic_1.php
@@ -1,6 +1,6 @@
 @kphp_should_fail
 /in callF2\$n2<int, string>/
-/Too many arguments to function call, expected 2, have 5/
+/Too many arguments in call to f2\(\), expected 2, have 5/
 <?php
 
 function f2(int $a, string $b) {

--- a/tests/phpt/json/115_wrong_json_args_count.php
+++ b/tests/phpt/json/115_wrong_json_args_count.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Too few arguments in call to JsonEncoder::encode\(\), expected 1, have 0/
+/Too few arguments in call to MyE::decode\(\), expected 2, have 0/
+<?php
+
+class MyE extends JsonEncoder {}
+
+JsonEncoder::encode();
+MyE::decode();
+

--- a/tests/phpt/variadic_args/112_bad_count_after_unpack.php
+++ b/tests/phpt/variadic_args/112_bad_count_after_unpack.php
@@ -1,7 +1,7 @@
 @kphp_should_fail
-/Too many arguments to function call, expected 2, have 4/
-/Too many arguments to function call, expected 2, have 5/
-/Too few arguments to function call, expected 2, have 1/
+/Too many arguments in call to f\(\), expected 2, have 4/
+/Too many arguments in call to f\(\), expected 2, have 5/
+/Too few arguments in call to g\(\), expected 2, have 1/
 <?php
 
 function f(int $s, int $i) {


### PR DESCRIPTION
PHP allows to create a class by name / call a method by name. Generally, KPHP does not, but in case of generics, now it works. 
If `$class` is a compile-time known `class-string<T>`, now it's possible to use such constructions:

```php
/**
 * @kphp-generic T
 * @param class-string<T> $class_name
 */
function demo($class_name) {
  $obj = new $class_name;         // ok
  $obj->afterCreated();
  $class_name::staticMethod();    // also ok
}

demo(A::class);     // actually, demo<A>('A')
demo(B::class);     // actually, demo<B>('B')
```

Here it's possible **because $class_name is compile-time known** (it's a const string within each instantiation), everything is statically resolved.

This gives you an ability to write wrappers around constructors:
```php
/**
 * @kphp-generic TCreated
 * @param class-string<TCreated> $cn
 * @return TCreated
 */
function createAndCheckValid(string $cn, int $arg) {
  $obj = new $cn($arg);
  if (!$obj->isValid()) {
    throw new RuntimeException("Object($cn) is not valid for arg=$arg");
  }
  return $obj;
} 
```

You can pass here any classes accepting `int` in constructor and having `isValid()` method.

### Combined with **variadic generics** 

This feature becomes much more powerful:

```php
class A {
  function __construct() { ... }
  function init() { ... }
}
class B {
  function __construct(int $a) { ... }
  function init() { ... }
}
class C {
  function __construct(A $a, ?B $b) { ... }
  function init() { ... } 
}

/**
 * @kphp-generic T, ...TArg
 * @param class-string<T> $class_name
 * @param TArg ...$args
 * @return T
 */
function createAndInit($class_name, ...$args) {
  $obj = new $class_name(...$args);
  $obj->init();
  return $obj;
}

createAndInit(A::class);
createAndInit(B::class, 10);
createAndInit(C::class, new A, new B(0));
```

If generic Ts can't be auto-reified by arguments, they could be provided manually, as before:
```php
// without a hint, it's impossible to guess what 'null' means
createAndInit/*<C, A, B>*/(C::class, null, null);
```

Same for wrappers around calling any static method:
```php
/**
 * @kphp-generic T, ...TArg
 * @param class-string<T> $class_name
 * @param TArg ...$args
 */
function calcAndCheckGreater0($class_name, ...$args): int {
  $res = $class_name::calcCoeff(...$args);
  if ($res <= 0) {
    log("Unexpected coeff=$res for $class_name");
  }
  return $res;
} 
```


### These syntax constructions would work

* `new $class` (probably with arguments)
* `$class::staticMethod()` (probably with arguments)
* `$class::CONST`
* `$class::$STATIC_FIELD` (even for writing)

`$class::instanceMethod()` does not work, and should not.  
`$class::$dynamic_method()` also does not, a method name should be compile-time known.


### Implementation

1. `new $c(...)` is stored as `_by_name_construct($c, ...)` in AST. 
2. When generics are instantiated, `$c` is replaced by a const string, leading to `_by_name_construct('SomeClass', ...)`. 
3. Later, when checking func calls (when assumptions are available, but before creating a call graph), `_by_name_construct('C', ...)` is replaced by `C::__construct(op_alloc, ...)`. 

If used not in generics, then `$c` is not replaced by a const string prior this point, which leads to an error *"new $class can be used only when $class is compile-time known"*.

Four new internal functions are introduced to store replacements in AST:
* `new $c(...)` => `_by_name_construct($c, ...)`
* `$c::method()` => `_by_name_call_method($c, 'method')`
* `$c::CONST` => `_by_name_get_const($c, 'CONST')`
* `$c::$field` => `_by_name_get_field($c, 'field')`

See *replace-extern-func-calls.cpp*.