### PR TITLE
hide custom_php_project.cmake under KPHP_CUSTOM_CMAKE option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ include(${BASE_DIR}/compiler/compiler.cmake)
 
 include(${BASE_DIR}/tests/tests.cmake)
 
-if(EXISTS ${OBJS_DIR}/custom_php_project.cmake)
+if(KPHP_CUSTOM_CMAKE AND EXISTS ${OBJS_DIR}/custom_php_project.cmake)
     include(${OBJS_DIR}/custom_php_project.cmake)
 endif()
 

--- a/cmake/init-compilation-flags.cmake
+++ b/cmake/init-compilation-flags.cmake
@@ -81,6 +81,9 @@ cmake_print_variables(PDO_DRIVER_PGSQL)
 option(KPHP_TESTS "Build the tests" ON)
 cmake_print_variables(KPHP_TESTS)
 
+option(KPHP_CUSTOM_CMAKE "Use CMakeLists.txt of custom php project" OFF)
+cmake_print_variables(KPHP_CUSTOM_CMAKE)
+
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "Setting build type to `${DEFAULT_BUILD_TYPE}` as none was specified.")
     set(CMAKE_BUILD_TYPE ${DEFAULT_BUILD_TYPE} CACHE STRING "Build type (default ${DEFAULT_BUILD_TYPE})" FORCE)


### PR DESCRIPTION
Use custom_php_project.cmake only when KPHP_CUSTOM_CMAKE=ON option passed to make CMakeLists.txt