### PR TITLE
not_null(T) and not_false(T) in @param/@return, useful for generics

### DIFF
--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -170,6 +170,12 @@ void TypeHintFuture::recalc_type_data_in_context_of_call(TypeData *dst, VertexPt
   dst->set_lca_at(MultiKey::any_key(1), &nested);
 }
 
+void TypeHintNotNull::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
+  TypeData nested(*TypeData::get_type(tp_any));
+  inner->recalc_type_data_in_context_of_call(&nested, call);
+  dst->set_lca(&nested, !drop_not_false, !drop_not_null);
+}
+
 void TypeHintInstance::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call __attribute__ ((unused))) const {
   dst->set_lca(resolve()->type_data);
 }

--- a/compiler/phpdoc.cpp
+++ b/compiler/phpdoc.cpp
@@ -484,6 +484,14 @@ const TypeHint *PhpDocTypeHintParser::parse_simple_type() {
         }
         return TypeHintPrimitive::create(tp_tmp_string);
       }
+      if (cur_tok->str_val == "not_null") {
+        cur_tok++;
+        return TypeHintNotNull::create(parse_nested_one_type_hint(), true, false);
+      }
+      if (cur_tok->str_val == "not_false") {
+        cur_tok++;
+        return TypeHintNotNull::create(parse_nested_one_type_hint(), false, true);
+      }
       // otherwise interpreted as a class name (including the lowercase names);
       // it works with the absolute and relative names as well as for a special names like 'self';
       // file 'use' directives are taken into the account

--- a/compiler/type-hint.h
+++ b/compiler/type-hint.h
@@ -380,6 +380,31 @@ public:
 };
 
 /**
+ * not_null(T), not_false(T), not_null<T>, not_false<T>.
+ * Primarily used in generics to unwrap genericT, similar to std::remove_reference.
+ */
+class TypeHintNotNull : public TypeHint {
+  explicit TypeHintNotNull(const TypeHint *inner, bool drop_not_null, bool drop_not_false)
+    : TypeHint(0)
+    , inner(inner)
+    , drop_not_null(drop_not_null)
+    , drop_not_false(drop_not_false) {}
+
+public:
+  const TypeHint *inner;
+  bool drop_not_null;
+  bool drop_not_false;
+
+  static const TypeHint *create(const TypeHint *inner, bool drop_not_null, bool drop_not_false);
+
+  std::string as_human_readable() const final;
+  void traverse(const TraverserCallbackT &callback) const final;
+  const TypeHint *replace_self_static_parent(FunctionPtr resolve_context) const final;
+  const TypeHint *replace_children_custom(const ReplacerCallbackT &callback) const final;
+  void recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr func_call) const final;
+};
+
+/**
  * A, VK\Namespaced, self — these all are instances
  * Note, that self/static/parent are saved as full_class_name, but storing them here is an intermediate moment of parsing
  * Because self is not constexpr: it should be replaced with an actual context to be used in inferring

--- a/tests/phpt/generics/027_generic_drop_null.php
+++ b/tests/phpt/generics/027_generic_drop_null.php
@@ -1,0 +1,107 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+class A {}
+
+function takeInt(int $a) { echo $a, "\n"; }
+/** @param int[] $a */
+function takeArrInt($a) { echo "n ", count($a), "\n"; }
+function takeA(A $a) {}
+
+/** @return int[] */
+function getArrInt(): array {
+    /** @var ?int[] $arr */
+    $arr = [];
+    return dropNull($arr);
+}
+
+/**
+ * @kphp-generic T
+ * @param ?T $data
+ * @return not_null(T)
+ */
+function dropNull($data) {
+  return not_null($data);
+}
+
+/**
+ * @kphp-generic T
+ * @param T $data
+ * @return not_false<T>
+ */
+function dropFalse($data) {
+  return not_false($data);
+}
+
+/**
+ * @kphp-generic T
+ * @param T $data
+ * @return not_false<not_null<T>>
+ */
+function dropNullFalse($data) {
+  return not_false(not_null($data));
+}
+
+function demo1() {
+  /** @var ?int $i_or_null */
+  $i_or_null = 3;
+  takeInt(dropNull($i_or_null));
+  takeInt(dropNull/*<int>*/(3+4 ? 1 : null));
+  takeInt(dropNull(dropFalse($i_or_null)));
+  takeArrInt([dropNull($i_or_null)]);
+}
+
+function demo2() {
+    /** @var int|false $i_or_false */
+    $i_or_false = 3 ? 3 : false;
+    takeInt(dropFalse($i_or_false));
+    takeInt(dropFalse/*<int|false>*/(3 ? 3 : false));
+    $a = [];
+    for ($i = 0; $i < 10; ++$i)
+        $a[] = dropNull(dropFalse($i_or_false));
+    takeArrInt($a);
+    /** @var int|false|null $ifn */
+    $ifn = 3;
+    takeInt(dropFalse/*<int|false>*/(not_null($ifn)));
+}
+
+function demo3() {
+    takeA(new A);
+    takeA(dropFalse(new A));
+    if (0) takeA(dropNull/*<A>*/(null));
+}
+
+function demo4() {
+    /** @var mixed $v1 */
+    $v1 = dropNull(3);
+    /** @var string $v2 */
+    $v2 = dropNull/*<string>*/('s');
+    /** @var string $v3 */
+    $v3 = dropNull/*<string>*/('s' ?: null);
+    /** @var string $v4 */
+    $v4 = dropNull/*<?string>*/('s');
+    /** @var string $v5 */
+    $v5 = dropNull/*<?string>*/('s' ?: null);
+}
+
+/** @param int|null|false $i */
+function demo5($i) {
+    /** @var int|null|false $i */
+    takeInt(dropNullFalse($i));
+}
+
+/** @param not_null(int) $i */
+function demo6($i) {
+    /** @var not_false(not_null(int|false|null)) $j */
+    $j = 0;
+    takeInt($i);
+    takeInt($j);
+}
+
+demo1();
+demo2();
+demo3();
+demo4();
+demo5(4);
+demo6(10);

--- a/tests/phpt/generics/130_bad_drop_null.php
+++ b/tests/phpt/generics/130_bad_drop_null.php
@@ -1,0 +1,41 @@
+@kphp_should_fail
+KPHP_SHOW_ALL_TYPE_ERRORS=1
+/pass int\|false to argument \$a of takeInt/
+/pass \?int to argument \$a of takeInt/
+<?php
+
+
+function takeInt(int $a) {}
+
+/**
+ * @kphp-generic T
+ * @param ?T $data
+ * @return not_null(T)
+ */
+function dropNull($data) {
+  return not_null($data);
+}
+
+/**
+ * @kphp-generic T
+ * @param T $data
+ * @return not_false<T>
+ */
+function dropFalse($data) {
+  return not_null($data);
+}
+
+/**
+ * @kphp-generic T
+ * @param T $data
+ * @return not_false<not_null<T>>
+ */
+function dropNullFalse($data) {
+  return not_false(not_null($data));
+}
+
+/** @var int|null|false $i1 */
+$i1 = 0;
+takeInt(dropNull(dropNull($i1)));
+takeInt(dropFalse/*<?int>*/(dropNullFalse($i1) ?? null));
+


### PR DESCRIPTION
Previously, there was not way to express "drop null/false from a type". This attempt is wrong:
```php
/**
 * @kphp-generic T
 * @param ?T $n
 * @return T
 */
function dropNull($n) {
  return not_null($n);
}
```
It's wrong, because when called with `T=?int`, then `$n ::: ?(?int)`, and it returns `?int` obviously. We want `int`.

Now, it's possible to be expressed like this:
```php
/**
 * ...
 * @return not_null(T)
 */
```

Along with `not_null(T)`, there is `not_false(T)`. Square braces are also acceptable.
It's a regular type hint, so even `not_null(?int)` is a valid but meaningless notation.