### PR TITLE
enable shutdown functions on several timeout situations

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -65,6 +65,7 @@
 #include "server/php-queries.h"
 #include "server/php-query-data.h"
 #include "server/php-worker.h"
+#include "server/php-runner.h"
 #include "server/workers-control.h"
 
 static enum {
@@ -634,15 +635,15 @@ int get_shutdown_functions_count() {
 }
 
 void run_shutdown_functions_from_timeout() {
-// TODO: now it sometimes leads to critical errors in runtime. Need to rework it generally.
-//  // to safely run the shutdown handlers in the timeout context, we set
-//  // a recovery point to be used from the user-called die/exit;
-//  // without that, exit would lead to a finished state instead of the error state
-//  // we were about to enter (since timeout is an error state)
-//  shutdown_functions_status_value = shutdown_functions_status::running_from_timeout;
-//  if (setjmp(timeout_exit) == 0) {
-//    run_shutdown_functions();
-//  }
+  shutdown_functions_status_value = shutdown_functions_status::running_from_timeout;
+  // to safely run the shutdown handlers in the timeout context, we set
+  // a recovery point to be used from the user-called die/exit;
+  // without that, exit would lead to a finished state instead of the error state
+  // we were about to enter (since timeout is an error state)
+  reset_script_timeout();
+  if (setjmp(timeout_exit) == 0) {
+    run_shutdown_functions();
+  }
 }
 
 void run_shutdown_functions_from_script() {
@@ -669,6 +670,7 @@ void f$register_shutdown_function(const shutdown_function_type &f) {
 }
 
 void finish(int64_t exit_code) {
+  check_script_timeout();
   if (!finished) {
     finished = true;
     forcibly_stop_profiler();

--- a/runtime/resumable.cpp
+++ b/runtime/resumable.cpp
@@ -7,6 +7,7 @@
 #include "common/kprintf.h"
 
 #include "runtime/net_events.h"
+#include "server/php-queries.h"
 
 DEFINE_VERBOSITY(resumable);
 
@@ -471,6 +472,7 @@ static void debug_print_resumables() noexcept {
 static bool wait_started_resumable(int64_t resumable_id) noexcept;
 
 Storage *start_resumable_impl(Resumable *resumable) noexcept {
+  check_script_timeout();
   int64_t id = register_started_resumable(resumable);
 
   if (resumable->resume(id, nullptr)) {

--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -121,8 +121,8 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         zstd.cpp)
 
 set_source_files_properties(
-        ${BASE_DIR}/server/php-runner.cpp
         ${BASE_DIR}/server/php-engine.cpp
+        ${BASE_DIR}/server/signal-handlers.cpp
         ${BASE_DIR}/runtime/interface.cpp
         ${COMMON_DIR}/dl-utils-lite.cpp
         ${COMMON_DIR}/netconf.cpp

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -85,6 +85,7 @@
 #include "server/server-log.h"
 #include "server/server-stats.h"
 #include "server/shared-data-worker-cache.h"
+#include "server/signal-handlers.h"
 #include "server/statshouse/statshouse-client.h"
 #include "server/statshouse/worker-stats-buffer.h"
 #include "server/workers-control.h"

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -1051,6 +1051,10 @@ void finish_script(int exit_code __attribute__((unused))) {
   assert (0);
 }
 
+void check_script_timeout() {
+  PhpScript::current_script->check_delayed_timeout();
+}
+
 void reset_script_timeout() {
   PhpScript::current_script->reset_script_timeout();
 }

--- a/server/php-queries.cpp
+++ b/server/php-queries.cpp
@@ -1052,7 +1052,7 @@ void finish_script(int exit_code __attribute__((unused))) {
 }
 
 void check_script_timeout() {
-  PhpScript::current_script->check_delayed_timeout();
+  PhpScript::current_script->try_run_shutdown_functions_on_timeout();
 }
 
 void reset_script_timeout() {

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -305,6 +305,7 @@ int mc_connect_to(const char *host_name, int port);
 void mc_run_query(int host_num, const char *request, int request_len, int timeout_ms, int query_type, void (*callback)(const char *result, int result_len)) ubsan_supp("alignment");
 int db_proxy_connect();
 void db_run_query(int host_num, const char *request, int request_len, int timeout_ms, void (*callback)(const char *result, int result_len));
+void check_script_timeout();
 void reset_script_timeout();
 double get_net_time();
 double get_script_time();

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -84,7 +84,7 @@ void PhpScript::try_run_shutdown_functions_on_timeout() noexcept {
 
 void PhpScript::check_net_context_errors() noexcept {
   php_assert(PhpScript::in_script_context);
-  if (memory_limit_exceeded ) {
+  if (memory_limit_exceeded) {
     vk::singleton<OomHandler>::get().invoke();
     perform_error_if_running("memory limit exit\n", script_error_t::memory_limit);
   }

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -123,6 +123,7 @@ public:
   PhpScript(size_t mem_size, double oom_handling_memory_ratio, size_t stack_size) noexcept;
   ~PhpScript() noexcept;
 
+  void check_delayed_timeout() noexcept;
   void check_delayed_errors() noexcept;
 
   void init(script_t *script, php_query_data *data_to_set) noexcept;

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -88,8 +88,6 @@ class PhpScript {
 private:
   int swapcontext_helper(ucontext_t_portable *oucp, const ucontext_t_portable *ucp);
 
-  void on_request_timeout_error();
-
   void assert_state(run_state_t expected);
 
 public:
@@ -121,8 +119,8 @@ public:
   PhpScript(size_t mem_size, double oom_handling_memory_ratio, size_t stack_size) noexcept;
   ~PhpScript() noexcept;
 
-  void check_delayed_timeout() noexcept;
-  void check_delayed_errors() noexcept;
+  void try_run_shutdown_functions_on_timeout() noexcept;
+  void check_net_context_errors() noexcept;
 
   void init(script_t *script, php_query_data *data_to_set) noexcept;
 

--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -56,8 +56,6 @@ extern long long query_stats_id;
 
 void dump_query_stats();
 
-void init_handlers();
-
 class PhpScriptStack : vk::not_copyable {
 public:
   explicit PhpScriptStack(size_t stack_size) noexcept;

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -28,6 +28,7 @@ prepend(KPHP_SERVER_SOURCES ${BASE_DIR}/server/
         slot-ids-factory.cpp
         workers-control.cpp
         shared-data-worker-cache.cpp
+        signal-handlers.cpp
         statshouse/statshouse-client.cpp
         statshouse/add-metrics-batch.cpp
         statshouse/worker-stats-buffer.cpp)

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -1,0 +1,230 @@
+#include "server/signal-handlers.h"
+
+#include <execinfo.h>
+#include <sys/time.h>
+
+#include "common/kprintf.h"
+#include "common/server/crash-dump.h"
+#include "common/server/signals.h"
+#include "runtime/critical_section.h"
+#include "runtime/interface.h"
+#include "server/json-logger.h"
+#include "server/server-log.h"
+
+namespace {
+
+void kwrite_str(int fd, const char *s) noexcept {
+  kwrite(fd, s, static_cast<int>(strlen(s)));
+}
+
+void write_str(int fd, const char *s) noexcept {
+  write(fd, s, std::min(strlen(s), size_t{1000}));
+}
+
+bool check_signal_critical_section(int sig_num, const char *sig_name) {
+  if (dl::in_critical_section) {
+    const size_t message_1kw_size = 100;
+    char message_1kw[message_1kw_size];
+    snprintf(message_1kw, message_1kw_size, "in critical section: pending %s caught\n", sig_name);
+    kwrite_str(2, message_1kw);
+    dl::pending_signals = dl::pending_signals | (1ll << sig_num);
+    return false;
+  }
+  dl::pending_signals = 0;
+  return true;
+}
+}
+
+namespace kphp_runtime_signal_handlers {
+
+static void sigalrm_in_net_context() {
+  PhpScript::time_limit_exceeded = true;
+}
+
+static void sigalrm_in_script_context() {
+  PhpScript::time_limit_exceeded = true;
+  if (is_json_log_on_timeout_enabled) {
+    vk::singleton<JsonLogger>::get().write_log_with_backtrace("Maximum execution time exceeded", E_ERROR);
+  }
+}
+
+static void sigalrm_set_timeout_ex() {
+  static itimerval timer;
+  memset(&timer, 0, sizeof(itimerval));
+  timer.it_value.tv_sec = 2;
+  setitimer(ITIMER_REAL, &timer, nullptr);
+}
+
+static void sigalrm_handler(int signum) {
+  kwrite_str(2, "in sigalrm_handler\n");
+  if (check_signal_critical_section(signum, "SIGALRM")) {
+    // There are 3 possible situations when a timeout occurs
+    // [1] code in net context
+    //                        --> save the timeout fact in order to process it in the script context
+    // [2] code in script context and this is the first timeout
+    //                        --> process timeout and setup ex timeout which is deadline of shutdown functions call @see check_delayed_timeout
+    // [3] code in script context and this is the second timeout
+    //                        --> time to start shutdown functions has expired, emergency shutdown
+    if (!PhpScript::in_script_context) {
+      sigalrm_in_net_context();
+    } else if (!PhpScript::time_limit_exceeded) {
+      sigalrm_in_script_context();
+      sigalrm_set_timeout_ex();
+    } else {
+      perform_error_if_running("timeout exit\n", script_error_t::timeout);
+    }
+  }
+}
+
+static void sigusr2_handler(int signum) {
+  kwrite_str(2, "in sigusr2_handler\n");
+  if (check_signal_critical_section(signum, "SIGUSR2")) {
+    PhpScript::memory_limit_exceeded = true;
+    if (PhpScript::in_script_context) {
+      perform_error_if_running("memory limit exit\n", script_error_t::memory_limit);
+    }
+  }
+}
+
+static void php_assert_handler(int signum) {
+  kwrite_str(2, "in php_assert_handler (SIGRTMIN+1 signal)\n");
+  if (check_signal_critical_section(signum, "SIGRTMIN+1")) {
+    perform_error_if_running("php assert error\n", script_error_t::php_assert);
+  }
+}
+
+static void stack_overflow_handler(int signum) {
+  kwrite_str(2, "in stack_overflow_handler (SIGRTMIN+2 signal)\n");
+  if (check_signal_critical_section(signum, "SIGRTMIN+2")) {
+    perform_error_if_running("stack overflow error\n", script_error_t::stack_overflow);
+  }
+}
+
+void print_http_data() {
+  if (!PhpScript::in_script_context) {
+    return;
+  }
+  if (!PhpScript::current_script) {
+    write_str(2, "\nPHPScriptBase::current_script is nullptr\n");
+  } else if (PhpScript::current_script->data) {
+    if (http_query_data *data = PhpScript::current_script->data->http_data) {
+      write_str(2, "\nuri\n");
+      write(2, data->uri, data->uri_len);
+      write_str(2, "\nget\n");
+      write(2, data->get, data->get_len);
+      write_str(2, "\nheaders\n");
+      write(2, data->headers, data->headers_len);
+      write_str(2, "\npost\n");
+      if (data->post && data->post_len > 0) {
+        write(2, data->post, data->post_len);
+      }
+    }
+  }
+}
+
+void print_prologue(int64_t cur_time) noexcept {
+  write_str(2, engine_tag);
+
+  char buf[13];
+  char *s = buf + 13;
+  auto t = static_cast<int>(cur_time);
+  *--s = 0;
+  do {
+    *--s = static_cast<char>(t % 10 + '0');
+    t /= 10;
+  } while (t > 0);
+  write_str(2, s);
+  write_str(2, engine_pid);
+}
+
+void kill_workers() noexcept {
+#if defined(__APPLE__)
+  if (master_flag == 1) {
+    killpg(getpgid(pid), SIGKILL);
+  }
+#endif
+}
+
+void sigsegv_handler(int signum, siginfo_t *info, void *ucontext) {
+  crash_dump_write(static_cast<ucontext_t *>(ucontext));
+
+  const int64_t cur_time = time(nullptr);
+  print_prologue(cur_time);
+
+  void *trace[64];
+  const int trace_size = backtrace(trace, 64);
+
+  void *addr = info->si_addr;
+  if (PhpScript::in_script_context && PhpScript::current_script->script_stack.is_protected(static_cast<char *>(addr))) {
+    vk::singleton<JsonLogger>::get().write_stack_overflow_log(E_ERROR);
+    write_str(2, "Error -1: Callstack overflow\n");
+    print_http_data();
+    dl_print_backtrace(trace, trace_size);
+    if (dl::in_critical_section) {
+      vk::singleton<JsonLogger>::get().fsync_log_file();
+      kwrite_str(2, "In critical section: calling _exit (124)\n");
+      _exit(124);
+    } else {
+      PhpScript::error("sigsegv(stack overflow)", script_error_t::stack_overflow);
+    }
+  } else {
+    const char *msg = signum == SIGBUS ? "SIGBUS terminating program" : "SIGSEGV terminating program";
+    vk::singleton<JsonLogger>::get().write_log(msg, static_cast<int>(ServerLog::Critical), cur_time, trace, trace_size, true);
+    vk::singleton<JsonLogger>::get().fsync_log_file();
+    write_str(2, "Error -2: Segmentation fault\n");
+    print_http_data();
+    dl_print_backtrace(trace, trace_size);
+    kill_workers();
+    raise(SIGQUIT); // hack for generate core dump
+    _exit(123);
+  }
+}
+
+void sigabrt_handler(int) {
+  const int64_t cur_time = time(nullptr);
+  void *trace[64];
+  const int trace_size = backtrace(trace, 64);
+  vk::string_view msg{dl_get_assert_message()};
+  if (msg.empty()) {
+    msg = "SIGABRT terminating program";
+  }
+  vk::singleton<JsonLogger>::get().write_log(msg, static_cast<int>(ServerLog::Critical), cur_time, trace, trace_size, true);
+  vk::singleton<JsonLogger>::get().fsync_log_file();
+
+  print_prologue(cur_time);
+  write_str(2, "SIGABRT terminating program\n");
+  print_http_data();
+  dl_print_backtrace(trace, trace_size);
+  kill_workers();
+  _exit(EXIT_FAILURE);
+}
+} // namespace kphp_runtime_signal_handlers
+
+void perform_error_if_running(const char *msg, script_error_t error_type) {
+  if (PhpScript::in_script_context) {
+    kwrite_str(2, msg);
+    PhpScript::error(msg, error_type);
+    assert ("unreachable point" && 0);
+  }
+}
+
+//C interface
+void init_handlers() {
+  constexpr size_t SEGV_STACK_SIZE = 65536;
+  static std::array<char, SEGV_STACK_SIZE> buffer;
+
+  stack_t segv_stack;
+  segv_stack.ss_sp = buffer.data();
+  segv_stack.ss_flags = 0;
+  segv_stack.ss_size = SEGV_STACK_SIZE;
+  sigaltstack(&segv_stack, nullptr);
+
+  ksignal(SIGALRM, kphp_runtime_signal_handlers::sigalrm_handler);
+  ksignal(SIGUSR2, kphp_runtime_signal_handlers::sigusr2_handler);
+  ksignal(SIGPHPASSERT, kphp_runtime_signal_handlers::php_assert_handler);
+  ksignal(SIGSTACKOVERFLOW, kphp_runtime_signal_handlers::stack_overflow_handler);
+
+  dl_sigaction(SIGSEGV, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, kphp_runtime_signal_handlers::sigsegv_handler);
+  dl_sigaction(SIGBUS, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, kphp_runtime_signal_handlers::sigsegv_handler);
+  dl_signal(SIGABRT, kphp_runtime_signal_handlers::sigabrt_handler);
+}

--- a/server/signal-handlers.h
+++ b/server/signal-handlers.h
@@ -1,0 +1,6 @@
+#include "server/php-runner.h"
+
+
+void perform_error_if_running(const char *msg, script_error_t error_type);
+
+void init_handlers();

--- a/server/signal-handlers.h
+++ b/server/signal-handlers.h
@@ -1,3 +1,7 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
 #include "server/php-runner.h"
 
 

--- a/tests/python/tests/http_server/php/test_oom_handler.php
+++ b/tests/python/tests/http_server/php/test_oom_handler.php
@@ -23,7 +23,7 @@ function make_oom_error() {
 }
 
 function make_timeout_error() {
-  safe_sleep(1.5);
+  safe_sleep(2);
 }
 
 function fake_query(float $time_to_sleep) {

--- a/tests/python/tests/http_server/test_oom_handler.py
+++ b/tests/python/tests/http_server/test_oom_handler.py
@@ -74,5 +74,5 @@ class TestOomHandler(KphpServerAutoTestCase):
         self.assertEqual(resp.status_code, 500)
         self.kphp_server.assert_log([
             "allocations_cnt=[1-9]\\d?,memory_allocated=8\\d{5},estimate_memory_usage\\(arr\\)=8\\d{5}",
-            "timeout exit in OOM handler",
+            "timeout exit",
         ], timeout=5)

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -178,6 +178,11 @@ function main() {
         do_sleep(0.001);
         rpc_flush();
         break;
+      case "send_long_rpc":
+        $master_port = (int)$action["master_port"];
+        $duration = (float)$action["duration"];
+        send_rpc($master_port, $duration);
+        break;
       case "register_shutdown_function":
         do_register_shutdown_function((string)$action["msg"]);
         break;

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -9,46 +9,46 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
             "--verbosity-resumable=2": True,
         })
 
-    # TODO: shutdown functions from timeouts now disabled
-    # def test_timeout_reset_at_shutdown_function(self):
-    #     # test that the timeout timer resets, giving the shutdown functions a chance to complete
-    #     # if they're executed *before* the timeout but after a long-running script
-    #     resp = self.kphp_server.http_post(
-    #         json=[
-    #             {"op": "register_shutdown_function", "msg": "shutdown_after_long_work"},
-    #             {"op": "sleep", "duration": 0.75},
-    #         ])
-    #     self.assertEqual(resp.text, "ok")
-    #     self.assertEqual(resp.status_code, 200)
-    #     self.kphp_server.assert_log(["shutdown function managed to finish"], timeout=5)
-    #
-    # def test_timeout_shutdown_exit(self):
-    #     # test that if we're doing an exit(0) in shutdown handler *after* the timeout
-    #     # that request will still end up in error state with 500 status code
-    #     resp = self.kphp_server.http_post(
-    #         json=[
-    #             {"op": "register_shutdown_function", "msg": "shutdown_with_exit"},
-    #             {"op": "long_work", "duration": 2}
-    #         ])
-    #     self.assertEqual(resp.text, "ERROR")
-    #     self.assertEqual(resp.status_code, 500)
-    #     self.kphp_server.assert_log([
-    #         "Critical error during script execution: timeout exit",
-    #         "running shutdown handler 1"
-    #     ], timeout=5)
-    #
-    # def test_timeout_after_timeout_at_shutdown_function(self):
-    #     # test that we do set up a second timeout for the shutdown functions
-    #     # that were executed *after* the (first) timeout
-    #     resp = self.kphp_server.http_post(
-    #         json=[
-    #             {"op": "register_shutdown_function", "msg": "shutdown_endless_loop"},
-    #             {"op": "long_work", "duration": 2}
-    #         ])
-    #     self.assertEqual(resp.text, "ERROR")
-    #     self.assertEqual(resp.status_code, 500)
-    #     self.kphp_server.assert_log(["Critical error during script execution: timeout exit"], timeout=5)
-    #
+    def test_timeout_reset_at_shutdown_function(self):
+        # test that the timeout timer resets, giving the shutdown functions a chance to complete
+        # if they're executed *before* the timeout but after a long-running script
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_after_long_work"},
+                {"op": "sleep", "duration": 0.75},
+            ])
+        self.assertEqual(resp.text, "ok")
+        self.assertEqual(resp.status_code, 200)
+        self.kphp_server.assert_log(["shutdown function managed to finish"], timeout=5)
+
+    def test_timeout_shutdown_exit(self):
+        # test that if we're doing an exit(0) in shutdown handler *after* the timeout
+        # that request will still end up in error state with 500 status code
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_with_exit"},
+                {"op": "long_work", "duration": 1.5}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log([
+            "Critical error during script execution: timeout exit",
+            "running shutdown handler 1"
+        ], timeout=5)
+
+    def test_timeout_after_timeout_at_shutdown_function(self):
+        # test that we do set up a second timeout for the shutdown functions
+        # that were executed *after* the (first) timeout
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_endless_loop"},
+                {"op": "long_work", "duration": 2}
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log(["Critical error during script execution: timeout exit"], timeout=5)
+
+    # TODO enable shutdown functions call if timeout occurs in net context
     # def test_timeout_from_resumable_in_main_thread(self):
     #     # tests that when timeout is raised inside some 'started' resumable in main thread
     #     # and shutdown functions run, fork switching and resumables handling works correctly
@@ -107,3 +107,15 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
     #                                  "after yield",
     #                                  "after wait",
     #                                  ], timeout=5)
+    #
+    # def test_timeout_in_net_context(self):
+    #     #tests that script execute shutdown functions if timeout was in net context
+    #     resp = self.kphp_server.http_post(
+    #         json=[
+    #             {"op": "register_shutdown_function", "msg": "shutdown_after_long_work"},
+    #             {"op": "send_long_rpc", "duration": 1, "master_port": self.kphp_server.master_port},
+    #         ])
+    #     self.assertEqual(resp.text, "ERROR")
+    #     self.assertEqual(resp.status_code, 500)
+    #     self.kphp_server.assert_log(["Critical error during script execution: timeout",
+    #                                  "shutdown function managed to finish"], timeout=5)


### PR DESCRIPTION
General
-----------
Enable shutdown functions if timeout was in script context and script call swap context or start resumable

Details
---------
Remove longjmp from sigalrm handler. Instead of this remember timeout fact and set up second timeout that is deadline to call shutdown functions from runtime