### PR TITLE
Allow trailing comma in tuples

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -656,7 +656,7 @@ VertexPtr GenTree::get_expr_top(bool was_arrow, const PhpDocComment *phpdoc) {
       return_flag = false; // array is valid postfix expression operand
       break;
     case tok_tuple:
-      res = get_func_call<op_tuple, op_err>();
+      res = get_func_call<op_tuple, op_none>();
       CE (!kphp_error(res.as<op_tuple>()->size(), "tuple() must have at least one argument"));
       break;
     case tok_shape:

--- a/tests/phpt/tup/001_tuple_create.php
+++ b/tests/phpt/tup/001_tuple_create.php
@@ -16,4 +16,21 @@ function demo() {
     echo "string = ", $string, "\n";
 }
 
+function demo2() {
+    $a = tuple(
+        1,
+        'str',
+    );
+
+    /** @var int $int */
+    /** @var string $string */
+
+    $int = $a[0];
+    $string = $a[1];
+
+    echo "int = ", $int, "\n";
+    echo "string = ", $string, "\n";
+}
+
 demo();
+demo2();

--- a/tests/phpt/tup/111_internal_comma.php
+++ b/tests/phpt/tup/111_internal_comma.php
@@ -1,0 +1,10 @@
+@kphp_should_fail
+/Expected '\)', found ','/
+<?php
+
+function test_many_extra_comma() {
+  $tuple = tuple(1,,5);
+  echo $tuple[0];
+}
+
+test_many_extra_comma();


### PR DESCRIPTION
Code like `tuple(1,2,)` was compiled with error. This PR fixes this issue,  such code is going to be successfully compiled.