### PR TITLE
Fix MySQL installation

### DIFF
--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -16,6 +16,7 @@ RUN apt-get update && \
     rm -f "$TEMP_DEB" && \
     echo "deb http://apt.postgresql.org/pub/repos/apt buster-pgdg main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       git cmake-data=3.18* cmake=3.18* make g++ gperf netcat \


### PR DESCRIPTION
Last month MySQL started rotating out their GPG signing keys for packages.
Currently, the signing key is stored under /etc/pki/rpm-gpg/RPM-GPG-KEY-mysql-2022 and it is set to expire on 2023-12-14. I assume aptitude is marked mysql as a config no replace file, which means that any attempts to add new signing keys won't work without user intervention because all that will happened is that a ".rpmnew" repo file will be made.