### PR TITLE
[compiler] add basic support for type-checked mixed union types

### DIFF
--- a/compiler/inferring/node-recalc.cpp
+++ b/compiler/inferring/node-recalc.cpp
@@ -103,7 +103,12 @@ void NodeRecalc::set_lca_at(const MultiKey *key, const RValue &rvalue) {
     key = &MultiKey::any_key(0);
   }
 
-  new_type_->set_lca_at(*key, type, !rvalue.drop_or_false, !rvalue.drop_or_null, rvalue.ffi_flags);
+  TypeData::LCAFlags lca_flags;
+  lca_flags.save_or_false = !rvalue.drop_or_false;
+  lca_flags.save_or_null = !rvalue.drop_or_null;
+  lca_flags.ffi_drop_ref = rvalue.ffi_drop_ref;
+  lca_flags.ffi_take_addr = rvalue.ffi_take_addr;
+  new_type_->set_lca_at(*key, type, lca_flags);
 
   if (unlikely(new_type_->error_flag())) {
     on_new_type_became_tpError(type, rvalue);

--- a/compiler/inferring/rvalue.h
+++ b/compiler/inferring/rvalue.h
@@ -26,20 +26,21 @@ struct RValue {
   const MultiKey *key{nullptr};
   bool drop_or_false{false};
   bool drop_or_null{false};
-  TypeData::FFIRvalueFlags ffi_flags;
+  bool ffi_drop_ref{false};
+  bool ffi_take_addr{false};
 };
 
 // take &T cdata type and return it as T;
 // for non-cdata types it has no effect
 inline RValue ffi_rvalue_drop_ref(RValue rvalue) {
-  rvalue.ffi_flags.drop_ref = true;
+  rvalue.ffi_drop_ref = true;
   return rvalue;
 }
 
 // take T cdata type and return it as *T;
 // for non-cdata types it has no effect
 inline RValue ffi_rvalue_take_addr(RValue rvalue) {
-  rvalue.ffi_flags.take_addr = true;
+  rvalue.ffi_take_addr = true;
   return rvalue;
 }
 

--- a/compiler/inferring/type-hint-recalc.cpp
+++ b/compiler/inferring/type-hint-recalc.cpp
@@ -93,7 +93,7 @@ void TypeHintArgSubkeyGet::recalc_type_data_in_context_of_call(TypeData *dst, Ve
 }
 
 void TypeHintArray::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
-  dst->set_lca(TypeData::get_type(tp_array));
+  dst->set_lca(TypeData::get_type(tp_array), TypeData::LCAFlags::for_phpdoc());
   TypeData nested(*TypeData::get_type(tp_any));
   inner->recalc_type_data_in_context_of_call(&nested, call);
   dst->set_lca_at(MultiKey::any_key(1), &nested);
@@ -187,10 +187,10 @@ void TypeHintRefToMethod::recalc_type_data_in_context_of_call(TypeData *dst, Ver
 void TypeHintOptional::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call) const {
   inner->recalc_type_data_in_context_of_call(dst, call);
   if (or_null) {
-    dst->set_lca(TypeData::get_type(tp_Null));
+    dst->set_lca(TypeData::get_type(tp_Null), TypeData::LCAFlags::for_phpdoc());
   }
   if (or_false) {
-    dst->set_lca(TypeData::get_type(tp_False));
+    dst->set_lca(TypeData::get_type(tp_False), TypeData::LCAFlags::for_phpdoc());
   }
 }
 
@@ -201,7 +201,7 @@ void TypeHintPipe::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr 
 }
 
 void TypeHintPrimitive::recalc_type_data_in_context_of_call(TypeData *dst, VertexPtr call __attribute__ ((unused))) const {
-  dst->set_lca(TypeData::get_type(ptype));
+  dst->set_lca(TypeData::get_type(ptype), TypeData::LCAFlags::for_phpdoc());
 }
 
 void TypeHintObject::recalc_type_data_in_context_of_call(TypeData *dst __attribute__ ((unused)), VertexPtr call __attribute__ ((unused))) const {

--- a/compiler/pipes/collect-main-edges.cpp
+++ b/compiler/pipes/collect-main-edges.cpp
@@ -393,7 +393,7 @@ void CollectMainEdgesPass::on_foreach(VertexAdaptor<op_foreach> foreach_op) {
   }
   create_set(as_lvalue(x->var_id), params);
   if (key) {
-    create_type_assign(as_lvalue(key->var_id), TypeData::get_type(tp_mixed));
+    create_type_assign(as_lvalue(key->var_id), TypeData::get_foreach_key_type());
   }
 }
 

--- a/tests/phpt/generics/021_default_T.php
+++ b/tests/phpt/generics/021_default_T.php
@@ -154,8 +154,12 @@ var_dump($ints);
 
 /** @var mixed[] */
 $mixeds = pushInOne([1,2,3], ['1','2','3']);
-$mixeds = pushInOne([1,2,3], ['1','2','3'], [true], [null]);
+$mixeds = pushInOne([1,2,3], ['1','2','3'], [true], [1]);
 var_dump($mixeds);
+$mixeds2 = pushInOne([1,2,3], ['1','2','3'], [true], [false]);
+var_dump($mixeds2);
+$mixeds3 = pushInOne([1,2,3], ['1','2','3'], [true], ['str']);
+var_dump($mixeds3);
 
 $as = pushInOne([new A]);
 $as = pushInOne([new A], [new A]);

--- a/tests/phpt/phpdocs/106_boolean_in_phpdoc.php
+++ b/tests/phpt/phpdocs/106_boolean_in_phpdoc.php
@@ -7,3 +7,4 @@ function foo($a) {
 }
 
 foo(false);
+foo(true);

--- a/tests/phpt/restricted_mixed/correct_usage.php
+++ b/tests/phpt/restricted_mixed/correct_usage.php
@@ -1,0 +1,290 @@
+@ok
+<?php
+
+/** @param string $x */
+function ensure_string($x) {}
+
+/** @param int|string $x */
+function int_or_string($x) {}
+
+/** @param string|float $x */
+function string_or_float($x) {}
+
+/** @param boolean|string|int $x */
+function bool_or_string_or_int($x) {}
+
+/** @param int|(mixed[]) $x */
+function int_or_mixedarray($x) {}
+
+/** @param array|int $x */
+function array_or_int($x) {}
+
+/** @param ?(array|string|int) $x */
+function nullable_array_or_string_or_int($x) {}
+
+/** @param array|string|null|int $x */
+function nullable_array_or_string_or_int2($x) {}
+
+/** @param array|string|false $x */
+function array_or_string_or_false($x) {}
+
+/** @param int|string|false|null $x */
+function int_or_string_or_false_or_null($x) {}
+
+/** @param int|float|string|array|boolean|null $x */
+function full_mixed($x) {}
+
+/** @param int|float|string|boolean|null $x */
+function mixed_except_arrays($x) {}
+
+/** @param int|float $x */
+function int_or_float($x) {}
+
+/** @param int|float|string $x */
+function int_or_float_or_string($x) {}
+
+/** @param int|string|float $x */
+function int_or_float_or_string2($x) {}
+
+/** @param float|string $x */
+function float_or_string($x) {}
+
+/**
+ * mixing any primitive type with mixed gives mixed
+ * @param int|mixed $x
+ */
+function union_with_mixed($x) {}
+
+/** @param int|string $x */
+function default_int_or_string($x = 1) {
+  var_dump($x);
+}
+
+/**
+ * the type system is not good enough to handle this,
+ * $x type will be inferred as mixed[]
+ * @param boolean[]|float[] $x
+ */
+function typed_array_union($x) {}
+
+/** @param (int|string)[]|(string|boolean)[] $x */
+function typed_array_union2($x) {}
+
+/**
+ * this will work as expected
+ * @param (boolean|float)[] $x
+ */
+function typed_array_union3($x) {}
+
+/** @param int|string|false|null $x */
+function optional_int_or_string($x) {}
+
+class Example {
+  /** @var int|string */
+  public $int_or_string;
+
+  /** @var int|string */
+  public $int_or_string2;
+
+  /** @var ?(string|array) */
+  public $nullable_string_or_array;
+
+  /** @var ?(string|array) */
+  public $nullable_string_or_array2;
+}
+
+function auto_casts1() {
+  /** @var string|null $nullable_string_var */
+  $nullable_string_var = null;
+  /** @var string|null|false $optional_string_var */
+  $optional_string_var = false;
+
+  if ($optional_string_var) {
+    int_or_string($optional_string_var);
+  }
+  if (!is_null($nullable_string_var)) {
+    int_or_string($nullable_string_var);
+  }
+  if ($nullable_string_var !== null) {
+    int_or_string($nullable_string_var);
+  }
+}
+
+function auto_casts2() {
+  /** @var string|false $s */
+  $s = false;
+  if ($s === false || $s === '') {
+    return;
+  }
+  int_or_string($s);
+}
+
+function main() {
+  /** @var mixed $mixed */
+  $mixed = 35;
+
+  /** @var string|array $string_or_array_var */
+  $string_or_array_var = [];
+  /** @var int|boolean $int_or_bool_var */
+  $int_or_bool_var = false;
+  /** @var int|string $int_or_string_var */
+  $int_or_string_var = 'str';
+  /** @var string|null $nullable_string_var */
+  $nullable_string_var = null;
+  /** @var string|null|false $optional_string_var */
+  $optional_string_var = false;
+
+  auto_casts1();
+  auto_casts2();
+
+  // since local variables can't preserve the restricted mixed property,
+  // we allow mixed to be passed as a restricted mixed argument
+  int_or_string($mixed);
+
+  int_or_string($string_or_array_var);
+  int_or_string($int_or_bool_var);
+
+  int_or_string(1);
+  int_or_string('str');
+
+  string_or_float('str');
+  string_or_float(2.5);
+
+  bool_or_string_or_int(true);
+  bool_or_string_or_int(false);
+  bool_or_string_or_int('str');
+  bool_or_string_or_int(1);
+
+  int_or_mixedarray(1);
+  int_or_mixedarray([1]);
+  int_or_mixedarray(['str']);
+
+  array_or_int([1]);
+  array_or_int(['str']);
+  array_or_int(1);
+
+  nullable_array_or_string_or_int([1]);
+  nullable_array_or_string_or_int('str');
+  nullable_array_or_string_or_int(143);
+  nullable_array_or_string_or_int(null);
+
+  nullable_array_or_string_or_int2([1]);
+  nullable_array_or_string_or_int2('str');
+  nullable_array_or_string_or_int2(143);
+  nullable_array_or_string_or_int2(null);
+
+  array_or_string_or_false(['str']);
+  array_or_string_or_false([1]);
+  array_or_string_or_false('str');
+  array_or_string_or_false(false);
+
+  int_or_string_or_false_or_null(1);
+  int_or_string_or_false_or_null('str');
+  int_or_string_or_false_or_null(false);
+  int_or_string_or_false_or_null(null);
+
+  full_mixed(1);
+  full_mixed(1.4);
+  full_mixed('str');
+  full_mixed([1]);
+  full_mixed(['str']);
+  full_mixed(true);
+  full_mixed(false);
+  full_mixed(null);
+
+  mixed_except_arrays(1);
+  mixed_except_arrays(1.4);
+  mixed_except_arrays('str');
+  mixed_except_arrays(true);
+  mixed_except_arrays(false);
+  mixed_except_arrays(null);
+
+  int_or_float(1);
+  int_or_float(1.4);
+
+  int_or_float_or_string(1);
+  int_or_float_or_string(1.5);
+  int_or_float_or_string('str');
+
+  int_or_float_or_string2(1);
+  int_or_float_or_string2(1.5);
+  int_or_float_or_string2('str');
+
+  // float type accepts int, since float|int is reduced to float;
+  // to make it consistent, float also behaves like int|float
+  $int = 1;
+  float_or_string(1);
+  float_or_string($int);
+  float_or_string(1.5);
+  float_or_string('str');
+
+  $obj = new Example();
+
+  var_dump($obj->int_or_string); // this will be null, even though the type is int|string
+  $obj->int_or_string = 134;
+  $obj->int_or_string = 'str';
+
+  $obj->int_or_string2 = $obj->int_or_string;
+
+  $local_int_or_string = $obj->int_or_string;
+  // for now, even if $local_int_or_string type is mixed, we allow assignments
+  // of mixed to a restricted mixed to decrease the amount of new compile errors;
+  // when restricted mixed types are preserved between the assignments,
+  // it will be forbidden to assign an incompatible mixed type
+  $obj->int_or_string2 = $local_int_or_string;
+  $obj->int_or_string2 = $mixed;
+  if (is_string($local_int_or_string)) {
+    ensure_string($local_int_or_string);
+  }
+
+  $obj->nullable_string_or_array = null;
+  $obj->nullable_string_or_array = 'str';
+  $obj->nullable_string_or_array = [1];
+  $obj->nullable_string_or_array = ['str'];
+  $obj->nullable_string_or_array = [];
+
+  $obj->nullable_string_or_array2 = null;
+  $obj->nullable_string_or_array2 = $obj->nullable_string_or_array;
+
+  default_int_or_string($mixed);
+  default_int_or_string(1);
+  default_int_or_string('str');
+  default_int_or_string($obj->int_or_string);
+
+  union_with_mixed(1);
+  union_with_mixed(1.4);
+  union_with_mixed('str');
+  union_with_mixed([1]);
+  union_with_mixed(['str']);
+  union_with_mixed(true);
+  union_with_mixed(false);
+  union_with_mixed(null);
+
+  typed_array_union(['x']);
+  typed_array_union([1]);
+  typed_array_union([1.6]);
+  typed_array_union([true]);
+  typed_array_union([]);
+  typed_array_union([$mixed]);
+
+  typed_array_union2(['x']);
+  typed_array_union2([1]);
+  typed_array_union2([false]);
+  typed_array_union2([true]);
+  typed_array_union2([]);
+
+  typed_array_union3([3.5]);
+  typed_array_union3([1]);
+  typed_array_union3([]);
+  typed_array_union3([true]);
+
+  optional_int_or_string($int_or_string_var);
+  optional_int_or_string($nullable_string_var);
+  optional_int_or_string($optional_string_var);
+  optional_int_or_string(null);
+  optional_int_or_string(false);
+  optional_int_or_string(1);
+  optional_int_or_string('str');
+}
+
+main();

--- a/tests/phpt/restricted_mixed/error_param_float_or_string.php
+++ b/tests/phpt/restricted_mixed/error_param_float_or_string.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/pass bool to argument \$x of f/
+/declared as @param float\|string/
+<?php
+
+/** @param float|string $x */
+function f($x) {}
+
+f(true);

--- a/tests/phpt/restricted_mixed/error_param_float_or_string2.php
+++ b/tests/phpt/restricted_mixed/error_param_float_or_string2.php
@@ -1,0 +1,14 @@
+@kphp_should_fail
+/pass bool to argument \$x of f/
+/declared as @param float\|string/
+<?php
+
+/** @param float|string $x */
+function f($x) {}
+
+function test() {
+  $b = true;
+  f($b);
+}
+
+test();

--- a/tests/phpt/restricted_mixed/error_param_float_or_string3.php
+++ b/tests/phpt/restricted_mixed/error_param_float_or_string3.php
@@ -1,0 +1,9 @@
+@kphp_should_fail
+/pass false to argument \$x of f/
+/declared as @param float\|string/
+<?php
+
+/** @param float|string $x */
+function f($x) {}
+
+f(false);

--- a/tests/phpt/restricted_mixed/error_return_int_or_string.php
+++ b/tests/phpt/restricted_mixed/error_return_int_or_string.php
@@ -1,0 +1,17 @@
+@kphp_should_fail
+/return float from f/
+/declared as @return int\|string/
+<?php
+
+/** @return int|string */
+function f($cond) {
+  if ($cond === 1) {
+    return 1; // OK
+  }
+  if ($cond === 2) {
+    return 'str'; // OK
+  }
+  return 2.5; // error
+}
+
+f(1);

--- a/tests/phpt/restricted_mixed/todo.php
+++ b/tests/phpt/restricted_mixed/todo.php
@@ -1,0 +1,35 @@
+@ok
+<?php
+
+/**
+ * we don't propagate mixed union info to vars right now,
+ * so using an incorrect default init is not an error yet
+ * @param int|string $x
+ */
+function int_or_string_null_default($x = null) {}
+
+/** @return float|boolean */
+function get_float_or_bool() { return 0.5; }
+
+/** @param int|string $x */
+function expect_int_or_string($x) {}
+
+/** @param int|string $x */
+function mismatching_check($x) {
+  // when mixed unions stop accept bare mixed type and are propagated properly,
+  // this code should probably result in a compile error (or some warning)
+  if (is_array($x)) {
+    var_dump('should never happen');
+  }
+}
+
+function test() {
+  int_or_string_null_default();
+
+  // unions as return values are not preserved as types yet
+  expect_int_or_string(get_float_or_bool());
+
+  mismatching_check(1);
+}
+
+test();


### PR DESCRIPTION
Types like `int|string` can now be expressed in the type system. Every mixed union variant sets a bit flag inside TypeData.

When generating the C++ code, any mixed unions become simple mixed types.

Right now we only check function parameters passing and field assignments. Mixed union types are washed away in all contexts except for the phpdoc. We'll remove this restriction later, when more code will be ready to adapt for this change.