### PR TITLE
Fix curl resumable epoll related crash

### DIFF
--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -1129,6 +1129,15 @@ void CurlRequest::detach_multi_and_easy_handles() const noexcept {
 }
 
 static int curl_epoll_cb(int fd, void *data, event_t *ev) {
+  // Sometimes epoll callbacks can be invoked AFTER the related 'fd' is removed from epoll.
+  // It happens because our net_reactor at first stores epoll events from epoll_wait, and only then runs related callbacks (see epoll_fetch_events())
+  // Usually this situation is handled via some additional connection flags (conn_expect_query, C_WANTRD etc.)
+  // in callbacks like `server_read_write_gateway` and related.
+  // But here we try to keep it simple and not to do all of this stuff.
+  // So we need to check explicitly that this fd is still present in epoll reactor:
+  if (!(ev->state & EVT_IN_EPOLL)) {
+    return 0;
+  }
   auto *curl_request = static_cast<CurlRequest *>(data);
   php_assert(curl_request);
 


### PR DESCRIPTION
## Problem
Sometimes `SIGSEGV` is raised on production from `curl_epoll_cb` on accessing data from script memory.
##  Reason
`curl_epoll_cb` runs after script termination, when script memory is already freed, despite the related `fd` is removed from epoll on script termination.

It happens because sometimes epoll callbacks can be invoked **after** the related 'fd' is removed from epoll. Our net_reactor at first stores epoll events from `epoll_wait`, and only then runs the related callbacks (see `epoll_fetch_events()`), and sometimes it happens that between events fetching and processing script termination is happened.
Usually this situation is handled via some additional connection flags (`conn_expect_query`, `C_WANTRD` etc.) in callbacks like `server_read_write_gateway` and related. But in `curl_epoll_cb` we try to keep it simple and not to do all of this stuff.
## Fixes
- explicitly check in `curl_epoll_cb` that `fd` is still present in epoll reactor

And more general fix is in the separate PR #897: don't fetch net events right before script termination

relates to `KPHP-1578`