### PR TITLE
move function bodies of auto generated classes in source files 

### DIFF
--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -338,7 +338,7 @@ std::unique_ptr<TlDependentTypesUsings> InterfaceDeclaration::detect_if_needs_tl
 }
 
 void FFIDeclaration::compile(CodeGenerator &W) const {
-  W << OpenFile(ffi_scope->header_name, ffi_scope->get_subdir());
+  W << OpenFile(ffi_scope->h_filename, ffi_scope->get_subdir());
 
   W << "#pragma once" << NL;
 
@@ -391,7 +391,7 @@ void FFIDeclaration::compile(CodeGenerator &W) const {
 }
 
 void InterfaceDeclaration::compile(CodeGenerator &W) const {
-  W << OpenFile(interface->header_name, interface->get_subdir());
+  W << OpenFile(interface->h_filename, interface->get_subdir());
   W << "#pragma once" << NL;
 
   IncludesCollector includes;
@@ -468,7 +468,7 @@ std::unique_ptr<TlDependentTypesUsings> ClassDeclaration::detect_if_needs_tl_usi
 }
 
 void ClassDeclaration::compile(CodeGenerator &W) const {
-  W << OpenFile(klass->header_name, klass->get_subdir());
+  W << OpenFile(klass->h_filename, klass->get_subdir());
   W << "#pragma once" << NL;
 
   auto front_includes = compile_front_includes(W);

--- a/compiler/code-gen/declarations.cpp
+++ b/compiler/code-gen/declarations.cpp
@@ -902,7 +902,7 @@ static void do_compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass, boo
 }
 
 void ClassDeclaration::compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass) {
-  for (auto[encoder, to_encode] : klass->json_encoders) {
+  for (auto [encoder, to_encode] : klass->json_encoders) {
     W << NL;
     do_compile_accept_json_visitor(W, klass, to_encode, encoder, true);
   }

--- a/compiler/code-gen/declarations.h
+++ b/compiler/code-gen/declarations.h
@@ -136,7 +136,7 @@ private:
 
   static void compile_accept_visitor(CodeGenerator &W, ClassPtr klass, const char *visitor_type);
   static void compile_generic_accept(CodeGenerator &W, ClassPtr klass);
-  static void compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass, bool to_encode, ClassPtr json_encoder);
+  static void compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass);
   IncludesCollector compile_front_includes(CodeGenerator &W) const;
   void compile_back_includes(CodeGenerator &W, IncludesCollector &&front_includes) const;
   void compile_job_worker_shared_memory_piece_methods(CodeGenerator &W, bool compile_declaration_only = false) const;
@@ -151,6 +151,7 @@ struct ClassMembersDefinition : CodeGenRootCmd {
   void compile(CodeGenerator &W) const final;
 
 private:
+  static void compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass);
   static void compile_msgpack_serialize(CodeGenerator &W, ClassPtr klass);
   static void compile_msgpack_deserialize(CodeGenerator &W, ClassPtr klass);
 };

--- a/compiler/code-gen/declarations.h
+++ b/compiler/code-gen/declarations.h
@@ -127,8 +127,7 @@ private:
   static void compile_get_class(CodeGenerator &W, ClassPtr klass);
   static void compile_get_hash(CodeGenerator &W, ClassPtr klass);
   static void compile_accept_visitor_methods(CodeGenerator &W, ClassPtr klass);
-  static void compile_msgpack_serialize(CodeGenerator &W, ClassPtr klass);
-  static void compile_msgpack_deserialize(CodeGenerator &W, ClassPtr klass);
+  static void compile_msgpack_declarations(CodeGenerator &W, ClassPtr klass);
   static void compile_virtual_builtin_functions(CodeGenerator &W, ClassPtr klass);
   static void compile_wakeup(CodeGenerator &W, ClassPtr klass);
 
@@ -143,6 +142,17 @@ private:
   void compile_job_worker_shared_memory_piece_methods(CodeGenerator &W, bool compile_declaration_only = false) const;
   void declare_all_variables(VertexPtr v, CodeGenerator &W) const;
   std::unique_ptr<TlDependentTypesUsings> detect_if_needs_tl_usings() const;
+};
+
+struct ClassMembersDefinition : CodeGenRootCmd {
+  ClassPtr klass;
+  explicit ClassMembersDefinition(ClassPtr klass)
+    : klass(klass) {}
+  void compile(CodeGenerator &W) const final;
+
+private:
+  static void compile_msgpack_serialize(CodeGenerator &W, ClassPtr klass);
+  static void compile_msgpack_deserialize(CodeGenerator &W, ClassPtr klass);
 };
 
 struct StaticLibraryRunGlobal {

--- a/compiler/code-gen/declarations.h
+++ b/compiler/code-gen/declarations.h
@@ -151,6 +151,8 @@ struct ClassMembersDefinition : CodeGenRootCmd {
   void compile(CodeGenerator &W) const final;
 
 private:
+  static void compile_generic_accept(CodeGenerator &W, ClassPtr klass);
+  static void compile_generic_accept_instantiations(CodeGenerator &W, ClassPtr klass, vk::string_view type);
   static void compile_accept_json_visitor(CodeGenerator &W, ClassPtr klass);
   static void compile_msgpack_serialize(CodeGenerator &W, ClassPtr klass);
   static void compile_msgpack_deserialize(CodeGenerator &W, ClassPtr klass);

--- a/compiler/code-gen/includes.cpp
+++ b/compiler/code-gen/includes.cpp
@@ -171,7 +171,7 @@ void IncludesCollector::compile(CodeGenerator &W) const {
       class_to_include = klass;
     }
     if (class_to_include && !prev_classes_.count(class_to_include)) {
-      class_headers.emplace(class_to_include->get_subdir() + "/" + class_to_include->header_name);
+      class_headers.emplace(class_to_include->get_subdir() + "/" + class_to_include->h_filename);
     }
   }
   for (const auto &class_header : class_headers) {

--- a/compiler/code-gen/naming.h
+++ b/compiler/code-gen/naming.h
@@ -70,7 +70,7 @@ public:
       if (inline_) {
         W_ << "inline ";
       }
-      if (virtual_) {
+      if (!definition_ && virtual_) {
         W_ << "virtual ";
       }
       is_empty_ = false;
@@ -122,6 +122,11 @@ public:
     return std::move(*this);
   }
 
+  FunctionSignatureGenerator &&set_definition(bool new_value = true) && noexcept {
+    definition_ = new_value;
+    return std::move(*this);
+  }
+
 private:
   template<class T>
   FunctionSignatureGenerator &&generate_specifiers(const T &value) noexcept {
@@ -134,11 +139,11 @@ private:
         W_ << " noexcept ";
       }
 
-      if (final_) {
+      if (!definition_ && final_) {
         W_ << " final ";
       }
 
-      if (overridden_) {
+      if (!definition_ && overridden_) {
         W_ << " override ";
       }
 
@@ -166,6 +171,7 @@ private:
   bool final_ = false;
   bool pure_virtual_ = false;
   bool inline_ = false;
+  bool definition_ = false;
 };
 
 struct FunctionName {

--- a/compiler/data/class-data.cpp
+++ b/compiler/data/class-data.cpp
@@ -35,7 +35,8 @@ ClassData::ClassData(ClassType type) :
 void ClassData::set_name_and_src_name(const std::string &full_name) {
   this->name = full_name;
   this->src_name = std::string("C$").append(replace_backslashes(full_name));
-  this->header_name = replace_characters(src_name + ".h", '$', '@');
+  this->cpp_filename = replace_characters(src_name + ".cpp", '$', '@');
+  this->h_filename = replace_characters(src_name + ".h", '$', '@');
   this->type_hint = TypeHintInstance::create(full_name);
 
   size_t pos = full_name.find_last_of('\\');

--- a/compiler/data/class-data.h
+++ b/compiler/data/class-data.h
@@ -68,7 +68,9 @@ public:
   SrcFilePtr file_id;
   ModulitePtr modulite;
   int location_line_num{-1};
-  std::string src_name, header_name;
+  std::string src_name;
+  std::string cpp_filename;
+  std::string h_filename;
 
   std::atomic<bool> need_to_array_debug_visitor{false};
   std::atomic<bool> need_instance_cache_visitors{false};

--- a/compiler/pipes/code-gen.cpp
+++ b/compiler/pipes/code-gen.cpp
@@ -76,6 +76,7 @@ void CodeGenF::on_finish(DataStream<std::unique_ptr<CodeGenRootCmd>> &os) {
     switch (c->class_type) {
       case ClassType::klass:
         code_gen_start_root_task(os, std::make_unique<ClassDeclaration>(c));
+        code_gen_start_root_task(os, std::make_unique<ClassMembersDefinition>(c));
         break;
       case ClassType::interface:
         code_gen_start_root_task(os, std::make_unique<InterfaceDeclaration>(c));


### PR DESCRIPTION
Currently all member function definitions of auto generated classes are located in header files. This slows down compilation. Here I move definitions of next functions in sources files:
1) `msgpack_pack()` and `msgpack_unpack()`
2) `accept()` method for `JsonEncoder`
3) and template:
```
  template<class Visitor>
  void generic_accept(Visitor &&visitor) noexcept;
```
This also requires explicit instantiation of template in source file.

This measures allow to reduce total size of all object files at ~30% and cold compilation time at ~35% in vkcom.