### PR TITLE
Causing Compile Error at reset of global constants that are initialized by non-const values

### DIFF
--- a/compiler/pipes/check-modifications-of-const-vars.cpp
+++ b/compiler/pipes/check-modifications-of-const-vars.cpp
@@ -111,8 +111,16 @@ void CheckModificationsOfConstVars::check_modifications(VertexPtr v, bool write_
                                             const_var->class_id->construct_function == current_function &&
                                             v->type() == op_instance_prop &&
                                             v.as<op_instance_prop>()->instance()->get_string() == "this";
-          auto err_msg = "Modification of const variable: " + TermStringFormat::paint(const_var->name, TermStringFormat::red);
-          kphp_error(modification_allowed, err_msg.c_str());
+          static constexpr auto constant_prefix = "d$";
+
+          if (vk::string_view(const_var->name).starts_with(constant_prefix)) { // constant
+            kphp_error(modification_allowed,
+                       fmt_format("Modification of constant: {}",
+                                  TermStringFormat::paint(std::string(std::next(const_var->name.begin(), std::strlen(constant_prefix)), const_var->name.end()),
+                                                          TermStringFormat::red)));
+          } else {
+            kphp_error(modification_allowed, fmt_format("Modification of const variable: {}", TermStringFormat::paint(const_var->name, TermStringFormat::red)));
+          }
         }
       }
       break;

--- a/compiler/pipes/erase-defines-declarations.cpp
+++ b/compiler/pipes/erase-defines-declarations.cpp
@@ -18,6 +18,7 @@ VertexPtr EraseDefinesDeclarationsPass::on_exit_vertex(VertexPtr root) {
       auto var = VertexAdaptor<op_var>::create().set_location(root);
       var->extra_type = op_ex_var_superglobal;
       var->str_val = "d$" + define->name;
+      var->is_const = true;
 
       auto new_root = VertexAdaptor<op_set>::create(var, define->val).set_location(root);
       root = new_root;

--- a/tests/phpt/constants/002_modification.php
+++ b/tests/phpt/constants/002_modification.php
@@ -1,0 +1,8 @@
+@kphp_should_fail
+/Modification of constant: INT_CONST/
+<?php
+function getInt(int $x) {
+    return ($x + 4) * 2;
+}
+const INT_CONST = getInt(17);
+INT_CONST = 123;


### PR DESCRIPTION
For now KPHP successfully compiles the following example:
```php
<?php
function getInt(int $x) { // 1
    return ($x + 4) * 2; // 2
} // 3
const INT_CONST = getInt(17); // 4
INT_CONST = 123; // 5
```
The behavior differs from PHP, it should be Compile Error on line 3.
But naturally we should temporarily support such possibility because there are some cases in vkcom code base that use this feature and cannot stop doing this effortlessly. At the moment, KPHP also compiles line 5 because it is supposed on later passes that line 4 is impossible.
Yes, primarily  we should do our best to prohibit construction on line 4, but for now **this PR causes Compile Error at reset of global constants that are initialized by non-const values.**