### PR TITLE
classof() compatible with constexpr switch for function overloading

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1911,7 +1911,7 @@ void compile_shape(VertexAdaptor<op_shape> root, CodeGenerator &W) {
     sorted_by_hash.emplace_back(string_hash(key_str.c_str(), key_str.size()), double_arrow.as<op_double_arrow>()->rhs());
   }
   std::sort(sorted_by_hash.begin(), sorted_by_hash.end(), [](const auto &a, const auto &b) -> bool {
-    kphp_assert(a.first != b.first);
+    kphp_assert(a.second == b.second || a.first != b.first);
     return a.first < b.first;
   });
 

--- a/compiler/generics-reification.cpp
+++ b/compiler/generics-reification.cpp
@@ -190,12 +190,6 @@ static void reify_genericT_from_call_argument(FunctionPtr current_function, Func
     if (call_arg->type() == op_string) {
       klassT = G->get_class(call_arg->get_string());
       kphp_error_return(klassT, fmt_format("Class {} not found", call_arg->get_string()));
-    } else if (call_arg->type() == op_func_call && call_arg->extra_type != op_ex_func_call_arrow) {
-      auto args = call_arg.as<op_func_call>()->args();
-      if (call_arg->get_string() == "classof" && args.size() == 1) {
-        klassT = assume_class_of_expr(current_function, args[0], call).try_as_class();
-        kphp_error_return(klassT, fmt_format("Could not detect a class of classof()"));
-      }
     }
 
     kphp_error_return(klassT, "Expected ::class as a parameter, but got not a const string");

--- a/compiler/pipes/early-optimization.cpp
+++ b/compiler/pipes/early-optimization.cpp
@@ -86,10 +86,10 @@ private:
     // for every f(substr(...)) replace substr(...) with _tmp_substr(...)
     // if f() marks its associated parameter with readonly attribute
 
-    auto fn = root->func_id;
+    FunctionPtr fn = root->func_id;
 
     // fast path: skip functions that have no readonly params
-    if (fn->readonly_param_index == -1) {
+    if (!fn || fn->readonly_param_index == -1) {
       return root;
     }
     if (root->args().size() <= fn->readonly_param_index) {

--- a/compiler/rewrite-rules/replace-extern-func-calls.cpp
+++ b/compiler/rewrite-rules/replace-extern-func-calls.cpp
@@ -179,13 +179,10 @@ static VertexPtr replace_JsonEncoder_getLastError(VertexAdaptor<op_func_call> ca
   return call;
 }
 
-// `classof(expr)` => `assumption(expr)::class`
-static VertexPtr replace_classof(FunctionPtr current_function, VertexAdaptor<op_func_call> call) {
-  ClassPtr klassT = assume_class_of_expr(current_function, call->args()[0], call).try_as_class();
-  kphp_error_act(klassT, "classof() used for non-instance", return call);
-  auto v_class_name = VertexAdaptor<op_string>::create();
-  v_class_name->str_val = klassT->name;
-  return v_class_name;
+// `classof(expr)` should be replaced in advance: it's not a regular function, it's available only in f<T>
+static VertexPtr replace_classof([[maybe_unused]] FunctionPtr current_function, VertexAdaptor<op_func_call> call) {
+  kphp_error(0, "classof() used incorrectly: it's a keyword to be used only for a single variable which is a generic parameter");
+  return call;
 }
 
 

--- a/tests/phpt/generics/018_classof_keyword.php
+++ b/tests/phpt/generics/018_classof_keyword.php
@@ -3,12 +3,15 @@
 require_once 'kphp_tester_include.php';
 
 class B {
+    const NAME = 'B';
     function method() { echo "B method\n"; return 1; }
 }
 class D1 extends B {
+    const NAME = 'D1';
     function dMethod() { echo "d1\n"; }
 }
 class D2 extends B {
+    const NAME = 'D2';
     function dMethod() { echo "d2\n"; }
 }
 
@@ -94,10 +97,26 @@ castO2ToTypeofO1($bb, new D1);
  * @param T $o1
  */
 function castToClassofLocal($o1) {
-    $d1 = new D1;
-    $casted = instance_cast($o1, classof($d1));
+    $casted = instance_cast($o1, classof($o1));
     echo $casted ? "can cast\n" : "can't cast\n";
 }
 
 castToClassofLocal(new D1);
 castToClassofLocal(new D2);
+
+
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function printNameConst($class_name) {
+    echo 'NAME=', $class_name::NAME, "\n";
+}
+
+function acceptO(object $o) {
+    printNameConst(classof($o));
+}
+
+acceptO(new B);
+acceptO(new D2);

--- a/tests/phpt/generics/020_extends_hint.php
+++ b/tests/phpt/generics/020_extends_hint.php
@@ -36,18 +36,18 @@ tplTwo/*<TemplateMagic>*/(null);
 tplTwo(new TemplateMagic);
 
 
-interface Stringable {
+interface MStringable {
     function __toString(): string;
 }
 
-class S1 implements Stringable {
+class S1 implements MStringable {
     function __toString(): string {
         return "S1\n";
     }
 }
 
 /**
- * @kphp-generic T: Stringable | string
+ * @kphp-generic T: MStringable | string
  * @param T $toStr
  */
 function printToString($toStr) {

--- a/tests/phpt/generics/027_constexpr_switch.php
+++ b/tests/phpt/generics/027_constexpr_switch.php
@@ -1,5 +1,6 @@
 @ok
 <?php
+require_once 'kphp_tester_include.php';
 
 class A {
     public int $value;
@@ -204,3 +205,50 @@ D1::info();
 D2::info();
 D3::info();
 D4::info();
+
+
+class ModelA {
+    public int $a = 0;
+}
+class ModelB {
+    public string $b = 'b';
+}
+
+function overloaded1(object $o) {
+    echo "overloaded function for ", get_class($o), "\n";
+    switch (classof($o)) {
+    case ModelA::class:
+        echo "a = ", $o->a;
+        break;
+    case ModelB::class:
+        echo "b = '", $o->b, "'";
+        break;
+    }
+    echo "\n";
+}
+
+overloaded1(new ModelA);
+overloaded1(new ModelB);
+
+
+/**
+ * @kphp-generic T
+ * @param T $o
+ */
+function overloaded2($o) {
+    switch (true) {
+    case true:
+        switch (classof($o)) {
+        case ModelA::class:
+            if ($o === null) echo 'o = null';
+            else echo "a = ", $o->a;
+            break;
+        default:
+            break;
+        }
+    }
+    echo "\n";
+}
+
+overloaded2(new ModelA);
+overloaded2(new ModelB);

--- a/tests/phpt/generics/123_no_use_in_lambda_typeof.php
+++ b/tests/phpt/generics/123_no_use_in_lambda_typeof.php
@@ -1,5 +1,6 @@
 @kphp_should_fail
-/classof\(\) used for non-instance/
+/in a lambda inside castO2ToTypeofO1<BB, D1>/
+/classof\(\) used incorrectly: it's a keyword to be used only for a single variable which is a generic parameter/
 <?php
 
 class BB {
@@ -95,15 +96,6 @@ function demo1() {
         $b->bf();
 }
 
-function demo2() {
-    global $i_arr;
-    $a2 = [new A];
-    foreach (havingClass($i_arr, classof($a2[0])) as $a)
-        $a->af();
-    foreach (havingClass($i_arr, classof(new B)) as $b)
-        $b->bf();
-}
-
 function demo3() {
     global $i_arr;
     foreach (havingClassLike($i_arr, new A) as $a)
@@ -119,7 +111,6 @@ function demo4() {
 }
 
 demo1(); echo "\n";
-demo2(); echo "\n";
 demo3(); echo "\n";
 demo4(); echo "\n";
 

--- a/tests/phpt/generics/131_invalid_classof.php
+++ b/tests/phpt/generics/131_invalid_classof.php
@@ -1,0 +1,19 @@
+@kphp_should_fail
+/Expected ::class as a parameter, but got not a const string/
+/Couldn't reify generic <T> for call/
+<?php
+
+class A {
+    const NAME = 'A';
+}
+
+/**
+ * @kphp-generic T
+ * @param class-string<T> $class_name
+ */
+function printNameConst($class_name) {
+    echo 'NAME=', $class_name::NAME, "\n";
+}
+
+
+printNameConst(classof(new A));


### PR DESCRIPTION
Now, `classof($generic_arg)` is handled at generic functions instantiation and produces a constexpr string, so that `switch(classof($generic_arg))` is treated as a constexpr switch within a generic function.

This gives an ability to implement function overloading for arguments if that arguments are instances (even without a common base):
```php
function overloaded(object $o) {
  // common code

  switch (classof($o)) {
  case ModelA::class:
    ...
    break;
  case ModelB::class:
    ...
    break;
  }

  // common code
}
```

From this PR, `classof()` became more strict: think of it like a compiler keyword available only for generic parameters. `classof(new A)` and `classof($local_var)` won't work.

### `classof($o)` vs `$o::class`

The latter syntax is much more pretty and will be available some time after.

For now, it can't be used in PHP, since it's available from PHP 8 only, and is a syntax error in PHP 7.4.

Closes #763 