### PR TITLE
handle switch over a constexpr string, a pattern for generic factories

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1260,6 +1260,9 @@ void compile_switch(VertexAdaptor<op_switch> root, CodeGenerator &W) {
     compile_switch_str(root, W);
   } else if (root->kind == SwitchKind::IntSwitch) {
     compile_switch_int(root, W);
+  } else if (root->kind == SwitchKind::EmptySwitch) {                         // will contain only inlined 'default' case
+    W << "static_cast<void>(" << root->matched_with_one_case() << ");" << NL; // suppress g++ 'unused variable' warning
+    compile_switch_var(root, W);
   } else {
     compile_switch_var(root, W);
   }

--- a/compiler/gentree.h
+++ b/compiler/gentree.h
@@ -40,10 +40,6 @@ class GenTree {
 public:
   Location auto_location() const { return Location{this->line_num}; }
 
-  VertexAdaptor<op_var> create_superlocal_var(const std::string& name_prefix);
-  static VertexAdaptor<op_var> create_superlocal_var(const std::string& name_prefix, FunctionPtr cur_function);
-  static VertexAdaptor<op_switch> create_switch_vertex(FunctionPtr cur_function, VertexPtr switch_condition, std::vector<VertexPtr> &&cases);
-
   static bool is_magic_method_name_allowed(const std::string &name);
 
 

--- a/compiler/pipes/generate-virtual-methods.cpp
+++ b/compiler/pipes/generate-virtual-methods.cpp
@@ -10,7 +10,6 @@
 #include "compiler/data/class-data.h"
 #include "compiler/data/function-data.h"
 #include "compiler/data/src-file.h"
-#include "compiler/gentree.h"
 #include "compiler/vertex-util.h"
 #include "compiler/type-hint.h"
 
@@ -437,7 +436,7 @@ void generate_body_of_virtual_method(FunctionPtr virtual_function) {
     auto call_get_hash = VertexAdaptor<op_func_call>::create(ClassData::gen_vertex_this({}));
     call_get_hash->str_val = "get_hash_of_class";
     call_get_hash->func_id = G->get_function(call_get_hash->str_val);
-    virtual_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(GenTree::create_switch_vertex(virtual_function, call_get_hash, std::move(cases)));
+    virtual_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(VertexUtil::create_switch_vertex(virtual_function, call_get_hash, std::move(cases)));
   }
 
   virtual_function->type = FunctionData::func_local;    // could be func_extern before, but now it has a body

--- a/compiler/pipes/instantiate-generics-and-lambdas.cpp
+++ b/compiler/pipes/instantiate-generics-and-lambdas.cpp
@@ -55,7 +55,7 @@ public:
         if (const auto *as_class_string = param->type_hint->try_as<TypeHintClassString>()) {
           const TypeHint *instT = instantiationTs->find(as_class_string->inner->try_as<TypeHintGenericT>()->nameT);
           if (instT && instT->try_as<TypeHintInstance>()) {
-            return VertexUtil::create_string_const(instT->try_as<TypeHintInstance>()->full_class_name);
+            return VertexUtil::create_string_const(instT->try_as<TypeHintInstance>()->full_class_name).set_location(root);
           }
         }
       }

--- a/compiler/pipes/transform-to-smart-instanceof.h
+++ b/compiler/pipes/transform-to-smart-instanceof.h
@@ -36,5 +36,7 @@ private:
   bool on_catch_user_recursion(VertexAdaptor<op_catch> v_catch);
   bool on_lambda_user_recursion(VertexAdaptor<op_lambda> v_lambda);
 
+  VertexPtr try_replace_switch_when_constexpr(VertexAdaptor<op_switch> v_switch);
+
   std::map<std::string, std::stack<std::string>> new_names_of_var;
 };

--- a/compiler/vertex-util.h
+++ b/compiler/vertex-util.h
@@ -21,6 +21,8 @@ public:
   static VertexAdaptor<meta_op_unary> create_conv_to_lval(PrimitiveType targetType, VertexPtr x);
   static VertexPtr create_int_const(int64_t number);
   static VertexAdaptor<op_string> create_string_const(const std::string &s);
+  static VertexAdaptor<op_var> create_superlocal_var(const std::string& name_prefix, FunctionPtr cur_function);
+  static VertexAdaptor<op_switch> create_switch_vertex(FunctionPtr cur_function, VertexPtr switch_condition, std::vector<VertexPtr> &&cases);
 
   static VertexPtr unwrap_array_value(VertexPtr v);
   static VertexPtr unwrap_string_value(VertexPtr v);

--- a/tests/phpt/generics/027_constexpr_switch.php
+++ b/tests/phpt/generics/027_constexpr_switch.php
@@ -1,0 +1,206 @@
+@ok
+<?php
+
+class A {
+    public int $value;
+
+    function __construct(int $value) {
+        $this->value = $value;
+    }
+
+    function printMe() {
+        echo "A value=$this->value\n";
+    }
+
+    function inc() {
+        $this->value++;
+        return $this;
+    }
+}
+
+class B {
+    public string $marker;
+
+    function __construct(string $marker) {
+        $this->marker = $marker;
+    }
+
+    function printMe() {
+        echo "B marker=$this->marker\n";
+    }
+
+    function append() {
+        $this->marker .= '!';
+        return $this;
+    }
+}
+
+class Emptyn {}
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T
+ */
+function fact1(string $cn) {
+    switch($cn) {
+    case A::class:
+        $obj = new A(10);
+        $obj->inc();
+        break;
+    case B::class:
+        $obj = new B('fact1');
+        $obj->append();
+        break;
+    }
+
+    $obj->printMe();
+    return $obj;
+}
+
+fact1(A::class)->inc()->printMe();
+fact1(B::class)->append()->printMe();
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T
+ */
+function fact2(string $cn) {
+    switch($cn) {
+    case A::class:
+        $obj = new A(20);
+        if ($obj->value == 20)
+            break;
+        $obj->inc();
+        break;
+    default:
+        $obj = new B('fact2');
+        $obj->append();
+        break;
+    }
+
+    $obj->printMe();
+    return $obj;
+}
+
+fact2(A::class)->inc()->printMe();
+fact2(B::class)->append()->printMe();
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return A
+ */
+function fact3(string $cn) {
+    switch($cn) {
+    case A::class:
+    case B::class:
+        echo "passed $cn, create A\n";
+        $obj = new A(10);
+        $obj->inc();
+        break;
+    }
+
+    $obj->printMe();
+    return $obj;
+}
+
+fact3(A::class)->inc()->printMe();
+fact3(B::class)->inc()->printMe();
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return B
+ */
+function fact4(string $cn) {
+    switch($cn) {
+    case A::class:
+    case B::class:
+    default:
+        echo "passed $cn, create B\n";
+        $obj = new B('');
+        break;
+        $obj->append();
+    }
+
+    $obj->printMe();
+    return $obj;
+}
+
+fact4(A::class)->append()->printMe();
+fact4(B::class)->append()->printMe();
+fact4(Emptyn::class)->append()->printMe();
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return Emptyn
+ */
+function fact5(string $cn) {
+    switch($cn) {
+    default:
+        echo "passed $cn, create Emptyn\n";
+        $obj = new Emptyn();
+    }
+    return $obj;
+}
+
+fact5(A::class);
+fact5(B::class);
+fact5(Emptyn::class);
+
+
+function ceNonGen() {
+    switch ('kk') {
+    case 'kk':
+        $obj = new A(30);
+        $obj->inc();
+        $obj->printMe();
+        break;
+    case 'dd':
+        // this case never reached, dropped off early and does not prevent compilation
+        $obj = new B('ceNonGen');
+        $obj->append2374623874();
+        break;
+    }
+}
+
+ceNonGen();
+
+class BaseC {
+    const TYPE = 'curator';
+
+    static function info() {
+        switch (static::TYPE) {
+        case 'false':
+        case 'curator':
+        case 'D3':
+            $t = static::TYPE;
+            echo "overridden for $t in ", static::class, "\n";
+            break;
+        case 'D4':
+            if(0) exit();
+            if(1)
+                var_dump(0);
+            break;
+        default:
+            echo "const of ", static::class, "\n";
+        }
+    }
+}
+class D1 extends BaseC {}
+class D2 extends BaseC { const TYPE = 'D2'; }
+class D3 extends BaseC { const TYPE = 'D3'; }
+class D4 extends BaseC { const TYPE = 'D4'; }
+
+BaseC::info();
+D1::info();
+D2::info();
+D3::info();
+D4::info();

--- a/tests/phpt/generics/028_constexpr_services_cont.php
+++ b/tests/phpt/generics/028_constexpr_services_cont.php
@@ -1,0 +1,102 @@
+@ok
+<?php
+
+class ServicesContainer {
+    private const HIDDEN = [
+        ServicePrivate::class => true,
+    ];
+
+    private ?ServiceFoo $foo = null;
+    private ?ServiceBar $bar = null;
+
+    private int $fooArg;
+
+    function __construct(int $fooArg) {
+        $this->fooArg = $fooArg;
+    }
+
+    private function createFoo(): ServiceFoo {
+        return new ServiceFoo($this->fooArg);
+    }
+
+    private function getBar(): ServiceBar {
+        return $this->bar ?? ($this->bar = new ServiceBar('bar from ' . __CLASS__));
+    }
+
+    /**
+     * Main API
+     * @kphp-generic TService
+     * @param class-string<TService> $serviceClass
+     * @return TService
+     */
+    function getInstance(string $serviceClass) {
+        switch ($serviceClass) {
+        case ServiceFoo::class:
+            return $this->foo ?? ($this->foo = $this->createFoo());
+        case ServiceBar::class:
+            return $this->getBar();
+        case ServiceException::class:
+            throw new Exception("ServiceException unimplemented");
+        }
+
+        if (isset(self::HIDDEN[$serviceClass])) {
+            throw new Exception("$serviceClass is private and can not be used");
+        }
+        throw new Exception("$serviceClass not found");
+    }
+}
+
+class ServiceFoo {
+    private int $a;
+    function __construct(int $a) { $this->a = $a; }
+    function fooMethod() { echo "fooMethod $this->a\n"; }
+}
+
+class ServiceBar {
+    private ?string $b;
+    function __construct(?string $b) { $this->b = $b; }
+    function barMethod() { echo "barMethod $this->b\n"; }
+}
+
+class ServicePrivate {
+    function privateMethod() { echo "privateMethod\n"; }
+}
+
+class ServiceException {
+    function exceptionMethod() { echo "exceptionMethod\n"; }
+}
+
+class ServiceUnknown {
+    function unknownMethod() { echo "unknownMethod\n"; }
+}
+
+function demo1() {
+    $factory = new ServicesContainer(42);
+    $factory->getInstance(ServiceFoo::class)->fooMethod();
+    $factory->getInstance(ServiceBar::class)->barMethod();
+}
+
+function demo2() {
+    (new ServicesContainer(-1))->getInstance(ServicePrivate::class)->privateMethod();
+}
+
+function demo3() {
+    (new ServicesContainer(-1))->getInstance(ServiceException::class)->exceptionMethod();
+}
+
+function demo4() {
+    (new ServicesContainer(-1))->getInstance(ServiceUnknown::class)->unknownMethod();
+}
+
+function tryCatch(callable $cb) {
+    try {
+        $cb();
+    } catch (Exception $ex) {
+        echo "exception: {$ex->getMessage()}\n";
+    }
+}
+
+tryCatch(fn() => demo1());
+tryCatch(fn() => demo2());
+tryCatch(fn() => demo3());
+tryCatch(fn() => demo4());

--- a/tests/phpt/generics/130_not_constexpr_switch_1.php
+++ b/tests/phpt/generics/130_not_constexpr_switch_1.php
@@ -1,0 +1,85 @@
+@kphp_should_fail
+/in fact1<A>/
+/Method bMethod\(\) not found in class A/
+/in fact1<B>/
+/Method aMethod\(\) not found in class B/
+/in fact2<A>/
+/in fact2<B>/
+/\$obj is assumed to be both A and B/
+/in fact3<A>/
+/\$obj is assumed to be both A3 and B3/
+<?php
+
+class A { function __construct(int $x) {} function aMethod() {} }
+class B { function bMethod() {} }
+class A3 { function __construct(int $x) {} function aMethod() {} }
+class B3 { function bMethod() {} }
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T
+ */
+function fact1(string $cn) {
+    /** @var T $obj */
+    $copy = $cn;        // becomes not constexpr
+    switch($copy) {
+    case A::class:
+        $obj = new A(10);
+        $obj->aMethod();
+        break;
+    case B::class:
+        $obj = new B();
+        $obj->bMethod();
+        break;
+    }
+    return $obj;
+}
+
+fact1(A::class);
+fact1(B::class);
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T
+ */
+function fact2(string $cn) {
+    $copy = $cn;        // becomes not constexpr
+    switch($copy) {
+    case A::class:
+        $obj = new A(10);
+        $obj->aMethod();
+        break;
+    case B::class:
+        $obj = new B();
+        $obj->bMethod();
+        break;
+    }
+    return $obj;
+}
+
+fact2(A::class);
+fact2(B::class);
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $cn
+ * @return T
+ */
+function fact3(string $cn) {
+    switch($cn) {
+    case A::class:
+        $obj = new A3(10);
+        $obj->aMethod();
+    case B::class:
+        $obj = new B3();
+        $obj->bMethod();
+        break;
+    }
+    return $obj;
+}
+
+fact3(A::class);


### PR DESCRIPTION
Suppose you want something like `$factory->getInstance<T>()`, to be used like
```php
$factory->getInstance(FooService::class)->fooMethod();
$factory->getInstance(AnotherService::class)->anotherMethod();
```

Here is a possible implementation:
```php
/**
 * @kphp-generic TService
 * @param class-string<TService> $serviceClass
 * @return TService
 */
function getInstance(string $serviceClass) {
  switch ($serviceClass) {
  case FooService::class:
    return $this->foo ?? ($this->foo = $this->createFoo());
  case AnotherService::class:
    return $this->getAnother();
  // more services
  }
  
  if (isset(self::HIDDEN[$serviceClass])) {
    throw new Exception("$serviceClass is private and can not be used");
  }
  throw new Exception("$serviceClass not found");
}
```

### This PR makes it work as expected. Before, it did not

Let's see how `getInstance<FooService>` would look like:
```php
function getInstance<FooService>(string $serviceClass = 'FooService'): FooService {
  switch ($serviceClass) {
  case FooService::class:
    // return FooService object, ok
  case AnotherService::class:
    // return another object, ERROR! types mismatch, FooService expected
  }
  ...
}
```

As you see, without any modifications, the code is erroneous. 

But we have a guarantee that `$serviceClass` is 'FooService' in this cocrete generic specialization.
In other terms, it's a **constexpr** compile-time known string. We have a switch over a constexpr string,
so the only case is valid, which is also calculated at compile-time, so `switch` itself could be just replaced 
with a body of a true `case`, or `default` if all cases are false. Also, `$serviceClass` variable can not be modified.

### Implementation

KPHP automatically performs such transformations for `switch` over constexpr a string, with constexpr cases,
where every non-empty case ends with break/return/throw. Constructions like `if/else` are not analyzed.

More precisely, the following AST is produced:
```php
function getInstance<FooService>(string $serviceClass = 'FooService'): FooService {
  switch ($serviceClass) {
  default:
    // body of true case 'FooService::class'
    return $this->foo ?? ($this->foo = $this->createFoo());
  }
  ...
}
```

Instead of a switch with many cases, KPHP leaves a switch with an only `default` case containing body of a true case. It's easier then to replace the switch itself, as we don't have to eliminate `break;` inside.