### PR TITLE
Shutdown functions on timeout: improvements

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -53,20 +53,21 @@
 #include "runtime/udp.h"
 #include "runtime/url.h"
 #include "runtime/zlib.h"
-#include "server/server-config.h"
 #include "server/curl-adaptor.h"
 #include "server/database-drivers/adaptor.h"
 #include "server/database-drivers/mysql/mysql.h"
 #include "server/database-drivers/pgsql/pgsql.h"
-#include "server/shared-data-worker-cache.h"
 #include "server/job-workers/job-message.h"
 #include "server/json-logger.h"
 #include "server/numa-configuration.h"
 #include "server/php-engine-vars.h"
 #include "server/php-queries.h"
 #include "server/php-query-data.h"
-#include "server/php-worker.h"
 #include "server/php-runner.h"
+#include "server/php-worker.h"
+#include "server/server-config.h"
+#include "server/shared-data-worker-cache.h"
+#include "server/signal-handlers.h"
 #include "server/workers-control.h"
 
 static enum {
@@ -2438,9 +2439,10 @@ void free_runtime_environment() {
   dl::free_script_allocator();
 }
 
-void worker_global_init() noexcept {
+void worker_global_init(WorkerType worker_type) noexcept {
   worker_global_init_slot_factories();
   vk::singleton<JsonLogger>::get().reset_json_logs_count();
+  worker_global_init_handlers(worker_type);
 }
 
 void read_engine_tag(const char *file_name) {

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -11,6 +11,7 @@
 #include "runtime/kphp_core.h"
 #include "runtime/optional.h"
 #include "server/php-query-data.h"
+#include "server/workers-control.h"
 
 extern string_buffer *coub;//TODO static
 using shutdown_function_type = std::function<void()>;
@@ -190,7 +191,7 @@ void init_runtime_environment(php_query_data *data, void *mem, size_t script_mem
 void free_runtime_environment();
 
 // called only once at the beginning of each worker
-void worker_global_init() noexcept;
+void worker_global_init(WorkerType worker_type) noexcept;
 
 void use_utf8();
 

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -54,6 +54,7 @@ int master_sfd_inited = 0;
  ***/
 int sql_target_id = -1;
 int script_timeout = 0;
+int hard_timeout = 1;
 int disable_access_log = 0;
 int force_clear_sql_connection = 0;
 long long static_buffer_length_limit = -1;

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -54,7 +54,7 @@ int master_sfd_inited = 0;
  ***/
 int sql_target_id = -1;
 int script_timeout = 0;
-int hard_timeout = 1;
+double hard_timeout = 1.0;
 int disable_access_log = 0;
 int force_clear_sql_connection = 0;
 long long static_buffer_length_limit = -1;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -65,6 +65,7 @@ extern int rpc_stopped;
  ***/
 extern int sql_target_id;
 extern int script_timeout;
+extern int hard_timeout;
 extern int disable_access_log;
 extern int force_clear_sql_connection;
 extern long long static_buffer_length_limit;

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -65,7 +65,7 @@ extern int rpc_stopped;
  ***/
 extern int sql_target_id;
 extern int script_timeout;
-extern int hard_timeout;
+extern double hard_timeout;
 extern int disable_access_log;
 extern int force_clear_sql_connection;
 extern long long static_buffer_length_limit;

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2184,7 +2184,7 @@ int main_args_handler(int i, const char *long_option) {
       return read_option_to(long_option, 0.0, 0.5, oom_handling_memory_ratio);
     }
     case 2034: {
-      return read_option_to(long_option, 0, 5, hard_timeout);
+      return read_option_to(long_option, 0.0, 5.0, hard_timeout);
     }
     default:
       return -1;

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2183,6 +2183,9 @@ int main_args_handler(int i, const char *long_option) {
     case 2033: {
       return read_option_to(long_option, 0.0, 0.5, oom_handling_memory_ratio);
     }
+    case 2034: {
+      return read_option_to(long_option, 0, 5, hard_timeout);
+    }
     default:
       return -1;
   }
@@ -2289,6 +2292,7 @@ void parse_main_args(int argc, char *argv[]) {
                                                                                           "messages count = coefficient * processes_count");
   parse_option("runtime-config", required_argument, 2032, "JSON file path that will be available at runtime as 'mixed' via 'kphp_runtime_config()");
   parse_option("oom-handling-memory-ratio", required_argument, 2033, "memory ratio of overall script memory to handle OOM errors (default: 0.00)");
+  parse_option("hard-time-limit", required_argument, 2034, "time limit for script termination after the main timeout has expired (default: 1 sec). Use 0 to disable");
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);
   // TODO: remove it after successful migration from kphb.readyV2 to kphb.readyV3

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1636,7 +1636,7 @@ void start_server() {
     worker_type = start_master();
   }
 
-  worker_global_init();
+  worker_global_init(worker_type);
   generic_event_loop(worker_type, !master_flag);
 }
 

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -13,6 +13,7 @@
 #include "runtime/critical_section.h"
 #include "runtime/interface.h"
 #include "server/json-logger.h"
+#include "server/php-engine-vars.h"
 #include "server/server-log.h"
 
 namespace {
@@ -68,11 +69,11 @@ void sigalrm_handler(int signum) {
       if (is_json_log_on_timeout_enabled) {
         vk::singleton<JsonLogger>::get().write_log_with_backtrace("Maximum execution time exceeded", E_ERROR);
       }
-      if (get_shutdown_functions_count() > 0) {
+      if (hard_timeout != 0 && get_shutdown_functions_count() > 0) {
         // setup hard timeout which is deadline of shutdown functions call @see try_run_shutdown_functions_on_timeout
         static itimerval timer;
         memset(&timer, 0, sizeof(itimerval));
-        timer.it_value.tv_sec = 1;
+        timer.it_value.tv_sec = hard_timeout;
         setitimer(ITIMER_REAL, &timer, nullptr);
       } else {
         // if there's no shutdown functions terminate script now

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -37,11 +37,23 @@ bool check_signal_critical_section(int sig_num, const char *sig_name) {
   dl::pending_signals = 0;
   return true;
 }
+
+void job_worker_sigalrm_handler(int signum) {
+  // It's critical for job workers to terminate as soon as possible after normal timeout.
+  // Because timeouts are usually small and always used for fine-grained job duration control
+  kwrite_str(2, "in job_worker_sigalrm_handler\n");
+  if (check_signal_critical_section(signum, "SIGALRM")) {
+    PhpScript::time_limit_exceeded = true;
+    if (PhpScript::in_script_context) {
+      if (is_json_log_on_timeout_enabled) {
+        vk::singleton<JsonLogger>::get().write_log_with_backtrace("Maximum execution time exceeded", E_ERROR);
+      }
+      perform_error_if_running("timeout exit\n", script_error_t::timeout);
+    }
+  }
 }
 
-namespace kphp_runtime_signal_handlers {
-
-static void sigalrm_handler(int signum) {
+void sigalrm_handler(int signum) {
   kwrite_str(2, "in sigalrm_handler\n");
   if (check_signal_critical_section(signum, "SIGALRM")) {
     // There are 3 possible situations when a timeout occurs
@@ -75,7 +87,7 @@ static void sigalrm_handler(int signum) {
   }
 }
 
-static void sigusr2_handler(int signum) {
+void sigusr2_handler(int signum) {
   kwrite_str(2, "in sigusr2_handler\n");
   if (check_signal_critical_section(signum, "SIGUSR2")) {
     PhpScript::memory_limit_exceeded = true;
@@ -85,14 +97,14 @@ static void sigusr2_handler(int signum) {
   }
 }
 
-static void php_assert_handler(int signum) {
+void php_assert_handler(int signum) {
   kwrite_str(2, "in php_assert_handler (SIGRTMIN+1 signal)\n");
   if (check_signal_critical_section(signum, "SIGRTMIN+1")) {
     perform_error_if_running("php assert error\n", script_error_t::php_assert);
   }
 }
 
-static void stack_overflow_handler(int signum) {
+void stack_overflow_handler(int signum) {
   kwrite_str(2, "in stack_overflow_handler (SIGRTMIN+2 signal)\n");
   if (check_signal_critical_section(signum, "SIGRTMIN+2")) {
     perform_error_if_running("stack overflow error\n", script_error_t::stack_overflow);
@@ -197,7 +209,7 @@ void sigabrt_handler(int) {
   kill_workers();
   _exit(EXIT_FAILURE);
 }
-} // namespace kphp_runtime_signal_handlers
+} // namespace
 
 
 //mark no return
@@ -220,12 +232,18 @@ void init_handlers() {
   segv_stack.ss_size = SEGV_STACK_SIZE;
   sigaltstack(&segv_stack, nullptr);
 
-  ksignal(SIGALRM, kphp_runtime_signal_handlers::sigalrm_handler);
-  ksignal(SIGUSR2, kphp_runtime_signal_handlers::sigusr2_handler);
-  ksignal(SIGPHPASSERT, kphp_runtime_signal_handlers::php_assert_handler);
-  ksignal(SIGSTACKOVERFLOW, kphp_runtime_signal_handlers::stack_overflow_handler);
+  ksignal(SIGALRM, sigalrm_handler);
+  ksignal(SIGUSR2, sigusr2_handler);
+  ksignal(SIGPHPASSERT, php_assert_handler);
+  ksignal(SIGSTACKOVERFLOW, stack_overflow_handler);
 
-  dl_sigaction(SIGSEGV, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, kphp_runtime_signal_handlers::sigsegv_handler);
-  dl_sigaction(SIGBUS, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, kphp_runtime_signal_handlers::sigsegv_handler);
-  dl_signal(SIGABRT, kphp_runtime_signal_handlers::sigabrt_handler);
+  dl_sigaction(SIGSEGV, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, sigsegv_handler);
+  dl_sigaction(SIGBUS, nullptr, dl_get_empty_sigset(), SA_SIGINFO | SA_ONSTACK | SA_RESTART, sigsegv_handler);
+  dl_signal(SIGABRT, sigabrt_handler);
+}
+
+void worker_global_init_handlers(WorkerType worker_type) {
+  if (worker_type == WorkerType::job_worker) {
+    ksignal(SIGALRM, job_worker_sigalrm_handler);
+  }
 }

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -73,7 +73,8 @@ void sigalrm_handler(int signum) {
         // setup hard timeout which is deadline of shutdown functions call @see try_run_shutdown_functions_on_timeout
         static itimerval timer;
         memset(&timer, 0, sizeof(itimerval));
-        timer.it_value.tv_sec = hard_timeout;
+        timer.it_value.tv_sec = static_cast<decltype(timer.it_value.tv_sec)>(std::floor(hard_timeout));
+        timer.it_value.tv_usec = static_cast<decltype(timer.it_value.tv_usec)>(1e6 * (hard_timeout - std::floor(hard_timeout)));
         setitimer(ITIMER_REAL, &timer, nullptr);
       } else {
         // if there's no shutdown functions terminate script now

--- a/server/signal-handlers.h
+++ b/server/signal-handlers.h
@@ -3,8 +3,9 @@
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #include "server/php-runner.h"
-
+#include "server/workers-control.h"
 
 void perform_error_if_running(const char *msg, script_error_t error_type);
 
 void init_handlers();
+void worker_global_init_handlers(WorkerType worker_type);

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -46,7 +46,7 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
             ])
         self.assertEqual(resp.text, "ERROR")
         self.assertEqual(resp.status_code, 500)
-        self.kphp_server.assert_log(["Critical error during script execution: timeout exit"], timeout=5)
+        self.kphp_server.assert_log(["Critical error during script execution: hard timeout exit"], timeout=5)
 
     # TODO enable shutdown functions call if timeout occurs in net context
     # def test_timeout_from_resumable_in_main_thread(self):


### PR DESCRIPTION
- Don't delay timeout if there's no shutdown functions
- Add option for hard-timeout to turn it off in case of emergency (by default 1 sec is enabled)
- Never delay timeout in job workers because it's critical