### PR TITLE
drop env KPHP_ENABLE_MODULITE, now it's on and can't be turned off

### DIFF
--- a/compiler/compiler-settings.h
+++ b/compiler/compiler-settings.h
@@ -124,8 +124,6 @@ public:
   KphpOption<std::string> composer_root;
   KphpOption<bool> composer_autoload_dev;
 
-  KphpOption<uint64_t> modulite_enabled;   // 0 disabled, 1 enabled with errors, 2 enabled with warnings
-
   KphpOption<bool> force_make;
   KphpOption<bool> no_make;
   KphpOption<uint64_t> jobs_count;

--- a/compiler/data/modulite-data.cpp
+++ b/compiler/data/modulite-data.cpp
@@ -42,19 +42,13 @@
 
 static const std::string EMPTY_STRING_RETURNED_WHEN_GOT_NONSTRING_IN_YAML;
 
-// we do all checks if 1/2, but for 2, we just output to console instead of an error
-// todo this will be removed after testing for a month in production
-#define kphp_error_modulite(cond, str) \
-  if (G->settings().modulite_enabled.get() == 2) { kphp_notice(str); } \
-  else { kphp_error(cond, str); }
-
 
 [[gnu::cold]] static void fire_yaml_error(ModulitePtr inside_m, const std::string &reason, int line) {
   inside_m->yaml_file->load();  // load a file from disk, so that error message in console outputs a line
 
   stage::set_file(inside_m->yaml_file);
   stage::set_line(line);
-  kphp_error_modulite(0, fmt_format("Failed loading {}:\n{}", inside_m->yaml_file->relative_file_name, reason));
+  kphp_error(0, fmt_format("Failed loading {}:\n{}", inside_m->yaml_file->relative_file_name, reason));
 }
 
 [[gnu::cold]] static void fire_yaml_error(ModulitePtr inside_m, const std::string &reason, const YAML::Node &y_node) {

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -291,8 +291,6 @@ int main(int argc, char *argv[]) {
              "composer-root", "KPHP_COMPOSER_ROOT");
   parser.add("Include autoload-dev section for the root composer file", settings->composer_autoload_dev,
              "composer-autoload-dev", "KPHP_COMPOSER_AUTOLOAD_DEV");
-  parser.add("Enable modulite experimental support", settings->modulite_enabled,
-             "enable-modulite", "KPHP_ENABLE_MODULITE");
   parser.add("Require functions typing (1 - @param / type hint is mandatory, 0 - auto infer or check if exists)", settings->require_functions_typing,
              "require-functions-typing", "KPHP_REQUIRE_FUNCTIONS_TYPING");
   parser.add("Require class typing (1 - @var / default value is mandatory, 0 - auto infer or check if exists)", settings->require_class_typing,

--- a/compiler/modulite-check-rules.cpp
+++ b/compiler/modulite-check-rules.cpp
@@ -55,17 +55,6 @@ static inline bool should_this_usage_context_be_ignored(FunctionPtr usage_contex
   return false;
 }
 
-static inline bool is_env_modulite_enabled() {
-  // 0 disabled, 1 enabled with errors, 2 enabled with warnings
-  return G->settings().modulite_enabled.get();
-}
-
-// we do all checks if 1/2, but for 2, we just output to console instead of an error
-// todo this will be removed after testing for a month in production
-#define kphp_error_modulite(cond, str) \
-  if (G->settings().modulite_enabled.get() == 2) { kphp_notice(str); } \
-  else { kphp_error(cond, str); }
-
 // class A is exported from a modulite when
 // - "A" is declared in 'export'
 // - or "A" is declared in 'allow internal' for current usage context
@@ -341,7 +330,7 @@ public:
     , desc(fmt_format("use global {}", TermStringFormat::paint_bold("$" + global_var_name))) {}
 
   [[gnu::cold]] void print_error_symbol_is_not_exported() {
-    kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, it's internal in {}", desc, another_m->modulite_name));
+    kphp_error(0, fmt_format("[modulite] restricted to {}, it's internal in {}", desc, another_m->modulite_name));
   }
 
   [[gnu::cold]] void print_error_submodulite_is_not_exported() {
@@ -350,32 +339,28 @@ public:
     while (is_submodulite_exported(child_internal, usage_context, false)) {
       child_internal = child_internal->parent;
     }
-    kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, {} is internal in {}", desc, child_internal->modulite_name, child_internal->parent->modulite_name));
+    kphp_error(0, fmt_format("[modulite] restricted to {}, {} is internal in {}", desc, child_internal->modulite_name, child_internal->parent->modulite_name));
   }
 
   [[gnu::cold]] void print_error_modulite_is_not_required() {
     if (inside_m->composer_json && another_m->composer_json) {
-      kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, {} is not required by {} in composer.json", desc, another_m->modulite_name, inside_m->modulite_name));
+      kphp_error(0, fmt_format("[modulite] restricted to {}, {} is not required by {} in composer.json", desc, another_m->modulite_name, inside_m->modulite_name));
     } else {
-      kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, {} is not required by {}", desc, another_m->modulite_name, inside_m->modulite_name));
+      kphp_error(0, fmt_format("[modulite] restricted to {}, {} is not required by {}", desc, another_m->modulite_name, inside_m->modulite_name));
     }
   }
 
   [[gnu::cold]] void print_error_symbol_is_not_required() {
     if (inside_m->is_composer_package) {
-      kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, it does not belong to package {}", desc, inside_m->modulite_name));
+      kphp_error(0, fmt_format("[modulite] restricted to {}, it does not belong to package {}", desc, inside_m->modulite_name));
     } else {
-      kphp_error_modulite(0, fmt_format("[modulite] restricted to {}, it's not required by {}", desc, inside_m->modulite_name));
+      kphp_error(0, fmt_format("[modulite] restricted to {}, it's not required by {}", desc, inside_m->modulite_name));
     }
   }
 };
 
 
 void modulite_check_when_use_class(FunctionPtr usage_context, ClassPtr klass) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   ModulitePtr another_m = klass->modulite;
   if (inside_m == another_m || should_this_usage_context_be_ignored(usage_context)) {
@@ -413,10 +398,6 @@ void modulite_check_when_use_class(FunctionPtr usage_context, ClassPtr klass) {
 }
 
 void modulite_check_when_use_global_const(FunctionPtr usage_context, DefinePtr used_c) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   ModulitePtr another_m = used_c->modulite;
   if (inside_m == another_m || should_this_usage_context_be_ignored(usage_context)) {
@@ -454,10 +435,6 @@ void modulite_check_when_use_global_const(FunctionPtr usage_context, DefinePtr u
 }
 
 void modulite_check_when_use_constant(FunctionPtr usage_context, DefinePtr used_c, ClassPtr requested_class) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   ModulitePtr another_m = requested_class->modulite;
   if (inside_m == another_m || should_this_usage_context_be_ignored(usage_context)) {
@@ -496,10 +473,6 @@ void modulite_check_when_use_constant(FunctionPtr usage_context, DefinePtr used_
 }
 
 void modulite_check_when_call_function(FunctionPtr usage_context, FunctionPtr called_f) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   ModulitePtr another_m = called_f->modulite;
   if (inside_m == another_m || should_this_usage_context_be_ignored(usage_context)) {
@@ -544,10 +517,6 @@ void modulite_check_when_call_function(FunctionPtr usage_context, FunctionPtr ca
 }
 
 void modulite_check_when_use_static_field(FunctionPtr usage_context, VarPtr property, ClassPtr requested_class) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   ModulitePtr another_m = requested_class->modulite;
   if (inside_m == another_m || should_this_usage_context_be_ignored(usage_context)) {
@@ -586,10 +555,6 @@ void modulite_check_when_use_static_field(FunctionPtr usage_context, VarPtr prop
 }
 
 void modulite_check_when_global_keyword(FunctionPtr usage_context, const std::string &global_var_name) {
-  if (!is_env_modulite_enabled()) {
-    return;
-  }
-
   ModulitePtr inside_m = usage_context->modulite;
   if (should_this_usage_context_be_ignored(usage_context)) {
     return;

--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -208,10 +208,6 @@ private:
   // moreover, symbols listed in "export" are used for classes collecting, see require_all_deps_of_modulite()
   // while parsing, cross-references like SomeClass or @another-m are not resolved, it will be done on all classes loaded
   ModulitePtr load_modulite_inside_dir(SrcDirPtr dir) {
-    if (!G->settings().modulite_enabled.get()) {
-      return {};
-    }
-
     if (dir->has_composer_json) {
       // composer packages are implicit modulites "#vendorname/packagename" ("#" + json->name)
       // for instance, if a modulite in a project calls a function from a package, it's auto checked to be required

--- a/compiler/pipes/wait-for-all-classes.cpp
+++ b/compiler/pipes/wait-for-all-classes.cpp
@@ -35,10 +35,6 @@ void WaitForAllClassesF::on_finish(DataStream<FunctionPtr> &os) {
 // after all classes have been loaded, we can resolve symbols in modulite configs
 // (until this point, yaml files were parsed, but stored as strings)
 void WaitForAllClassesF::resolve_and_validate_modulites() {
-  if (!G->settings().modulite_enabled.get()) {
-    return;
-  }
-
   // sort all modulites from short to long, so that a parent appears before a child when iterating
   // this fact is used to fill `child->exported_from_parent` by lookup, and some others
   std::vector<ModulitePtr> all_modulites = G->get_modulites();

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -102,7 +102,6 @@ def make_test_file(file_path, test_tmp_dir, test_tags):
             else:  # <?php
                 break
 
-        env_vars["KPHP_ENABLE_MODULITE"] = "1"
         return TestFile(file_path, test_tmp_dir, tags, env_vars, out_regexps, forbidden_regexps)
 
 

--- a/tests/phpt/modulite/001_simple_yaml_project/001_simple_yaml_project.php
+++ b/tests/phpt/modulite/001_simple_yaml_project/001_simple_yaml_project.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/002_ok_require_submod/002_ok_require_submod.php
+++ b/tests/phpt/modulite/002_ok_require_submod/002_ok_require_submod.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/003_allow_internal/003_allow_internal.php
+++ b/tests/phpt/modulite/003_allow_internal/003_allow_internal.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/004_instance_methods/004_instance_methods.php
+++ b/tests/phpt/modulite/004_instance_methods/004_instance_methods.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/005_inheritance/005_inheritance.php
+++ b/tests/phpt/modulite/005_inheritance/005_inheritance.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/006_known_bugs/006_known_bugs.php
+++ b/tests/phpt/modulite/006_known_bugs/006_known_bugs.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/007_composer_ok/007_composer_ok.php
+++ b/tests/phpt/modulite/007_composer_ok/007_composer_ok.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 <?php
 require_once __DIR__ . '/vendor/autoload.php';

--- a/tests/phpt/modulite/008_mod_generics/008_mod_generics.php
+++ b/tests/phpt/modulite/008_mod_generics/008_mod_generics.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/009_mod_magic_m/009_mod_magic_m.php
+++ b/tests/phpt/modulite/009_mod_magic_m/009_mod_magic_m.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/010_mod_unreachable/010_mod_unreachable.php
+++ b/tests/phpt/modulite/010_mod_unreachable/010_mod_unreachable.php
@@ -1,5 +1,4 @@
 @ok
-KPHP_ENABLE_MODULITE=1
 <?php
 #ifndef KPHP
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/modulite/100_empty_yaml_file/100_empty_yaml_file.php
+++ b/tests/phpt/modulite/100_empty_yaml_file/100_empty_yaml_file.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Failed loading .modulite.yaml:/
 /'name' not specified/
 /'namespace' not specified/

--- a/tests/phpt/modulite/101_corrupted_yaml_file/101_corrupted_yaml_file.php
+++ b/tests/phpt/modulite/101_corrupted_yaml_file/101_corrupted_yaml_file.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Algo101\/\.modulite\.yaml:5/
 /"asdf":/
 /'export' has incorrect format/

--- a/tests/phpt/modulite/102_unknown_symbols/102_unknown_symbols.php
+++ b/tests/phpt/modulite/102_unknown_symbols/102_unknown_symbols.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Failed loading Utils102\/.modulite.yaml:/
 /can't find class\/constant Utils102\\StringsNot/
 /can't find function Utils102\\basicFn\(\)/

--- a/tests/phpt/modulite/103_unknown_refs/103_unknown_refs.php
+++ b/tests/phpt/modulite/103_unknown_refs/103_unknown_refs.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Failed loading Utils103\/.modulite.yaml:/
 /"@utils\/sub"/
 /@utils\/sub not found/

--- a/tests/phpt/modulite/104_invalid_export/104_invalid_export.php
+++ b/tests/phpt/modulite/104_invalid_export/104_invalid_export.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /'require' contains a member of @utils; you should require @utils directly, not its members/
 /"\\\\AAA104"/
 /'export' contains a symbol that does not belong to @algo/

--- a/tests/phpt/modulite/105_inconsistent_nesting/105_inconsistent_nesting.php
+++ b/tests/phpt/modulite/105_inconsistent_nesting/105_inconsistent_nesting.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Utils105\/.modulite.yaml:-1/
 /inconsistent nesting: @msg\/utils placed outside of @msg/
 /inconsistent nesting: @feed placed in @msg/

--- a/tests/phpt/modulite/106_internal_submod/106_internal_submod.php
+++ b/tests/phpt/modulite/106_internal_submod/106_internal_submod.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Failed loading Messages106\/.modulite.yaml:/
 /can't require @api\/impl: @api\/impl is internal in @api/
 /can't require @msg\/channels\/infra: @msg\/channels\/infra is internal in @msg\/channels/

--- a/tests/phpt/modulite/110_check_extends/110_check_extends.php
+++ b/tests/phpt/modulite/110_check_extends/110_check_extends.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /Utils110\/More110.php:5/
 /interface I110 extends/
 /restricted to use Feed110\\IRank110, it's internal in @feed/

--- a/tests/phpt/modulite/111_check_calls/111_check_calls.php
+++ b/tests/phpt/modulite/111_check_calls/111_check_calls.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /restricted to call Utils111\\Hidden111::demo\(\), it's internal in @utils/
 /restricted to call globalDemo\(\), it's not required by @feed/
 /restricted to call Messages111\\Core111\\Core111::demo1\(\), @msg\/core is internal in @msg/

--- a/tests/phpt/modulite/112_check_constants/112_check_constants.php
+++ b/tests/phpt/modulite/112_check_constants/112_check_constants.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /in global scope/
 /restricted to use Feed112\\Infra112\\Hidden112, it's internal in @feed\/infra/
 /restricted to use OTHER_112_CONST, it's internal in @other/

--- a/tests/phpt/modulite/113_check_fields/113_check_fields.php
+++ b/tests/phpt/modulite/113_check_fields/113_check_fields.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /in global scope/
 /restricted to use Feed113\\Infra113\\Hidden113, it's internal in @feed\/infra/
 /in Post113::demo/

--- a/tests/phpt/modulite/114_check_classes/114_check_classes.php
+++ b/tests/phpt/modulite/114_check_classes/114_check_classes.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /in global scope/
 /restricted to use Feed114\\Infra114\\Strings114, @feed\/infra is internal in @feed/
 /in other114/

--- a/tests/phpt/modulite/115_check_globals/115_check_globals.php
+++ b/tests/phpt/modulite/115_check_globals/115_check_globals.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 /in global scope/
 /restricted to use global \$in_plain_115, it's not required by @plain/
 /in Post115::demo/

--- a/tests/phpt/modulite/120_composer_uses_outer/120_composer_uses_outer.php
+++ b/tests/phpt/modulite/120_composer_uses_outer/120_composer_uses_outer.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 /restricted to use MONOLITH_CONST_120, it does not belong to package #vk\/strings/
 /restricted to use VK\\RPC\\RpcQuery120, #vk\/rpc is not required by #vk\/strings in composer.json/

--- a/tests/phpt/modulite/121_composer_called_no_req/121_composer_called_no_req.php
+++ b/tests/phpt/modulite/121_composer_called_no_req/121_composer_called_no_req.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 /restricted to call concatStr\(\), #vk\/strings is not required by @msg/
 /restricted to call rpcFunctionCallingVkStrings\(\), #vk\/rpc is not required by @msg/

--- a/tests/phpt/modulite/122_composer_req_symbol/122_composer_req_symbol.php
+++ b/tests/phpt/modulite/122_composer_req_symbol/122_composer_req_symbol.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 /Strings122"/
 /Strings122::\$SIZE"/

--- a/tests/phpt/modulite/123_call_composer_submod/123_call_composer_submod.php
+++ b/tests/phpt/modulite/123_call_composer_submod/123_call_composer_submod.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 /restricted to call VK\\Strings\\Internals123\\Append123::notExportedF\(\), it's internal in #vk\/strings\/@internals/
 /in VK\\RPC\\Rpc123::callToStringsInternals/

--- a/tests/phpt/modulite/124_root_composer_fields/124_root_composer_fields.php
+++ b/tests/phpt/modulite/124_root_composer_fields/124_root_composer_fields.php
@@ -1,5 +1,4 @@
 @kphp_should_fail
-KPHP_ENABLE_MODULITE=1
 KPHP_COMPOSER_ROOT={dir}
 /restricted to use VK\\RPC\\RpcLogger124, it's internal in #vk\/rpc/
 /restricted to use VK\\Strings\\Strings124, it's internal in #vk\/strings/


### PR DESCRIPTION
Previously, this env var could be used to turn Modulite off (if something goes completely wrong). It was never used for several months. Now I'm dropping it away.