### PR TITLE
OOM handler

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -176,6 +176,7 @@ function register_kphp_on_warning_callback(callable(string $warning_message, str
 function kphp_set_context_on_error(mixed[] $tags, mixed $extra_info, string $env = "") ::: void;
 function kphp_get_runtime_config() ::: mixed;
 function kphp_backtrace($pretty ::: bool = true) ::: string[];
+function register_kphp_on_oom_callback(callable():void $callback) ::: bool;
 
 function ini_get ($s ::: string) ::: string | false;
 function ini_set ($s ::: string, $v ::: string) ::: bool;

--- a/compiler/pipes/register-kphp-configuration.cpp
+++ b/compiler/pipes/register-kphp-configuration.cpp
@@ -6,6 +6,7 @@
 
 #include <re2/re2.h>
 
+#include "common/algorithms/find.h"
 #include "compiler/compiler-core.h"
 #include "compiler/data/class-data.h"
 #include "compiler/data/function-data.h"
@@ -130,12 +131,10 @@ void RegisterKphpConfiguration::handle_constant_runtime_options(const ClassMembe
       register_mysql_db_name(opt_pair->value());
     } else if (*opt_key == net_dc_mask_key_) {
       register_net_dc_mask(opt_pair->value());
-    }  else if (*opt_key == warmup_workers_part_key_) {
-      register_warmup_workers_part(opt_pair->value());
-    }  else if (*opt_key == warmup_instance_cache_elements_part_key_) {
-      register_warmup_instance_cache_elements_part(opt_pair->value());
-    }  else if (*opt_key == warmup_timeout_sec_key_) {
-      register_warmup_timeout_sec(opt_pair->value());
+    } else if (vk::any_of_equal(*opt_key,
+                                warmup_workers_part_key_, warmup_instance_cache_elements_part_key_, warmup_timeout_sec_key_,
+                                oom_handling_memory_ratio_key_)) {
+      generic_register_simple_option(opt_pair->value(), *opt_key);
     } else {
       kphp_error(0, fmt_format("Got unexpected option {}::{}['{}']",
                                configuration_class_name_, runtime_options_name_, *opt_key));
@@ -195,16 +194,4 @@ void RegisterKphpConfiguration::register_net_dc_mask(VertexPtr value) const noex
     G->add_kphp_runtime_opt(static_cast<std::string>(net_dc_mask_key_));
     G->add_kphp_runtime_opt(*index_ipv4_subnet);
   }
-}
-
-void RegisterKphpConfiguration::register_warmup_workers_part(VertexPtr value) const noexcept {
-  generic_register_simple_option(value, warmup_workers_part_key_);
-}
-
-void RegisterKphpConfiguration::register_warmup_instance_cache_elements_part(VertexPtr value) const noexcept {
-  generic_register_simple_option(value, warmup_instance_cache_elements_part_key_);
-}
-
-void RegisterKphpConfiguration::register_warmup_timeout_sec(VertexPtr value) const noexcept {
-  generic_register_simple_option(value, warmup_timeout_sec_key_);
 }

--- a/compiler/pipes/register-kphp-configuration.h
+++ b/compiler/pipes/register-kphp-configuration.h
@@ -22,9 +22,6 @@ class RegisterKphpConfiguration final : public SyncPipeF<FunctionPtr> {
   void register_confdata_predefined_wildcard(VertexPtr value) const noexcept;
   void register_mysql_db_name(VertexPtr value) const noexcept;
   void register_net_dc_mask(VertexPtr value) const noexcept;
-  void register_warmup_workers_part(VertexPtr value) const noexcept;
-  void register_warmup_instance_cache_elements_part(VertexPtr value) const noexcept;
-  void register_warmup_timeout_sec(VertexPtr value) const noexcept;
 
   void handle_constant_function_palette(const ClassMemberConstant &c);
   void parse_palette(VertexPtr const_val, function_palette::Palette &palette);
@@ -43,6 +40,8 @@ class RegisterKphpConfiguration final : public SyncPipeF<FunctionPtr> {
   const vk::string_view warmup_workers_part_key_{"--warmup-workers-ratio"};
   const vk::string_view warmup_instance_cache_elements_part_key_{"--warmup-instance-cache-elements-ratio"};
   const vk::string_view warmup_timeout_sec_key_{"--warmup-timeout"};
+
+  const vk::string_view oom_handling_memory_ratio_key_{"--oom-handling-memory-ratio"};
 
 public:
   void execute(FunctionPtr function, DataStream<FunctionPtr> &unused_os) final;

--- a/runtime/allocator.cpp
+++ b/runtime/allocator.cpp
@@ -76,14 +76,14 @@ void global_init_script_allocator() noexcept {
   query_num++;
 }
 
-void init_script_allocator(void *buffer, size_t buffer_size) noexcept {
+void init_script_allocator(void *buffer, size_t script_mem_size, size_t oom_handling_mem_size) noexcept {
   auto &dealer = get_memory_dealer();
   php_assert(!dealer.heap_script_resource_replacer());
   php_assert(dealer.is_default_allocator_used());
   php_assert(!is_malloc_replaced());
 
   CriticalSectionGuard lock;
-  dealer.current_script_resource().init(buffer, buffer_size);
+  dealer.current_script_resource().init(buffer, script_mem_size, oom_handling_mem_size);
   script_allocator_enabled = true;
   query_num++;
 }

--- a/runtime/allocator.h
+++ b/runtime/allocator.h
@@ -29,7 +29,7 @@ const memory_resource::MemoryStats &get_script_memory_stats() noexcept;
 size_t get_heap_memory_used() noexcept;
 
 void global_init_script_allocator() noexcept;
-void init_script_allocator(void *buffer, size_t script_mem_size, size_t oom_handling_mem_size) noexcept; // init script allocator with arena of n bytes at buf
+void init_script_allocator(void *buffer, size_t script_mem_size, size_t oom_handling_mem_size) noexcept;
 void free_script_allocator() noexcept;
 
 void *allocate(size_t n) noexcept; // allocate script memory

--- a/runtime/allocator.h
+++ b/runtime/allocator.h
@@ -29,7 +29,7 @@ const memory_resource::MemoryStats &get_script_memory_stats() noexcept;
 size_t get_heap_memory_used() noexcept;
 
 void global_init_script_allocator() noexcept;
-void init_script_allocator(void *buffer, size_t buffer_size) noexcept; // init script allocator with arena of n bytes at buf
+void init_script_allocator(void *buffer, size_t script_mem_size, size_t oom_handling_mem_size) noexcept; // init script allocator with arena of n bytes at buf
 void free_script_allocator() noexcept;
 
 void *allocate(size_t n) noexcept; // allocate script memory

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -183,7 +183,7 @@ Optional<array<mixed>> f$getopt(const string &options, array<string> longopts = 
 void global_init_runtime_libs();
 void global_init_script_allocator();
 
-void init_runtime_environment(php_query_data *data, void *mem, size_t mem_size);
+void init_runtime_environment(php_query_data *data, void *mem, size_t script_mem_size, size_t oom_handling_mem_size = 0);
 
 void free_runtime_environment();
 

--- a/runtime/memory_resource/monotonic_buffer_resource.cpp
+++ b/runtime/memory_resource/monotonic_buffer_resource.cpp
@@ -6,6 +6,7 @@
 
 #include <array>
 #include "runtime/allocator.h"
+#include "runtime/oom_handler.h"
 
 namespace memory_resource {
 
@@ -49,6 +50,8 @@ void monotonic_buffer::critical_dump(void *mem, size_t size) const noexcept {
 }
 
 void monotonic_buffer_resource::raise_oom(size_t size) const noexcept {
+  vk::singleton<OomHandler>::get().invoke();
+
   auto mem_pool_size = stats_.memory_limit;
   size_t mem_available = mem_pool_size - stats_.memory_used;
   if (mem_available < size) {

--- a/runtime/memory_resource/unsynchronized_pool_resource.cpp
+++ b/runtime/memory_resource/unsynchronized_pool_resource.cpp
@@ -12,7 +12,7 @@ namespace memory_resource {
 
 constexpr size_t unsynchronized_pool_resource::MAX_CHUNK_BLOCK_SIZE_;
 
-void unsynchronized_pool_resource::init(void *buffer, size_t buffer_size) noexcept {
+void unsynchronized_pool_resource::init(void *buffer, size_t buffer_size, size_t oom_handling_buffer_size) noexcept {
   monotonic_buffer_resource::init(buffer, buffer_size);
 
   huge_pieces_.hard_reset();
@@ -20,10 +20,18 @@ void unsynchronized_pool_resource::init(void *buffer, size_t buffer_size) noexce
   free_chunks_.fill(details::memory_chunk_list{});
 
   extra_memory_head_ = &extra_memory_tail_;
+
+  oom_handling_memory_size_ = oom_handling_buffer_size;
 }
 
 void unsynchronized_pool_resource::hard_reset() noexcept {
   init(memory_begin_, memory_end_ - memory_begin_);
+  oom_handling_memory_size_ = 0;
+}
+
+void unsynchronized_pool_resource::unfreeze_oom_handling_memory() noexcept {
+  memory_end_ += oom_handling_memory_size_;
+  oom_handling_memory_size_ = 0;
 }
 
 void unsynchronized_pool_resource::perform_defragmentation() noexcept {

--- a/runtime/memory_resource/unsynchronized_pool_resource.h
+++ b/runtime/memory_resource/unsynchronized_pool_resource.h
@@ -22,8 +22,9 @@ public:
   using monotonic_buffer_resource::get_memory_stats;
   using monotonic_buffer_resource::memory_begin;
 
-  void init(void *buffer, size_t buffer_size) noexcept;
+  void init(void *buffer, size_t buffer_size, size_t oom_handling_buffer_size = 0) noexcept;
   void hard_reset() noexcept;
+  void unfreeze_oom_handling_memory() noexcept;
 
   void *allocate(size_t size) noexcept {
     void *mem = nullptr;
@@ -134,6 +135,7 @@ private:
 
   details::memory_chunk_tree huge_pieces_;
   monotonic_buffer_resource fallback_resource_;
+  size_t oom_handling_memory_size_{0};
 
   extra_memory_pool *extra_memory_head_{nullptr};
   extra_memory_pool extra_memory_tail_{sizeof(extra_memory_pool)};

--- a/runtime/oom_handler.cpp
+++ b/runtime/oom_handler.cpp
@@ -1,0 +1,47 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/oom_handler.h"
+
+#include "common/kprintf.h"
+#include "runtime/allocator.h"
+#include "runtime/critical_section.h"
+#include "runtime/memory_resource/unsynchronized_pool_resource.h"
+#include "runtime/php_assert.h"
+#include "server/php-runner.h"
+
+bool f$register_kphp_on_oom_callback(const on_oom_callback_t &callback) {
+  OomHandler &oom_handler_ctx = vk::singleton<OomHandler>::get();
+  if (PhpScript::current_script->oom_handling_memory_ratio == 0) {
+    php_warning("Trying to register OOM handler callback with no memory to run it on. You need to specify '--oom-handling-memory-ratio' option for it.");
+    return false;
+  }
+  oom_handler_ctx.set_callback(callback);
+  return true;
+}
+
+void OomHandler::invoke() noexcept {
+  if (!callback_) {
+    return;
+  }
+  if (callback_running_) {
+    php_critical_error("Out of memory error happened inside OOM handler");
+  } else {
+    kprintf("Invoking OOM handler\n");
+    dl::CriticalSectionGuard guard;
+    dl::get_default_script_allocator().unfreeze_oom_handling_memory();
+    callback_running_ = true;
+    callback_();
+    callback_running_ = false;
+  }
+}
+
+void OomHandler::set_callback(const on_oom_callback_t &callback) noexcept {
+  callback_ = callback;
+}
+
+void OomHandler::reset() noexcept {
+  callback_ = {};
+  callback_running_ = false;
+}

--- a/runtime/oom_handler.cpp
+++ b/runtime/oom_handler.cpp
@@ -22,7 +22,7 @@ bool f$register_kphp_on_oom_callback(const on_oom_callback_t &callback) {
 }
 
 void OomHandler::invoke() noexcept {
-  if (!callback_) {
+  if (!callback_ || !PhpScript::in_script_context) {
     return;
   }
   if (callback_running_) {

--- a/runtime/oom_handler.cpp
+++ b/runtime/oom_handler.cpp
@@ -7,9 +7,9 @@
 #include "common/kprintf.h"
 #include "runtime/allocator.h"
 #include "runtime/critical_section.h"
-#include "runtime/memory_resource/unsynchronized_pool_resource.h"
 #include "runtime/php_assert.h"
 #include "server/php-runner.h"
+#include "runtime/resumable.h"
 
 bool f$register_kphp_on_oom_callback(const on_oom_callback_t &callback) {
   OomHandler &oom_handler_ctx = vk::singleton<OomHandler>::get();
@@ -30,6 +30,7 @@ void OomHandler::invoke() noexcept {
   } else {
     kprintf("Invoking OOM handler\n");
     dl::CriticalSectionGuard guard;
+    forcibly_stop_all_running_resumables();
     dl::get_default_script_allocator().unfreeze_oom_handling_memory();
     callback_running_ = true;
     callback_();

--- a/runtime/oom_handler.h
+++ b/runtime/oom_handler.h
@@ -1,0 +1,29 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <functional>
+
+#include "common/mixin/not_copyable.h"
+#include "common/smart_ptrs/singleton.h"
+
+using on_oom_callback_t = std::function<void()>;
+
+class OomHandler : vk::not_copyable {
+public:
+  void reset() noexcept;
+
+  void set_callback(const on_oom_callback_t &callback) noexcept;
+  void invoke() noexcept;
+private:
+  on_oom_callback_t callback_;
+  bool callback_running_ = false;
+
+  OomHandler() = default;
+
+  friend class vk::singleton<OomHandler>;
+};
+
+bool f$register_kphp_on_oom_callback(const on_oom_callback_t &callback);

--- a/runtime/resumable.cpp
+++ b/runtime/resumable.cpp
@@ -52,6 +52,8 @@ void Resumable::update_output() {
   output_ = in_main_thread() ? nullptr : get_storage(runned_resumable_id);
 }
 
+namespace {
+
 struct resumable_info {
   Storage output;
   Resumable *continuation;
@@ -77,19 +79,18 @@ struct started_resumable_info : resumable_info {
   int64_t fork_id;
 };
 
-static int64_t first_forked_resumable_id;
-static int64_t first_array_forked_resumable_id;
-static int64_t current_forked_resumable_id = 1123456789;
-static forked_resumable_info *forked_resumables;
-static forked_resumable_info gotten_forked_resumable_info;
-static uint32_t forked_resumables_size;
+int64_t first_forked_resumable_id;
+int64_t first_array_forked_resumable_id;
+int64_t current_forked_resumable_id = 1123456789;
+forked_resumable_info *forked_resumables;
+forked_resumable_info gotten_forked_resumable_info;
+uint32_t forked_resumables_size;
 
-static int64_t first_started_resumable_id;
-static int64_t current_started_resumable_id = 123456789;
-static started_resumable_info *started_resumables;
-static uint32_t started_resumables_size;
-static int64_t first_free_started_resumable_id;
-
+int64_t first_started_resumable_id;
+int64_t current_started_resumable_id = 123456789;
+started_resumable_info *started_resumables;
+uint32_t started_resumables_size;
+int64_t first_free_started_resumable_id;
 
 struct wait_queue {
   int64_t first_finished_function;
@@ -100,25 +101,24 @@ struct wait_queue {
   int64_t resumable_id;
 };
 
-static wait_queue *wait_queues;
-static uint32_t wait_queues_size;
-static int64_t wait_next_queue_id;
+wait_queue *wait_queues;
+uint32_t wait_queues_size;
+int64_t wait_next_queue_id;
 
+int64_t *finished_resumables;
+uint32_t finished_resumables_size;
+uint32_t finished_resumables_count;
 
-static int64_t *finished_resumables;
-static uint32_t finished_resumables_size;
-static uint32_t finished_resumables_count;
+int64_t *yielded_resumables;
+uint32_t yielded_resumables_l;
+uint32_t yielded_resumables_r;
+uint32_t yielded_resumables_size;
 
-static int64_t *yielded_resumables;
-static uint32_t yielded_resumables_l;
-static uint32_t yielded_resumables_r;
-static uint32_t yielded_resumables_size;
-
-static inline bool is_forked_resumable_id(int64_t resumable_id) {
+inline bool is_forked_resumable_id(int64_t resumable_id) {
   return first_forked_resumable_id <= resumable_id && resumable_id < current_forked_resumable_id;
 }
 
-static inline forked_resumable_info *get_forked_resumable_info(int64_t resumable_id) {
+inline forked_resumable_info *get_forked_resumable_info(int64_t resumable_id) {
   php_assert(is_forked_resumable_id(resumable_id));
   if (resumable_id < first_array_forked_resumable_id) {
     return &gotten_forked_resumable_info;
@@ -126,27 +126,29 @@ static inline forked_resumable_info *get_forked_resumable_info(int64_t resumable
   return &forked_resumables[resumable_id - first_array_forked_resumable_id];
 }
 
-static inline bool is_started_resumable_id(int64_t resumable_id) {
+inline bool is_started_resumable_id(int64_t resumable_id) {
   return first_started_resumable_id <= resumable_id && resumable_id < current_started_resumable_id;
 }
 
-static inline started_resumable_info *get_started_resumable_info(int64_t resumable_id) {
+inline started_resumable_info *get_started_resumable_info(int64_t resumable_id) {
   php_assert(is_started_resumable_id(resumable_id));
   return &started_resumables[resumable_id - first_started_resumable_id];
 }
 
-static inline bool is_wait_queue_id(int64_t queue_id) {
+inline bool is_wait_queue_id(int64_t queue_id) {
   return 0 < queue_id && queue_id <= wait_next_queue_id && wait_queues[queue_id - 1].resumable_id >= 0;
 }
 
-static inline wait_queue *get_wait_queue(int64_t queue_id) {
+inline wait_queue *get_wait_queue(int64_t queue_id) {
   php_assert(is_wait_queue_id(queue_id));
   return &wait_queues[queue_id - 1];
 }
 
-static Storage *get_started_storage(int64_t resumable_id) noexcept {
+Storage *get_started_storage(int64_t resumable_id) noexcept {
   return &get_started_resumable_info(resumable_id)->output;
 }
+
+} // namespace
 
 Storage *get_forked_storage(int64_t resumable_id) {
   return &get_forked_resumable_info(resumable_id)->output;
@@ -1314,4 +1316,16 @@ int32_t get_resumable_stack(void **buffer, int32_t limit) {
     }
   }
   return limit;
+}
+
+void forcibly_stop_all_running_resumables() {
+  resumable_finished = true;
+  runned_resumable_id = 0;
+  Resumable::update_output();
+  // Forcibly bind all suspension points to main thread.
+  // It will prevent all previously started forks from continuing
+  for (int64_t i = first_started_resumable_id; i < current_started_resumable_id; ++i) {
+    started_resumable_info *info = get_started_resumable_info(i);
+    info->parent_id = 0;
+  }
 }

--- a/runtime/resumable.h
+++ b/runtime/resumable.h
@@ -232,3 +232,5 @@ template<typename T>
 T f$wait_multi(const array<int64_t> &resumable_ids) {
   return start_resumable<T>(new wait_multi_resumable<T>(resumable_ids));
 }
+
+void forcibly_stop_all_running_resumables();

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -91,6 +91,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         mysql.cpp
         net_events.cpp
         on_kphp_warning_callback.cpp
+        oom_handler.cpp
         openssl.cpp
         php_assert.cpp
         profiler.cpp

--- a/server/database-drivers/adaptor.cpp
+++ b/server/database-drivers/adaptor.cpp
@@ -61,7 +61,7 @@ void Adaptor::create_outbound_connections() noexcept {
 }
 
 int Adaptor::initiate_connect(std::unique_ptr<Connector> &&connector) noexcept {
-  assert(PhpScript::is_running);
+  assert(PhpScript::in_script_context);
 
   // DO NOT use query after script is terminated!!!
   ::external_driver_connect q{std::move(connector)};

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -18,6 +18,7 @@ int initial_verbosity = 0;
 char *logname_pattern = nullptr;
 int logname_id = 0;
 long long max_memory = 1 << 29;
+double oom_handling_memory_ratio = 0.00;
 
 int worker_id = -1;
 int pid = -1;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -29,6 +29,7 @@ extern int initial_verbosity;
 extern char *logname_pattern;
 extern int logname_id;
 extern long long max_memory;
+extern double oom_handling_memory_ratio;
 
 extern int worker_id;
 extern int pid;

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2162,6 +2162,9 @@ int main_args_handler(int i, const char *long_option) {
       runtime_config = std::move(config);
       return 0;
     }
+    case 2033: {
+      return read_option_to(long_option, 0.0, 0.5, oom_handling_memory_ratio);
+    }
     default:
       return -1;
   }
@@ -2265,6 +2268,7 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("job-workers-shared-messages-process-multiplier", required_argument, 2031, "Coefficient used to calculate the total count of the shared messages for job workers related communication:\n"
                                                                                           "messages count = coefficient * processes_count");
   parse_option("runtime-config", required_argument, 2032, "JSON file path that will be available at runtime as 'mixed' via 'kphp_runtime_config()");
+  parse_option("oom-handling-memory-ratio", required_argument, 2033, "memory ratio of overall script memory to handle OOM errors (default: 0.00)");
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);
   // TODO: remove it after successful migration from kphb.readyV2 to kphb.readyV3

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -51,7 +51,7 @@ static void save_last_net_error(const char *s) {
 
 /** create connection query **/
 php_query_http_load_post_answer_t *php_query_http_load(char *buf, int min_len, int max_len) {
-  assert (PhpScript::is_running);
+  assert (PhpScript::in_script_context);
 
   //DO NOT use query after script is terminated!!!
   php_query_http_load_post_t q;
@@ -309,7 +309,7 @@ void chain_append(chain_t *chain, data_reader_t *reader) {
 
 /** test x^2 query **/
 php_query_x2_answer_t *php_query_x2(int x) {
-  assert (PhpScript::is_running);
+  assert (PhpScript::in_script_context);
 
   //DO NOT use query after script is terminated!!!
   php_query_x2_t q;
@@ -322,7 +322,7 @@ php_query_x2_answer_t *php_query_x2(int x) {
 
 /** create connection query **/
 php_query_connect_answer_t *php_query_connect(const char *host, int port, protocol_type protocol) {
-  assert (PhpScript::is_running);
+  assert (PhpScript::in_script_context);
 
   //DO NOT use query after script is terminated!!!
   php_query_connect_t q;
@@ -802,7 +802,7 @@ static StaticQueue<net_event_t, 2000000> net_events;
 static StaticQueue<net_query_t, 2000000> net_queries;
 
 void *dl_allocate_safe(size_t size) {
-  if (size == 0 || PhpScript::ml_flag) {
+  if (size == 0 || PhpScript::memory_limit_exceeded) {
     return nullptr;
   }
 
@@ -985,7 +985,7 @@ slot_id_t rpc_send_query(int host_num, char *request, int request_size, int time
 }
 
 void wait_net_events(int timeout_ms) {
-  assert (PhpScript::is_running);
+  assert (PhpScript::in_script_context);
   php_query_wait_t q;
   q.timeout_ms = timeout_ms;
 
@@ -1001,7 +1001,7 @@ const net_event_t *get_last_net_event() {
 }
 
 void rpc_answer(const char *res, int res_len) {
-  assert (PhpScript::is_running);
+  assert (PhpScript::in_script_context);
   php_query_rpc_answer q;
   q.data = res;
   q.data_len = res_len;

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -52,7 +52,7 @@ bool check_signal_critical_section(int sig_num, const char *sig_name) {
     char message_1kw[message_1kw_size];
     snprintf(message_1kw, message_1kw_size, "in critical section: pending %s caught\n", sig_name);
     kwrite_str(2, message_1kw);
-    dl::pending_signals = dl::pending_signals | (1 << sig_num);
+    dl::pending_signals = dl::pending_signals | (1ll << sig_num);
     return false;
   }
   dl::pending_signals = 0;

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -509,9 +509,9 @@ int PhpScript::get_net_queries_count() const noexcept {
 
 PhpScript *volatile PhpScript::current_script;
 ucontext_t_portable PhpScript::exit_context;
-bool PhpScript::in_script_context = false;
-bool PhpScript::time_limit_exceeded = false;
-bool PhpScript::memory_limit_exceeded = false;
+volatile bool PhpScript::in_script_context = false;
+volatile bool PhpScript::time_limit_exceeded = false;
+volatile bool PhpScript::memory_limit_exceeded = false;
 
 void write_str(int fd, const char *s) noexcept {
   write(fd, s, std::min(strlen(s), size_t{1000}));

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -87,9 +87,12 @@ void PhpScript::error(const char *error_message, script_error_t error_type) noex
 void PhpScript::check_delayed_errors() noexcept {
   php_assert(PhpScript::in_script_context);
   if (time_limit_exceeded) {
+    time_limit_exceeded = false;
     perform_error_if_running("timeout exit\n", script_error_t::timeout);
   }
   if (memory_limit_exceeded) {
+    memory_limit_exceeded = false;
+    vk::singleton<OomHandler>::get().invoke();
     perform_error_if_running("memory limit exit\n", script_error_t::memory_limit);
   }
 }

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -97,9 +97,9 @@ private:
 public:
   static PhpScript *volatile current_script;
   static ucontext_t_portable exit_context;
-  volatile static bool is_running;
-  volatile static bool tl_flag;
-  volatile static bool ml_flag;
+  static bool in_script_context;
+  static bool time_limit_exceeded;
+  static bool memory_limit_exceeded;
 
   run_state_t state{run_state_t::empty};
   const char *error_message{nullptr};
@@ -123,7 +123,7 @@ public:
   PhpScript(size_t mem_size, double oom_handling_memory_ratio, size_t stack_size) noexcept;
   ~PhpScript() noexcept;
 
-  void check_tl() noexcept;
+  void check_delayed_errors() noexcept;
 
   void init(script_t *script, php_query_data *data_to_set) noexcept;
 

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -97,9 +97,9 @@ private:
 public:
   static PhpScript *volatile current_script;
   static ucontext_t_portable exit_context;
-  static bool in_script_context;
-  static bool time_limit_exceeded;
-  static bool memory_limit_exceeded;
+  volatile static bool in_script_context;
+  volatile static bool time_limit_exceeded;
+  volatile static bool memory_limit_exceeded;
 
   run_state_t state{run_state_t::empty};
   const char *error_message{nullptr};

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -106,6 +106,7 @@ public:
   script_error_t error_type{script_error_t::no_error};
   php_query_base_t *query{nullptr};
   const size_t mem_size{0};
+  double oom_handling_memory_ratio{0};
   char *run_mem{nullptr};
   PhpScriptStack script_stack;
 
@@ -119,7 +120,7 @@ public:
   static void script_context_entrypoint() noexcept;
   static void error(const char *error_message, script_error_t error_type) noexcept;
 
-  PhpScript(size_t mem_size, size_t stack_size) noexcept;
+  PhpScript(size_t mem_size, double oom_handling_memory_ratio, size_t stack_size) noexcept;
   ~PhpScript() noexcept;
 
   void check_tl() noexcept;

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -144,7 +144,7 @@ void PhpWorker::state_init_script() noexcept {
   script_t *script = get_script();
   dl_assert(script != nullptr, "failed to get script");
   if (php_script == nullptr) {
-    php_script = new PhpScript(max_memory, 8 << 20);
+    php_script = new PhpScript(max_memory, oom_handling_memory_ratio, 8 << 20);
   }
   dl::init_critical_section();
   php_script->init(script, data);

--- a/tests/phpt/kphp_configuration/8_warm_up_configuration.php
+++ b/tests/phpt/kphp_configuration/8_warm_up_configuration.php
@@ -1,0 +1,10 @@
+@ok
+<?php
+
+class KphpConfiguration {
+  const DEFAULT_RUNTIME_OPTIONS = [
+    "--oom-handling-memory-ratio" => "0.42",
+  ];
+}
+
+echo "successfully compiled\n";

--- a/tests/python/tests/http_server/php/A.php
+++ b/tests/python/tests/http_server/php/A.php
@@ -1,0 +1,9 @@
+<?php
+
+/** @kphp-immutable-class */
+class A {
+  /** @var int */
+  public $a = 42;
+  /** @var string */
+  public $b = "hello";
+}

--- a/tests/python/tests/http_server/php/X2Request.php
+++ b/tests/python/tests/http_server/php/X2Request.php
@@ -1,0 +1,15 @@
+<?php
+
+class X2Request implements KphpJobWorkerRequest {
+  /**
+   * @var int[]
+   */
+  public $arr_request = [];
+
+  /**
+   * @param int[] $arr_request
+   */
+  public function __construct(array $arr_request) {
+    $this->arr_request = $arr_request;
+  }
+}

--- a/tests/python/tests/http_server/php/X2Response.php
+++ b/tests/python/tests/http_server/php/X2Response.php
@@ -1,0 +1,5 @@
+<?php
+
+class X2Response implements KphpJobWorkerResponse {
+  public $arr_reply = [];
+}

--- a/tests/python/tests/http_server/php/index.php
+++ b/tests/python/tests/http_server/php/index.php
@@ -1,13 +1,5 @@
 <?php
 
-/** @kphp-immutable-class */
-class A {
-  /** @var int */
-  public $a = 42;
-  /** @var string */
-  public $b = "hello";
-}
-
 /**
  * @kphp-required
  */
@@ -60,8 +52,9 @@ class RpcWorker implements I {
    }
 }
 
-
-if ($_SERVER["PHP_SELF"] === "/ini_get") {
+if (isset($_SERVER["JOB_ID"])) {
+  require_once "job_worker.php";
+} else if ($_SERVER["PHP_SELF"] === "/ini_get") {
   echo ini_get($_SERVER["QUERY_STRING"]);
 } else if (substr($_SERVER["PHP_SELF"], 0, 12) === "/test_limits") {
   echo json_encode($_SERVER);
@@ -200,6 +193,8 @@ if ($_SERVER["PHP_SELF"] === "/ini_get") {
     echo "pid=" . posix_getpid();
 } else if ($_SERVER["PHP_SELF"] === "/test_script_errors") {
   critical_error("Test error");
+} else if ($_SERVER["PHP_SELF"] === "/test_oom_handler") {
+  require_once "test_oom_handler.php";
 } else {
     if ($_GET["hints"] === "yes") {
         send_http_103_early_hints(["Content-Type: text/plain or application/json", "Link: </script.js>; rel=preload; as=script"]);

--- a/tests/python/tests/http_server/php/job_worker.php
+++ b/tests/python/tests/http_server/php/job_worker.php
@@ -1,0 +1,16 @@
+<?php
+
+function job_worker_main() {
+  $req = kphp_job_worker_fetch_request();
+  if ($req instanceof X2Request) {
+    $x2_resp = new X2Response;
+    foreach ($req->arr_request as $value) {
+      $x2_resp->arr_reply[] = $value ** 2;
+    }
+    kphp_job_worker_store_response($x2_resp);
+  } else {
+    critical_error("Unexpected job " . get_class($req) . "\n");
+  }
+}
+
+job_worker_main();

--- a/tests/python/tests/http_server/php/test_oom_handler.php
+++ b/tests/python/tests/http_server/php/test_oom_handler.php
@@ -1,0 +1,143 @@
+<?php
+
+function make_array_of_volume(int $bytes) {
+  $arr = [];
+  $size = $bytes / 8;
+  array_reserve_vector($arr, $size);
+  for ($i = 0; $i < $size; $i++) {
+    $arr[$i] = $i;
+  }
+  return $arr;
+}
+
+function make_oom_error() {
+  make_array_of_volume(11 * 1024 * 1024);
+}
+
+function fake_query(float $time_to_sleep) {
+  sched_yield_sleep($time_to_sleep);
+  return true;
+}
+
+$script_allocated_array = [];
+
+/**
+ * @kphp-required
+ */
+function oom_handler() {
+  global $script_allocated_array, $test_case;
+
+  $fork_id = (int)get_running_fork_id();
+  fprintf(STDERR, "start OOM handler from fork_id=$fork_id\n");
+
+  [$allocations_cnt_start, $mem_allocated_start] = memory_get_allocations();
+  $arr = [];
+  array_reserve_vector($arr, 100000);
+  for ($i = 0; $i < 100000; $i++) {
+    $arr[] = $i;
+  }
+
+  if ($test_case === "oom_inside_oom_handler") {
+    make_oom_error();
+  } else if ($test_case === "with_rpc_request") {
+    $master_port = (int)$_GET["master_port"];
+    $conn = new_rpc_connection('127.0.0.1', $master_port, 0, 5);
+    $req_id = rpc_tl_query_one($conn, ["_" => "engine.sleep", "time_ms" => 100]);
+    $resp = rpc_tl_query_result_one($req_id);
+    $result = $resp["result"];
+    fprintf(STDERR, "rpc_request_succeeded=$result\n");
+  } else if ($test_case === "with_job_request") {
+    $req_arr = [1,2,3,4,5,6,7,8,9];
+    $i = new X2Request($req_arr);
+    $future = kphp_job_worker_start($i, 1);
+    $resp = wait($future);
+    if ($resp instanceof X2Response) {
+      for ($i = 0; $i < count($req_arr); $i++) {
+        $req_arr[$i] **= 2;
+      }
+      $diff = array_diff($req_arr, $resp->arr_reply);
+      $success = count($diff) === 0;
+      fprintf(STDERR, "job_request_succeeded=$success\n");
+    }
+  } else if ($test_case === "with_instance_cache") {
+    $success = instance_cache_store("oom_handler_test_key", new A);
+    fprintf(STDERR, "instance_cache_store_succeeded=$success\n");
+  } else if ($test_case === "script_memory_dealloc") {
+    $refcnt = get_reference_counter($script_allocated_array);
+    fprintf(STDERR, "refcnt_before_unset=$refcnt\n");
+    $script_allocated_array = [];
+  } else if ($test_case === "script_memory_realloc") {
+    [$realloc_allocations_cnt_start, $realloc_mem_allocated_start] = memory_get_allocations();
+    $len = count($script_allocated_array);
+    for ($i = 0; $i < 2 * $len; $i++) {
+       $script_allocated_array[] = 1000 + $i;
+    }
+    [$realloc_allocations_cnt_end, $realloc_mem_allocated_end] = memory_get_allocations();
+    $realloc_allocations_cnt = $realloc_allocations_cnt_end - $realloc_allocations_cnt_start;
+    $realloc_mem_allocated = $realloc_mem_allocated_end - $realloc_mem_allocated_start;
+    fprintf(STDERR, "realloc_allocations_cnt=$realloc_allocations_cnt,realloc_mem_allocated=$realloc_mem_allocated\n");
+  } else if ($test_case === "resume_yielded_script_fork_from_oom_handler" ||
+             $test_case === "resume_suspended_script_fork_from_oom_handler" ||
+             $test_case === "oom_from_fork") {
+    $future = fork(fake_query(0.2));
+    $ans = wait($future);
+    if ($ans !== true) {
+      critical_error("fork wait failed, wait(future)=" . var_export($ans, true));
+    }
+  } else if ($test_case !== "basic") {
+    critical_error("Unexpected test case $test_case");
+  }
+
+  $small_arr = [];
+  $small_arr["key"] = "Hello";
+  $small_arr["key"] .= "World" . rand(); // test allocations in the end of handler
+  unset($small_arr);
+
+  [$allocations_cnt, $mem_allocated] = memory_get_allocations();
+  $allocations_cnt -= $allocations_cnt_start;
+  $mem_allocated -= $mem_allocated_start;
+  $arr_mem_usage = estimate_memory_usage($arr);
+  fprintf(STDERR, "allocations_cnt=$allocations_cnt,memory_allocated=$mem_allocated,estimate_memory_usage(arr)=$arr_mem_usage\n");
+
+}
+
+function my_fork(string $test_case) {
+  $fork_id = (int)get_running_fork_id();
+  fprintf(STDERR, "fork_started_succesfully=%d\n", $fork_id !== 0);
+  if ($test_case === "oom_from_fork") {
+    make_oom_error();
+  } else if ($test_case === "resume_yielded_script_fork_from_oom_handler") {
+    sched_yield();
+    critical_error("Trying to resume yielded fork started from script in OOM handler");
+  } else if ($test_case === "resume_suspended_script_fork_from_oom_handler") {
+    $future = fork(fake_query(0.1));
+    wait($future);
+    critical_error("Trying to resume suspended fork started from script in OOM handler");
+  } else {
+    critical_error("Unknown test_case=$test_case in fork");
+  }
+  return null;
+}
+
+function main() {
+  global $script_allocated_array, $test_case;
+  $test_case = (string)$_GET["test_case"];
+  $script_allocated_array = [1,2,3,4,5];
+  $script_allocated_array[] = rand();
+  $ok = register_kphp_on_oom_callback('oom_handler');
+  if (!$ok) {
+    critical_error("Can't register OOM handler");
+  }
+  if ($test_case === "oom_from_fork") {
+    $future = fork(my_fork($test_case));
+    wait($future);
+  } else if ($test_case === "resume_yielded_script_fork_from_oom_handler" || $test_case === "resume_suspended_script_fork_from_oom_handler") {
+    fork(my_fork($test_case));
+    make_oom_error();
+  } else {
+    make_oom_error();
+  }
+  critical_error("Must be unreachable - OOM expected\n");
+}
+
+main();

--- a/tests/python/tests/http_server/test_oom_handler.py
+++ b/tests/python/tests/http_server/test_oom_handler.py
@@ -1,0 +1,69 @@
+import requests.exceptions
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class TestOomHandler(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 2,
+            "--job-workers-ratio": 0.5,
+            "--hard-memory-limit": "10m",
+            "--oom-handling-memory-ratio": 0.1,
+        })
+
+    def _generic_test(self, params: str):
+        resp = self.kphp_server.http_get("/test_oom_handler?" + params)
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log([
+            "allocations_cnt=[1-9]\\d?,memory_allocated=8\\d{5},estimate_memory_usage\\(arr\\)=8\\d{5}",
+            "Critical error during script execution: memory limit exit",
+            "Warning: Can't allocate \\d+ bytes",
+        ], timeout=5)
+
+    def test_basic(self):
+        self._generic_test("test_case=basic")
+
+    def test_with_rpc_request(self):
+        self._generic_test("test_case=with_rpc_request&master_port={}".format(self.kphp_server.master_port))
+        self.kphp_server.assert_log(["rpc_request_succeeded=1"], timeout=5)
+
+    def test_oom_inside_oom_handler(self):
+        try:
+            self.kphp_server.http_get("/test_oom_handler?test_case=oom_inside_oom_handler")
+        except requests.exceptions.ConnectionError:
+            pass
+        self.kphp_server.assert_log([
+            'Warning: Critical error "Out of memory error happened inside OOM handler"'
+        ], timeout=5)
+
+    def test_script_memory_dealloc(self):
+        self._generic_test("test_case=script_memory_dealloc")
+        self.kphp_server.assert_log(["refcnt_before_unset=1"], timeout=5)
+
+    def test_script_memory_realloc(self):
+        self._generic_test("test_case=script_memory_realloc")
+        self.kphp_server.assert_log(["realloc_allocations_cnt=1,realloc_mem_allocated=[1-9]\\d*"], timeout=5)
+
+    def test_with_job_request(self):
+        self._generic_test("test_case=with_job_request")
+        self.kphp_server.assert_log(["job_request_succeeded=1"], timeout=5)
+
+    def test_with_instance_cache(self):
+        self._generic_test("test_case=with_instance_cache")
+        self.kphp_server.assert_log(["instance_cache_store_succeeded=1"], timeout=5)
+
+    def test_resume_yielded_script_fork_from_oom_handler(self):
+        self._generic_test("test_case=resume_yielded_script_fork_from_oom_handler&master_port={}".format(self.kphp_server.master_port))
+        self.kphp_server.assert_log(["fork_started_succesfully=1",
+                                     "start OOM handler from fork_id=0"], timeout=5)
+
+    def test_resume_suspended_script_fork_from_oom_handler(self):
+        self._generic_test("test_case=resume_suspended_script_fork_from_oom_handler&master_port={}".format(self.kphp_server.master_port))
+        self.kphp_server.assert_log(["fork_started_succesfully=1",
+                                     "start OOM handler from fork_id=0"], timeout=5)
+
+    def test_oom_from_fork(self):
+        self._generic_test("test_case=oom_from_fork".format(self.kphp_server.master_port))
+        self.kphp_server.assert_log(["fork_started_succesfully=1",
+                                     "start OOM handler from fork_id=0"], timeout=5)


### PR DESCRIPTION
Before these changes Out Of Memory (OOM) errors leaded to immediate script termination. Now there's a way to register custom PHP function as OOM handler. It will be called when OOM error occurs before script termination. 

The main problem is that almost any PHP code always use script memory, but in case of OOM no these memory is left. To handle this, we will keep some part of script memory beforehand to run OOM handler on it. It's implemented via moving `end` pointer of memory arena used by script allocator.

Also there's a problem that some suspended forks started from script can be resumed from OOM handler, which is incorrect and can lead to critical runtime errors. There's the same problem in shutdown functions now. To handle this, we forcibly stop all running resumables, by binding all suspension points (aka started resumables) to main thread.