### PR TITLE
docs: add a note about const char* return values

### DIFF
--- a/docs/kphp-language/php-extensions/ffi.md
+++ b/docs/kphp-language/php-extensions/ffi.md
@@ -76,7 +76,7 @@ function g($foo) { var_dump($foo->value); }
 /** @param ffi_cdata<example, struct Foo*> */
 function g_ptr($foo) { var_dump($foo->value); }
 
-$cdef = FFI::cdef('
+  $cdef = FFI::cdef('
   #define FFI_SCOPE "example"
   struct Foo { int value; };
 ');
@@ -222,6 +222,8 @@ When a `c2php` can happen:
 | `T*`                                    | `ffi_cdata<$scope, T*>` | Alloc-free.                                        |
 
 > (*) Only for function results, but not struct/union fields reads.
+
+
 
 Keep in mind: KPHP will try to behave identically to how PHP would. This means that marking a function return as `const char*` if it needs a `free()` will cause a **memory leak** in both PHP and KPHP.
 
@@ -498,6 +500,26 @@ to the library being loaded.
 
 
 ## Useful tricks and hints
+
+### Handling string results that are not null-terminated
+
+Imagine that some C function result is declared as `const char*`. KPHP would try to create a `string` value, assuming that `const char*` contains a C-string value that is null-terminated.
+
+If that's not the case and `const char*` is not null-terminated, you may need to declare that return type as something that is not `const char*`; a type like `const uint8_t*` should do the trick. While still compatible on the calling convention level, this allows us to disable the auto-conversion.
+
+After acquiring a `const uint8_t*` pointer that holds some raw data, you can construct a string yourself if you know its real length by using `\FFI::string()` function.
+
+```php
+$cdef = FFI::cdef('
+    const uint8_t *get_data(int size);
+');
+
+$size = 10;
+$raw_bytes = $cdef->get_data($size);
+$s = FFI::string($raw_bytes, $size);
+```
+
+Keep in mind that FFI/KPHP don't know anything about the data encoding. You may need to convert the raw bytes to some other valid state before using `\FFI::string()`. KPHP strings can contain binary data, but some string functions may not be binary-safe.
 
 ### Cross-library types
 

--- a/docs/kphp-language/php-extensions/ffi.md
+++ b/docs/kphp-language/php-extensions/ffi.md
@@ -76,7 +76,7 @@ function g($foo) { var_dump($foo->value); }
 /** @param ffi_cdata<example, struct Foo*> */
 function g_ptr($foo) { var_dump($foo->value); }
 
-  $cdef = FFI::cdef('
+$cdef = FFI::cdef('
   #define FFI_SCOPE "example"
   struct Foo { int value; };
 ');
@@ -222,8 +222,6 @@ When a `c2php` can happen:
 | `T*`                                    | `ffi_cdata<$scope, T*>` | Alloc-free.                                        |
 
 > (*) Only for function results, but not struct/union fields reads.
-
-
 
 Keep in mind: KPHP will try to behave identically to how PHP would. This means that marking a function return as `const char*` if it needs a `free()` will cause a **memory leak** in both PHP and KPHP.
 


### PR DESCRIPTION
This note explains what to do if `const char*` function result is not a proper C-string (i.e. it's not a null-terminated string).