### PR TITLE
to_array_debug(): suppressed visitting private and protected members.…

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -765,6 +765,8 @@ void ClassDeclaration::compile_generic_accept(CodeGenerator &W, ClassPtr klass) 
                                 << "void generic_accept(Visitor &&visitor) " << BEGIN;
   for (auto cur_klass = klass; cur_klass; cur_klass = cur_klass->parent_class) {
     cur_klass->members.for_each([&W](const ClassMemberInstanceField &f) {
+       if  (f.modifiers.is_private() ) return;
+       if  (f.modifiers.is_protected() ) return;
       // will generate visitor("field_name", $field_name);
       W << "visitor(\"" << f.local_name() << "\", $" << f.local_name() << ");" << NL;
     });


### PR DESCRIPTION
For to_array_debug(): suppressed visitting private and protected members. Because this method converts class instance to mixed for  json_encode() , but json_encode must not convert private and protected fields.

test case:
```php
<?php
class A
{
        public array $b = [];
        private int $privateVal = 1;
        protected  int $protectedVal = 2;
}
$obj = new A;

//echo json_encode($obj ); //does not accept class instance

$mixed= to_array_debug($obj, false);
print_r(  $mixed ); //for manual check

if  (count($mixed) !== 1 ) throw new \RuntimeException("to_array_debug() generated private and protected fields");
echo "ok\n";
```