### PR TITLE
suppress clang-tidy alert that variable may be declared as const.

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -47,8 +47,9 @@ Checks: |-
   -modernize-concat-nested-namespaces,
   -readability-named-parameter,
   -readability-identifier-length,
-  -bugprone-easily-swappable-parameters
-  -misc-no-recursion
+  -bugprone-easily-swappable-parameters,
+  -misc-no-recursion,
+  -misc-const-correctness
 
 CheckOptions:
   - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison


### PR DESCRIPTION
We have hundreds alerts that looks like:
![image](https://user-images.githubusercontent.com/14000874/221564897-5a24fe32-77b6-4a76-a142-df3eca05e49d.png)
Let's remove it, given that they are essentially useless and spoiling to much code.