### PR TITLE
Fix shutdown functions called from timeout behaviour

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -501,7 +501,6 @@ constexpr uint32_t MAX_SHUTDOWN_FUNCTIONS = 256;
 
 namespace {
 
-// i don't want destructors of this array to be called
 int shutdown_functions_count = 0;
 char shutdown_function_storage[MAX_SHUTDOWN_FUNCTIONS * sizeof(shutdown_function_type)];
 shutdown_function_type *const shutdown_functions = reinterpret_cast<shutdown_function_type *>(shutdown_function_storage);
@@ -616,6 +615,7 @@ void f$fastcgi_finish_request(int64_t exit_code) {
 
 void run_shutdown_functions() {
   php_assert(dl::is_malloc_replaced() == false);
+  forcibly_stop_all_running_resumables();
 
   ShutdownProfiler shutdown_profiler;
   for (int i = 0; i < shutdown_functions_count; i++) {

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -482,11 +482,10 @@ void PhpScript::run() noexcept {
 }
 
 void PhpScript::reset_script_timeout() noexcept {
-  // php_script_set_timeout has a side effect of setting the tl_flag to false;
-  // we want to avoid that, since timeout should set tl_flag to true
-  bool current_tl_flag = time_limit_exceeded;
+  // php_script_set_timeout has a side effect of setting the PhpScript::time_limit_exceeded to false;
+  // and we really do need this before executing shutdown functions otherwise shutdown functions will be terminated
+  // after the first swap context back to script at PhpScript::check_delayed_errors()
   set_timeout(script_timeout);
-  time_limit_exceeded = current_tl_flag;
 }
 
 double PhpScript::get_net_time() const noexcept {

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -25,7 +25,8 @@
 PhpWorker *active_worker = nullptr;
 
 double PhpWorker::enter_lifecycle() noexcept {
-  if (finish_time < precise_now + 0.01) {
+  if (vk::any_of_equal(state, phpq_try_start, phpq_init_script) // optimization makes sense only for skipping initialization of timeout expired scripts
+      && finish_time < precise_now + 0.01) {
     terminate(0, script_error_t::timeout, "timeout");
   }
   on_wakeup();

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -19,7 +19,7 @@ function shutdown_exception_warning() {
   } catch (Throwable $e) {
     $msg = "unexpected exception in shutdown handler";
   }
-  warning($msg);
+  fprintf(STDERR, $msg . "\n");
 }
 
 /** @kphp-required */
@@ -27,7 +27,7 @@ function shutdown_after_long_work() {
   // unless the timer resets to 0 before this function is executed, it will not
   // manage to finish successfully
   do_sleep(0.75);
-  warning("shutdown function managed to finish");
+  fprintf(STDERR, "shutdown function managed to finish\n");
 }
 
 /** @kphp-required */
@@ -37,34 +37,34 @@ function shutdown_endless_loop() {
 
 /** @kphp-required */
 function shutdown_with_exit1() {
-  warning("running shutdown handler 1");
+  fprintf(STDERR, "running shutdown handler 1\n");
   exit(0);
 }
 
 /** @kphp-required */
 function shutdown_with_exit2() {
-  warning("running shutdown handler 2");
+  fprintf(STDERR, "running shutdown handler 2\n");
 }
 
 /** @kphp-required */
 function shutdown_critical_error() {
-  warning("running shutdown handler critical errors");
+  fprintf(STDERR, "running shutdown handler critical errors\n");
   critical_error("critical error from shutdown function");
 }
 
 /** @kphp-required */
 function shutdown_fork_wait() {
-  warning("before fork");
+  fprintf(STDERR, "before fork\n");
   $resp_future = fork(forked_func(42));
-  warning("after fork");
+  fprintf(STDERR, "after fork\n");
   while (!wait_concurrently($resp_future)) {}
-  warning("after wait");
+  fprintf(STDERR, "after wait\n");
 }
 
 function forked_func(int $i): int {
-  warning("before yield");
+  fprintf(STDERR, "before yield\n");
   sched_yield_sleep(0.5); // wait net
-  warning("after yield");
+  fprintf(STDERR, "after yield\n");
   return $i;
 }
 

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions.py
@@ -2,10 +2,6 @@ from python.lib.testcase import KphpServerAutoTestCase
 
 
 class TestShutdownFunctions(KphpServerAutoTestCase):
-    @classmethod
-    def extra_class_setup(cls):
-        cls.kphp_server.ignore_log_errors()
-
     def test_fork_wait(self):
         resp = self.kphp_server.http_post(
             json=[
@@ -13,12 +9,10 @@ class TestShutdownFunctions(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ok")
         self.assertEqual(resp.status_code, 200)
-        self.kphp_server.assert_json_log(
-            expect=[
-                {"version": 0, "type": 2, "env": "", "msg": "before fork", "tags": {"uncaught": False}},
-                {"version": 0, "type": 2, "env": "", "msg": "after fork", "tags": {"uncaught": False}},
-                {"version": 0, "type": 2, "env": "", "msg": "before yield", "tags": {"uncaught": False}},
-                {"version": 0, "type": 2, "env": "", "msg": "after yield", "tags": {"uncaught": False}},
-                {"version": 0, "type": 2, "env": "", "msg": "after wait", "tags": {"uncaught": False}},
-            ],
-            timeout=5)
+        self.kphp_server.assert_log([
+            "before fork",
+            "after fork",
+            "before yield",
+            "after yield",
+            "after wait",
+        ], timeout=5)

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_errors.py
@@ -2,10 +2,6 @@ from python.lib.testcase import KphpServerAutoTestCase
 
 
 class TestShutdownFunctionsErrors(KphpServerAutoTestCase):
-    @classmethod
-    def extra_class_setup(cls):
-        cls.kphp_server.ignore_log_errors()
-
     def test_critical_error(self):
         # with self.assertRaises(RuntimeError):
         resp = self.kphp_server.http_post(
@@ -14,8 +10,7 @@ class TestShutdownFunctionsErrors(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ERROR")
         self.assertEqual(resp.status_code, 500)
-        self.kphp_server.assert_json_log(
-            expect=[
-                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler critical errors", "tags": {"uncaught": False}},
-                {"version": 0, "type": 1, "env": "", "msg": "critical error from shutdown function", "tags": {"uncaught": True}},
-            ])
+        self.kphp_server.assert_log([
+            "running shutdown handler critical errors",
+            "critical error from shutdown function",
+        ], timeout=5)

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_exceptions.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_exceptions.py
@@ -2,10 +2,6 @@ from python.lib.testcase import KphpServerAutoTestCase
 
 
 class TestShutdownFunctionsExceptions(KphpServerAutoTestCase):
-    @classmethod
-    def extra_class_setup(cls):
-        cls.kphp_server.ignore_log_errors()
-
     def test_exception_shutdown_function(self):
         # test that:
         # 1. we execute shutdown functions after the "uncaught exception" critical error
@@ -17,11 +13,8 @@ class TestShutdownFunctionsExceptions(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ERROR")
         self.assertEqual(resp.status_code, 500)
-        self.kphp_server.assert_json_log(
-            expect=[
-                {
-                    "version": 0, "type": 1, "env": "",  "tags": {"uncaught": True},
-                    "msg": "Unhandled ServerException from index.php:\\d+; Error 123; Message: hello",
-                },
-                {"version": 0, "type": 2, "env": "", "msg": "running shutdown handler", "tags": {"uncaught": False}},
-            ])
+        self.kphp_server.assert_log([
+            "running shutdown handler",
+            "Error 123: hello",
+            "Unhandled ServerException",
+        ], timeout=5)

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -5,7 +5,8 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
     @classmethod
     def extra_class_setup(cls):
         cls.kphp_server.update_options({
-            "--time-limit": 1
+            "--time-limit": 1,
+            "--verbosity-resumable=2": True,
         })
 
     def test_timeout_reset_at_shutdown_function(self):
@@ -46,3 +47,42 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
         self.assertEqual(resp.text, "ERROR")
         self.assertEqual(resp.status_code, 500)
         self.kphp_server.assert_log(["Critical error during script execution: timeout exit"], timeout=5)
+
+    def test_timeout_from_resumable_in_main_thread(self):
+        # tests that when timeout is raised inside some 'started' resumable in main thread
+        # and shutdown functions run, fork switching and resumables handling works correctly
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_fork_wait"},
+                {"op": "resumable_long_work", "duration": 2},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log(["Critical error during script execution: timeout",
+                                     "shutdown_fork_wait\\(\\): running_fork_id=0",
+                                     "before fork",
+                                     "after fork",
+                                     "before yield",
+                                     "after yield",
+                                     "after wait",
+                                     ], timeout=5)
+
+    def test_timeout_from_fork(self):
+        # tests that when timeout is raised inside some fork
+        # and shutdown functions run, fork switching and resumables handling works correctly
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_fork_wait"},
+                {"op": "fork_wait_resumable_long_work", "duration": 2},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log(["Critical error during script execution: timeout",
+                                     "shutdown_fork_wait\\(\\): running_fork_id=0",
+                                     "before fork",
+                                     "after fork",
+                                     "before yield",
+                                     "after yield",
+                                     "after wait",
+                                     ], timeout=5)
+


### PR DESCRIPTION
Here're 2 bug fixes:
1. Before that shutdown functions called from timeout were always terminated at the first from script to net context swap because of 2 reasons: 
a) `PhpScript::time_limit_exceeded` flag wasn't reset
b) Optimization that terminates script preventively 10 ms before timeout uses script finish time for calculating this => 
     shutdown functions always were terminated at that point, despite script timeout was reset.
2. Also there's a problem that some suspended forks started from script can be resumed from shutdown functions, which is incorrect and can lead to critical runtime errors. Now it's fixed the same way as at #762

