### PR TITLE
[runtime] add incremental compression

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -103,6 +103,10 @@ final class mysqli {
     private function __construct() ::: \mysqli;
 }
 
+final class DeflateContext {
+    private function __construct() ::: DeflateContext;
+}
+
 /** @var mixed $_SERVER */
 global $_SERVER;
 /** @var mixed $_GET */
@@ -513,9 +517,29 @@ function openssl_encrypt($data ::: string, $method ::: string, $key ::: string, 
 function openssl_decrypt($data ::: string, $method ::: string, $key ::: string, $options ::: int = 0, $iv ::: string  = '',
                         $tag ::: string = '', $aad ::: string = '') ::: string | false;
 
+define('ZLIB_ENCODING_RAW', -0x0f);
+define('ZLIB_ENCODING_DEFLATE', 0x0f);
+define('ZLIB_ENCODING_GZIP', 0x1f);
+
+define('ZLIB_NO_FLUSH', 0);
+define('ZLIB_PARTIAL_FLUSH', 1);
+define('ZLIB_SYNC_FLUSH', 2);
+define('ZLIB_FULL_FLUSH', 3);
+define('ZLIB_FINISH', 4);
+define('ZLIB_BLOCK', 5);
+define('ZLIB_TREES', 6);
+
+define('ZLIB_FILTERED', 1);
+define('ZLIB_HUFFMAN_ONLY', 2);
+define('ZLIB_RLE', 3);
+define('ZLIB_FIXED', 4);
+define('ZLIB_DEFAULT_STRATEGY', 0);
+
 define('PHP_QUERY_RFC1738', 1);
 define('PHP_QUERY_RFC3986', 2);
 
+function deflate_init(int $encoding, array $options = []) ::: ?DeflateContext;
+function deflate_add(DeflateContext $context, string $data, int $flush_mode = ZLIB_SYNC_FLUSH) ::: string | false;
 function gzencode ($str ::: string, $level ::: int = -1) ::: string;
 function gzdecode ($str ::: string) ::: string;
 function gzcompress ($str ::: string, $level ::: int = -1) ::: string;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -521,10 +521,10 @@ static const string_buffer * compress_http_query_body(string_buffer * http_query
   } else {
     if ((http_need_gzip & 5) == 5) {
       header("Content-Encoding: gzip", 22, true);
-      return zlib_encode(http_query_body->c_str(), http_query_body->size(), 6, ZLIB_ENCODE);
+      return zlib_encode(http_query_body->c_str(), http_query_body->size(), 6, ZLIB_ENCODING_GZIP);
     } else if ((http_need_gzip & 6) == 6) {
       header("Content-Encoding: deflate", 25, true);
-      return zlib_encode(http_query_body->c_str(), http_query_body->size(), 6, ZLIB_COMPRESS);
+      return zlib_encode(http_query_body->c_str(), http_query_body->size(), 6, ZLIB_ENCODING_DEFLATE);
     } else {
       return http_query_body;
     }

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -368,7 +368,7 @@ void f$store_finish_gzip_pack(int64_t threshold) {
     php_assert (rpc_pack_from % sizeof(int) == 0 && 0 <= rpc_pack_from && 0 <= answer_size);
     if (answer_size >= threshold) {
       const char *answer_begin = data_buf.c_str() + rpc_pack_from;
-      const string_buffer *compressed = zlib_encode(answer_begin, static_cast<int32_t>(answer_size), 6, ZLIB_ENCODE);
+      const string_buffer *compressed = zlib_encode(answer_begin, static_cast<int32_t>(answer_size), 6, ZLIB_ENCODING_GZIP);
 
       if (compressed->size() + 2 * sizeof(int) < answer_size) {
         data_buf.set_pos(rpc_pack_from);

--- a/runtime/zlib.cpp
+++ b/runtime/zlib.cpp
@@ -4,12 +4,11 @@
 
 #include "runtime/zlib.h"
 
-#include <zlib.h>
-
 #include "runtime/critical_section.h"
 #include "runtime/string_functions.h"
 
-static voidpf zlib_alloc(voidpf opaque, uInt items, uInt size) {
+namespace {
+voidpf zlib_static_alloc(voidpf opaque, uInt items, uInt size) {
   int *buf_pos = (int *)opaque;
   php_assert (items != 0 && (PHP_BUF_LEN - *buf_pos) / items >= size);
 
@@ -19,14 +18,22 @@ static voidpf zlib_alloc(voidpf opaque, uInt items, uInt size) {
   return php_buf + pos;
 }
 
-static void zlib_free(voidpf opaque __attribute__((unused)), voidpf address __attribute__((unused))) {
+void zlib_static_free(voidpf opaque __attribute__((unused)), voidpf address __attribute__((unused))) {}
+
+voidpf zlib_dynamic_alloc(voidpf opaque __attribute__((unused)), uInt items, uInt size) {
+  return static_cast<voidpf>(dl::script_allocator_calloc(items, size));
 }
+
+void zlib_dynamic_free(voidpf opaque __attribute__((unused)), voidpf address) {
+  dl::script_allocator_free(address);
+}
+} // namespace
 
 const string_buffer *zlib_encode(const char *s, int32_t s_len, int32_t level, int32_t encoding) {
   int buf_pos = 0;
   z_stream strm;
-  strm.zalloc = zlib_alloc;
-  strm.zfree = zlib_free;
+  strm.zalloc = zlib_static_alloc;
+  strm.zfree = zlib_static_free;
   strm.opaque = &buf_pos;
 
   unsigned int res_len = (unsigned int)compressBound(s_len) + 30;
@@ -58,13 +65,147 @@ const string_buffer *zlib_encode(const char *s, int32_t s_len, int32_t level, in
   return &static_SB;
 }
 
+class_instance<C$DeflateContext> f$deflate_init(int encoding, const array<mixed> &options) {
+  int level = -1;
+  int memory = 8;
+  int window = 15;
+  int strategy = Z_DEFAULT_STRATEGY;
+  string_buffer dict;
+  for (const auto &option : options) {
+    mixed value;
+    if (!option.is_string_key()) {
+      php_warning("deflate_init() : unsupported option");
+      return {};
+    }
+    if (option.get_string_key() == string("level")) {
+      value = options.get_value(string("level"));
+      if (value.is_int() && value.as_int() >= -1 && value.as_int() <= 9) {
+        level = value.as_int();
+      } else {
+        php_warning("deflate_init() : option level should be number between -1..9");
+        return {};
+      }
+    } else if (option.get_string_key() == string("memory")) {
+      value = options.get_value(string("memory"));
+      if (value.is_int() && value.as_int() >= 1 && value.as_int() <= 9) {
+        level = value.as_int();
+      } else {
+        php_warning("deflate_init() : option memory should be number between 1..9");
+        return {};
+      }
+    } else if (option.get_string_key() == string("window")) {
+      value = options.get_value(string("window"));
+      if (value.is_int() && value.as_int() >= 8 && value.as_int() <= 15) {
+        level = value.as_int();
+      } else {
+        php_warning("deflate_init() : option window should be number between 8..15");
+        return {};
+      }
+    } else if (option.get_string_key() == string("strategy")) {
+      value = options.get_value(string("strategy"));
+      if (value.is_int()) {
+        switch (value.as_int()) {
+          case Z_FILTERED:
+          case Z_HUFFMAN_ONLY:
+          case Z_RLE:
+          case Z_FIXED:
+          case Z_DEFAULT_STRATEGY:
+            strategy = value.as_int();
+            break;
+          default:
+            php_warning("deflate_init() : option strategy should be one of ZLIB_FILTERED, ZLIB_HUFFMAN_ONLY, ZLIB_RLE, ZLIB_FIXED or ZLIB_DEFAULT_STRATEGY");
+            return {};
+        }
+      } else {
+        php_warning("deflate_init() : option strategy should be one of ZLIB_FILTERED, ZLIB_HUFFMAN_ONLY, ZLIB_RLE, ZLIB_FIXED or ZLIB_DEFAULT_STRATEGY");
+        return {};
+      }
+    } else if (option.get_string_key() == string("dictionary")) {
+      php_warning("deflate_init() : option dictionary isn't supported yet");
+      return {};
+    } else {
+      php_warning("deflate_init() : unknown option name \"%s\"", option.get_string_key().c_str());
+      return {};
+    }
+  }
+
+  class_instance<C$DeflateContext> context;
+  context.alloc();
+
+  z_stream *stream = &context.get()->stream;
+  stream->zalloc = zlib_dynamic_alloc;
+  stream->zfree = zlib_dynamic_free;
+  stream->opaque = nullptr;
+
+  if (encoding < 0) {
+    encoding += 15 - window;
+  } else {
+    encoding -= 15 - window;
+  }
+
+  dl::CriticalSectionGuard guard;
+  int err = deflateInit2(stream, level, Z_DEFLATED, encoding, memory, strategy);
+  if (err != Z_OK) {
+    php_warning("deflate_init() : zlib error %s", zError(err));
+    context.destroy();
+    return {};
+  }
+  return context;
+}
+
+Optional<string> f$deflate_add(const class_instance<C$DeflateContext> &context, string &data, int64_t flush_type) {
+  switch (flush_type) {
+    case Z_BLOCK:
+    case Z_NO_FLUSH:
+    case Z_PARTIAL_FLUSH:
+    case Z_SYNC_FLUSH:
+    case Z_FULL_FLUSH:
+    case Z_FINISH:
+      break;
+    default:
+      php_warning("deflate_add() : flush type should be one of ZLIB_NO_FLUSH, ZLIB_PARTIAL_FLUSH, ZLIB_SYNC_FLUSH, ZLIB_FULL_FLUSH, ZLIB_FINISH, ZLIB_BLOCK, ZLIB_TREES");
+      return {};
+  }
+
+  string_buffer buffer;
+  int out_size = compressBound(data.size()) + 30;
+  buffer.reserve(out_size);
+  z_stream *stream = &context.get()->stream;
+  stream->next_in = reinterpret_cast<Bytef *>(data.buffer());
+  stream->next_out = reinterpret_cast<Bytef *>(buffer.buffer());
+  stream->avail_in = data.size();
+  stream->avail_out = out_size;
+
+  dl::CriticalSectionGuard guard;
+  int res = deflate(stream, flush_type);
+  int len;
+  switch (res) {
+    case Z_OK:
+      len = stream->next_out - reinterpret_cast<Bytef *>(buffer.buffer());
+      if (len != 0) {
+        buffer.set_pos(len);
+      }
+      return buffer.str();
+    case Z_STREAM_END:
+      len = stream->next_out - reinterpret_cast<Bytef *>(buffer.buffer());
+      if (len != 0) {
+        buffer.set_pos(len);
+      }
+      deflateReset(stream);
+      return buffer.str();
+    default:
+      php_warning("deflate_add() : zlib error %s", zError(res));
+      return {};
+  }
+}
+
 string f$gzcompress(const string &s, int64_t level) {
   if (level < -1 || level > 9) {
     php_warning("Wrong parameter level = %" PRIi64 " in function gzcompress", level);
     level = 6;
   }
 
-  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_COMPRESS)->str();
+  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_ENCODING_DEFLATE)->str();
 }
 
 string f$gzdeflate(const string &s, int64_t level) {
@@ -73,7 +214,7 @@ string f$gzdeflate(const string &s, int64_t level) {
     level = 6;
   }
 
-  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_RAW)->str();
+  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_ENCODING_RAW)->str();
 }
 
 string f$gzencode(const string &s, int64_t level) {
@@ -81,11 +222,11 @@ string f$gzencode(const string &s, int64_t level) {
     php_warning("Wrong parameter level = %" PRIi64 " in function gzencode", level);
   }
 
-  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_ENCODE)->str();
+  return zlib_encode(s.c_str(), s.size(), static_cast<int32_t>(level), ZLIB_ENCODING_GZIP)->str();
 }
 
 static string::size_type zlib_decode_raw(vk::string_view s, int encoding) {
-  dl::enter_critical_section();//OK
+  dl::enter_critical_section(); // OK
 
   z_stream strm;
   strm.zalloc = Z_NULL;
@@ -94,9 +235,9 @@ static string::size_type zlib_decode_raw(vk::string_view s, int encoding) {
   strm.avail_in = s.size();
   strm.next_in = reinterpret_cast<Bytef *>(const_cast<char *>(s.data()));
   strm.avail_out = PHP_BUF_LEN;
-  strm.next_out = reinterpret_cast <Bytef *> (php_buf);
+  strm.next_out = reinterpret_cast<Bytef *>(php_buf);
 
-  int ret = inflateInit2 (&strm, encoding);
+  int ret = inflateInit2(&strm, encoding);
   if (ret != Z_OK) {
     dl::leave_critical_section();
     return -1;
@@ -111,7 +252,7 @@ static string::size_type zlib_decode_raw(vk::string_view s, int encoding) {
       inflateEnd(&strm);
       dl::leave_critical_section();
 
-      php_assert (ret != Z_STREAM_ERROR);
+      php_assert(ret != Z_STREAM_ERROR);
       return -1;
   }
 
@@ -131,7 +272,7 @@ static string::size_type zlib_decode_raw(vk::string_view s, int encoding) {
 }
 
 const char *gzuncompress_raw(vk::string_view s, string::size_type *result_len) {
-  auto len = zlib_decode_raw(s, ZLIB_COMPRESS);
+  auto len = zlib_decode_raw(s, ZLIB_ENCODING_DEFLATE);
   if (len == -1u) {
     *result_len = 0;
     return "";
@@ -140,8 +281,7 @@ const char *gzuncompress_raw(vk::string_view s, string::size_type *result_len) {
   return php_buf;
 }
 
-
-string zlib_decode(const string&s, int encoding) {
+string zlib_decode(const string &s, int encoding) {
   int len = zlib_decode_raw({s.c_str(), s.size()}, encoding);
   if (len == -1u) {
     return {};
@@ -150,13 +290,13 @@ string zlib_decode(const string&s, int encoding) {
 }
 
 string f$gzdecode(const string &s) {
-  return zlib_decode(s, ZLIB_ENCODE);
+  return zlib_decode(s, ZLIB_ENCODING_GZIP);
 }
 
 string f$gzuncompress(const string &s) {
-  return zlib_decode(s, ZLIB_COMPRESS);
+  return zlib_decode(s, ZLIB_ENCODING_DEFLATE);
 }
 
 string f$gzinflate(const string &s) {
-  return zlib_decode(s, ZLIB_RAW);
+  return zlib_decode(s, ZLIB_ENCODING_RAW);
 }

--- a/runtime/zlib.h
+++ b/runtime/zlib.h
@@ -30,9 +30,9 @@ struct C$DeflateContext : public refcountable_php_classes<C$DeflateContext>, pri
 
 const string_buffer *zlib_encode(const char *s, int32_t s_len, int32_t level, int32_t encoding);//returns pointer to static_SB
 
-class_instance<C$DeflateContext> f$deflate_init(int encoding, const array<mixed> & options = {});
+class_instance<C$DeflateContext> f$deflate_init(int64_t encoding, const array<mixed> & options = {});
 
-Optional<string> f$deflate_add(const class_instance<C$DeflateContext> & context, string & data, int64_t flush_type = Z_SYNC_FLUSH);
+Optional<string> f$deflate_add(const class_instance<C$DeflateContext> & context, const string & data, int64_t flush_type = Z_SYNC_FLUSH);
 
 string f$gzcompress(const string &s, int64_t level = -1);
 

--- a/runtime/zlib.h
+++ b/runtime/zlib.h
@@ -4,15 +4,35 @@
 
 #pragma once
 
+#include <zlib.h>
+
 #include "common/wrappers/string_view.h"
 
 #include "runtime/kphp_core.h"
+#include "runtime/refcountable_php_classes.h"
+#include "runtime/dummy-visitor-methods.h"
 
-constexpr int32_t ZLIB_RAW = -0x0f;
-constexpr int32_t ZLIB_COMPRESS = 0x0f;
-constexpr int32_t ZLIB_ENCODE = 0x1f;
+constexpr int64_t ZLIB_ENCODING_RAW = -0x0f;
+constexpr int64_t ZLIB_ENCODING_DEFLATE = 0x0f;
+constexpr int64_t ZLIB_ENCODING_GZIP = 0x1f;
+
+struct C$DeflateContext : public refcountable_php_classes<C$DeflateContext>, private DummyVisitorMethods {
+  C$DeflateContext() = default;
+  using DummyVisitorMethods::accept;
+
+  ~C$DeflateContext() {
+    dl::CriticalSectionGuard guard;
+    deflateEnd(&stream);
+  }
+
+  z_stream stream{};
+};
 
 const string_buffer *zlib_encode(const char *s, int32_t s_len, int32_t level, int32_t encoding);//returns pointer to static_SB
+
+class_instance<C$DeflateContext> f$deflate_init(int encoding, const array<mixed> & options = {});
+
+Optional<string> f$deflate_add(const class_instance<C$DeflateContext> & context, string & data, int64_t flush_type = Z_SYNC_FLUSH);
 
 string f$gzcompress(const string &s, int64_t level = -1);
 

--- a/tests/phpt/pk/016_gzip.php
+++ b/tests/phpt/pk/016_gzip.php
@@ -20,15 +20,18 @@ var_dump(gzdecode($encoded));
 
 
 function dump_test($ctx) {
-    $out = deflate_add($ctx, 'this ', ZLIB_NO_FLUSH);
-    $out .= deflate_add($ctx, 'is ', ZLIB_NO_FLUSH);
-    $out .= deflate_add($ctx, 'a test.', ZLIB_SYNC_FLUSH);
-    $out .= deflate_add($ctx, '', ZLIB_FINISH);
+    $chunks = ['myxa', 'myxophyta', 'myxopod', 'nab', 'nabbed', 'nabbing', 'nabit', 'nabk', 'nabob', 'nacarat', 'nacelle'];
+    $out = "";
+    for($i = 0; $i < count($chunks); $i++) {
+        $type = $i % 2 == 0 ? ZLIB_NO_FLUSH : ZLIB_SYNC_FLUSH;
+        $out .= deflate_add($ctx, $chunks[$i], $type);
+    }
+    $out .= deflate_add($ctx, $chunks[count($chunks) - 1], ZLIB_FINISH);
     var_dump(crc32($out));
     return $out;
 }
 
-$gzip_ctx = deflate_init(ZLIB_ENCODING_GZIP, ['window' => 9, 'memory' => 3]);
+$gzip_ctx = deflate_init(ZLIB_ENCODING_GZIP, ['window' => 10, 'memory' => 2]);
 $raw_ctx = deflate_init(ZLIB_ENCODING_RAW, ['level' => 8]);
 $deflate_ctx = deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => ZLIB_HUFFMAN_ONLY]);
 

--- a/tests/phpt/pk/016_gzip.php
+++ b/tests/phpt/pk/016_gzip.php
@@ -17,3 +17,29 @@ var_dump(crc32($encoded));
 var_dump(gzinflate($deflated));
 var_dump(gzuncompress($compressed));
 var_dump(gzdecode($encoded));
+
+
+function dump_test($ctx) {
+    $out = deflate_add($ctx, 'this ', ZLIB_NO_FLUSH);
+    $out .= deflate_add($ctx, 'is ', ZLIB_NO_FLUSH);
+    $out .= deflate_add($ctx, 'a test.', ZLIB_SYNC_FLUSH);
+    $out .= deflate_add($ctx, '', ZLIB_FINISH);
+    var_dump(crc32($out));
+    return $out;
+}
+
+$gzip_ctx = deflate_init(ZLIB_ENCODING_GZIP, ['window' => 9, 'memory' => 3]);
+$raw_ctx = deflate_init(ZLIB_ENCODING_RAW, ['level' => 8]);
+$deflate_ctx = deflate_init(ZLIB_ENCODING_DEFLATE, ['strategy' => ZLIB_HUFFMAN_ONLY]);
+
+$encoded = dump_test($gzip_ctx);
+$deflated = dump_test($raw_ctx);
+$compressed = dump_test($deflate_ctx);
+
+var_dump(crc32($deflated));
+var_dump(crc32($compressed));
+var_dump(crc32($encoded));
+
+var_dump(gzinflate($deflated));
+var_dump(gzuncompress($compressed));
+var_dump(gzdecode($encoded));


### PR DESCRIPTION
General
-----------
This pr add two functions [`deflate_init(...)`](https://www.php.net/manual/en/function.deflate-init.php) and  [`deflate_add(...)`](https://www.php.net/manual/en/function.deflate-add.php) from php, new class [`DeflateContext`](https://www.php.net/manual/en/class.deflatecontext.php) which store compression context and several constants from zlib.

Details
--------- 
Since incremental compression is performed in several steps, functions have been added for dynamic memory allocation for zlib