### PR TITLE
reset script state before run shutdown functions

### DIFF
--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -78,6 +78,8 @@ void PhpScript::try_run_shutdown_functions_on_timeout() noexcept {
   }
 
   if (get_shutdown_functions_count() != 0 && get_shutdown_functions_status() == shutdown_functions_status::not_executed) {
+    // set up state to running to execute shutdown functions
+    state = run_state_t::running;
     run_shutdown_functions_from_timeout();
   }
   perform_error_if_running("timeout exit\n", script_error_t::timeout);

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -70,7 +70,7 @@ function shutdown_fork_wait() {
 /** @kphp-required */
 function shutdown_send_rpc() {
     fprintf(STDERR, "try send rpc from shutdown\n");
-    send_rpc(8081, 0.5);
+    rpc_flush();
 }
 
 function forked_func(int $i, float $duration = 0.5): int {

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -9,6 +9,11 @@ function may_throw(bool $cond, string $msg) {
 }
 
 /** @kphp-required */
+function shutdown_simple() {
+  fprintf(STDERR, "execute simple shutdown\n");
+}
+
+/** @kphp-required */
 function shutdown_exception_warning() {
   $msg = "running shutdown handler";
   try {
@@ -62,6 +67,12 @@ function shutdown_fork_wait() {
   fprintf(STDERR, "after wait\n");
 }
 
+/** @kphp-required */
+function shutdown_send_rpc() {
+    fprintf(STDERR, "try send rpc from shutdown\n");
+    send_rpc(8081, 0.5);
+}
+
 function forked_func(int $i, float $duration = 0.5): int {
   fprintf(STDERR, "before yield\n");
   sched_yield_sleep($duration); // wait net
@@ -93,6 +104,12 @@ function do_register_shutdown_function(string $fn) {
       break;
     case "shutdown_fork_wait":
       register_shutdown_function("shutdown_fork_wait");
+      break;
+    case "shutdown_simple":
+      register_shutdown_function("shutdown_simple");
+      break;
+    case "shutdown_send_rpc":
+      register_shutdown_function("shutdown_send_rpc");
       break;
   }
 }
@@ -182,6 +199,9 @@ function main() {
         $master_port = (int)$action["master_port"];
         $duration = (float)$action["duration"];
         send_rpc($master_port, $duration);
+        break;
+      case "critical_error":
+        critical_error("this code shouldn't be executed");
         break;
       case "register_shutdown_function":
         do_register_shutdown_function((string)$action["msg"]);

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -162,8 +162,8 @@ function send_rpc(int $master_port, float $duration, bool $expect_resume = true)
 
 function main() {
   foreach (json_decode(file_get_contents('php://input')) as $action) {
+    fprintf(STDERR, $action["op"] . "\n");
     switch ($action["op"]) {
-      fprintf(STDERR, $action["op"] . "\n");
       case "sigsegv":
         do_sigsegv();
         break;

--- a/tests/python/tests/shutdown_functions/php/index.php
+++ b/tests/python/tests/shutdown_functions/php/index.php
@@ -163,6 +163,7 @@ function send_rpc(int $master_port, float $duration, bool $expect_resume = true)
 function main() {
   foreach (json_decode(file_get_contents('php://input')) as $action) {
     switch ($action["op"]) {
+      fprintf(STDERR, $action["op"] . "\n");
       case "sigsegv":
         do_sigsegv();
         break;
@@ -176,7 +177,9 @@ function main() {
         do_long_work((int)$action["duration"]);
         break;
       case "resumable_long_work":
+        fprintf(STDERR, "start resumable_long_work\n");
         long_resumable((int)$action["duration"]);
+        fprintf(STDERR, "finish resumable_long_work\n");
         break;
       case "fork_wait_resumable_long_work":
         $f = fork(long_resumable((int)$action["duration"]));

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -15,7 +15,7 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
             json=[
                 {"op": "register_shutdown_function", "msg": "shutdown_simple"},
                 {"op": "register_shutdown_function", "msg": "shutdown_send_rpc"},
-                {"op": "sleep", "duration": 1},
+                {"op": "sleep", "duration": 1.2},
                 {"op": "send_long_rpc", "duration": 0.1, "master_port": self.kphp_server.master_port},
                 {"op": "critical_error"},
             ])
@@ -29,7 +29,7 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
             json=[
                 {"op": "register_shutdown_function", "msg": "shutdown_simple"},
                 {"op": "register_shutdown_function", "msg": "shutdown_send_rpc"},
-                {"op": "sleep", "duration": 1},
+                {"op": "sleep", "duration": 1.5},
                 {"op": "resumable_long_work", "duration": 0.2},
                 {"op": "critical_error"},
             ])

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_timeouts.py
@@ -9,6 +9,34 @@ class TestShutdownFunctionsTimeouts(KphpServerAutoTestCase):
             "--verbosity-resumable=2": True,
         })
 
+    def test_soft_timeout_checking_in_query(self):
+        # test that kphp check soft timeout in query inside swap context
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_simple"},
+                {"op": "register_shutdown_function", "msg": "shutdown_send_rpc"},
+                {"op": "sleep", "duration": 1},
+                {"op": "send_long_rpc", "duration": 0.1, "master_port": self.kphp_server.master_port},
+                {"op": "critical_error"},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log(["execute simple shutdown", "try send rpc from shutdown"], timeout=5)
+
+    def test_soft_timeout_checking_in_resumable(self):
+        # test that kphp check soft timeout on resumable start
+        resp = self.kphp_server.http_post(
+            json=[
+                {"op": "register_shutdown_function", "msg": "shutdown_simple"},
+                {"op": "register_shutdown_function", "msg": "shutdown_send_rpc"},
+                {"op": "sleep", "duration": 1},
+                {"op": "resumable_long_work", "duration": 0.2},
+                {"op": "critical_error"},
+            ])
+        self.assertEqual(resp.text, "ERROR")
+        self.assertEqual(resp.status_code, 500)
+        self.kphp_server.assert_log(["execute simple shutdown", "try send rpc from shutdown"], timeout=5)
+
     def test_timeout_reset_at_shutdown_function(self):
         # test that the timeout timer resets, giving the shutdown functions a chance to complete
         # if they're executed *before* the timeout but after a long-running script


### PR DESCRIPTION
In this https://github.com/VKCOM/kphp/pull/841 pr shutdown functions began to execute after the soft timeout check. 
This pr fix error with script state and add tests to verify checking soft timeout in several cases