### PR TITLE
[compiler] fixed `catch` location detection

### DIFF
--- a/compiler/gentree.cpp
+++ b/compiler/gentree.cpp
@@ -1991,6 +1991,8 @@ GenericsInstantiationPhpComment *GenTree::parse_php_commentTs(vk::string_view st
 }
 
 VertexAdaptor<op_catch> GenTree::get_catch() {
+  auto location = auto_location();
+
   CE (expect(tok_catch, "'catch'"));
   CE (expect(tok_oppar, "'('"));
   auto exception_class = cur->str_val;
@@ -2003,7 +2005,7 @@ VertexAdaptor<op_catch> GenTree::get_catch() {
   auto catch_body = get_statement();
   CE (!kphp_error(catch_body, "Cannot parse catch block"));
 
-  auto catch_op = VertexAdaptor<op_catch>::create(exception_var_name.as<op_var>(), VertexUtil::embrace(catch_body));
+  auto catch_op = VertexAdaptor<op_catch>::create(exception_var_name.as<op_var>(), VertexUtil::embrace(catch_body)).set_location(location);
   catch_op->type_declaration = resolve_uses(cur_function, static_cast<std::string>(exception_class));
 
   return catch_op;
@@ -2179,7 +2181,6 @@ VertexPtr GenTree::get_statement(const PhpDocComment *phpdoc) {
       while (test_expect(tok_catch)) {
         auto catch_op = get_catch();
         CE (!kphp_error(catch_op, "Cannot parse catch statement"));
-        catch_op.set_location(location);
         catch_list.emplace_back(catch_op);
       }
       CE (!kphp_error(!catch_list.empty(), "Expected at least 1 'catch' statement"));


### PR DESCRIPTION
PHP code:
```c++
1| <?php
2| try {
3|   // ...
4| } catch (Exception $e) {
5|   // ...
6| }
```

`AST` with `location`(line) before:
```
op_try 
  op_seq 0
  op_catch 
    op_var $e
    op_seq 0
line: 2

op_seq 0
line: 4

op_catch 
  op_var $e
  op_seq 0
line: 2

op_var $e
line: 4

op_seq 0
line: 6

```

`AST` with `location`(line) after:
```
op_try 
  op_seq 0
  op_catch 
    op_var $e
    op_seq 0
line: 2

op_seq 0
line: 4

op_catch 
  op_var $e
  op_seq 0
line: 4

op_var $e
line: 4

op_seq 0
line: 6
```