### PR TITLE
fix modulite issue on inheriting Derived in modulite1 from Base in modulite2

### DIFF
--- a/compiler/modulite-check-rules.h
+++ b/compiler/modulite-check-rules.h
@@ -8,8 +8,9 @@
 #include "compiler/data/modulite-data.h"
 
 void modulite_check_when_use_class(FunctionPtr usage_context, ClassPtr klass);
+void modulite_check_when_use_global_const(FunctionPtr usage_context, DefinePtr used_c);
 void modulite_check_when_use_constant(FunctionPtr usage_context, DefinePtr used_c, ClassPtr requested_class);
 void modulite_check_when_call_function(FunctionPtr usage_context, FunctionPtr called_f);
-void modulite_check_when_use_static_field(FunctionPtr usage_context, VarPtr field, ClassPtr requested_class);
+void modulite_check_when_use_static_field(FunctionPtr usage_context, VarPtr property, ClassPtr requested_class);
 void modulite_check_when_global_keyword(FunctionPtr usage_context, const std::string &global_var_name);
 

--- a/compiler/pipes/calc-real-defines-values.cpp
+++ b/compiler/pipes/calc-real-defines-values.cpp
@@ -59,7 +59,7 @@ void CalcRealDefinesAndAssignModulitesF::on_finish(DataStream<FunctionPtr> &os) 
 
   for (DefinePtr define : G->get_defines()) {
     process_define(define);
-    define->modulite = define->file_id->dir->nested_files_modulite;
+    define->modulite = (define->class_id ? define->class_id->file_id : define->file_id)->dir->nested_files_modulite;
   }
   stage::die_if_global_errors();
 

--- a/compiler/pipes/inline-defines-usages.cpp
+++ b/compiler/pipes/inline-defines-usages.cpp
@@ -42,13 +42,12 @@ VertexPtr InlineDefinesUsagesPass::on_enter_vertex(VertexPtr root) {
     if (current_function->modulite != def->modulite) {
       // When `class B extends A`, def=B::CONST would refer to A::CONST actually,
       // but we should perform all checks for B (requested_class), not for A
-      ClassPtr requested_class;
       if (name[0] == 'c' && name[1] == '#') {
         std::string requested_cn = root->get_string().substr(0, root->get_string().find("$$"));
-        requested_class = G->get_class(requested_cn);
-        kphp_assert(requested_class);
+        modulite_check_when_use_constant(current_function, def, G->get_class(requested_cn));
+      } else {
+        modulite_check_when_use_global_const(current_function, def);
       }
-      modulite_check_when_use_constant(current_function, def, requested_class);
     }
 
     if (def->type() == DefineData::def_var) {

--- a/tests/phpt/modulite/005_inheritance/005_inheritance.php
+++ b/tests/phpt/modulite/005_inheritance/005_inheritance.php
@@ -8,6 +8,7 @@ require_once 'kphp_tester_include.php';
 use Feed005\Rank005\RankImpl1;
 use Feed005\Rank005\RankImpl2;
 use Feed005\SenderFactory;
+require_once 'plain005/plain005.php';
 
 GImportTrait::pubStaticFn();
 $mmm = new GImportTrait;
@@ -32,6 +33,7 @@ callSend(SenderFactory::createSender('email'));
 callSend(SenderFactory::createSender('sms'));
 
 printCurDescInherit();
+plainPrintCurDescInherit();
 
 Common005\CallOthers005::accessGloDer();
 Common005\CallOthers005::accessMessage();

--- a/tests/phpt/modulite/005_inheritance/ConnectNoMod005/ErrNoMod005.php
+++ b/tests/phpt/modulite/005_inheritance/ConnectNoMod005/ErrNoMod005.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace ConnectNoMod005;
+
+final class ErrNoMod005 extends \SakCommon005\ErrSak005 {
+}

--- a/tests/phpt/modulite/005_inheritance/SakCommon005/.modulite.yaml
+++ b/tests/phpt/modulite/005_inheritance/SakCommon005/.modulite.yaml
@@ -1,0 +1,12 @@
+name: "@sak"
+namespace: "SakCommon005\\"
+
+export:
+  - "ErrSak005"
+
+force-internal:
+
+require:
+  - "@feed"
+
+allow-internal-access:

--- a/tests/phpt/modulite/005_inheritance/SakCommon005/ErrSak005.php
+++ b/tests/phpt/modulite/005_inheritance/SakCommon005/ErrSak005.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SakCommon005;
+
+class ErrSak005 {
+    const MODE = 1;
+    static public int $count = 0;
+
+    static function create() {
+        echo "create err";
+        return new static;
+    }
+}

--- a/tests/phpt/modulite/005_inheritance/plain005/.modulite.yaml
+++ b/tests/phpt/modulite/005_inheritance/plain005/.modulite.yaml
@@ -1,0 +1,14 @@
+name: "@plain005"
+namespace: ""
+
+export:
+  - "plainPrintCurDescInherit()"
+
+force-internal:
+
+require:
+  - "ConnectNoMod005\\ErrNoMod005::MODE"
+  - "ConnectNoMod005\\ErrNoMod005::$count"
+  - "ConnectNoMod005\\ErrNoMod005::create()"
+
+allow-internal-access:

--- a/tests/phpt/modulite/005_inheritance/plain005/plain005.php
+++ b/tests/phpt/modulite/005_inheritance/plain005/plain005.php
@@ -1,0 +1,7 @@
+<?php
+
+function plainPrintCurDescInherit() {
+    ConnectNoMod005\ErrNoMod005::create();
+    ConnectNoMod005\ErrNoMod005::MODE;
+    ConnectNoMod005\ErrNoMod005::$count++;
+}


### PR DESCRIPTION
Consider the following:
```php
class A {
  const C = 1;
}

class B extends A {
}
```

In KPHP internals, `B::C` refers to `A::C` actually.
(when we parse `"B::C"` in yaml, we call `$b->get_constant('C')`, it returns a member of `A`)

What bug is fixed here:
**if B and A belong to different modulites, this fact leads to unexpected errors**
Same for methods and properties.

