### PR TITLE
[docs] added `bash_profile` reload command in `epoll-shim` configuration instruction

### DIFF
--- a/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
+++ b/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
@@ -95,6 +95,7 @@ git clone https://github.com/VKCOM/epoll-shim.git
 cd epoll-shim
 git checkout osx-platform
 echo 'export "EPOLL_SHIM_REPO=$(pwd)" >> ~/.bash_profile'
+source ~/.bash_profile
 ```
 
 Clone somewhere local [h3 from GitHub]({{site.url_package_h3_mac}}) and switch to *stable-3.x* branch.


### PR DESCRIPTION
Hi!
I can suggest some improvement in the [documentation](https://vkcom.github.io/kphp/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.html).
I think you need to mention about reloading `bash_profile` from the command line when configure `epoll-shim`.