### PR TITLE
implement curl_exec_concurrently()

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -49,7 +49,8 @@ Checks: |-
   -readability-identifier-length,
   -bugprone-easily-swappable-parameters,
   -misc-no-recursion,
-  -misc-const-correctness
+  -misc-const-correctness,
+  -cppcoreguidelines-avoid-const-or-ref-data-members
 
 CheckOptions:
   - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -1085,6 +1085,9 @@ function curl_error ($curl_handle ::: int) ::: string;
 function curl_errno ($curl_handle ::: int) ::: int;
 function curl_close ($curl_handle ::: int) ::: void;
 
+/** @kphp-extern-func-info resumable */
+function curl_exec_concurrently($curl_handle ::: int, $timeout ::: float = 1.0): ?string;
+
 function curl_multi_init () ::: int;
 function curl_multi_add_handle ($multi_handle ::: int, $curl_handle ::: int) ::: int|false;
 function curl_multi_getcontent ($curl_handle ::: int ) ::: string|false|null;

--- a/runtime/curl-async.cpp
+++ b/runtime/curl-async.cpp
@@ -1,0 +1,40 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/curl-async.h"
+
+#include "runtime/resumable.h"
+#include "server/curl-adaptor.h"
+
+class curl_exec_concurrently final : public Resumable {
+private:
+  using ReturnT = Optional<string>;
+
+  std::unique_ptr<CurlRequest> request;
+  double timeout_s{0.0};
+  int resumable_id{0};
+  std::unique_ptr<CurlResponse> response;
+
+public:
+  curl_exec_concurrently(std::unique_ptr<CurlRequest> &&request, double timeout_s) noexcept
+    : request(std::move(request))
+    , timeout_s(timeout_s) {}
+
+  bool run() noexcept final {
+    RESUMABLE_BEGIN
+    resumable_id = vk::singleton<CurlAdaptor>::get().launch_request_resumable(std::move(request));
+    response = f$wait<std::unique_ptr<CurlResponse>, false>(resumable_id, timeout_s);
+    TRY_WAIT(curl_exec_concurrently_label, response, std::unique_ptr<CurlResponse>);
+    RETURN(response ? response->response : ReturnT{false});
+    RESUMABLE_END
+  }
+};
+
+Optional<string> f$curl_exec_concurrently(curl_easy easy_id, double timeout_s) {
+  auto request = CurlRequest::build(easy_id);
+  if (!request) {
+    return false;
+  }
+  return start_resumable<Optional<string>>(new curl_exec_concurrently(std::move(request), timeout_s));
+}

--- a/runtime/curl-async.cpp
+++ b/runtime/curl-async.cpp
@@ -7,6 +7,8 @@
 #include "runtime/resumable.h"
 #include "server/curl-adaptor.h"
 
+namespace curl_async {
+
 class curl_exec_concurrently final : public Resumable {
 private:
   using ReturnT = Optional<string>;
@@ -33,11 +35,12 @@ public:
     RESUMABLE_END
   }
 };
+} // namespace curl_async
 
 Optional<string> f$curl_exec_concurrently(curl_easy easy_id, double timeout_s) {
-  auto request = CurlRequest::build(easy_id);
+  auto request = curl_async::CurlRequest::build(easy_id);
   if (!request) {
     return false;
   }
-  return start_resumable<Optional<string>>(new curl_exec_concurrently(std::move(request), timeout_s));
+  return start_resumable<Optional<string>>(new curl_async::curl_exec_concurrently(std::move(request), timeout_s));
 }

--- a/runtime/curl-async.cpp
+++ b/runtime/curl-async.cpp
@@ -14,23 +14,21 @@ private:
   using ReturnT = Optional<string>;
 
   const double timeout_s{0.0};
-  const int request_id{0};
   int resumable_id{0};
-  std::unique_ptr<CurlRequest> request;
+  const CurlRequest request;
   std::unique_ptr<CurlResponse> response;
 
 public:
-  curl_exec_concurrently(std::unique_ptr<CurlRequest> &&request, double timeout_s) noexcept
+  curl_exec_concurrently(const CurlRequest &request, double timeout_s) noexcept
     : timeout_s(timeout_s)
-    , request_id(request->request_id)
-    , request(std::move(request)) {}
+    , request(request) {}
 
   bool run() noexcept final {
     RESUMABLE_BEGIN
-    resumable_id = vk::singleton<CurlAdaptor>::get().launch_request_resumable(std::move(request));
+    resumable_id = vk::singleton<CurlAdaptor>::get().launch_request_resumable(request);
     response = f$wait<std::unique_ptr<CurlResponse>, false>(resumable_id, timeout_s);
     TRY_WAIT(curl_exec_concurrently_label, response, std::unique_ptr<CurlResponse>);
-    vk::singleton<CurlAdaptor>::get().finish_request(request_id);
+    vk::singleton<CurlAdaptor>::get().finish_request(request);
     RETURN(response ? response->response : ReturnT{false});
     RESUMABLE_END
   }
@@ -38,9 +36,10 @@ public:
 } // namespace curl_async
 
 Optional<string> f$curl_exec_concurrently(curl_easy easy_id, double timeout_s) {
-  auto request = curl_async::CurlRequest::build(easy_id);
-  if (!request) {
+  try {
+    auto request = curl_async::CurlRequest::build(easy_id);
+    return start_resumable<Optional<string>>(new curl_async::curl_exec_concurrently(request, timeout_s));
+  } catch (...) {
     return false;
   }
-  return start_resumable<Optional<string>>(new curl_async::curl_exec_concurrently(std::move(request), timeout_s));
 }

--- a/runtime/curl-async.cpp
+++ b/runtime/curl-async.cpp
@@ -11,21 +11,24 @@ class curl_exec_concurrently final : public Resumable {
 private:
   using ReturnT = Optional<string>;
 
-  std::unique_ptr<CurlRequest> request;
-  double timeout_s{0.0};
+  const double timeout_s{0.0};
+  const int request_id{0};
   int resumable_id{0};
+  std::unique_ptr<CurlRequest> request;
   std::unique_ptr<CurlResponse> response;
 
 public:
   curl_exec_concurrently(std::unique_ptr<CurlRequest> &&request, double timeout_s) noexcept
-    : request(std::move(request))
-    , timeout_s(timeout_s) {}
+    : timeout_s(timeout_s)
+    , request_id(request->request_id)
+    , request(std::move(request)) {}
 
   bool run() noexcept final {
     RESUMABLE_BEGIN
     resumable_id = vk::singleton<CurlAdaptor>::get().launch_request_resumable(std::move(request));
     response = f$wait<std::unique_ptr<CurlResponse>, false>(resumable_id, timeout_s);
     TRY_WAIT(curl_exec_concurrently_label, response, std::unique_ptr<CurlResponse>);
+    vk::singleton<CurlAdaptor>::get().finish_request(request_id);
     RETURN(response ? response->response : ReturnT{false});
     RESUMABLE_END
   }

--- a/runtime/curl-async.h
+++ b/runtime/curl-async.h
@@ -1,0 +1,11 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/kphp_core.h"
+
+#include "runtime/curl.h"
+
+Optional<string> f$curl_exec_concurrently(curl_easy easy_id, double timeout_s = 1.0);

--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -990,6 +990,8 @@ void free_curl_lib() noexcept {
   vk::singleton<CurlMemoryUsage>::get().total_allocated = 0;
 }
 
+namespace curl_async {
+
 std::unique_ptr<CurlRequest> CurlRequest::build(curl_easy easy_id) {
   curl_multi multi_id = f$curl_multi_init();
   if (!multi_id || !get_context<EasyContext>(easy_id)) {
@@ -1119,3 +1121,4 @@ static int curl_socketfunction_cb(CURL */*easy*/, curl_socket_t fd, int action, 
 
   return 0;
 }
+} // namespace curl_async

--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -1058,6 +1058,7 @@ void CurlRequest::detach_multi_and_easy_handles() const noexcept {
 
 static int curl_epoll_cb(int fd, void *data, event_t *ev) {
   auto *curl_request = static_cast<CurlRequest *>(data);
+  php_assert(curl_request);
 
   int flags = 0;
   if (ev->ready & EVT_READ) {
@@ -1096,6 +1097,8 @@ static int curl_epoll_cb(int fd, void *data, event_t *ev) {
 
 static int curl_socketfunction_cb(CURL */*easy*/, curl_socket_t fd, int action, void *userp, void */*socketp*/) {
   auto *curl_request = static_cast<CurlRequest *>(userp);
+  php_assert(curl_request);
+
   switch (action) {
     case CURL_POLL_IN:
     case CURL_POLL_OUT:

--- a/runtime/curl.h
+++ b/runtime/curl.h
@@ -68,6 +68,8 @@ private:
   friend class vk::singleton<CurlMemoryUsage>;
 };
 
+namespace curl_async {
+
 class CurlRequest : public ManagedThroughDlAllocator, vk::not_copyable {
 public:
   static std::unique_ptr<CurlRequest> build(curl_easy easy_id);
@@ -93,3 +95,4 @@ public:
   Optional<string> response;
   const int bound_request_id{0};
 };
+} // namespace curl_async

--- a/runtime/curl.h
+++ b/runtime/curl.h
@@ -68,7 +68,7 @@ private:
   friend class vk::singleton<CurlMemoryUsage>;
 };
 
-class CurlRequest : private vk::not_copyable {
+class CurlRequest : public ManagedThroughDlAllocator, vk::not_copyable {
 public:
   static std::unique_ptr<CurlRequest> build(curl_easy easy_id);
 
@@ -84,7 +84,7 @@ private:
   CurlRequest(curl_easy easy_id, curl_multi multi_id) noexcept;
 };
 
-class CurlResponse : private vk::not_copyable {
+class CurlResponse : public ManagedThroughDlAllocator, vk::not_copyable {
 public:
   CurlResponse(Optional<string> &&response, int bound_request_id) noexcept
     : response(std::move(response))

--- a/runtime/curl.h
+++ b/runtime/curl.h
@@ -70,9 +70,9 @@ private:
 
 namespace curl_async {
 
-class CurlRequest : public ManagedThroughDlAllocator, vk::not_copyable {
+class CurlRequest {
 public:
-  static std::unique_ptr<CurlRequest> build(curl_easy easy_id);
+  static CurlRequest build(curl_easy easy_id);
 
   void send_async() const;
   void finish_request(Optional<string> &&respone = false) const;

--- a/runtime/curl.h
+++ b/runtime/curl.h
@@ -74,15 +74,14 @@ public:
 
   void send_async() const;
   void finish_request(Optional<string> &&respone = false) const;
+  void detach_multi_and_easy_handles() const noexcept;
 
-  int request_id{0};
   const curl_easy easy_id{0};
   const curl_multi multi_id{0};
+  const int request_id{0};
 
 private:
-  CurlRequest(curl_easy easy_id, curl_multi multi_id) noexcept
-    : easy_id(easy_id)
-    , multi_id(multi_id) {}
+  CurlRequest(curl_easy easy_id, curl_multi multi_id) noexcept;
 };
 
 class CurlResponse : private vk::not_copyable {

--- a/runtime/curl.h
+++ b/runtime/curl.h
@@ -67,3 +67,30 @@ private:
 
   friend class vk::singleton<CurlMemoryUsage>;
 };
+
+class CurlRequest : private vk::not_copyable {
+public:
+  static std::unique_ptr<CurlRequest> build(curl_easy easy_id);
+
+  void send_async() const;
+  void finish_request(Optional<string> &&respone = false) const;
+
+  int request_id{0};
+  const curl_easy easy_id{0};
+  const curl_multi multi_id{0};
+
+private:
+  CurlRequest(curl_easy easy_id, curl_multi multi_id) noexcept
+    : easy_id(easy_id)
+    , multi_id(multi_id) {}
+};
+
+class CurlResponse : private vk::not_copyable {
+public:
+  CurlResponse(Optional<string> &&response, int bound_request_id) noexcept
+    : response(std::move(response))
+    , bound_request_id(bound_request_id) {}
+
+  Optional<string> response;
+  const int bound_request_id{0};
+};

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2389,7 +2389,7 @@ static void free_runtime_libs() {
   database_drivers::free_pgsql_lib();
 #endif
   vk::singleton<database_drivers::Adaptor>::get().reset();
-  vk::singleton<CurlAdaptor>::get().reset();
+  vk::singleton<curl_async::CurlAdaptor>::get().reset();
   vk::singleton<OomHandler>::get().reset();
   free_interface_lib();
   hard_reset_var(JsonEncoderError::msg);

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -54,6 +54,7 @@
 #include "runtime/url.h"
 #include "runtime/zlib.h"
 #include "server/server-config.h"
+#include "server/curl-adaptor.h"
 #include "server/database-drivers/adaptor.h"
 #include "server/database-drivers/mysql/mysql.h"
 #include "server/database-drivers/pgsql/pgsql.h"
@@ -2388,6 +2389,7 @@ static void free_runtime_libs() {
   database_drivers::free_pgsql_lib();
 #endif
   vk::singleton<database_drivers::Adaptor>::get().reset();
+  vk::singleton<CurlAdaptor>::get().reset();
   vk::singleton<OomHandler>::get().reset();
   free_interface_lib();
   hard_reset_var(JsonEncoderError::msg);

--- a/runtime/net_events.cpp
+++ b/runtime/net_events.cpp
@@ -58,9 +58,9 @@ bool process_net_event(net_event_t *e) {
          php_assert(e->slot_id == response->bound_request_id);
          vk::singleton<database_drivers::Adaptor>::get().process_external_db_response_event(std::unique_ptr<database_drivers::Response>(response));
      },
-     [&](CurlResponse *response) {
+     [&](curl_async::CurlResponse *response) {
          php_assert(e->slot_id == response->bound_request_id);
-         vk::singleton<CurlAdaptor>::get().process_response_event(std::unique_ptr<CurlResponse>(response));
+         vk::singleton<curl_async::CurlAdaptor>::get().process_response_event(std::unique_ptr<curl_async::CurlResponse>(response));
      }
     }, e->data);
 

--- a/runtime/net_events.cpp
+++ b/runtime/net_events.cpp
@@ -8,8 +8,10 @@
 #include "common/wrappers/overloaded.h"
 
 #include "runtime/allocator.h"
+#include "runtime/curl.h"
 #include "runtime/job-workers/job-interface.h"
 #include "runtime/rpc.h"
+#include "server/curl-adaptor.h"
 #include "server/database-drivers/adaptor.h"
 #include "server/database-drivers/response.h"
 #include "server/php-queries.h"
@@ -56,6 +58,10 @@ bool process_net_event(net_event_t *e) {
          php_assert(e->slot_id == response->bound_request_id);
          vk::singleton<database_drivers::Adaptor>::get().process_external_db_response_event(std::unique_ptr<database_drivers::Response>(response));
      },
+     [&](CurlResponse *response) {
+         php_assert(e->slot_id == response->bound_request_id);
+         vk::singleton<CurlAdaptor>::get().process_response_event(std::unique_ptr<CurlResponse>(response));
+     }
     }, e->data);
 
   return true;

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -68,6 +68,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         critical_section.cpp
         ctype.cpp
         curl.cpp
+        curl-async.cpp
         env.cpp
         exception.cpp
         exec.cpp

--- a/server/curl-adaptor.cpp
+++ b/server/curl-adaptor.cpp
@@ -1,0 +1,93 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "server/curl-adaptor.h"
+
+#include "runtime/curl.h"
+#include "runtime/resumable.h"
+#include "server/php-engine.h"
+#include "server/slot-ids-factory.h"
+#include "server/php-queries.h"
+
+template<>
+int Storage::tagger<std::unique_ptr<CurlResponse>>::get_tag() noexcept {
+  return 447403581;
+}
+
+class CurlAdaptor::CurlRequestResumable final : public Resumable {
+  using ReturnT = std::unique_ptr<CurlResponse>;
+  int request_id{0};
+
+public:
+  explicit CurlRequestResumable(int request_id) noexcept
+    : request_id(request_id) {}
+
+protected:
+  bool run() final {
+    ReturnT res = vk::singleton<CurlAdaptor>::get().withdraw_response(request_id);
+    RETURN(std::move(res));
+  }
+};
+
+void CurlAdaptor::reset() noexcept {
+  processing_requests.clear();
+  processing_requests_holder.clear();
+}
+
+int CurlAdaptor::launch_request_resumable(std::unique_ptr<CurlRequest> &&request) noexcept {
+  slot_id_t request_id = curl_requests_factory.create_slot();
+  request->request_id = request_id;
+
+  net_query_t *query = create_net_query();
+  query->slot_id = request_id;
+  query->data = request.release();
+  int resumable_id = register_forked_resumable(new CurlRequestResumable{request_id});
+  processing_requests.insert(request_id, CurlRequestInfo{resumable_id});
+
+  return resumable_id;
+}
+
+void CurlAdaptor::process_request_net_query(std::unique_ptr<CurlRequest> &&request) noexcept {
+  request->send_async();
+  int request_id = request->request_id;
+  processing_requests_holder.insert(request_id, std::move(request));
+}
+
+void CurlAdaptor::finish_request_resumable(std::unique_ptr<CurlResponse> &&response) noexcept {
+  int event_status = 0;
+  if (curl_requests_factory.is_from_current_script_execution(response->bound_request_id)) {
+    net_event_t *event = nullptr;
+    event_status = alloc_net_event(response->bound_request_id, &event);
+    if (event_status > 0) {
+      event->data = response.release();
+      event_status = 1;
+    }
+  }
+  on_net_event(event_status);
+}
+
+void CurlAdaptor::process_response_event(std::unique_ptr<CurlResponse> &&response) noexcept {
+  int resumable_id = finish_request_processing(response->bound_request_id, std::move(response));
+  if (resumable_id == 0) {
+    return;
+  }
+  resumable_run_ready(resumable_id);
+}
+
+int CurlAdaptor::finish_request_processing(int request_id, std::unique_ptr<CurlResponse> &&response) noexcept {
+  auto *req_info = processing_requests.get(request_id);
+  if (req_info == nullptr) {
+    return 0;
+  }
+  int resumable_id = req_info->resumable_id;
+  processing_requests.insert_or_assign(request_id, CurlRequestInfo{resumable_id, std::move(response)});
+  return resumable_id;
+}
+
+std::unique_ptr<CurlResponse> CurlAdaptor::withdraw_response(int request_id) noexcept {
+  CurlRequestInfo req_info = processing_requests.extract(request_id);
+  php_assert(req_info.resumable_id != 0);
+  php_assert(req_info.response);
+  return std::move(req_info.response);
+}

--- a/server/curl-adaptor.cpp
+++ b/server/curl-adaptor.cpp
@@ -11,9 +11,11 @@
 #include "server/php-queries.h"
 
 template<>
-int Storage::tagger<std::unique_ptr<CurlResponse>>::get_tag() noexcept {
-  return 447403581;
+int Storage::tagger<std::unique_ptr<curl_async::CurlResponse>>::get_tag() noexcept {
+  return -1245890489;
 }
+
+namespace curl_async {
 
 class CurlAdaptor::CurlRequestResumable final : public Resumable {
   using ReturnT = std::unique_ptr<CurlResponse>;
@@ -95,3 +97,4 @@ void CurlAdaptor::finish_request(int request_id) noexcept {
     request->detach_multi_and_easy_handles();
   }
 }
+} // namespace curl_async

--- a/server/curl-adaptor.cpp
+++ b/server/curl-adaptor.cpp
@@ -5,10 +5,11 @@
 #include "server/curl-adaptor.h"
 
 #include "runtime/curl.h"
+#include "runtime/net_events.h"
 #include "runtime/resumable.h"
 #include "server/php-engine.h"
-#include "server/slot-ids-factory.h"
 #include "server/php-queries.h"
+#include "server/slot-ids-factory.h"
 
 template<>
 int Storage::tagger<std::unique_ptr<curl_async::CurlResponse>>::get_tag() noexcept {
@@ -44,6 +45,11 @@ int CurlAdaptor::launch_request_resumable(std::unique_ptr<CurlRequest> &&request
   query->data = request.release();
   int resumable_id = register_forked_resumable(new CurlRequestResumable{request_id});
   processing_requests.insert(request_id, CurlRequestInfo{resumable_id});
+
+  update_precise_now();
+  wait_net(0);
+  update_precise_now();
+
   return resumable_id;
 }
 

--- a/server/curl-adaptor.h
+++ b/server/curl-adaptor.h
@@ -22,20 +22,19 @@ struct CurlRequestInfo {
 
 class CurlAdaptor : vk::not_copyable {
 public:
-  int launch_request_resumable(std::unique_ptr<CurlRequest> &&request) noexcept;
-  void process_request_net_query(std::unique_ptr<CurlRequest> &&request) noexcept;
+  int launch_request_resumable(const CurlRequest &request) noexcept;
+  void process_request_net_query(const CurlRequest &request) noexcept;
   void finish_request_resumable(std::unique_ptr<CurlResponse> &&response) noexcept;
   void process_response_event(std::unique_ptr<CurlResponse> &&response) noexcept;
 
   std::unique_ptr<CurlResponse> withdraw_response(int request_id) noexcept;
-  void finish_request(int request_id) noexcept;
+  void finish_request(const CurlRequest &request) noexcept;
   void reset() noexcept;
 
 private:
   class CurlRequestResumable;
   int finish_request_processing(int request_id, std::unique_ptr<CurlResponse> &&response) noexcept;
 
-  SignalSafeHashtable<int, std::unique_ptr<CurlRequest>> processing_requests_holder;
   SignalSafeHashtable<int, CurlRequestInfo> processing_requests;
 };
 } // namespace curl_async

--- a/server/curl-adaptor.h
+++ b/server/curl-adaptor.h
@@ -26,6 +26,7 @@ public:
   void process_response_event(std::unique_ptr<CurlResponse> &&response) noexcept;
 
   std::unique_ptr<CurlResponse> withdraw_response(int request_id) noexcept;
+  void finish_request(int request_id) noexcept;
   void reset() noexcept;
 
 private:

--- a/server/curl-adaptor.h
+++ b/server/curl-adaptor.h
@@ -10,6 +10,8 @@
 #include "common/mixin/not_copyable.h"
 #include "runtime/signal_safe_hashtable.h"
 
+namespace curl_async {
+
 class CurlRequest;
 class CurlResponse;
 
@@ -36,3 +38,4 @@ private:
   SignalSafeHashtable<int, std::unique_ptr<CurlRequest>> processing_requests_holder;
   SignalSafeHashtable<int, CurlRequestInfo> processing_requests;
 };
+} // namespace curl_async

--- a/server/curl-adaptor.h
+++ b/server/curl-adaptor.h
@@ -1,0 +1,37 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <memory>
+
+#include "common/smart_ptrs/singleton.h"
+#include "common/mixin/not_copyable.h"
+#include "runtime/signal_safe_hashtable.h"
+
+class CurlRequest;
+class CurlResponse;
+
+struct CurlRequestInfo {
+  int resumable_id{0};
+  std::unique_ptr<CurlResponse> response;
+};
+
+class CurlAdaptor : vk::not_copyable {
+public:
+  int launch_request_resumable(std::unique_ptr<CurlRequest> &&request) noexcept;
+  void process_request_net_query(std::unique_ptr<CurlRequest> &&request) noexcept;
+  void finish_request_resumable(std::unique_ptr<CurlResponse> &&response) noexcept;
+  void process_response_event(std::unique_ptr<CurlResponse> &&response) noexcept;
+
+  std::unique_ptr<CurlResponse> withdraw_response(int request_id) noexcept;
+  void reset() noexcept;
+
+private:
+  class CurlRequestResumable;
+  int finish_request_processing(int request_id, std::unique_ptr<CurlResponse> &&response) noexcept;
+
+  SignalSafeHashtable<int, std::unique_ptr<CurlRequest>> processing_requests_holder;
+  SignalSafeHashtable<int, CurlRequestInfo> processing_requests;
+};

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -1121,7 +1121,7 @@ const char *net_event_t::get_description() const noexcept {
     [](const database_drivers::Response *) {
       snprintf(BUF.data(), BUF.size(), "EXTERNAL_DB_ANSWER");
     },
-    [](const CurlResponse *) {
+    [](const curl_async::CurlResponse *) {
       snprintf(BUF.data(), BUF.size(), "CURL_ASYNC_RESPONSE");
     },
   }, data);

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -1121,6 +1121,9 @@ const char *net_event_t::get_description() const noexcept {
     [](const database_drivers::Response *) {
       snprintf(BUF.data(), BUF.size(), "EXTERNAL_DB_ANSWER");
     },
+    [](const CurlResponse *) {
+      snprintf(BUF.data(), BUF.size(), "CURL_ASYNC_RESPONSE");
+    },
   }, data);
   return BUF.data();
 }

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -46,9 +46,12 @@ class Request;
 class Connector;
 }
 
+class CurlRequest;
+class CurlResponse;
+
 struct net_event_t {
   slot_id_t slot_id;
-  std::variant<net_events_data::rpc_answer, net_events_data::rpc_error, net_events_data::job_worker_answer, database_drivers::Response *> data;
+  std::variant<net_events_data::rpc_answer, net_events_data::rpc_error, net_events_data::job_worker_answer, database_drivers::Response *, CurlResponse *> data;
 
   const char *get_description() const noexcept;
 };
@@ -66,7 +69,7 @@ struct rpc_send {
 
 struct net_query_t {
   slot_id_t slot_id;
-  std::variant<net_queries_data::rpc_send, database_drivers::Request *> data;
+  std::variant<net_queries_data::rpc_send, database_drivers::Request *, CurlRequest *> data;
 };
 
 #pragma pack(push, 4)

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -71,7 +71,7 @@ struct rpc_send {
 
 struct net_query_t {
   slot_id_t slot_id;
-  std::variant<net_queries_data::rpc_send, database_drivers::Request *, curl_async::CurlRequest *> data;
+  std::variant<net_queries_data::rpc_send, database_drivers::Request *, std::reference_wrapper<const curl_async::CurlRequest>> data;
 };
 
 #pragma pack(push, 4)

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -46,12 +46,14 @@ class Request;
 class Connector;
 }
 
+namespace curl_async {
 class CurlRequest;
 class CurlResponse;
+} // namespace curl_async
 
 struct net_event_t {
   slot_id_t slot_id;
-  std::variant<net_events_data::rpc_answer, net_events_data::rpc_error, net_events_data::job_worker_answer, database_drivers::Response *, CurlResponse *> data;
+  std::variant<net_events_data::rpc_answer, net_events_data::rpc_error, net_events_data::job_worker_answer, database_drivers::Response *, curl_async::CurlResponse *> data;
 
   const char *get_description() const noexcept;
 };
@@ -69,7 +71,7 @@ struct rpc_send {
 
 struct net_query_t {
   slot_id_t slot_id;
-  std::variant<net_queries_data::rpc_send, database_drivers::Request *, CurlRequest *> data;
+  std::variant<net_queries_data::rpc_send, database_drivers::Request *, curl_async::CurlRequest *> data;
 };
 
 #pragma pack(push, 4)

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -193,9 +193,9 @@ void php_worker_run_net_queue(PhpWorker *worker __attribute__((unused))) {
                    php_assert(query->slot_id == data->request_id);
                    vk::singleton<database_drivers::Adaptor>::get().process_external_db_request_net_query(std::unique_ptr<database_drivers::Request>(data));
                  },
-                 [&](curl_async::CurlRequest *request) {
-                   php_assert(query->slot_id == request->request_id);
-                   vk::singleton<curl_async::CurlAdaptor>::get().process_request_net_query(std::unique_ptr<curl_async::CurlRequest>(request));
+                 [&](const curl_async::CurlRequest &request) {
+                   php_assert(query->slot_id == request.request_id);
+                   vk::singleton<curl_async::CurlAdaptor>::get().process_request_net_query(request);
                  }},
                query->data);
   }

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -9,8 +9,10 @@
 #include "common/rpc-error-codes.h"
 #include "common/wrappers/overloaded.h"
 #include "net/net-connections.h"
+#include "runtime/curl.h"
 #include "runtime/job-workers/job-interface.h"
 #include "runtime/rpc.h"
+#include "server/curl-adaptor.h"
 #include "server/database-drivers/adaptor.h"
 #include "server/database-drivers/request.h"
 #include "server/job-workers/job-stats.h"
@@ -191,7 +193,10 @@ void php_worker_run_net_queue(PhpWorker *worker __attribute__((unused))) {
                    php_assert(query->slot_id == data->request_id);
                    vk::singleton<database_drivers::Adaptor>::get().process_external_db_request_net_query(std::unique_ptr<database_drivers::Request>(data));
                  },
-               },
+                 [&](CurlRequest *request) {
+                   php_assert(query->slot_id == request->request_id);
+                   vk::singleton<CurlAdaptor>::get().process_request_net_query(std::unique_ptr<CurlRequest>(request));
+                 }},
                query->data);
   }
 }

--- a/server/php-worker.cpp
+++ b/server/php-worker.cpp
@@ -193,9 +193,9 @@ void php_worker_run_net_queue(PhpWorker *worker __attribute__((unused))) {
                    php_assert(query->slot_id == data->request_id);
                    vk::singleton<database_drivers::Adaptor>::get().process_external_db_request_net_query(std::unique_ptr<database_drivers::Request>(data));
                  },
-                 [&](CurlRequest *request) {
+                 [&](curl_async::CurlRequest *request) {
                    php_assert(query->slot_id == request->request_id);
-                   vk::singleton<CurlAdaptor>::get().process_request_net_query(std::unique_ptr<CurlRequest>(request));
+                   vk::singleton<curl_async::CurlAdaptor>::get().process_request_net_query(std::unique_ptr<curl_async::CurlRequest>(request));
                  }},
                query->data);
   }

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -2,6 +2,7 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         master-name.cpp
         confdata-binlog-replay.cpp
         confdata-stats.cpp
+        curl-adaptor.cpp
         shared-data.cpp
         http-server-context.cpp
         json-logger.cpp

--- a/server/slot-ids-factory.cpp
+++ b/server/slot-ids-factory.cpp
@@ -16,6 +16,7 @@ static constexpr slot_id_t MAX_SLOT_ID = 2000000000;
 SlotIdsFactory rpc_ids_factory;
 SlotIdsFactory parallel_job_ids_factory;
 SlotIdsFactory external_db_requests_factory;
+SlotIdsFactory curl_requests_factory;
 
 
 void SlotIdsFactory::init() {
@@ -37,16 +38,19 @@ void init_slot_factories() {
   rpc_ids_factory.renew();
   parallel_job_ids_factory.renew();
   external_db_requests_factory.renew();
+  curl_requests_factory.renew();
 }
 
 void free_slot_factories() {
   rpc_ids_factory.clear();
   parallel_job_ids_factory.clear();
   external_db_requests_factory.clear();
+  curl_requests_factory.clear();
 }
 
 void worker_global_init_slot_factories() {
   rpc_ids_factory.init();
   parallel_job_ids_factory.init();
   external_db_requests_factory.init();
+  curl_requests_factory.init();
 }

--- a/server/slot-ids-factory.h
+++ b/server/slot-ids-factory.h
@@ -49,6 +49,7 @@ private:
 extern SlotIdsFactory rpc_ids_factory;
 extern SlotIdsFactory parallel_job_ids_factory;
 extern SlotIdsFactory external_db_requests_factory;
+extern SlotIdsFactory curl_requests_factory;
 
 void init_slot_factories();
 void free_slot_factories();

--- a/tests/python/tests/curl/curl_test_case.py
+++ b/tests/python/tests/curl/curl_test_case.py
@@ -1,0 +1,38 @@
+from python.lib.testcase import KphpServerAutoTestCase
+
+
+class CurlTestCase(KphpServerAutoTestCase):
+    maxDiff = 16 * 1024
+
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 2,
+        })
+
+    def _curl_request(self, uri, return_transfer=1, post=None, headers=None, timeout=None, connect_only=None):
+        url = "localhost:{}{}".format(self.kphp_server.http_port, uri) if uri.startswith('/') else uri
+        resp = self.kphp_server.http_post(
+            uri=self.test_case_uri,
+            json={
+                "url": url,
+                "return_transfer": return_transfer,
+                "post": post,
+                "headers": headers,
+                "timeout": timeout,
+                "connect_only": connect_only
+            })
+        self.assertEqual(resp.status_code, 200)
+        return resp.json()
+
+    def _prepare_result(self, uri, method, extra=None):
+        res = {
+            "HTTP_ACCEPT": "*/*",
+            "HTTP_HOST": "localhost:{}".format(self.kphp_server.http_port),
+            "REQUEST_METHOD": method,
+            "REQUEST_URI": uri,
+            "SERVER_PROTOCOL": "HTTP/1.1"
+        }
+        if extra:
+            res.update(extra)
+        return res

--- a/tests/python/tests/curl/php/index.php
+++ b/tests/python/tests/curl/php/index.php
@@ -1,7 +1,15 @@
 <?php
 
+function simple_function() {
+    fwrite(STDERR, "start_resumable_function\n");
+    sched_yield_sleep(0.3);
+    fwrite(STDERR, "end_resumable_function\n");
+    return true;
+}
+
 function main() {
   if (strpos($_SERVER["PHP_SELF"], "/echo") === 0) {
+    usleep(500000);
     $resp = array_filter_by_key($_SERVER, function ($key): bool {
       return strpos($key, "HTTP_") === 0 ||
         in_array($key, ["REQUEST_URI", "REQUEST_METHOD", "SERVER_PROTOCOL"]);
@@ -14,15 +22,22 @@ function main() {
   }
 
   switch ($_SERVER["PHP_SELF"]) {
-    case "/test_curl":
-      test_curl();
-      return;
+    case "/test_curl": {
+        test_curl();
+        return;
+      }
+      case "/test_curl_resumable": {
+        $future = fork(simple_function());
+        test_curl(true);
+        wait($future);
+        return;
+      }
   }
 
   critical_error("unknown test");
 }
 
-function test_curl() {
+function test_curl($curl_resumable = false) {
   $params = json_decode(file_get_contents('php://input'));
 
   $ch = curl_init();
@@ -38,12 +53,24 @@ function test_curl() {
     curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
   }
 
+  $timeout_s = $params["timeout"];
+  if (!$curl_resumable) {
+    // CURLOPT_TIMEOUT_MS for resumable case isn't working, instead timeout may be set as curl_exec_concurrently() param
+    curl_setopt($ch, CURLOPT_TIMEOUT_MS, $timeout_s * 1000);
+  }
+
+  if ($connection_only = $params["connect_only"]) {
+    curl_setopt($ch, CURLOPT_CONNECT_ONLY, 1);
+  }
+
   ob_start();
 
-  $output = curl_exec($ch);
+  fwrite(STDERR, "start_curl_query\n");
+  $output = $curl_resumable ? curl_exec_concurrently($ch, $timeout_s) : curl_exec($ch);
+  fwrite(STDERR, "end_curl_query\n");
   curl_close($ch);
 
-  $resp = ["exec_result" => is_string($output) ? json_decode($output) : $output];
+  $resp = ["exec_result" => is_string($output) && $output != '' ? json_decode($output) : $output];
   if ($ob_json = ob_get_clean()) {
     $resp["output_buffer"] = json_decode($ob_json);
   }

--- a/tests/python/tests/curl/test_curl_resumable_reuse_handle.py
+++ b/tests/python/tests/curl/test_curl_resumable_reuse_handle.py
@@ -1,0 +1,18 @@
+import re
+from python.tests.curl.curl_test_case import CurlTestCase
+
+
+class TestCurlResumableReuseHandle(CurlTestCase):
+    test_case_uri="/test_curl_resumable_reuse_handle"
+
+    def test_curl_resumable_reuse_handle(self):
+        self.assertEqual(self._curl_request("/echo/test_get"), {
+            "exec_result1": self._prepare_result("/echo/test_get", "GET"),
+            "exec_result2": self._prepare_result("/echo/test_get", "GET")
+        })
+
+    def test_curl_resumable_reuse_handle_after_timeout(self):
+        self.assertEqual(self._curl_request("/echo/test_get", timeout=0.1), {
+            "exec_result1": False,
+            "exec_result2": self._prepare_result("/echo/test_get", "GET")
+        })

--- a/tests/python/tests/curl/test_curl_reuse_handle.py
+++ b/tests/python/tests/curl/test_curl_reuse_handle.py
@@ -1,0 +1,18 @@
+import re
+from python.tests.curl.curl_test_case import CurlTestCase
+
+
+class TestCurlReuseHandle(CurlTestCase):
+    test_case_uri="/test_curl_reuse_handle"
+
+    def test_curl_reuse_handle(self):
+        self.assertEqual(self._curl_request("/echo/test_get"), {
+            "exec_result1": self._prepare_result("/echo/test_get", "GET"),
+            "exec_result2": self._prepare_result("/echo/test_get", "GET")
+        })
+
+    def test_curl_reuse_handle_after_timeout(self):
+        self.assertEqual(self._curl_request("/echo/test_get", timeout=0.1), {
+            "exec_result1": False,
+            "exec_result2": self._prepare_result("/echo/test_get", "GET")
+        })


### PR DESCRIPTION
This PR introduce `curl_exec_concurrently()` function which may be used as drop-in replacement for regular `curl_exec()` with the only difference that it meets our [fork](https://vkcom.github.io/kphp/kphp-language/best-practices/async-programming-forks.html) concept.

### Intro
Let's assume we have a simple server running on `localhost:9000`, which can accept `sleep_time_s` url param and sleep specified amount of seconds before responding. So e.g. it will respond on `localhost:9000/?sleep_time_s=0.5` request after 0.5 second.

Now let's send 2 request and see what happens:
```
function run_curl_request($remote_sleep_s) {
  fprintf(STDERR, "\nstart run_curl_request($remote_sleep_s)\n");
  $ch = curl_init("localhost:9000/?sleep_time_s=$remote_sleep_s");
  $resp = curl_exec_concurrently($ch);
  curl_close($ch);
  fprintf(STDERR, "\nfinish run_curl_request($remote_sleep_s)\n");
  return $resp;
}
# here we run 2 requests
$fut1 = fork(run_curl_request(0.1));
$fut2 = fork(run_curl_request(0.3));
# and wait for them asynchronously
$res1 = wait($fut1);
$res2 = wait($fut2);
```
The output will be:
```
// we start 2 requests almost simultaneously
start curl_local(0.1)
start curl_local(0.3)
// we get first response after 0.1 sec await
finish curl_local(0.1)
// and now we get the second after another 0.2 sec await
finish curl_local(0.3)
// so total await time is exact 0.3 sec
```
So it is possible to run any amount of forks, and switch between them as soon as one is ready. Needless to say, that with regular `curl_exec()` in this example we would first wait 0.1 sec till end of first request, and then another 0.3 till the second. With total await time 0.4 sec.

### API
The full signature of new function is:
`function curl_exec_concurrently(int $curl_handle, float $timeout = 1.0): ?string;`
As mentioned above, this function is supposed to be used as replacement of `curl_exec()`. It means that you first create curl handle with `curl_init()`, set up any amount of option on that handle and call `curl_exec_concurrently()`.
After that you can either close handle calling `curl_close()`, or re-use further.

There are two differences in signature comparing to regular:
`function curl_exec(int $curl_handle): string|bool;`

1. The return type.
There is an `CURLOPT_RETURNTRANSFER` option affecting return type. Quoting [doc](https://www.php.net/manual/en/function.curl-setopt.php):

> curl_exec() returns true on success or false on failure. However, if the CURLOPT_RETURNTRANSFER option is [set](https://www.php.net/manual/en/function.curl-setopt.php), it will return the result on success, false on failure.

In our case execution performs in async way, so it is unknown when output would be sent to STDOUT. That's why `CURLOPT_RETURNTRANSFER` is forced to `true` making our function returning `?string`

2. Timeout.
There is an `CURLOPT_TIMEOUT_MS`, that:

> set the maximum number of milliseconds to allow cURL functions to execute

It works perfect with `curl_exec()` because you're waiting response, being blocked on the call itself. But this is not the case with `curl_exec_concurrently()`, where you aren't waiting response at all. Instead you just will be notified by epoll when response arrive.
The second param of `curl_exec_concurrently(..., float $timeout)` may be used to set timeout in seconds which works in desired way. 

### Implementation details
Under the hood the curl mutli socket api is used, namely those parts containing [curl_multi_socket_action()](https://curl.se/libcurl/c/curl_multi_socket_action.html). You can read more about it at curl page [here](https://curl.se/libcurl/c/libcurl-multi.html).
As usual, we add file descriptors curl gives us in epoll for monitoring, and call appropriate callback `curl_socketfunction_cb()` in case of activity on them.

For usage of this api we need both easy and multi curl handles. While first we get as param of `curl_exec_concurrently(int $curl_handle, ...)`, the second we create manually under the hood. It is hidden from php code.

**Those file descriptors are removed from epoll as follows:**
1)  curl request was successfully completed. Here curl lib calls `curl_socketfunction_cb(handle, fd, CURL_POLL_REMOVE)` from regular `curl_multi_socket_action()` asking to remove fd.
2) curl request experienced timeout or error. In this case we call `curl_multi_remove_handle()` in order to detach curh easy and curl multi handles. This action also stops all transfers leaving curl easy in valid state for reusage. And again curl calls `curl_socketfunction_cb(handle, fd, CURL_POLL_REMOVE)`.
3) signal received. In this case we will get into global `free_curl_lib()`, where we call `curl_easy_cleanup()` for all handles. This also stops transfers and calls `curl_socketfunction_cb(handle, fd, CURL_POLL_REMOVE)`.

**Order of removing curl's entities**
This is another important topic. [In curl doc](https://curl.se/libcurl/c/curl_multi_cleanup.html) stated, that we firstly should:
1) detach easy and milti handles calling  `curl_multi_remove_handle()`
2) delete easy handle with `curl_easy_cleanup()`
3) and after that same for multi handle with `curl_multi_cleanup()`

Here point 1) fulfilled in any case. But the lifetime of easy handle is under user control, that's why we don't remove curl multi handle at the end of `curl_exec_concurrently()`. Instead, the detached multi handle will be removed at the end of script.