### PR TITLE
[compiler] Improve AST traversal DFS in case of x86_64 

### DIFF
--- a/compiler/function-pass.h
+++ b/compiler/function-pass.h
@@ -70,7 +70,7 @@ void run_function_pass(VertexPtr &vertex, FunctionPassT *pass) {
     if (reinterpret_cast<uintptr_t>(x) & MASK) {
       vertex_stack.pop_back();
       x = reinterpret_cast<VertexPtr*>(reinterpret_cast<uintptr_t>(x) ^ MASK);
-      stage::set_location((*x)->get_location());
+//      stage::set_location((*x)->get_location());
       *x = pass->on_exit_vertex(*x);
       continue;
     }

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -141,17 +141,17 @@ public:
 
   iterator end() { return iterator(arr() - size() + 1); }
 
-  xiterator cbegin() { return xiterator(arr() - size() + 1); }
+  xiterator rbegin() { return xiterator(arr() - size() + 1); }
 
-  xiterator cend() { return xiterator(arr()  + 1); }
+  xiterator rend() { return xiterator(arr() + 1); }
 
   const_iterator begin() const { return const_iterator(arr() + 1); }
 
   const_iterator end() const { return const_iterator(arr() - size() + 1); }
 
-  const_xiterator cbegin() const { return const_xiterator(arr() -  size() +  1); }
+  const_xiterator rbegin() const { return const_xiterator(arr() -  size() + 1); }
 
-  const_xiterator cend() const { return const_xiterator(arr() + 1); }
+  const_xiterator rend() const { return const_xiterator(arr() - 1); }
 
   const Location &get_location() const { return location; }
 

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -141,9 +141,17 @@ public:
 
   iterator end() { return iterator(arr() - size() + 1); }
 
+  xiterator cbegin() { return xiterator(arr() - size() + 1); }
+
+  xiterator cend() { return xiterator(arr()  + 1); }
+
   const_iterator begin() const { return const_iterator(arr() + 1); }
 
   const_iterator end() const { return const_iterator(arr() - size() + 1); }
+
+  const_xiterator cbegin() const { return const_xiterator(arr() -  size() +  1); }
+
+  const_xiterator cend() const { return const_xiterator(arr() + 1); }
 
   const Location &get_location() const { return location; }
 


### PR DESCRIPTION
*  Fix drawback - there was wrong location with call `on_exit_vertex`

*  Add optimization - iterative DFS in `run_function_pass`. Tagged pointers are used to define direction: top-down or bottom-up.
I measured the build time of vkcom and found out that this optimization accelerated the build time by an average of 4%. Note: if I do not use tagged pointers (and use additional memory, which means direction of traversal), then the time difference becomes invisible. Therefore, in the absence of tagged pointers, I left the old algorithm.