### PR TITLE
[runtime] add flag for the implementation version of gmmktime 

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1401,7 +1401,7 @@ function set_detect_incorrect_encoding_names_warning(bool $show) ::: void;
 
 function set_json_log_on_timeout_mode(bool $enabled) ::: void;
 
-function set_use_updated_gmmktime($enable ::: bool) ::: void;
+function set_use_updated_gmmktime(bool $enable) ::: void;
 
 // re-initialize given ArrayIterator with another array;
 // in KPHP it returns the same ArrayIterator that is ready to be used

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1401,6 +1401,8 @@ function set_detect_incorrect_encoding_names_warning(bool $show) ::: void;
 
 function set_json_log_on_timeout_mode(bool $enabled) ::: void;
 
+function set_use_updated_gmmktime($enable ::: bool) ::: void;
+
 // re-initialize given ArrayIterator with another array;
 // in KPHP it returns the same ArrayIterator that is ready to be used
 // in PHP (via polyfills) it returns a newly allocated object

--- a/runtime/datetime/datetime_functions.h
+++ b/runtime/datetime/datetime_functions.h
@@ -16,6 +16,8 @@ string f$date_default_timezone_get();
 
 array<mixed> f$getdate(int64_t timestamp = std::numeric_limits<int64_t>::min());
 
+void f$set_use_updated_gmmktime(bool enable);
+
 string f$gmdate(const string &format, int64_t timestamp = std::numeric_limits<int64_t>::min());
 
 int64_t f$gmmktime(int64_t h = std::numeric_limits<int64_t>::min(),
@@ -30,6 +32,8 @@ array<mixed> f$localtime(int64_t timestamp = std::numeric_limits<int64_t>::min()
 double microtime_monotonic();
 
 double microtime();
+
+void free_use_updated_gmmktime();
 
 mixed f$microtime(bool get_as_float = false);
 string f$_microtime_string();

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2379,6 +2379,7 @@ static void free_runtime_libs() {
   free_kphp_backtrace();
 
   free_migration_php8();
+  free_use_updated_gmmktime();
   free_detect_incorrect_encoding_names();
 
   vk::singleton<JsonLogger>::get().reset_buffers();


### PR DESCRIPTION
General
-----------
This pr adds a function `set_use_updated_gmmktime(...)` to enable the updated implementation of the gmmktime function

Details
---------
In the past, the source code of gmmktime used the trick of changing the environment variable "TZ" and using `mktime`. This could cause it to not work correctly on some platforms. Now taking the timestamp is done with `timegm`. The magic constants were also removed 