### PR TITLE
joint arrays' buckets

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -50,7 +50,8 @@ Checks: |-
   -bugprone-easily-swappable-parameters,
   -misc-no-recursion,
   -misc-const-correctness,
-  -cppcoreguidelines-avoid-const-or-ref-data-members
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
+  -cppcoreguidelines-macro-usage
 
 CheckOptions:
   - key:             bugprone-suspicious-string-compare.WarnOnImplicitComparison

--- a/compiler/code-gen/files/global_vars_memory_stats.cpp
+++ b/compiler/code-gen/files/global_vars_memory_stats.cpp
@@ -36,7 +36,7 @@ void GlobalVarsMemoryStats::compile(CodeGenerator &W) const {
 
   FunctionSignatureGenerator(W) << "array<int64_t> " << getter_name_ << "(int64_t lower_bound) " << BEGIN
                                 << "array<int64_t> result;" << NL
-                                << "result.reserve(" << global_vars_count << ", " << global_vars_count << ", false);" << NL << NL;
+                                << "result.reserve(" << global_vars_count << ", false);" << NL << NL;
 
   for (size_t part_id = 0; part_id < global_var_parts.size(); ++part_id) {
     W << "void " << getter_name_ << "_" << part_id << "(int64_t lower_bound, array<int64_t> &result);" << NL

--- a/compiler/code-gen/files/tl2cpp/tl2cpp.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl2cpp.cpp
@@ -198,7 +198,7 @@ void write_tl_query_handlers(CodeGenerator &W) {
   W << END << ";" << NL << NL;
 
   W << "void tl_magic_fill_all_functions_impl(array<string> &out) noexcept " << BEGIN
-    << "out.reserve(" << tl->functions.size() << ", 0, false);" << NL
+    << "out.reserve(" << tl->functions.size() << ", false);" << NL
     << "for (int i=0; i<" << tl->functions.size() << "; ++i)" << BEGIN
     << "out.set_value(static_cast<int64_t>(tl_magic_ids[i]), string(tl_magic_names[i]));" << NL << END
     << NL << END << NL;

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -101,7 +101,7 @@ DepLevelContainer::const_iterator &DepLevelContainer::const_iterator::operator++
 }
 
 static inline int array_len() {
-  return (10 * sizeof(int)) / sizeof(double);
+  return (8 * sizeof(int)) / sizeof(double);
 }
 
 std::vector<int> compile_arrays_raw_representation(const DepLevelContainer &const_raw_array_vars, CodeGenerator &W) {
@@ -149,18 +149,15 @@ std::vector<int> compile_arrays_raw_representation(const DepLevelContainer &cons
     shifts.push_back(shift);
     shift += array_len_in_doubles;
 
-    // stub, ref_cnt
-    W << "{ .is = { .a = 0, .b = " << ExtraRefCnt::for_global_const << "}},";
+    // is_vector_internal, ref_cnt
+    W << "{ .is = { .a = 1, .b = " << ExtraRefCnt::for_global_const << "}},";
     // max_key
     W << "{ .i64 = " << array_size - 1 << "},";
     // end_.next, end_.prev
     W << "{ .is = { .a = 0, .b = 0}},";
 
     // int_size, int_buf_size
-    W << "{ .is = { .a = " << array_size << ", .b = " << array_size << "}},";
-
-    // string_size, string_buf_size
-    W << "{ .is = { .a = 0 , .b = " << std::numeric_limits<uint32_t>::max() << " }}";
+    W << "{ .is = { .a = " << array_size << ", .b = " << array_size << "}}";
 
     auto args_end = vertex->args().end();
     for (auto it = vertex->args().begin(); it != args_end; ++it) {

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -156,7 +156,7 @@ std::vector<int> compile_arrays_raw_representation(const DepLevelContainer &cons
     // end_.next, end_.prev
     W << "{ .is = { .a = 0, .b = 0}},";
 
-    // size, int_buf_size
+    // size, buf_size
     W << "{ .is = { .a = " << array_size << ", .b = " << array_size << "}}";
 
     auto args_end = vertex->args().end();

--- a/compiler/code-gen/raw-data.cpp
+++ b/compiler/code-gen/raw-data.cpp
@@ -156,7 +156,7 @@ std::vector<int> compile_arrays_raw_representation(const DepLevelContainer &cons
     // end_.next, end_.prev
     W << "{ .is = { .a = 0, .b = 0}},";
 
-    // int_size, int_buf_size
+    // size, int_buf_size
     W << "{ .is = { .a = " << array_size << ", .b = " << array_size << "}}";
 
     auto args_end = vertex->args().end();

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -1845,35 +1845,17 @@ void compile_array(VertexAdaptor<op_array> root, CodeGenerator &W) {
   }
 
   bool has_double_arrow = false;
-  int int_cnt = 0, string_cnt = 0, xx_cnt = 0;
+  const int size = root->args().size();
   for (size_t key_id = 0; key_id < root->args().size(); ++key_id) {
     if (auto arrow = root->args()[key_id].try_as<op_double_arrow>()) {
       VertexPtr key = VertexUtil::get_actual_value(arrow->key());
       if (!has_double_arrow && key->type() == op_int_const) {
         if (key.as<op_int_const>()->str_val == std::to_string(key_id)) {
           root->args()[key_id] = arrow->value();
-          int_cnt++;
           continue;
         }
       }
       has_double_arrow = true;
-      PrimitiveType tp = tinf::get_type(key)->ptype();
-      if (tp == tp_int) {
-        int_cnt++;
-      } else {
-        if (tp == tp_string && key->type() == op_string) {
-          const std::string &key_str = key.as<op_string>()->str_val;
-          if (php_is_int(key_str.c_str(), key_str.size())) {
-            int_cnt++;
-          } else {
-            string_cnt++;
-          }
-        } else {
-          xx_cnt++;
-        }
-      }
-    } else {
-      int_cnt++;
     }
   }
   if (n <= 10 && !has_double_arrow && type->ptype() == tp_array && root->extra_type != op_ex_safe_version) {
@@ -1893,8 +1875,7 @@ void compile_array(VertexAdaptor<op_array> root, CodeGenerator &W) {
     W << "array <mixed>";
   }
   W << " (array_size ("
-    << int_cnt + xx_cnt << ", "
-    << string_cnt + xx_cnt << ", "
+    << size << ", "
     << (has_double_arrow ? "false" : "true") << "));" << NL;
   for (auto cur : root->args()) {
     W << arr_name;

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -106,7 +106,7 @@ bool array<T>::is_int_key(const typename array<T>::key_type &key) {
 template<>
 inline typename array<Unknown>::array_inner *array<Unknown>::array_inner::empty_array() {
   static array_inner_control empty_array{
-    1, ExtraRefCnt::for_global_const, -1,
+    true, ExtraRefCnt::for_global_const, -1,
     {0, 0},
     0, 2,
   };
@@ -1877,7 +1877,7 @@ void array<T>::sort(const T1 &compare, bool renumber) {
   array_bucket **arTmp = (array_bucket **)dl::allocate(n * sizeof(array_bucket * ));
   uint32_t i = 0;
   for (array_bucket *it = p->begin(); it != p->end(); it = p->next(it)) {
-    arTmp[i++] = (array_bucket *)it;
+    arTmp[i++] = it;
   }
   php_assert (i == n);
 

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -12,28 +12,28 @@
   #error "this file must be included only from kphp_core.h"
 #endif
 
-array_size::array_size(int64_t int_size, bool is_vector) :
-  int_size(int_size),
-  is_vector(is_vector) {}
+array_size::array_size(int64_t int_size, bool is_vector)
+  : size(int_size)
+  , is_vector(is_vector) {}
 
-array_size::array_size(int64_t int_size, int64_t string_size, bool is_vector) :
-  int_size(int_size + string_size),
-  is_vector(is_vector) {}
+array_size::array_size(int64_t int_size, int64_t string_size, bool is_vector)
+  : size(int_size + string_size)
+  , is_vector(is_vector) {}
 
 array_size array_size::operator+(const array_size &other) const {
-  return {int_size + other.int_size, 0, is_vector && other.is_vector};
+  return {size + other.size, 0, is_vector && other.is_vector};
 }
 
 array_size &array_size::cut(int64_t length) {
-  if (int_size > length) {
-    int_size = length;
+  if (size > length) {
+    size = length;
   }
   return *this;
 }
 
 array_size &array_size::min(const array_size &other) {
-  if (int_size > other.int_size) {
-    int_size = other.int_size;
+  if (size > other.size) {
+    size = other.size;
   }
 
   is_vector &= other.is_vector;
@@ -922,7 +922,7 @@ array<T>::array():
 
 template<class T>
 array<T>::array(const array_size &s) :
-  p(array_inner::create(s.int_size, s.is_vector)) {
+  p(array_inner::create(s.size, s.is_vector)) {
 }
 
 template<class T>
@@ -1997,7 +1997,7 @@ T array<T>::shift() {
     array_size new_size = size().cut(count() - 1);
     bool is_v = new_size.is_vector;
 
-    array_inner *new_array = array_inner::create(new_size.int_size, is_v);
+    array_inner *new_array = array_inner::create(new_size.size, is_v);
     array_bucket *it = p->begin();
     T res = it->value;
 
@@ -2036,7 +2036,7 @@ int64_t array<T>::unshift(const T &val) {
     array_size new_size = size();
     bool is_v = new_size.is_vector;
 
-    array_inner *new_array = array_inner::create(new_size.int_size + 1, is_v);
+    array_inner *new_array = array_inner::create(new_size.size + 1, is_v);
     array_bucket *it = p->begin();
 
     if (is_v) {

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -1818,7 +1818,7 @@ void array<T>::memcpy_vector(int64_t num __attribute__((unused)), const void *sr
     php_assert(is_vector() && p->size == 0 && num <= p->buf_size);
     mutate_if_vector_shared();
 
-    memcpy(p->entries, src_buf, num * sizeof(T));
+    memcpy(reinterpret_cast<T *>(p->entries), src_buf, num * sizeof(T));
     p->max_key = num - 1;
     p->size = static_cast<uint32_t>(num);
   } else {

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -12,26 +12,22 @@
   #error "this file must be included only from kphp_core.h"
 #endif
 
-array_size::array_size(int64_t int_size, bool is_vector)
+array_size::array_size(int64_t int_size, bool is_vector) noexcept
   : size(int_size)
   , is_vector(is_vector) {}
 
-array_size::array_size(int64_t int_size, int64_t string_size, bool is_vector)
-  : size(int_size + string_size)
-  , is_vector(is_vector) {}
-
-array_size array_size::operator+(const array_size &other) const {
-  return {size + other.size, 0, is_vector && other.is_vector};
+array_size array_size::operator+(const array_size &other) const noexcept {
+  return {size + other.size, is_vector && other.is_vector};
 }
 
-array_size &array_size::cut(int64_t length) {
+array_size &array_size::cut(int64_t length) noexcept {
   if (size > length) {
     size = length;
   }
   return *this;
 }
 
-array_size &array_size::min(const array_size &other) {
+array_size &array_size::min(const array_size &other) noexcept {
   if (size > other.size) {
     size = other.size;
   }
@@ -984,7 +980,7 @@ template<class... Args>
 inline array<T> array<T>::create(Args &&... args) {
   static_assert((std::is_convertible<std::decay_t<Args>, T>::value && ...), "Args type must be convertible to T");
 
-  array<T> res{array_size{sizeof...(args), 0, true}};
+  array<T> res{array_size{sizeof...(args), true}};
   (res.p->emplace_back_vector_value(std::forward<Args>(args)), ...);
   return res;
 }
@@ -1923,7 +1919,7 @@ void array<T>::ksort(const T1 &compare) {
     mutate_if_map_shared();
   }
 
-  array<key_type> keys(array_size(n, 0, true));
+  array<key_type> keys(array_size(n, true));
   for (auto *it = p->begin(); it != p->end(); it = p->next(it)) {
     keys.p->push_back_vector_value(it->get_key());
   }

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -272,7 +272,7 @@ void array<T>::array_inner::dispose() {
     if (ref_cnt <= -1) {
       if (is_vector()) {
         for (uint32_t i = 0; i < size; i++) {
-          ((T *)int_entries)[i].~T();
+          ((T *)entries)[i].~T();
         }
 
         dl::deallocate((void *)this, sizeof_vector(buf_size));
@@ -307,10 +307,10 @@ template<class ...Args>
 inline T &array<T>::array_inner::emplace_back_vector_value(Args &&... args) noexcept {
   static_assert(std::is_constructible<T, Args...>{}, "should be constructible");
   php_assert (size < buf_size);
-  new(&((T *)int_entries)[size]) T(std::forward<Args>(args)...);
+  new(&((T *)entries)[size]) T(std::forward<Args>(args)...);
   max_key++;
   size++;
-  return reinterpret_cast<T *>(int_entries)[max_key];
+  return reinterpret_cast<T *>(entries)[max_key];
 }
 
 template<class T>
@@ -320,19 +320,19 @@ T &array<T>::array_inner::push_back_vector_value(const T &v) {
 
 template<class T>
 T &array<T>::array_inner::get_vector_value(int64_t int_key) {
-  return reinterpret_cast<T *>(int_entries)[int_key];
+  return reinterpret_cast<T *>(entries)[int_key];
 }
 
 template<class T>
 const T &array<T>::array_inner::get_vector_value(int64_t int_key) const {
-  return reinterpret_cast<const T *>(int_entries)[int_key];
+  return reinterpret_cast<const T *>(entries)[int_key];
 }
 
 template<class T>
 template<class ...Args>
 T &array<T>::array_inner::emplace_vector_value(int64_t int_key, Args &&... args) noexcept {
   static_assert(std::is_constructible<T, Args...>{}, "should be constructible");
-  reinterpret_cast<T *>(int_entries)[int_key] = T(std::forward<Args>(args)...);
+  reinterpret_cast<T *>(entries)[int_key] = T(std::forward<Args>(args)...);
   return get_vector_value(int_key);
 }
 
@@ -346,24 +346,24 @@ template<class ...Args>
 T &array<T>::array_inner::emplace_int_key_map_value(overwrite_element policy, int64_t int_key, Args &&... args) noexcept {
   static_assert(std::is_constructible<T, Args...>{}, "should be constructible");
   uint32_t bucket = choose_bucket(int_key);
-  while (int_entries[bucket].next != EMPTY_POINTER &&
-         (int_entries[bucket].int_key != int_key || !int_entries[bucket].string_key.is_dummy_string())) {
+  while (entries[bucket].next != EMPTY_POINTER &&
+         (entries[bucket].int_key != int_key || !entries[bucket].string_key.is_dummy_string())) {
     if (unlikely(++bucket == buf_size)) {
       bucket = 0;
     }
   }
 
-  if (int_entries[bucket].next == EMPTY_POINTER) {
-    int_entries[bucket].int_key = int_key;
-    new(&int_entries[bucket].string_key) string{ArrayBucketDummyStrTag{}};
+  if (entries[bucket].next == EMPTY_POINTER) {
+    entries[bucket].int_key = int_key;
+    new(&entries[bucket].string_key) string{ArrayBucketDummyStrTag{}};
 
-    int_entries[bucket].prev = end()->prev;
-    get_entry(end()->prev)->next = get_pointer(&int_entries[bucket]);
+    entries[bucket].prev = end()->prev;
+    get_entry(end()->prev)->next = get_pointer(&entries[bucket]);
 
-    int_entries[bucket].next = get_pointer(end());
-    end()->prev = get_pointer(&int_entries[bucket]);
+    entries[bucket].next = get_pointer(end());
+    end()->prev = get_pointer(&entries[bucket]);
 
-    new(&int_entries[bucket].value) T(std::forward<Args>(args)...);
+    new(&entries[bucket].value) T(std::forward<Args>(args)...);
 
     size++;
 
@@ -371,10 +371,10 @@ T &array<T>::array_inner::emplace_int_key_map_value(overwrite_element policy, in
       max_key = int_key;
     }
   } else if (policy == overwrite_element::YES) {
-    int_entries[bucket].value = T(std::forward<Args>(args)...);
+    entries[bucket].value = T(std::forward<Args>(args)...);
   }
 
-  return int_entries[bucket].value;
+  return entries[bucket].value;
 }
 
 template<class T>
@@ -385,30 +385,30 @@ T &array<T>::array_inner::set_map_value(overwrite_element policy, int64_t int_ke
 template<class T>
 T array<T>::array_inner::unset_vector_value() {
   --size;
-  T res = std::move(reinterpret_cast<T *>(int_entries)[max_key--]);
+  T res = std::move(reinterpret_cast<T *>(entries)[max_key--]);
   return res;
 }
 
 template<class T>
 T array<T>::array_inner::unset_map_value(int64_t int_key) {
   uint32_t bucket = choose_bucket(int_key);
-  while (int_entries[bucket].next != EMPTY_POINTER &&
-         (int_entries[bucket].int_key != int_key || !int_entries[bucket].string_key.is_dummy_string())) {
+  while (entries[bucket].next != EMPTY_POINTER &&
+         (entries[bucket].int_key != int_key || !entries[bucket].string_key.is_dummy_string())) {
     if (unlikely (++bucket == buf_size)) {
       bucket = 0;
     }
   }
 
-  if (int_entries[bucket].next != EMPTY_POINTER) {
-    int_entries[bucket].int_key = 0;
+  if (entries[bucket].next != EMPTY_POINTER) {
+    entries[bucket].int_key = 0;
 
-    get_entry(int_entries[bucket].prev)->next = int_entries[bucket].next;
-    get_entry(int_entries[bucket].next)->prev = int_entries[bucket].prev;
+    get_entry(entries[bucket].prev)->next = entries[bucket].next;
+    get_entry(entries[bucket].next)->prev = entries[bucket].prev;
 
-    int_entries[bucket].next = EMPTY_POINTER;
-    int_entries[bucket].prev = EMPTY_POINTER;
+    entries[bucket].next = EMPTY_POINTER;
+    entries[bucket].prev = EMPTY_POINTER;
 
-    T res = std::move(int_entries[bucket].value);
+    T res = std::move(entries[bucket].value);
 
     size--;
 
@@ -417,15 +417,15 @@ T array<T>::array_inner::unset_map_value(int64_t int_key) {
     uint32_t j, rj, ri = bucket;
     for (j = bucket + 1; 1; j++) {
       rj = FIXD(j);
-      if (int_entries[rj].next == EMPTY_POINTER) {
+      if (entries[rj].next == EMPTY_POINTER) {
         break;
       }
 
-      uint32_t bucket_j = choose_bucket(int_entries[rj].int_key);
+      uint32_t bucket_j = choose_bucket(entries[rj].int_key);
       uint32_t wnt = FIXU(bucket_j, bucket);
 
       if (wnt > j || wnt <= bucket) {
-        list_hash_entry *ei = int_entries + ri, *ej = int_entries + rj;
+        list_hash_entry *ei = entries + ri, *ej = entries + rj;
         memcpy(ei, ej, sizeof(array_bucket));
         ej->next = EMPTY_POINTER;
 
@@ -447,14 +447,14 @@ template<class T>
 template<class S>
 auto &array<T>::array_inner::find_map_entry(S &self, int64_t int_key) noexcept {
   uint32_t bucket = self.choose_bucket(int_key);
-  while (self.int_entries[bucket].next != EMPTY_POINTER &&
-         (self.int_entries[bucket].int_key != int_key || !self.int_entries[bucket].string_key.is_dummy_string())) {
+  while (self.entries[bucket].next != EMPTY_POINTER &&
+         (self.entries[bucket].int_key != int_key || !self.entries[bucket].string_key.is_dummy_string())) {
     if (unlikely (++bucket == self.buf_size)) {
       bucket = 0;
     }
   }
 
-  return self.int_entries[bucket];
+  return self.entries[bucket];
 }
 
 template<class T>
@@ -469,7 +469,7 @@ auto &array<T>::array_inner::find_map_entry(S &self, const char *key, string::si
   static const auto str_not_eq = [](const string &lhs, const char *rhs, string::size_type rhs_size) {
     return lhs.size() != rhs_size || string::compare(lhs, rhs, rhs_size) != 0;
   };
-  auto *string_entries = self.int_entries;
+  auto *string_entries = self.entries;
   uint32_t bucket = self.choose_bucket(precomputed_hash);
   while (string_entries[bucket].next != EMPTY_POINTER &&
          (string_entries[bucket].int_key != precomputed_hash || string_entries[bucket].string_key.is_dummy_string() || str_not_eq(string_entries[bucket].string_key, key, key_size))) {
@@ -503,7 +503,7 @@ template<class STRING, class ...Args>
 std::pair<T &, bool> array<T>::array_inner::emplace_string_key_map_value(overwrite_element policy, int64_t int_key, STRING &&string_key, Args &&... args) noexcept {
   static_assert(std::is_same<std::decay_t<STRING>, string>::value, "string_key should be string");
 
-  array_bucket *string_entries = int_entries;
+  array_bucket *string_entries = entries;
   auto &fields = fields_for_map();
   uint32_t bucket = choose_bucket(fields, int_key);
   while (string_entries[bucket].next != EMPTY_POINTER &&
@@ -544,7 +544,7 @@ T &array<T>::array_inner::set_map_value(overwrite_element policy, int64_t int_ke
 
 template<class T>
 T array<T>::array_inner::unset_map_value(const string &string_key, int64_t precomputed_hash) {
-  array_bucket *string_entries = int_entries;
+  array_bucket *string_entries = entries;
   auto &fields = fields_for_map();
   uint32_t bucket = choose_bucket(fields, precomputed_hash);
   while (string_entries[bucket].next != EMPTY_POINTER &&
@@ -658,7 +658,7 @@ bool array<T>::mutate_to_size_if_vector_shared(int64_t int_size) {
     array_inner *new_array = array_inner::create(int_size, true);
 
     const auto size = static_cast<uint32_t>(p->size);
-    T *it = (T *)p->int_entries;
+    T *it = (T *)p->entries;
 
     for (uint32_t i = 0; i < size; i++) {
       new_array->push_back_vector_value(it[i]);
@@ -761,7 +761,7 @@ void array<T>::reserve(int64_t int_size, bool make_vector_if_possible) {
 
       if (is_vector()) {
         for (uint32_t it = 0; it != p->size; it++) {
-          new_array->set_map_value(overwrite_element::YES, it, ((T *)p->int_entries)[it]);
+          new_array->set_map_value(overwrite_element::YES, it, ((T *)p->entries)[it]);
         }
         php_assert (new_array->max_key == p->max_key);
       } else {
@@ -830,7 +830,7 @@ template<class T>
 void array<T>::convert_to_map() {
   array_inner *new_array = array_inner::create(p->size + 4, false);
 
-  T *elements = reinterpret_cast<T *>(p->int_entries);
+  T *elements = reinterpret_cast<T *>(p->entries);
   const bool move_values = p->ref_cnt == 0;
   if (move_values) {
     for (uint32_t it = 0; it != p->size; it++) {
@@ -860,7 +860,7 @@ void array<T>::copy_from(const array<T1> &other) {
 
   if (new_array->is_vector()) {
     uint32_t size = other.p->size;
-    T1 *it = reinterpret_cast<T1 *>(other.p->int_entries);
+    T1 *it = reinterpret_cast<T1 *>(other.p->entries);
     for (uint32_t i = 0; i < size; i++) {
       new_array->push_back_vector_value(convert_to<T>::convert(it[i]));
     }
@@ -897,7 +897,7 @@ void array<T>::move_from(array<T1> &&other) noexcept {
 
   if (new_array->is_vector()) {
     uint32_t size = other.p->size;
-    T1 *it = reinterpret_cast<T1 *>(other.p->int_entries);
+    T1 *it = reinterpret_cast<T1 *>(other.p->entries);
     for (uint32_t i = 0; i < size; i++) {
       new_array->emplace_back_vector_value(convert_to<T>::convert(std::move(it[i])));
     }
@@ -1101,7 +1101,7 @@ T &array<T>::operator[](double double_key) {
 template<class T>
 T &array<T>::operator[](const const_iterator &it) noexcept {
   if (it.self_->is_vector()) {
-    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->int_entries));
+    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->entries));
     return operator[](key);
   }
   auto *entry = reinterpret_cast<const array_bucket *>(it.entry_);
@@ -1265,7 +1265,7 @@ void array<T>::set_value(const Optional<OptionalT> &key, const T &value) noexcep
 template<class T>
 void array<T>::set_value(const const_iterator &it) noexcept {
   if (it.self_->is_vector()) {
-    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->int_entries));
+    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->entries));
     emplace_value(key, *reinterpret_cast<const T *>(it.entry_));
     return;
   }
@@ -1339,7 +1339,7 @@ const T *array<T>::find_value(double double_key) const noexcept {
 template<class T>
 const T *array<T>::find_value(const const_iterator &it) const noexcept {
   if (it.self_->is_vector()) {
-    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->int_entries));
+    const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->entries));
     return find_value(key);
   } else {
     auto *entry = reinterpret_cast<const array_bucket *>(it.entry_);
@@ -1559,7 +1559,7 @@ const array<T> array<T>::operator+(const array<T> &other) const {
 
   if (is_vector()) {
     uint32_t size = p->size;
-    T *it = (T *)p->int_entries;
+    T *it = (T *)p->entries;
 
     if (result.is_vector()) {
       for (uint32_t i = 0; i < size; i++) {
@@ -1582,7 +1582,7 @@ const array<T> array<T>::operator+(const array<T> &other) const {
 
   if (other.is_vector()) {
     uint32_t size = other.p->size;
-    T *it = (T *)other.p->int_entries;
+    T *it = (T *)other.p->entries;
 
     if (result.is_vector()) {
       for (uint32_t i = p->size; i < size; i++) {
@@ -1614,11 +1614,11 @@ array<T> &array<T>::operator+=(const array<T> &other) {
   if (is_vector()) {
     if (other.is_vector()) {
       uint32_t size = other.p->size;
-      T *it = (T *)other.p->int_entries;
+      T *it = (T *)other.p->entries;
 
       if (p->ref_cnt > 0) {
         uint32_t my_size = p->size;
-        T *my_it = (T *)p->int_entries;
+        T *my_it = (T *)p->entries;
 
         array_inner *new_array = array_inner::create(max(size, my_size), true);
 
@@ -1645,7 +1645,7 @@ array<T> &array<T>::operator+=(const array<T> &other) {
       return *this;
     } else {
       array_inner *new_array = array_inner::create(p->size + other.p->size + 4, false);
-      T *it = (T *)p->int_entries;
+      T *it = (T *)p->entries;
 
       for (uint32_t i = 0; i != p->size; i++) {
         new_array->set_map_value(overwrite_element::YES, i, it[i]);
@@ -1679,7 +1679,7 @@ array<T> &array<T>::operator+=(const array<T> &other) {
 
   if (other.is_vector()) {
     uint32_t size = other.p->size;
-    T *it = (T *)other.p->int_entries;
+    T *it = (T *)other.p->entries;
 
     for (uint32_t i = 0; i < size; i++) {
       p->set_map_value(overwrite_element::NO, i, it[i]);
@@ -1791,7 +1791,7 @@ void array<T>::swap_int_keys(int64_t idx1, int64_t idx2) noexcept {
   // this function is supposed to be used for vector optimization, else branch is just to be on the safe side
   if (is_vector() && idx1 >= 0 && idx2 >= 0 && idx1 < p->size && idx2 < p->size) {
     mutate_if_vector_shared();
-    std::swap(reinterpret_cast<T *>(p->int_entries)[idx1], reinterpret_cast<T *>(p->int_entries)[idx2]);
+    std::swap(reinterpret_cast<T *>(p->entries)[idx1], reinterpret_cast<T *>(p->entries)[idx2]);
   } else {
     if (auto *v1 = find_value(idx1)) {
       if (auto *v2 = find_value(idx2)) {
@@ -1807,7 +1807,7 @@ template<class T>
 void array<T>::fill_vector(int64_t num, const T &value) {
   php_assert(is_vector() && p->size == 0 && num <= p->buf_size);
 
-  std::uninitialized_fill((T *)p->int_entries, (T *)p->int_entries + num, value);
+  std::uninitialized_fill((T *)p->entries, (T *)p->entries + num, value);
   p->max_key = num - 1;
   p->size = static_cast<uint32_t>(num);
 }
@@ -1818,7 +1818,7 @@ void array<T>::memcpy_vector(int64_t num __attribute__((unused)), const void *sr
     php_assert(is_vector() && p->size == 0 && num <= p->buf_size);
     mutate_if_vector_shared();
 
-    memcpy(p->int_entries, src_buf, num * sizeof(T));
+    memcpy(p->entries, src_buf, num * sizeof(T));
     p->max_key = num - 1;
     p->size = static_cast<uint32_t>(num);
   } else {
@@ -1859,7 +1859,7 @@ void array<T>::sort(const T1 &compare, bool renumber) {
       [&compare](const T &lhs, const T &rhs) {
         return compare(lhs, rhs) > 0;
       };
-    T *begin = reinterpret_cast<T *>(p->int_entries);
+    T *begin = reinterpret_cast<T *>(p->entries);
     dl::sort<T, decltype(elements_cmp)>(begin, begin + n, elements_cmp);
     return;
   }
@@ -1919,7 +1919,7 @@ void array<T>::ksort(const T1 &compare) {
     keys.p->push_back_vector_value(it->get_key());
   }
 
-  key_type *keysp = (key_type *)keys.p->int_entries;
+  key_type *keysp = (key_type *)keys.p->entries;
   dl::sort<key_type, T1>(keysp, keysp + n, compare);
 
   list_hash_entry *prev = (list_hash_entry *)p->end();
@@ -1928,16 +1928,16 @@ void array<T>::ksort(const T1 &compare) {
     if (is_int_key(keysp[j])) {
       int64_t int_key = keysp[j].to_int();
       uint32_t bucket = p->choose_bucket(int_key);
-      while (p->int_entries[bucket].int_key != int_key || !p->int_entries[bucket].string_key.is_dummy_string()) {
+      while (p->entries[bucket].int_key != int_key || !p->entries[bucket].string_key.is_dummy_string()) {
         if (unlikely (++bucket == p->buf_size)) {
           bucket = 0;
         }
       }
-      cur = (list_hash_entry * ) & p->int_entries[bucket];
+      cur = (list_hash_entry * ) & p->entries[bucket];
     } else {
       string string_key = keysp[j].to_string();
       int64_t int_key = string_key.hash();
-      array_bucket *string_entries = p->int_entries;
+      array_bucket *string_entries = p->entries;
       uint32_t bucket = p->choose_bucket(int_key);
       while ((string_entries[bucket].int_key != int_key || string_entries[bucket].string_key.is_dummy_string() || string_entries[bucket].string_key != string_key)) {
         if (unlikely (++bucket == p->buf_size)) {
@@ -1998,7 +1998,7 @@ T array<T>::shift() {
   if (is_vector()) {
     mutate_if_vector_shared();
 
-    T *it = (T *)p->int_entries;
+    T *it = (T *)p->entries;
     T res = *it;
 
     it->~T();
@@ -2041,7 +2041,7 @@ int64_t array<T>::unshift(const T &val) {
   if (is_vector()) {
     mutate_if_vector_needs_space();
 
-    T *it = (T *)p->int_entries;
+    T *it = (T *)p->entries;
     memmove((void *)(it + 1), it, p->size++ * sizeof(T));
     p->max_key++;
     new(it) T(val);
@@ -2127,7 +2127,7 @@ void array<T>::force_destroy(ExtraRefCnt expected_ref_cnt) noexcept {
 template<class T>
 typename array<T>::iterator array<T>::begin_no_mutate() {
   if (is_vector()) {
-    return typename array<T>::iterator(p, p->int_entries);
+    return typename array<T>::iterator(p, p->entries);
   }
   return typename array<T>::iterator(p, p->begin());
 }

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -99,7 +99,7 @@ void sort(T *begin_init, T *end_init, const T1 &compare) {
 
 template<class T>
 typename array<T>::key_type array<T>::int_hash_entry::get_key() const {
-  return is_int ? key_type{int_key} : key_type{string_key};
+  return string_key.is_dummy_string() ? key_type{int_key} : key_type{string_key};
 }
 
 template<class T>
@@ -189,7 +189,7 @@ typename array<T>::int_hash_entry *array<T>::array_inner::end() {
 
 template<class T>
 bool array<T>::array_inner::is_string_hash_entry(const int_hash_entry *ptr) const {
-  return !ptr->is_int;
+  return !ptr->string_key.is_dummy_string();
 }
 
 template<class T>
@@ -353,7 +353,7 @@ T &array<T>::array_inner::emplace_int_key_map_value(overwrite_element policy, in
 
   if (int_entries[bucket].next == EMPTY_POINTER) {
     int_entries[bucket].int_key = int_key;
-    int_entries[bucket].is_int = true;
+    new(&int_entries[bucket].string_key) string{ArrayBucketDummyStrTag{}};
 
     int_entries[bucket].prev = end()->prev;
     get_entry(end()->prev)->next = get_pointer(&int_entries[bucket]);
@@ -510,7 +510,6 @@ std::pair<T &, bool> array<T>::array_inner::emplace_string_key_map_value(overwri
   bool inserted = false;
   if (string_entries[bucket].next == EMPTY_POINTER) {
     string_entries[bucket].int_key = int_key;
-    string_entries[bucket].is_int = false;
     new(&string_entries[bucket].string_key) string{std::forward<STRING>(string_key)};
 
     string_entries[bucket].prev = end()->prev;

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -751,11 +751,6 @@ void array<T>::mutate_to_map_if_vector_or_map_need_string() {
 }
 
 template<class T>
-void array<T>::reserve(int64_t int_size, int64_t string_size, bool make_vector_if_possible) {
-  reserve(int_size + string_size, make_vector_if_possible);
-}
-
-template<class T>
 void array<T>::reserve(int64_t int_size, bool make_vector_if_possible) {
   if (int_size > int64_t{p->buf_size}) {
     if (is_vector() && make_vector_if_possible) {

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -124,7 +124,7 @@ typename array<T>::array_inner *array<T>::array_inner::empty_array() {
 
 template<class T>
 uint32_t array<T>::array_inner::choose_bucket(int64_t key) const {
-  uint64_t modulo_helper = fields_for_map().modulo_helper_int_buf_size;
+  uint64_t modulo_helper = fields_for_map().modulo_helper_buf_size;
   return fastmod::fastmod_u32(static_cast<uint32_t>(key << 2), modulo_helper, buf_size);
 }
 
@@ -258,7 +258,7 @@ typename array<T>::array_inner *array<T>::array_inner::create(int64_t new_int_si
   p->end()->prev = p->get_pointer(p->end());
 
   p->buf_size = static_cast<uint32_t>(new_int_size);
-  p->fields_for_map().modulo_helper_int_buf_size = fastmod::computeM_u32(p->buf_size);
+  p->fields_for_map().modulo_helper_buf_size = fastmod::computeM_u32(p->buf_size);
 
   p->size = 0;
   return p;

--- a/runtime/array.inl
+++ b/runtime/array.inl
@@ -12,21 +12,21 @@
   #error "this file must be included only from kphp_core.h"
 #endif
 
-array_size::array_size(int64_t int_size, int64_t string_size, bool is_vector) :
+array_size::array_size(int64_t int_size, bool is_vector) :
   int_size(int_size),
-  string_size(string_size),
+  is_vector(is_vector) {}
+
+array_size::array_size(int64_t int_size, int64_t string_size, bool is_vector) :
+  int_size(int_size + string_size),
   is_vector(is_vector) {}
 
 array_size array_size::operator+(const array_size &other) const {
-  return array_size(int_size + other.int_size, string_size + other.string_size, is_vector && other.is_vector);
+  return {int_size + other.int_size, 0, is_vector && other.is_vector};
 }
 
 array_size &array_size::cut(int64_t length) {
   if (int_size > length) {
     int_size = length;
-  }
-  if (string_size > length) {
-    string_size = length;
   }
   return *this;
 }
@@ -34,10 +34,6 @@ array_size &array_size::cut(int64_t length) {
 array_size &array_size::min(const array_size &other) {
   if (int_size > other.int_size) {
     int_size = other.int_size;
-  }
-
-  if (string_size > other.string_size) {
-    string_size = other.string_size;
   }
 
   is_vector &= other.is_vector;
@@ -103,12 +99,7 @@ void sort(T *begin_init, T *end_init, const T1 &compare) {
 
 template<class T>
 typename array<T>::key_type array<T>::int_hash_entry::get_key() const {
-  return key_type(int_key);
-}
-
-template<class T>
-typename array<T>::key_type array<T>::string_hash_entry::get_key() const {
-  return key_type(string_key);
+  return is_int ? key_type{int_key} : key_type{string_key};
 }
 
 template<class T>
@@ -119,10 +110,9 @@ bool array<T>::is_int_key(const typename array<T>::key_type &key) {
 template<>
 inline typename array<Unknown>::array_inner *array<Unknown>::array_inner::empty_array() {
   static array_inner_control empty_array{
-    0, ExtraRefCnt::for_global_const, -1,
+    1, ExtraRefCnt::for_global_const, -1,
     {0, 0},
     0, 2,
-    0, std::numeric_limits<uint32_t>::max()
   };
   return static_cast<array<Unknown>::array_inner *>(&empty_array);
 }
@@ -133,23 +123,14 @@ typename array<T>::array_inner *array<T>::array_inner::empty_array() {
 }
 
 template<class T>
-uint32_t array<T>::array_inner::choose_bucket_int(int64_t key) const {
-  return choose_bucket(key, int_buf_size, fields_for_map().modulo_helper_int_buf_size);
-}
-
-template<class T>
-uint32_t array<T>::array_inner::choose_bucket_string(int64_t key) const {
-  return choose_bucket(key, string_buf_size, fields_for_map().modulo_helper_string_buf_size);
-}
-
-template<class T>
-uint32_t array<T>::array_inner::choose_bucket(int64_t key, uint32_t buf_size, uint64_t modulo_helper) {
-  return fastmod::fastmod_u32(static_cast<uint32_t>(key << 2), modulo_helper, buf_size);
+uint32_t array<T>::array_inner::choose_bucket(int64_t key) const {
+  uint64_t modulo_helper = fields_for_map().modulo_helper_int_buf_size;
+  return fastmod::fastmod_u32(static_cast<uint32_t>(key << 2), modulo_helper, int_buf_size);
 }
 
 template<class T>
 bool array<T>::array_inner::is_vector() const {
-  return string_buf_size == std::numeric_limits<uint32_t>::max();
+  return is_vector_internal;
 }
 
 
@@ -167,58 +148,48 @@ typename array<T>::entry_pointer_type array<T>::array_inner::get_pointer(list_ha
 
 
 template<class T>
-const typename array<T>::string_hash_entry *array<T>::array_inner::begin() const {
-  return (const string_hash_entry *)get_entry(last.next);
+const typename array<T>::int_hash_entry *array<T>::array_inner::begin() const {
+  return (const int_hash_entry *)get_entry(last.next);
 }
 
 template<class T>
-const typename array<T>::string_hash_entry *array<T>::array_inner::next(const string_hash_entry *p) const {
-  return (const string_hash_entry *)get_entry(p->next);
+const typename array<T>::int_hash_entry *array<T>::array_inner::next(const int_hash_entry *ptr) const {
+  return (const int_hash_entry *)get_entry(ptr->next);
 }
 
 template<class T>
-const typename array<T>::string_hash_entry *array<T>::array_inner::prev(const string_hash_entry *p) const {
-  return (const string_hash_entry *)get_entry(p->prev);
+const typename array<T>::int_hash_entry *array<T>::array_inner::prev(const int_hash_entry *ptr) const {
+  return (const int_hash_entry *)get_entry(ptr->prev);
 }
 
 template<class T>
-const typename array<T>::string_hash_entry *array<T>::array_inner::end() const {
+const typename array<T>::int_hash_entry *array<T>::array_inner::end() const {
   return const_cast<array<T>::array_inner *>(this)->end();
 }
 
 template<class T>
-typename array<T>::string_hash_entry *array<T>::array_inner::begin() {
-  return (string_hash_entry *)get_entry(end()->next);
+typename array<T>::int_hash_entry *array<T>::array_inner::begin() {
+  return (int_hash_entry *)get_entry(end()->next);
 }
 
 template<class T>
-typename array<T>::string_hash_entry *array<T>::array_inner::next(string_hash_entry *p) {
-  return (string_hash_entry *)get_entry(p->next);
+typename array<T>::int_hash_entry *array<T>::array_inner::next(int_hash_entry *ptr) {
+  return (int_hash_entry *)get_entry(ptr->next);
 }
 
 template<class T>
-typename array<T>::string_hash_entry *array<T>::array_inner::prev(string_hash_entry *p) {
-  return (string_hash_entry *)get_entry(p->prev);
+typename array<T>::int_hash_entry *array<T>::array_inner::prev(int_hash_entry *ptr) {
+  return (int_hash_entry *)get_entry(ptr->prev);
 }
 
 template<class T>
-typename array<T>::string_hash_entry *array<T>::array_inner::end() {
-  return (string_hash_entry * ) &last;
+typename array<T>::int_hash_entry *array<T>::array_inner::end() {
+  return (int_hash_entry * ) &last;
 }
 
 template<class T>
-bool array<T>::array_inner::is_string_hash_entry(const string_hash_entry *p) const {
-  return p >= get_string_entries();
-}
-
-template<class T>
-const typename array<T>::string_hash_entry *array<T>::array_inner::get_string_entries() const {
-  return (const string_hash_entry *)(int_entries + int_buf_size);
-}
-
-template<class T>
-typename array<T>::string_hash_entry *array<T>::array_inner::get_string_entries() {
-  return (string_hash_entry * )(int_entries + int_buf_size);
+bool array<T>::array_inner::is_string_hash_entry(const int_hash_entry *ptr) const {
+  return !ptr->is_int;
 }
 
 template<class T>
@@ -237,21 +208,19 @@ size_t array<T>::array_inner::sizeof_vector(uint32_t int_size) {
 }
 
 template<class T>
-size_t array<T>::array_inner::sizeof_map(uint32_t int_size, uint32_t string_size) {
-  return sizeof(array_inner_fields_for_map) + sizeof(array_inner) + int_size * sizeof(int_hash_entry) + string_size * sizeof(string_hash_entry);
+size_t array<T>::array_inner::sizeof_map(uint32_t int_size) {
+  return sizeof(array_inner_fields_for_map) + sizeof(array_inner) + int_size * sizeof(int_hash_entry);
 }
 
 template<class T>
-size_t array<T>::array_inner::estimate_size(int64_t &new_int_size, int64_t &new_string_size, bool is_vector) {
+size_t array<T>::array_inner::estimate_size(int64_t &new_int_size, bool is_vector) {
   new_int_size = std::max(new_int_size, int64_t{0});
-  new_string_size = std::max(new_string_size, int64_t{0});
 
-  if (new_int_size + new_string_size > MAX_HASHTABLE_SIZE) {
-    php_critical_error ("max array size exceeded: int_size = %" PRIi64 ", string_size = %" PRIi64, new_int_size, new_string_size);
+  if (new_int_size > MAX_HASHTABLE_SIZE) {
+    php_critical_error ("max array size exceeded: int_size = %" PRIi64, new_int_size);
   }
 
   if (is_vector) {
-    php_assert (new_string_size == 0);
     new_int_size += 2;
     return sizeof_vector(static_cast<uint32_t>(new_int_size));
   }
@@ -261,25 +230,19 @@ size_t array<T>::array_inner::estimate_size(int64_t &new_int_size, int64_t &new_
     new_int_size += 2;
   }
 
-  new_string_size = 2 * new_string_size + 3;
-  if (new_string_size % 5 == 0) {
-    new_string_size += 2;
-  }
-
-  return sizeof_map(static_cast<uint32_t>(new_int_size), static_cast<uint32_t>(new_string_size));
+  return sizeof_map(static_cast<uint32_t>(new_int_size));
 }
 
 template<class T>
-typename array<T>::array_inner *array<T>::array_inner::create(int64_t new_int_size, int64_t new_string_size, bool is_vector) {
-  const size_t mem_size = estimate_size(new_int_size, new_string_size, is_vector);
+typename array<T>::array_inner *array<T>::array_inner::create(int64_t new_int_size, bool is_vector) {
+  const size_t mem_size = estimate_size(new_int_size, is_vector);
   if (is_vector) {
     auto p = reinterpret_cast<array_inner *>(dl::allocate(mem_size));
+    p->is_vector_internal = true;
     p->ref_cnt = 0;
     p->max_key = -1;
     p->int_size = 0;
     p->int_buf_size = static_cast<uint32_t>(new_int_size);
-    p->string_size = 0;
-    p->string_buf_size = std::numeric_limits<uint32_t>::max();
     return p;
   }
 
@@ -288,6 +251,7 @@ typename array<T>::array_inner *array<T>::array_inner::create(int64_t new_int_si
   };
 
   array_inner *p = shift_pointer_to_array_inner(dl::allocate0(mem_size));
+  p->is_vector_internal = false;
   p->ref_cnt = 0;
   p->max_key = -1;
   p->end()->next = p->get_pointer(p->end());
@@ -296,11 +260,7 @@ typename array<T>::array_inner *array<T>::array_inner::create(int64_t new_int_si
   p->int_buf_size = static_cast<uint32_t>(new_int_size);
   p->fields_for_map().modulo_helper_int_buf_size = fastmod::computeM_u32(p->int_buf_size);
 
-  p->string_buf_size = static_cast<uint32_t>(new_string_size);
-  p->fields_for_map().modulo_helper_string_buf_size = fastmod::computeM_u32(p->string_buf_size);
-
   p->int_size = 0;
-  p->string_size = 0;
   return p;
 }
 
@@ -318,7 +278,7 @@ void array<T>::array_inner::dispose() {
         return;
       }
 
-      for (const string_hash_entry *it = begin(); it != end(); it = next(it)) {
+      for (const int_hash_entry *it = begin(); it != end(); it = next(it)) {
         it->value.~T();
         if (is_string_hash_entry(it)) {
           it->string_key.~string();
@@ -327,7 +287,7 @@ void array<T>::array_inner::dispose() {
 
       php_assert(this != empty_array());
       auto shifted_this = reinterpret_cast<char *>(this) - sizeof(array_inner_fields_for_map);
-      dl::deallocate(shifted_this, sizeof_map(int_buf_size, string_buf_size));
+      dl::deallocate(shifted_this, sizeof_map(int_buf_size));
     }
   }
 }
@@ -384,7 +344,7 @@ template<class T>
 template<class ...Args>
 T &array<T>::array_inner::emplace_int_key_map_value(overwrite_element policy, int64_t int_key, Args &&... args) noexcept {
   static_assert(std::is_constructible<T, Args...>{}, "should be constructible");
-  uint32_t bucket = choose_bucket_int(int_key);
+  uint32_t bucket = choose_bucket(int_key);
   while (int_entries[bucket].next != EMPTY_POINTER && int_entries[bucket].int_key != int_key) {
     if (unlikely (++bucket == int_buf_size)) {
       bucket = 0;
@@ -393,6 +353,7 @@ T &array<T>::array_inner::emplace_int_key_map_value(overwrite_element policy, in
 
   if (int_entries[bucket].next == EMPTY_POINTER) {
     int_entries[bucket].int_key = int_key;
+    int_entries[bucket].is_int = true;
 
     int_entries[bucket].prev = end()->prev;
     get_entry(end()->prev)->next = get_pointer(&int_entries[bucket]);
@@ -428,7 +389,7 @@ T array<T>::array_inner::unset_vector_value() {
 
 template<class T>
 T array<T>::array_inner::unset_map_value(int64_t int_key) {
-  uint32_t bucket = choose_bucket_int(int_key);
+  uint32_t bucket = choose_bucket(int_key);
   while (int_entries[bucket].next != EMPTY_POINTER && int_entries[bucket].int_key != int_key) {
     if (unlikely (++bucket == int_buf_size)) {
       bucket = 0;
@@ -457,7 +418,7 @@ T array<T>::array_inner::unset_map_value(int64_t int_key) {
         break;
       }
 
-      uint32_t bucket_j = choose_bucket_int(int_entries[rj].int_key);
+      uint32_t bucket_j = choose_bucket(int_entries[rj].int_key);
       uint32_t wnt = FIXU(bucket_j, bucket);
 
       if (wnt > j || wnt <= bucket) {
@@ -482,7 +443,7 @@ T array<T>::array_inner::unset_map_value(int64_t int_key) {
 template<class T>
 template<class S>
 auto &array<T>::array_inner::find_map_entry(S &self, int64_t int_key) noexcept {
-  uint32_t bucket = self.choose_bucket_int(int_key);
+  uint32_t bucket = self.choose_bucket(int_key);
   while (self.int_entries[bucket].next != EMPTY_POINTER && self.int_entries[bucket].int_key != int_key) {
     if (unlikely (++bucket == self.int_buf_size)) {
       bucket = 0;
@@ -504,11 +465,11 @@ auto &array<T>::array_inner::find_map_entry(S &self, const char *key, string::si
   static const auto str_not_eq = [](const string &lhs, const char *rhs, string::size_type rhs_size) {
     return lhs.size() != rhs_size || string::compare(lhs, rhs, rhs_size) != 0;
   };
-  auto *string_entries = self.get_string_entries();
-  uint32_t bucket = self.choose_bucket_string(precomputed_hash);
+  auto *string_entries = self.int_entries;
+  uint32_t bucket = self.choose_bucket(precomputed_hash);
   while (string_entries[bucket].next != EMPTY_POINTER &&
          (string_entries[bucket].int_key != precomputed_hash || str_not_eq(string_entries[bucket].string_key, key, key_size))) {
-    if (unlikely (++bucket == self.string_buf_size)) {
+    if (unlikely (++bucket == self.int_buf_size)) {
       bucket = 0;
     }
   }
@@ -538,10 +499,10 @@ template<class STRING, class ...Args>
 std::pair<T &, bool> array<T>::array_inner::emplace_string_key_map_value(overwrite_element policy, int64_t int_key, STRING &&string_key, Args &&... args) noexcept {
   static_assert(std::is_same<std::decay_t<STRING>, string>::value, "string_key should be string");
 
-  string_hash_entry *string_entries = get_string_entries();
-  uint32_t bucket = choose_bucket_string(int_key);
+  int_hash_entry *string_entries = int_entries;
+  uint32_t bucket = choose_bucket(int_key);
   while (string_entries[bucket].next != EMPTY_POINTER && (string_entries[bucket].int_key != int_key || string_entries[bucket].string_key != string_key)) {
-    if (unlikely (++bucket == string_buf_size)) {
+    if (unlikely (++bucket == int_buf_size)) {
       bucket = 0;
     }
   }
@@ -549,6 +510,7 @@ std::pair<T &, bool> array<T>::array_inner::emplace_string_key_map_value(overwri
   bool inserted = false;
   if (string_entries[bucket].next == EMPTY_POINTER) {
     string_entries[bucket].int_key = int_key;
+    string_entries[bucket].is_int = false;
     new(&string_entries[bucket].string_key) string{std::forward<STRING>(string_key)};
 
     string_entries[bucket].prev = end()->prev;
@@ -559,7 +521,7 @@ std::pair<T &, bool> array<T>::array_inner::emplace_string_key_map_value(overwri
 
     new(&string_entries[bucket].value) T(std::forward<Args>(args)...);
 
-    string_size++;
+    int_size++;
     inserted = true;
   } else if (policy == overwrite_element::YES) {
     string_entries[bucket].value = T(std::forward<Args>(args)...);
@@ -576,10 +538,10 @@ T &array<T>::array_inner::set_map_value(overwrite_element policy, int64_t int_ke
 
 template<class T>
 T array<T>::array_inner::unset_map_value(const string &string_key, int64_t precomputed_hash) {
-  string_hash_entry *string_entries = get_string_entries();
-  uint32_t bucket = choose_bucket_string(precomputed_hash);
+  int_hash_entry *string_entries = int_entries;
+  uint32_t bucket = choose_bucket(precomputed_hash);
   while (string_entries[bucket].next != EMPTY_POINTER && (string_entries[bucket].int_key != precomputed_hash || string_entries[bucket].string_key != string_key)) {
-    if (unlikely (++bucket == string_buf_size)) {
+    if (unlikely (++bucket == int_buf_size)) {
       bucket = 0;
     }
   }
@@ -596,10 +558,10 @@ T array<T>::array_inner::unset_map_value(const string &string_key, int64_t preco
 
     T res = std::move(string_entries[bucket].value);
 
-    string_size--;
+    int_size--;
 
-#define FIXD(a) ((a) >= string_buf_size ? (a) - string_buf_size : (a))
-#define FIXU(a, m) ((a) <= (m) ? (a) + string_buf_size : (a))
+#define FIXD(a) ((a) >= int_buf_size ? (a) - int_buf_size : (a))
+#define FIXU(a, m) ((a) <= (m) ? (a) + int_buf_size : (a))
     uint32_t j, rj, ri = bucket;
     for (j = bucket + 1; 1; j++) {
       rj = FIXD(j);
@@ -607,12 +569,12 @@ T array<T>::array_inner::unset_map_value(const string &string_key, int64_t preco
         break;
       }
 
-      uint32_t bucket_j = choose_bucket_string(string_entries[rj].int_key);
+      uint32_t bucket_j = choose_bucket(string_entries[rj].int_key);
       uint32_t wnt = FIXU(bucket_j, bucket);
 
       if (wnt > j || wnt <= bucket) {
         list_hash_entry *ei = string_entries + ri, *ej = string_entries + rj;
-        memcpy(ei, ej, sizeof(string_hash_entry));
+        memcpy(ei, ej, sizeof(int_hash_entry));
         ej->next = EMPTY_POINTER;
 
         get_entry(ei->prev)->next = get_pointer(ei);
@@ -637,13 +599,11 @@ bool array<T>::array_inner::is_vector_internal_or_last_index(int64_t key) const 
 template<class T>
 size_t array<T>::array_inner::estimate_memory_usage() const {
   int64_t int_elements = int_size;
-  int64_t string_elements = 0;
   const bool vector_structure = is_vector();
   if (vector_structure) {
-    return estimate_size(int_elements, string_elements, vector_structure);
+    return estimate_size(int_elements, vector_structure);
   }
-  string_elements = string_size;
-  return estimate_size(++int_elements, ++string_elements, vector_structure);
+  return estimate_size(++int_elements, vector_structure);
 }
 
 template<class T>
@@ -653,11 +613,11 @@ bool array<T>::is_vector() const {
 
 template<class T>
 bool array<T>::is_pseudo_vector() const {
-  if (p->string_size) {
-    return false;
-  }
   int64_t n = 0;
   for (auto element : *this) {
+    if (element.is_string_key()) {
+      return false;
+    }
     if (element.get_key().as_int() != n++) {
       return false;
     }
@@ -673,7 +633,7 @@ bool array<T>::mutate_if_vector_shared(uint32_t mul) {
 template<class T>
 bool array<T>::mutate_to_size_if_vector_shared(int64_t int_size) {
   if (p->ref_cnt > 0) {
-    array_inner *new_array = array_inner::create(int_size, 0, true);
+    array_inner *new_array = array_inner::create(int_size, true);
 
     const auto size = static_cast<uint32_t>(p->int_size);
     T *it = (T *)p->int_entries;
@@ -692,9 +652,9 @@ bool array<T>::mutate_to_size_if_vector_shared(int64_t int_size) {
 template<class T>
 bool array<T>::mutate_if_map_shared(uint32_t mul) {
   if (p->ref_cnt > 0) {
-    array_inner *new_array = array_inner::create(p->int_size * mul + 1, p->string_size * mul + 1, false);
+    array_inner *new_array = array_inner::create(p->int_size * mul + 1, false);
 
-    for (const string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+    for (const int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
       if (p->is_string_hash_entry(it)) {
         new_array->set_map_value(overwrite_element::YES, it->int_key, it->string_key, it->value);
       } else {
@@ -741,38 +701,10 @@ void array<T>::mutate_if_map_needed_int() {
 
   // not shared (ref_cnt == 0)
   if (p->int_size * 5 > 3 * p->int_buf_size) {
-    int64_t new_int_size = max(int64_t{p->int_size * 2 + 1}, int64_t{p->string_size});
-    int64_t new_string_size = max(int64_t{p->string_size}, int64_t{p->string_buf_size >> 1} - 1);
-    array_inner *new_array = array_inner::create(new_int_size, new_string_size, false);
+    int64_t new_int_size = p->int_size * 2 + 1;
+    array_inner *new_array = array_inner::create(new_int_size, false);
 
-    for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
-      if (p->is_string_hash_entry(it)) {
-        new_array->emplace_string_key_map_value(overwrite_element::YES,
-                                                it->int_key, std::move(it->string_key), std::move(it->value));
-      } else {
-        new_array->emplace_int_key_map_value(overwrite_element::YES,
-                                             it->int_key, std::move(it->value));
-      }
-    }
-
-    p->dispose();
-    p = new_array;
-  }
-}
-
-template<class T>
-void array<T>::mutate_if_map_needed_string() {
-  if (mutate_if_map_shared(2)) {
-    return;
-  }
-
-  // not shared (ref_cnt == 0)
-  if (p->string_size * 5 > 3 * p->string_buf_size) {
-    int64_t new_int_size = max(int64_t{p->int_size}, int64_t{p->int_buf_size >> 1} - 1);
-    int64_t new_string_size = max(int64_t{p->string_size * 2 + 1}, int64_t{p->int_size});
-    array_inner *new_array = array_inner::create(new_int_size, new_string_size, false);
-
-    for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+    for (int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
       if (p->is_string_hash_entry(it)) {
         new_array->emplace_string_key_map_value(overwrite_element::YES,
                                                 it->int_key, std::move(it->string_key), std::move(it->value));
@@ -792,19 +724,23 @@ void array<T>::mutate_to_map_if_vector_or_map_need_string() {
   if (is_vector()) {
     convert_to_map();
   } else {
-    mutate_if_map_needed_string();
+    mutate_if_map_needed_int();
   }
 }
 
 template<class T>
 void array<T>::reserve(int64_t int_size, int64_t string_size, bool make_vector_if_possible) {
-  if (int_size > int64_t{p->int_buf_size} || (string_size > 0 && string_size > int64_t{p->string_buf_size})) {
-    if (is_vector() && string_size == 0 && make_vector_if_possible) {
+  reserve(int_size + string_size, make_vector_if_possible);
+}
+
+template<class T>
+void array<T>::reserve(int64_t int_size, bool make_vector_if_possible) {
+  if (int_size > int64_t{p->int_buf_size}) {
+    if (is_vector() && make_vector_if_possible) {
       mutate_to_size(int_size);
     } else {
       const int64_t new_int_size = std::max(int_size, int64_t{p->int_buf_size});
-      const int64_t new_string_size = std::max(string_size, is_vector() ? 0L : int64_t{p->string_buf_size});
-      array_inner *new_array = array_inner::create(new_int_size, new_string_size, false);
+      array_inner *new_array = array_inner::create(new_int_size, false);
 
       if (is_vector()) {
         for (uint32_t it = 0; it != p->int_size; it++) {
@@ -812,7 +748,7 @@ void array<T>::reserve(int64_t int_size, int64_t string_size, bool make_vector_i
         }
         php_assert (new_array->max_key == p->max_key);
       } else {
-        for (const string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+        for (const int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
           if (p->is_string_hash_entry(it)) {
             new_array->set_map_value(overwrite_element::YES, it->int_key, it->string_key, it->value);
           } else {
@@ -875,7 +811,7 @@ typename array<T>::iterator array<T>::end() {
 
 template<class T>
 void array<T>::convert_to_map() {
-  array_inner *new_array = array_inner::create(p->int_size + 4, p->int_size + 4, false);
+  array_inner *new_array = array_inner::create(p->int_size + 4, false);
 
   T *elements = reinterpret_cast<T *>(p->int_entries);
   const bool move_values = p->ref_cnt == 0;
@@ -903,7 +839,7 @@ void array<T>::copy_from(const array<T1> &other) {
     return;
   }
 
-  array_inner *new_array = array_inner::create(other.p->int_size, other.p->string_size, other.is_vector());
+  array_inner *new_array = array_inner::create(other.p->int_size, other.is_vector());
 
   if (new_array->is_vector()) {
     uint32_t size = other.p->int_size;
@@ -912,7 +848,7 @@ void array<T>::copy_from(const array<T1> &other) {
       new_array->push_back_vector_value(convert_to<T>::convert(it[i]));
     }
   } else {
-    for (const typename array<T1>::string_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
+    for (const typename array<T1>::int_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
       if (other.p->is_string_hash_entry(it)) {
         new_array->set_map_value(overwrite_element::YES, it->int_key, it->string_key, convert_to<T>::convert(it->value));
       } else {
@@ -924,7 +860,6 @@ void array<T>::copy_from(const array<T1> &other) {
   p = new_array;
 
   php_assert (new_array->int_size == other.p->int_size);
-  php_assert (new_array->string_size == other.p->string_size);
 }
 
 template<class T>
@@ -941,7 +876,7 @@ void array<T>::move_from(array<T1> &&other) noexcept {
     return;
   }
 
-  array_inner *new_array = array_inner::create(other.p->int_size, other.p->string_size, other.is_vector());
+  array_inner *new_array = array_inner::create(other.p->int_size, other.is_vector());
 
   if (new_array->is_vector()) {
     uint32_t size = other.p->int_size;
@@ -963,7 +898,6 @@ void array<T>::move_from(array<T1> &&other) noexcept {
 
   p = new_array;
   php_assert (new_array->int_size == other.p->int_size);
-  php_assert (new_array->string_size == other.p->string_size);
 
   other = array<T1>{};
 }
@@ -984,7 +918,7 @@ array<T>::array():
 
 template<class T>
 array<T>::array(const array_size &s) :
-  p(array_inner::create(s.int_size, s.string_size, s.is_vector)) {
+  p(array_inner::create(s.int_size, s.is_vector)) {
 }
 
 template<class T>
@@ -1153,7 +1087,7 @@ T &array<T>::operator[](const const_iterator &it) noexcept {
     const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->int_entries));
     return operator[](key);
   }
-  auto *entry = reinterpret_cast<const string_hash_entry *>(it.entry_);
+  auto *entry = reinterpret_cast<const int_hash_entry *>(it.entry_);
   if (it.self_->is_string_hash_entry(entry)) {
     mutate_to_map_if_vector_or_map_need_string();
     return p->emplace_string_key_map_value(overwrite_element::NO, entry->int_key, entry->string_key).first;
@@ -1318,7 +1252,7 @@ void array<T>::set_value(const const_iterator &it) noexcept {
     emplace_value(key, *reinterpret_cast<const T *>(it.entry_));
     return;
   }
-  auto *entry = reinterpret_cast<const string_hash_entry *>(it.entry_);
+  auto *entry = reinterpret_cast<const int_hash_entry *>(it.entry_);
   if (it.self_->is_string_hash_entry(entry)) {
     mutate_to_map_if_vector_or_map_need_string();
     p->emplace_string_key_map_value(overwrite_element::YES, entry->int_key, entry->string_key, entry->value);
@@ -1391,7 +1325,7 @@ const T *array<T>::find_value(const const_iterator &it) const noexcept {
     const auto key = static_cast<int64_t>(reinterpret_cast<const T *>(it.entry_) - reinterpret_cast<const T *>(it.self_->int_entries));
     return find_value(key);
   } else {
-    auto *entry = reinterpret_cast<const string_hash_entry *>(it.entry_);
+    auto *entry = reinterpret_cast<const int_hash_entry *>(it.entry_);
     return it.self_->is_string_hash_entry(entry)
            ? find_value(entry->string_key, entry->int_key)
            : find_value(entry->int_key);
@@ -1566,12 +1500,12 @@ bool array<T>::empty() const {
 
 template<class T>
 int64_t array<T>::count() const {
-  return p->int_size + p->string_size;
+  return p->int_size;
 }
 
 template<class T>
 array_size array<T>::size() const {
-  return array_size(p->int_size, p->string_size, is_vector());
+  return {p->int_size, is_vector()};
 }
 
 template<class T>
@@ -1620,7 +1554,7 @@ const array<T> array<T>::operator+(const array<T> &other) const {
       }
     }
   } else {
-    for (const string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+    for (const int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
       if (p->is_string_hash_entry(it)) {
         result.p->set_map_value(overwrite_element::YES, it->int_key, it->string_key, it->value);
       } else {
@@ -1643,7 +1577,7 @@ const array<T> array<T>::operator+(const array<T> &other) const {
       }
     }
   } else {
-    for (const string_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
+    for (const int_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
       if (other.p->is_string_hash_entry(it)) {
         result.p->set_map_value(overwrite_element::NO, it->int_key, it->string_key, it->value);
       } else {
@@ -1669,7 +1603,7 @@ array<T> &array<T>::operator+=(const array<T> &other) {
         uint32_t my_size = p->int_size;
         T *my_it = (T *)p->int_entries;
 
-        array_inner *new_array = array_inner::create(max(size, my_size), 0, true);
+        array_inner *new_array = array_inner::create(max(size, my_size), true);
 
         for (uint32_t i = 0; i < my_size; i++) {
           new_array->push_back_vector_value(my_it[i]);
@@ -1693,7 +1627,7 @@ array<T> &array<T>::operator+=(const array<T> &other) {
 
       return *this;
     } else {
-      array_inner *new_array = array_inner::create(p->int_size + other.p->int_size + 4, other.p->string_size + 4, false);
+      array_inner *new_array = array_inner::create(p->int_size + other.p->int_size + 4, false);
       T *it = (T *)p->int_entries;
 
       for (uint32_t i = 0; i != p->int_size; i++) {
@@ -1709,12 +1643,11 @@ array<T> &array<T>::operator+=(const array<T> &other) {
     }
 
     uint32_t new_int_size = p->int_size + other.p->int_size;
-    uint32_t new_string_size = p->string_size + other.p->string_size;
 
-    if (new_int_size * 5 > 3 * p->int_buf_size || new_string_size * 5 > 3 * p->string_buf_size || p->ref_cnt > 0) {
-      array_inner *new_array = array_inner::create(max(new_int_size, 2 * p->int_size) + 1, max(new_string_size, 2 * p->string_size) + 1, false);
+    if (new_int_size * 5 > 3 * p->int_buf_size || p->ref_cnt > 0) {
+      array_inner *new_array = array_inner::create(max(new_int_size, 2 * p->int_size) + 1, false);
 
-      for (const string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+      for (const int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
         if (p->is_string_hash_entry(it)) {
           new_array->set_map_value(overwrite_element::YES, it->int_key, it->string_key, it->value);
         } else {
@@ -1735,7 +1668,7 @@ array<T> &array<T>::operator+=(const array<T> &other) {
       p->set_map_value(overwrite_element::NO, i, it[i]);
     }
   } else {
-    for (string_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
+    for (int_hash_entry *it = other.p->begin(); it != other.p->end(); it = other.p->next(it)) {
       if (other.p->is_string_hash_entry(it)) {
         p->set_map_value(overwrite_element::NO, it->int_key, it->string_key, it->value);
       } else {
@@ -1787,7 +1720,7 @@ void array<T>::push_back_iterator(const array_iterator<T1> &it) noexcept {
   if (it.self_->is_vector()) {
     emplace_back(*reinterpret_cast<const T1 *>(it.entry_));
   } else {
-    auto *entry = reinterpret_cast<typename array_iterator<T1>::string_hash_type *>(it.entry_);
+    auto *entry = reinterpret_cast<typename array_iterator<T1>::int_hash_type *>(it.entry_);
     if (it.self_->is_string_hash_entry(entry)) {
       mutate_to_map_if_vector_or_map_need_string();
 
@@ -1894,8 +1827,8 @@ void array<T>::sort(const T1 &compare, bool renumber) {
     }
 
     if (!is_vector()) {
-      array_inner *res = array_inner::create(n, 0, true);
-      for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+      array_inner *res = array_inner::create(n, true);
+      for (int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
         res->push_back_vector_value(it->value);
       }
 
@@ -1926,7 +1859,7 @@ void array<T>::sort(const T1 &compare, bool renumber) {
 
   int_hash_entry **arTmp = (int_hash_entry **)dl::allocate(n * sizeof(int_hash_entry * ));
   uint32_t i = 0;
-  for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
+  for (int_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
     arTmp[i++] = (int_hash_entry *)it;
   }
   php_assert (i == n);
@@ -1965,12 +1898,8 @@ void array<T>::ksort(const T1 &compare) {
   }
 
   array<key_type> keys(array_size(n, 0, true));
-  for (string_hash_entry *it = p->begin(); it != p->end(); it = p->next(it)) {
-    if (p->is_string_hash_entry(it)) {
-      keys.p->push_back_vector_value(it->get_key());
-    } else {
-      keys.p->push_back_vector_value(((int_hash_entry *)it)->get_key());
-    }
+  for (auto *it = p->begin(); it != p->end(); it = p->next(it)) {
+    keys.p->push_back_vector_value(it->get_key());
   }
 
   key_type *keysp = (key_type *)keys.p->int_entries;
@@ -1981,7 +1910,7 @@ void array<T>::ksort(const T1 &compare) {
     list_hash_entry *cur;
     if (is_int_key(keysp[j])) {
       int64_t int_key = keysp[j].to_int();
-      uint32_t bucket = p->choose_bucket_int(int_key);
+      uint32_t bucket = p->choose_bucket(int_key);
       while (p->int_entries[bucket].int_key != int_key) {
         if (unlikely (++bucket == p->int_buf_size)) {
           bucket = 0;
@@ -1991,10 +1920,10 @@ void array<T>::ksort(const T1 &compare) {
     } else {
       string string_key = keysp[j].to_string();
       int64_t int_key = string_key.hash();
-      string_hash_entry *string_entries = p->get_string_entries();
-      uint32_t bucket = p->choose_bucket_string(int_key);
+      int_hash_entry *string_entries = p->int_entries;
+      uint32_t bucket = p->choose_bucket(int_key);
       while ((string_entries[bucket].int_key != int_key || string_entries[bucket].string_key != string_key)) {
-        if (unlikely (++bucket == p->string_buf_size)) {
+        if (unlikely (++bucket == p->int_buf_size)) {
           bucket = 0;
         }
       }
@@ -2030,7 +1959,7 @@ T array<T>::pop() {
   }
 
   mutate_if_map_shared();
-  string_hash_entry *it = p->prev(p->end());
+  int_hash_entry *it = p->prev(p->end());
 
   return p->is_string_hash_entry(it) ?
     p->unset_map_value(it->string_key, it->int_key) :
@@ -2062,10 +1991,10 @@ T array<T>::shift() {
     return res;
   } else {
     array_size new_size = size().cut(count() - 1);
-    bool is_v = (new_size.string_size == 0);
+    bool is_v = new_size.is_vector;
 
-    array_inner *new_array = array_inner::create(new_size.int_size, new_size.string_size, is_v);
-    string_hash_entry *it = p->begin();
+    array_inner *new_array = array_inner::create(new_size.int_size, is_v);
+    int_hash_entry *it = p->begin();
     T res = it->value;
 
     it = p->next(it);
@@ -2101,10 +2030,10 @@ int64_t array<T>::unshift(const T &val) {
     new(it) T(val);
   } else {
     array_size new_size = size();
-    bool is_v = (new_size.string_size == 0);
+    bool is_v = new_size.is_vector;
 
-    array_inner *new_array = array_inner::create(new_size.int_size + 1, new_size.string_size, is_v);
-    string_hash_entry *it = p->begin();
+    array_inner *new_array = array_inner::create(new_size.int_size + 1, is_v);
+    int_hash_entry *it = p->begin();
 
     if (is_v) {
       new_array->push_back_vector_value(val);

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -51,6 +51,8 @@ struct array_list_hash_entry {
   list_entry_pointer_type prev;
 };
 
+struct ArrayBucketDummyStrTag{};
+
 struct array_inner_control {
   // This stub field is needed to ensure the alignment during the const arrays generation
   // TODO: figure out something smarter
@@ -78,7 +80,6 @@ private:
 
   struct int_hash_entry : list_hash_entry {
     T value;
-    bool is_int;
 
     int64_t int_key;
     string string_key;

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -78,7 +78,7 @@ private:
   using entry_pointer_type = list_entry_pointer_type;
   using list_hash_entry = array_list_hash_entry;
 
-  struct int_hash_entry : list_hash_entry {
+  struct array_bucket : list_hash_entry {
     T value;
 
     int64_t int_key;
@@ -104,24 +104,24 @@ private:
 
     static constexpr entry_pointer_type EMPTY_POINTER = 0;
 
-    int_hash_entry int_entries[KPHP_ARRAY_TAIL_SIZE];
+    array_bucket int_entries[KPHP_ARRAY_TAIL_SIZE];
 
     inline bool is_vector() const __attribute__ ((always_inline));
 
     inline list_hash_entry *get_entry(entry_pointer_type pointer) const __attribute__ ((always_inline));
     inline entry_pointer_type get_pointer(list_hash_entry *entry) const __attribute__ ((always_inline));
 
-    inline const int_hash_entry *begin() const __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline const int_hash_entry *next(const int_hash_entry *ptr) const __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline const int_hash_entry *prev(const int_hash_entry *ptr) const __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline const int_hash_entry *end() const __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline const array_bucket *begin() const __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline const array_bucket *next(const array_bucket *ptr) const __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline const array_bucket *prev(const array_bucket *ptr) const __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline const array_bucket *end() const __attribute__ ((always_inline)) ubsan_supp("alignment");
 
-    inline int_hash_entry *begin() __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline int_hash_entry *next(int_hash_entry *ptr) __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline int_hash_entry *prev(int_hash_entry *ptr) __attribute__ ((always_inline)) ubsan_supp("alignment");
-    inline int_hash_entry *end() __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline array_bucket *begin() __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline array_bucket *next(array_bucket *ptr) __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline array_bucket *prev(array_bucket *ptr) __attribute__ ((always_inline)) ubsan_supp("alignment");
+    inline array_bucket *end() __attribute__ ((always_inline)) ubsan_supp("alignment");
 
-    inline bool is_string_hash_entry(const int_hash_entry *ptr) const __attribute__ ((always_inline));
+    inline bool is_string_hash_entry(const array_bucket *ptr) const __attribute__ ((always_inline));
 
     inline array_inner_fields_for_map &fields_for_map() __attribute__((always_inline));
     inline const array_inner_fields_for_map &fields_for_map() const __attribute__((always_inline));

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -100,7 +100,7 @@ private:
     //empty hash_entry identified by (next == EMPTY_POINTER)
     static constexpr entry_pointer_type EMPTY_POINTER = 0;
 
-    array_bucket int_entries[KPHP_ARRAY_TAIL_SIZE];
+    array_bucket entries[KPHP_ARRAY_TAIL_SIZE];
 
     inline bool is_vector() const __attribute__ ((always_inline));
 

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -178,10 +178,6 @@ private:
 
     size_t estimate_memory_usage() const;
 
-    constexpr array_inner(int ref_cnt, int64_t max_key, list_hash_entry end, uint32_t int_size, uint32_t int_buf_size) noexcept :
-      array_inner_control{0, ref_cnt, max_key, end, int_size, int_buf_size} {
-    }
-
     inline array_inner(const array_inner &other) = delete;
     inline array_inner &operator=(const array_inner &other) = delete;
   };

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -60,7 +60,7 @@ struct array_inner_control {
   int ref_cnt;
   int64_t max_key;
   array_list_hash_entry last;
-  uint32_t int_size;
+  uint32_t size;
   uint32_t int_buf_size;
 };
 

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -12,7 +12,7 @@
 #endif
 
 struct array_size {
-  int64_t int_size{0};
+  int64_t size{0};
   bool is_vector{false};
 
   array_size() = default;

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -186,9 +186,9 @@ private:
   inline bool mutate_to_size_if_vector_shared(int64_t int_size);
   inline void mutate_to_size(int64_t int_size);
   inline bool mutate_if_map_shared(uint32_t mul = 1);
-  inline void mutate_if_vector_needed_int();
-  inline void mutate_if_map_needed_int();
-  inline void mutate_to_map_if_vector_or_map_need_string();
+  inline void mutate_if_vector_needs_space();
+  inline void mutate_if_map_needs_space();
+  inline void mutate_to_map_if_vector_or_map_need_space();
 
   inline void convert_to_map();
 

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -420,7 +420,6 @@ public:
   bool is_equal_inner_pointer(const array &other) const noexcept;
 
   void reserve(int64_t int_size, bool make_vector_if_possible);
-  void reserve(int64_t int_size, int64_t string_size, bool make_vector_if_possible);
 
   size_t estimate_memory_usage() const;
 

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -91,7 +91,7 @@ private:
   // but sometimes, for simplicity, we use them in vector too
   // to not add extra checks they are left in `array_inner`
   struct array_inner_fields_for_map {
-    uint64_t modulo_helper_int_buf_size{0};
+    uint64_t modulo_helper_buf_size{0};
   };
 
   struct array_inner : array_inner_control {

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -61,7 +61,7 @@ struct array_inner_control {
   int64_t max_key;
   array_list_hash_entry last;
   uint32_t size;
-  uint32_t int_buf_size;
+  uint32_t buf_size;
 };
 
 template<class T>

--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -17,14 +17,13 @@ struct array_size {
 
   array_size() = default;
 
-  inline array_size(int64_t int_size, bool is_vector);
-  inline array_size(int64_t int_size, int64_t string_size, bool is_vector);
+  inline array_size(int64_t int_size, bool is_vector) noexcept;
 
-  inline array_size operator+(const array_size &other) const;
+  inline array_size operator+(const array_size &other) const noexcept;
 
-  inline array_size &cut(int64_t length);
+  inline array_size &cut(int64_t length) noexcept;
 
-  inline array_size &min(const array_size &other);
+  inline array_size &min(const array_size &other) noexcept;
 };
 
 #if defined(__clang__) || (defined(__GNUC__) && __GNUC__ < 10)

--- a/runtime/array_functions.cpp
+++ b/runtime/array_functions.cpp
@@ -141,7 +141,7 @@ std::tuple<string, string, string, string> f$_explode_tuple4(const string &delim
 array<string> explode(char delimiter, const string &str, int64_t limit) {
   static char delimiter_storage[1] = {0};
   delimiter_storage[0] = delimiter;
-  array<string> res(array_size(limit < 10 ? limit : 1, 0, true));
+  array<string> res(array_size(limit < 10 ? limit : 1, true));
   walk_parts(delimiter_storage, 1, str, limit, [&](const char *s, string::size_type l) {
     res.push_back(string(s, l));
   });
@@ -158,7 +158,7 @@ array<string> f$explode(const string &delimiter, const string &str, int64_t limi
     return {};
   }
 
-  array<string> res(array_size(limit < 10 ? limit : 1, 0, true));
+  array<string> res(array_size(limit < 10 ? limit : 1, true));
   walk_parts(delimiter.c_str(), delimiter.size(), str, limit, [&](const char *s, string::size_type l) {
     res.push_back(string(s, l));
   });
@@ -171,7 +171,7 @@ array<mixed> range_int(int64_t from, int64_t to, int64_t step) {
       php_warning("Wrong parameters from = %" PRIi64 ", to = %" PRIi64 ", step = %" PRIi64 " in function range", from, to, step);
       return {};
     }
-    array<mixed> res(array_size((to - from + step) / step, 0, true));
+    array<mixed> res(array_size((to - from + step) / step, true));
     for (int64_t i = from; i <= to; i += step) {
       res.push_back(i);
     }
@@ -184,7 +184,7 @@ array<mixed> range_int(int64_t from, int64_t to, int64_t step) {
     if (step < 0) {
       step = -step;
     }
-    array<mixed> res(array_size((from - to + step) / step, 0, true));
+    array<mixed> res(array_size((from - to + step) / step, true));
     for (int64_t i = from; i >= to; i -= step) {
       res.push_back(i);
     }
@@ -203,13 +203,13 @@ array<mixed> range_string(const string &from_s, const string &to_s, int64_t step
   const int64_t from = static_cast<unsigned char>(from_s[0]);
   const int64_t to = static_cast<unsigned char>(to_s[0]);
   if (from < to) {
-    array<mixed> res(array_size(to - from + 1, 0, true));
+    array<mixed> res(array_size(to - from + 1, true));
     for (int64_t i = from; i <= to; i++) {
       res.push_back(f$chr(i));
     }
     return res;
   } else {
-    array<mixed> res(array_size(from - to + 1, 0, true));
+    array<mixed> res(array_size(from - to + 1, true));
     for (int64_t i = from; i >= to; i--) {
       res.push_back(f$chr(i));
     }

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -352,7 +352,6 @@ array<array<T>> f$array_chunk(const array<T> &a, int64_t chunk_size, bool preser
   array_size new_size = a.size().cut(chunk_size);
   if (!preserve_keys) {
     new_size.int_size = min(chunk_size, a.count());
-    new_size.string_size = 0;
     new_size.is_vector = true;
   }
 
@@ -409,7 +408,7 @@ array<T> f$array_slice(const array<T> &a, int64_t offset, const mixed &length_va
   }
 
   array_size result_size = a.size().cut(length);
-  result_size.is_vector = (!preserve_keys && result_size.string_size == 0) || (preserve_keys && offset == 0 && a.is_vector());
+  result_size.is_vector = !preserve_keys || (preserve_keys && offset == 0 && a.is_vector());
 
   array<T> result(result_size);
   auto it = a.middle(offset);
@@ -1291,7 +1290,7 @@ void f$array_reserve_map_string_keys(array<T> &a, int64_t size) {
 template<class T1, class T2>
 void f$array_reserve_from(array<T1> &a, const array<T2> &base) {
   auto size_info = base.size();
-  f$array_reserve(a, size_info.int_size, size_info.string_size, size_info.is_vector);
+  f$array_reserve(a, size_info.int_size, size_info.is_vector);
 }
 
 template<class T>

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -351,7 +351,7 @@ array<array<T>> f$array_chunk(const array<T> &a, int64_t chunk_size, bool preser
 
   array_size new_size = a.size().cut(chunk_size);
   if (!preserve_keys) {
-    new_size.int_size = min(chunk_size, a.count());
+    new_size.size = min(chunk_size, a.count());
     new_size.is_vector = true;
   }
 
@@ -1290,7 +1290,7 @@ void f$array_reserve_map_string_keys(array<T> &a, int64_t size) {
 template<class T1, class T2>
 void f$array_reserve_from(array<T1> &a, const array<T2> &base) {
   auto size_info = base.size();
-  f$array_reserve(a, size_info.int_size, size_info.is_vector);
+  f$array_reserve(a, size_info.size, size_info.is_vector);
 }
 
 template<class T>

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -1258,22 +1258,22 @@ T f$array_unset(array<T> &arr, const mixed &key) {
 
 template<class T>
 void f$array_reserve(array<T> &a, int64_t int_size, int64_t string_size, bool make_vector_if_possible) {
-  a.reserve(int_size, string_size, make_vector_if_possible);
+  a.reserve(int_size + string_size, make_vector_if_possible);
 }
 
 template<class T>
 void f$array_reserve_vector(array<T> &a, int64_t size) {
-  a.reserve(size, 0, true);
+  a.reserve(size, true);
 }
 
 template<class T>
 void f$array_reserve_map_int_keys(array<T> &a, int64_t size) {
-  a.reserve(size, 0, false);
+  a.reserve(size, false);
 }
 
 template<class T>
 void f$array_reserve_map_string_keys(array<T> &a, int64_t size) {
-  a.reserve(0, size, false);
+  a.reserve(size, false);
 }
 
 template<class T1, class T2>

--- a/runtime/array_functions.h
+++ b/runtime/array_functions.h
@@ -408,7 +408,7 @@ array<T> f$array_slice(const array<T> &a, int64_t offset, const mixed &length_va
   }
 
   array_size result_size = a.size().cut(length);
-  result_size.is_vector = !preserve_keys || (preserve_keys && offset == 0 && a.is_vector());
+  result_size.is_vector = (!preserve_keys && a.has_no_string_keys()) || (preserve_keys && offset == 0 && a.is_vector());
 
   array<T> result(result_size);
   auto it = a.middle(offset);

--- a/runtime/array_iterator.h
+++ b/runtime/array_iterator.h
@@ -26,7 +26,7 @@ public:
   using key_type = typename array_type::key_type;
   using inner_type = const_conditional_t<typename array_type::array_inner>;
   using list_hash_type = const_conditional_t<typename array_type::list_hash_entry>;
-  using int_hash_type = const_conditional_t<typename array_type::int_hash_entry>;
+  using bucket_type = const_conditional_t<typename array_type::array_bucket>;
 
   inline constexpr array_iterator() noexcept __attribute__ ((always_inline)) = default;
 
@@ -40,11 +40,11 @@ public:
   }
 
   inline value_type &get_value() noexcept __attribute__ ((always_inline)) {
-    return self_->is_vector() ? *reinterpret_cast<value_type *>(entry_) : static_cast<int_hash_type *>(entry_)->value;
+    return self_->is_vector() ? *reinterpret_cast<value_type *>(entry_) : static_cast<bucket_type *>(entry_)->value;
   }
 
   inline const value_type &get_value() const noexcept __attribute__ ((always_inline)) {
-    return self_->is_vector() ? *reinterpret_cast<value_type *>(entry_) : static_cast<int_hash_type *>(entry_)->value;
+    return self_->is_vector() ? *reinterpret_cast<value_type *>(entry_) : static_cast<bucket_type *>(entry_)->value;
   }
 
   inline key_type get_key() const noexcept __attribute__ ((always_inline)) {
@@ -60,36 +60,36 @@ public:
   }
 
   inline int64_t get_int_key() noexcept __attribute__ ((always_inline)) {
-    return static_cast<int_hash_type *>(entry_)->int_key;
+    return static_cast<bucket_type *>(entry_)->int_key;
   }
 
   inline int64_t get_int_key() const noexcept __attribute__ ((always_inline)) {
-    return static_cast<const int_hash_type *>(entry_)->int_key;
+    return static_cast<const bucket_type *>(entry_)->int_key;
   }
 
   inline bool is_string_key() const noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
-    return !self_->is_vector() && self_->is_string_hash_entry(static_cast<const int_hash_type *>(entry_));
+    return !self_->is_vector() && self_->is_string_hash_entry(static_cast<const bucket_type *>(entry_));
   }
 
   inline const_conditional_t<string> &get_string_key() noexcept __attribute__ ((always_inline)) {
-    return static_cast<int_hash_type *>(entry_)->string_key;
+    return static_cast<bucket_type *>(entry_)->string_key;
   }
 
   inline const string &get_string_key() const noexcept __attribute__ ((always_inline)) {
-    return static_cast<const int_hash_type *>(entry_)->string_key;
+    return static_cast<const bucket_type *>(entry_)->string_key;
   }
 
   inline array_iterator &operator++() noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
     entry_ = self_->is_vector()
              ? reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(entry_) + 1)
-             : self_->next(static_cast<int_hash_type *>(entry_));
+             : self_->next(static_cast<bucket_type *>(entry_));
     return *this;
   }
 
   inline array_iterator &operator--() noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
     entry_ = self_->is_vector()
              ? reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(entry_) - 1)
-             : self_->prev(static_cast<int_hash_type *>(entry_));
+             : self_->prev(static_cast<bucket_type *>(entry_));
     return *this;
   }
 
@@ -164,7 +164,7 @@ public:
       }
     }
 
-    int_hash_type *result = nullptr;
+    bucket_type *result = nullptr;
     if (n < 0) {
       result = arr.p->end();
       while (n < 0) {

--- a/runtime/array_iterator.h
+++ b/runtime/array_iterator.h
@@ -49,7 +49,7 @@ public:
 
   inline key_type get_key() const noexcept __attribute__ ((always_inline)) {
     if (self_->is_vector()) {
-      return key_type{static_cast<int64_t>(reinterpret_cast<value_type *>(entry_) - reinterpret_cast<value_type *>(self_->int_entries))};
+      return key_type{static_cast<int64_t>(reinterpret_cast<value_type *>(entry_) - reinterpret_cast<value_type *>(self_->entries))};
     }
 
     if (is_string_key()) {
@@ -112,7 +112,7 @@ public:
   static inline array_iterator make_begin(std::add_const_t<array_type> &arr) noexcept __attribute__ ((always_inline)) {
     static_assert(std::is_const<T>{}, "expected to be const");
     return arr.is_vector()
-           ? array_iterator{arr.p, arr.p->int_entries}
+           ? array_iterator{arr.p, arr.p->entries}
            : array_iterator{arr.p, arr.p->begin()};
   }
 
@@ -120,7 +120,7 @@ public:
     static_assert(!std::is_const<T>{}, "expected to be mutable");
     if (arr.is_vector()) {
       arr.mutate_if_vector_shared();
-      return array_iterator{arr.p, arr.p->int_entries};
+      return array_iterator{arr.p, arr.p->entries};
     }
 
     arr.mutate_if_map_shared();
@@ -129,7 +129,7 @@ public:
 
   static inline array_iterator make_end(array_type &arr) noexcept __attribute__ ((always_inline)) {
     return arr.is_vector()
-           ? array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->int_entries) + arr.p->size)}
+           ? array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->entries) + arr.p->size)}
            : array_iterator{arr.p, arr.p->end()};
   }
 
@@ -147,7 +147,7 @@ public:
         return make_end(arr);
       }
 
-      return array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->int_entries) + n)};
+      return array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->entries) + n)};
     }
 
     if (n < -l / 2) {

--- a/runtime/array_iterator.h
+++ b/runtime/array_iterator.h
@@ -27,7 +27,6 @@ public:
   using inner_type = const_conditional_t<typename array_type::array_inner>;
   using list_hash_type = const_conditional_t<typename array_type::list_hash_entry>;
   using int_hash_type = const_conditional_t<typename array_type::int_hash_entry>;
-  using string_hash_type = const_conditional_t<typename array_type::string_hash_entry>;
 
   inline constexpr array_iterator() noexcept __attribute__ ((always_inline)) = default;
 
@@ -69,28 +68,28 @@ public:
   }
 
   inline bool is_string_key() const noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
-    return !self_->is_vector() && self_->is_string_hash_entry(static_cast<const string_hash_type *>(entry_));
+    return !self_->is_vector() && self_->is_string_hash_entry(static_cast<const int_hash_type *>(entry_));
   }
 
   inline const_conditional_t<string> &get_string_key() noexcept __attribute__ ((always_inline)) {
-    return static_cast<string_hash_type *>(entry_)->string_key;
+    return static_cast<int_hash_type *>(entry_)->string_key;
   }
 
   inline const string &get_string_key() const noexcept __attribute__ ((always_inline)) {
-    return static_cast<const string_hash_type *>(entry_)->string_key;
+    return static_cast<const int_hash_type *>(entry_)->string_key;
   }
 
   inline array_iterator &operator++() noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
     entry_ = self_->is_vector()
              ? reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(entry_) + 1)
-             : self_->next(static_cast<string_hash_type *>(entry_));
+             : self_->next(static_cast<int_hash_type *>(entry_));
     return *this;
   }
 
   inline array_iterator &operator--() noexcept __attribute__ ((always_inline)) ubsan_supp("alignment") {
     entry_ = self_->is_vector()
              ? reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(entry_) - 1)
-             : self_->prev(static_cast<string_hash_type *>(entry_));
+             : self_->prev(static_cast<int_hash_type *>(entry_));
     return *this;
   }
 
@@ -165,7 +164,7 @@ public:
       }
     }
 
-    string_hash_type *result = nullptr;
+    int_hash_type *result = nullptr;
     if (n < 0) {
       result = arr.p->end();
       while (n < 0) {

--- a/runtime/array_iterator.h
+++ b/runtime/array_iterator.h
@@ -129,7 +129,7 @@ public:
 
   static inline array_iterator make_end(array_type &arr) noexcept __attribute__ ((always_inline)) {
     return arr.is_vector()
-           ? array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->int_entries) + arr.p->int_size)}
+           ? array_iterator{arr.p, reinterpret_cast<list_hash_type *>(reinterpret_cast<value_type *>(arr.p->int_entries) + arr.p->size)}
            : array_iterator{arr.p, arr.p->end()};
   }
 

--- a/runtime/comparison_operators.inl
+++ b/runtime/comparison_operators.inl
@@ -198,7 +198,7 @@ inline bool eq2(const TupleT &lhs, const array<Arg> &rhs, std::index_sequence<In
 
 template<class Arg, class ...Args>
 inline bool eq2(const std::tuple<Args...> &lhs, const array<Arg> &rhs) {
-  if (!rhs.is_vector() || sizeof...(Args) != rhs.size().int_size) {
+  if (!rhs.is_vector() || sizeof...(Args) != rhs.size().size) {
     return false;
   }
   return eq2(lhs, rhs, std::make_index_sequence<sizeof...(Args)>{});
@@ -497,7 +497,7 @@ inline bool equals(const TupleT &lhs, const array<Arg> &rhs, std::index_sequence
 
 template<class Arg, class ...Args>
 inline bool equals(const std::tuple<Args...> &lhs, const array<Arg> &rhs) {
-  if (!rhs.is_vector() || sizeof...(Args) != rhs.size().int_size) {
+  if (!rhs.is_vector() || sizeof...(Args) != rhs.size().size) {
     return false;
   }
   return equals(lhs, rhs, std::make_index_sequence<sizeof...(Args)>{});

--- a/runtime/confdata-functions.cpp
+++ b/runtime/confdata-functions.cpp
@@ -162,7 +162,7 @@ array<mixed> f$confdata_get_values_by_any_wildcard(const string &wildcard) noexc
     // it must be an array (we loaded it this way)
     const auto &second_key_array = iter->second.as_array();
     const auto inserting_size = second_key_array.size() + result.size();
-    result.reserve(inserting_size.int_size, inserting_size.string_size, inserting_size.is_vector);
+    result.reserve(inserting_size.int_size, inserting_size.is_vector);
     for (const auto &section_it : iter->second) {
       result.set_value(string{section_suffix}.append(section_it.get_key()), section_it.get_value());
     }

--- a/runtime/confdata-functions.cpp
+++ b/runtime/confdata-functions.cpp
@@ -162,7 +162,7 @@ array<mixed> f$confdata_get_values_by_any_wildcard(const string &wildcard) noexc
     // it must be an array (we loaded it this way)
     const auto &second_key_array = iter->second.as_array();
     const auto inserting_size = second_key_array.size() + result.size();
-    result.reserve(inserting_size.int_size, inserting_size.is_vector);
+    result.reserve(inserting_size.size, inserting_size.is_vector);
     for (const auto &section_it : iter->second) {
       result.set_value(string{section_suffix}.append(section_it.get_key()), section_it.get_value());
     }

--- a/runtime/conversions_types.inl
+++ b/runtime/conversions_types.inl
@@ -153,7 +153,7 @@ inline string f$strval(mixed &&val) {
 
 template<class T>
 inline array<T> f$arrayval(const T &val) {
-  array<T> res(array_size(1, 0, true));
+  array<T> res(array_size(1, true));
   res.push_back(val);
   return res;
 }

--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -705,7 +705,7 @@ mixed f$curl_getinfo(curl_easy easy_id, int64_t option) noexcept {
   }
 
   if (option == 0) {
-    array<mixed> result(array_size(0, 26, false));
+    array<mixed> result(array_size(26, false));
     easy_context->add_info_into_array(result, "url", CURLINFO_EFFECTIVE_URL);
     easy_context->add_info_into_array(result, "content_type", CURLINFO_CONTENT_TYPE);
     easy_context->add_info_into_array(result, "http_code", CURLINFO_RESPONSE_CODE);
@@ -909,7 +909,7 @@ Optional<array<int64_t>> f$curl_multi_info_read(curl_multi multi_id, int64_t &ms
     CURLMsg *msg = dl::critical_section_call(curl_multi_info_read, multi_context->multi_handle, &msgs_in_queue_int);
     msgs_in_queue = msgs_in_queue_int;
     if (msg) {
-      array<int64_t> result{array_size{0, 3, false}};
+      array<int64_t> result{array_size{3, false}};
       result.set_value(string{"msg"}, static_cast<int64_t>(msg->msg));
       result.set_value(string{"result"}, static_cast<int64_t>(msg->data.result));
 

--- a/runtime/datetime/datetime_functions.cpp
+++ b/runtime/datetime/datetime_functions.cpp
@@ -389,7 +389,7 @@ array<mixed> f$getdate(int64_t timestamp) {
   time_t timestamp_t = timestamp;
   localtime_r(&timestamp_t, &t);
 
-  array<mixed> result(array_size(1, 10, false));
+  array<mixed> result(array_size(11, false));
 
   result.set_value(string("seconds", 7), t.tm_sec);
   result.set_value(string("minutes", 7), t.tm_min);
@@ -476,7 +476,7 @@ array<mixed> f$localtime(int64_t timestamp, bool is_associative) {
     return array<mixed>::create(t.tm_sec, t.tm_min, t.tm_hour, t.tm_mday, t.tm_mon, t.tm_year, t.tm_wday, t.tm_yday, t.tm_isdst);
   }
 
-  array<mixed> result(array_size(0, 9, false));
+  array<mixed> result(array_size(9, false));
 
   result.set_value(string("tm_sec", 6), t.tm_sec);
   result.set_value(string("tm_min", 6), t.tm_min);

--- a/runtime/datetime/timelib_wrapper.cpp
+++ b/runtime/datetime/timelib_wrapper.cpp
@@ -38,7 +38,7 @@ array<mixed> dump_errors(const timelib_error_container &error) {
   array<mixed> result;
 
   array<string> result_warnings;
-  result_warnings.reserve(error.warning_count, 0, false);
+  result_warnings.reserve(error.warning_count, false);
   for (int i = 0; i < error.warning_count; i++) {
     result_warnings.set_value(error.warning_messages[i].position, string(error.warning_messages[i].message));
   }
@@ -46,7 +46,7 @@ array<mixed> dump_errors(const timelib_error_container &error) {
   result.set_value(string("warnings"), result_warnings);
 
   array<string> result_errors;
-  result_errors.reserve(error.error_count, 0, false);
+  result_errors.reserve(error.error_count, false);
   for (int i = 0; i < error.error_count; i++) {
     result_errors.set_value(error.error_messages[i].position, string(error.error_messages[i].message));
   }

--- a/runtime/exception.cpp
+++ b/runtime/exception.cpp
@@ -14,14 +14,14 @@ namespace {
 array<array<string>> make_backtrace(void **trace, int trace_size) noexcept {
   const string function_key{"function"};
 
-  array<array<string>> res{array_size{trace_size - 4, 0, true}};
+  array<array<string>> res{array_size{trace_size - 4, true}};
   const size_t buf_size = 20;
   char buf[buf_size];
   for (int i = 1; i < trace_size; i++) {
     dl::enter_critical_section();//OK
     snprintf(buf, buf_size, "%p", trace[i]);
     dl::leave_critical_section();
-    array<string> current{array_size{0, 1, false}};
+    array<string> current{array_size{1, false}};
     current.set_value(function_key, string{buf});
     res.emplace_back(std::move(current));
   }
@@ -105,7 +105,7 @@ void exception_initialize(const Throwable &e, const string &message, int64_t cod
 
   void *buffer[backtrace_size_limit];
   const int trace_size = get_backtrace(buffer, backtrace_size_limit);
-  e->raw_trace = array<void *>{array_size{trace_size, 0, true}};
+  e->raw_trace = array<void *>{array_size{trace_size, true}};
   e->raw_trace.memcpy_vector(trace_size, buffer);
 
   e->trace = make_backtrace(buffer, trace_size);

--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -566,7 +566,7 @@ Optional<array<string>> f$scandir(const string &directory) {
     }
     return false;
   }
-  array<string> file_list(array_size(namelist_size, 0, true));
+  array<string> file_list(array_size(namelist_size, true));
   for (int i = 0; i < namelist_size; i++) {
     char const *file_name = namelist[i]->d_name;
     string::size_type file_name_length = (string::size_type)strlen(file_name);

--- a/runtime/from-json-processor.h
+++ b/runtime/from-json-processor.h
@@ -121,7 +121,7 @@ private:
     const auto array_size = json_array.size();
     // overwrite (but not just merge) array data
     array.clear();
-    array.reserve(array_size.int_size, array_size.is_vector);
+    array.reserve(array_size.size, array_size.is_vector);
 
     json_path_.enter(nullptr);
     for (const auto it : json_array) {

--- a/runtime/from-json-processor.h
+++ b/runtime/from-json-processor.h
@@ -121,7 +121,7 @@ private:
     const auto array_size = json_array.size();
     // overwrite (but not just merge) array data
     array.clear();
-    array.reserve(array_size.int_size, array_size.string_size, array_size.is_vector);
+    array.reserve(array_size.int_size, array_size.is_vector);
 
     json_path_.enter(nullptr);
     for (const auto it : json_array) {

--- a/runtime/instance-copy-processor.h
+++ b/runtime/instance-copy-processor.h
@@ -265,7 +265,7 @@ private:
     if (const auto extra_ref_cnt = get_memory_ref_cnt()) {
       arr.set_reference_counter_to(extra_ref_cnt);
     }
-    const bool primitive_array = is_primitive<T>{} && arr.size().string_size == 0;
+    const bool primitive_array = is_primitive<T>{} && arr.is_vector();
     return primitive_array || Basic::process_range(first, arr.end());
   }
 

--- a/runtime/instance-copy-processor.h
+++ b/runtime/instance-copy-processor.h
@@ -265,7 +265,7 @@ private:
     if (const auto extra_ref_cnt = get_memory_ref_cnt()) {
       arr.set_reference_counter_to(extra_ref_cnt);
     }
-    const bool primitive_array = is_primitive<T>{} && arr.is_vector();
+    const bool primitive_array = is_primitive<T>{} && arr.has_no_string_keys();
     return primitive_array || Basic::process_range(first, arr.end());
   }
 

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1777,7 +1777,7 @@ static void init_superglobals(const http_query_data &http_data, const rpc_query_
 
   if (arg_vars == nullptr) {
     if (http_data.get_len > 0) {
-      array<mixed> argv_array(array_size(1, 0, true));
+      array<mixed> argv_array(array_size(1, true));
       argv_array.push_back(get_str);
 
       v$argv = argv_array;

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -1513,7 +1513,7 @@ static void save_rpc_query_headers(const tl_query_header_t &header) {
   }
   if (header.flags & flag::string_forward_keys) {
     array<string> string_forward_keys;
-    string_forward_keys.reserve(header.string_forward_keys.size(), 0, true);
+    string_forward_keys.reserve(header.string_forward_keys.size(), true);
     for (const auto &str_key : header.string_forward_keys) {
       string_forward_keys.emplace_back(string(str_key.data(), str_key.size()));
     }
@@ -1521,7 +1521,7 @@ static void save_rpc_query_headers(const tl_query_header_t &header) {
   }
   if (header.flags & flag::int_forward_keys) {
     array<int64_t> int_forward_keys;
-    int_forward_keys.reserve(header.int_forward_keys.size(), 0, true);
+    int_forward_keys.reserve(header.int_forward_keys.size(), true);
     for (int int_key : header.int_forward_keys) {
       int_forward_keys.emplace_back(int_key);
     }

--- a/runtime/kphp-backtrace.cpp
+++ b/runtime/kphp-backtrace.cpp
@@ -127,7 +127,7 @@ void free_kphp_backtrace() noexcept {
 array<string> f$kphp_backtrace(bool pretty) noexcept {
   std::array<void *, 128> buffer{};
   const int32_t nptrs = fast_backtrace(buffer.data(), buffer.size());
-  array<string> backtrace{array_size{nptrs, 0, true}};
+  array<string> backtrace{array_size{nptrs, true}};
   KphpBacktrace demangler{buffer.data(), nptrs};
   for (const char *name : demangler.make_demangled_backtrace_range()) {
     const size_t len = name ? strlen(name) : 0;

--- a/runtime/memcache.cpp
+++ b/runtime/memcache.cpp
@@ -487,7 +487,7 @@ mixed f$McMemcache$$get(const class_instance<C$McMemcache> &v$this, const mixed 
     }
     drivers_SB << "\r\n";
 
-    mc_res = array<mixed>(array_size(0, key_var.count(), false));
+    mc_res = array<mixed>(array_size(key_var.count(), false));
     auto cur_host = get_host(v$this->hosts);
     if (is_immediate_query) {
       mc_run_query(cur_host.host_num, drivers_SB.c_str(), drivers_SB.size(), cur_host.timeout_ms, 0, nullptr); //TODO wrong if we have no mc_proxy

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -75,7 +75,7 @@ public:
     return sizeof(*this);
   }
 
-  array<host> hosts{array_size{1, 0, true}};
+  array<host> hosts{array_size{1, true}};
 };
 
 class_instance<C$McMemcache> f$McMemcache$$__construct(const class_instance<C$McMemcache> &v$this);

--- a/runtime/misc.cpp
+++ b/runtime/misc.cpp
@@ -444,7 +444,7 @@ mixed f$getimagesize(const string &name) {
   close(read_fd);
   dl::leave_critical_section();
 
-  array<mixed> result(array_size(4, 3, false));
+  array<mixed> result(array_size(7, false));
   result.push_back(width);
   result.push_back(height);
   result.push_back(type);
@@ -483,7 +483,7 @@ Optional<array<mixed>> f$posix_getpwuid(int64_t uid) {
   if (!pwd) {
     return false;
   }
-  array<mixed> result(array_size(0, 7, false));
+  array<mixed> result(array_size(7, false));
   result.set_value(string("name", 4), string(pwd->pw_name));
   result.set_value(string("passwd", 6), string(pwd->pw_passwd));
   result.set_value(string("uid", 3), static_cast<int64_t>(pwd->pw_uid));

--- a/runtime/mixed.inl
+++ b/runtime/mixed.inl
@@ -604,7 +604,7 @@ const array<mixed> mixed::to_array() const {
     case type::INTEGER:
     case type::FLOAT:
     case type::STRING: {
-      array<mixed> res(array_size(1, 0, true));
+      array<mixed> res(array_size(1, true));
       res.push_back(*this);
       return res;
     }

--- a/runtime/msgpack/adaptors.h
+++ b/runtime/msgpack/adaptors.h
@@ -215,7 +215,7 @@ template<class T>
 struct convert<array<T>> {
   const msgpack::object &operator()(const msgpack::object &obj, array<T> &res_arr) const {
     if (obj.type == stored_type::ARRAY) {
-      res_arr.reserve(obj.via.array.size, 0, true);
+      res_arr.reserve(obj.via.array.size, true);
 
       for (uint32_t i = 0; i < obj.via.array.size; ++i) {
         res_arr.set_value(static_cast<int64_t>(i), obj.via.array.ptr[i].as<T>());

--- a/runtime/msgpack/adaptors.h
+++ b/runtime/msgpack/adaptors.h
@@ -227,9 +227,9 @@ struct convert<array<T>> {
     if (obj.type == stored_type::MAP) {
       array_size size(0, false);
       run_callbacks_on_map(
-        obj.via.map, [&size](int64_t, msgpack::object &) { size.int_size++; }, [&size](const string &, msgpack::object &) { size.int_size++; });
+        obj.via.map, [&size](int64_t, msgpack::object &) { size.size++; }, [&size](const string &, msgpack::object &) { size.size++; });
 
-      res_arr.reserve(size.int_size, size.is_vector);
+      res_arr.reserve(size.size, size.is_vector);
       run_callbacks_on_map(
         obj.via.map, [&res_arr](int64_t key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); },
         [&res_arr](const string &key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); });

--- a/runtime/msgpack/adaptors.h
+++ b/runtime/msgpack/adaptors.h
@@ -225,12 +225,7 @@ struct convert<array<T>> {
     }
 
     if (obj.type == stored_type::MAP) {
-      res_arr.reserve(obj.via.map.size, false);
-
-      run_callbacks_on_map(
-        obj.via.map, [&res_arr](int64_t key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); },
-        [&res_arr](const string &key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); });
-
+      fill_array_as_map(obj.via.map, res_arr);
       return obj;
     }
 
@@ -238,20 +233,25 @@ struct convert<array<T>> {
   }
 
 private:
-  template<class IntCallbackT, class StrCallbackT>
-  static void run_callbacks_on_map(const msgpack::object_map &obj_map, const IntCallbackT &on_integer, const StrCallbackT &on_string) {
+  static void fill_array_as_map(const msgpack::object_map &obj_map, array<T> &res_arr) {
+    res_arr.reserve(obj_map.size, false);
+
     for (size_t i = 0; i < obj_map.size; ++i) {
       auto &key = obj_map.ptr[i].key;
       auto &value = obj_map.ptr[i].val;
 
       switch (key.type) {
         case stored_type::POSITIVE_INTEGER:
-        case stored_type::NEGATIVE_INTEGER:
-          on_integer(key.as<int64_t>(), value);
+        case stored_type::NEGATIVE_INTEGER: {
+          const auto key_php = key.as<int64_t>();
+          res_arr.set_value(key_php, value.as<T>());
           break;
-        case stored_type::STR:
-          on_string(key.as<string>(), value);
+        }
+        case stored_type::STR: {
+          const auto &key_php = key.as<string>();
+          res_arr.set_value(key_php, value.as<T>());
           break;
+        }
         default:
           throw msgpack::unpack_error("expected string or integer in array unpacking");
       }

--- a/runtime/msgpack/adaptors.h
+++ b/runtime/msgpack/adaptors.h
@@ -225,11 +225,8 @@ struct convert<array<T>> {
     }
 
     if (obj.type == stored_type::MAP) {
-      array_size size(0, false);
-      run_callbacks_on_map(
-        obj.via.map, [&size](int64_t, msgpack::object &) { size.size++; }, [&size](const string &, msgpack::object &) { size.size++; });
+      res_arr.reserve(obj.via.map.size, false);
 
-      res_arr.reserve(size.size, size.is_vector);
       run_callbacks_on_map(
         obj.via.map, [&res_arr](int64_t key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); },
         [&res_arr](const string &key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); });

--- a/runtime/msgpack/adaptors.h
+++ b/runtime/msgpack/adaptors.h
@@ -225,11 +225,11 @@ struct convert<array<T>> {
     }
 
     if (obj.type == stored_type::MAP) {
-      array_size size(0, 0, false);
+      array_size size(0, false);
       run_callbacks_on_map(
-        obj.via.map, [&size](int64_t, msgpack::object &) { size.int_size++; }, [&size](const string &, msgpack::object &) { size.string_size++; });
+        obj.via.map, [&size](int64_t, msgpack::object &) { size.int_size++; }, [&size](const string &, msgpack::object &) { size.int_size++; });
 
-      res_arr.reserve(size.int_size, size.string_size, size.is_vector);
+      res_arr.reserve(size.int_size, size.is_vector);
       run_callbacks_on_map(
         obj.via.map, [&res_arr](int64_t key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); },
         [&res_arr](const string &key, msgpack::object &value) { res_arr.set_value(key, value.as<T>()); });

--- a/runtime/mysql.cpp
+++ b/runtime/mysql.cpp
@@ -136,7 +136,7 @@ static void mysql_query_callback(const char *result_, int result_len) {
         *query_id_ptr = false;
         return;
       }
-      *field_names_ptr = array<string>(array_size(*field_cnt_ptr, 0, true));
+      *field_names_ptr = array<string>(array_size(*field_cnt_ptr, true));
 
       mysql_callback_state = 1;
       break;
@@ -179,9 +179,7 @@ static void mysql_query_callback(const char *result_, int result_len) {
       break;
     case 3:
       if (result[0] != 254) {
-        array<mixed>
-        row(array_size(*field_cnt_ptr,
-        *field_cnt_ptr, false));
+        array<mixed> row(array_size(*field_cnt_ptr, false));
         for (int i = 0; i < *field_cnt_ptr; i++) {
           is_null = false;
           mixed value = mysql_read_string(result, result_len, is_null, true);

--- a/runtime/on_kphp_warning_callback.cpp
+++ b/runtime/on_kphp_warning_callback.cpp
@@ -32,7 +32,7 @@ void OnKphpWarningCallback::invoke_callback(const string &warning_message) {
     array<string> arg_stacktrace;
     if (nptrs > 2) {
       // start with the 2nd frame: 0 is invoke_callback(), 1 is php_warning(), 2 is what we want
-      arg_stacktrace.reserve(nptrs - 2, 0, true);
+      arg_stacktrace.reserve(nptrs - 2, true);
       KphpBacktrace demangler{buffer.data() + 2, nptrs - 2};
       for (const char *name : demangler.make_demangled_backtrace_range()) {
         if (name) {

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -116,7 +116,7 @@ const HashTraits &find_hash_algorithm(const char *algo) noexcept {
 
 array<string> f$hash_algos() noexcept {
   const auto &supported_algorithms = get_supported_hash_algorithms();
-  array<string> result{array_size{static_cast<int64_t>(supported_algorithms.size()), 0, true}};
+  array<string> result{array_size{static_cast<int64_t>(supported_algorithms.size()), true}};
   for (const auto &algo : supported_algorithms) {
     result.emplace_back(string{algo.name});
   }

--- a/runtime/pdo/pdo.cpp
+++ b/runtime/pdo/pdo.cpp
@@ -116,7 +116,7 @@ array<mixed> f$PDO$$errorInfo(const class_instance<C$PDO> &v$this) {
   }
   auto [error_code, error_msg] = v$this.get()->driver->error_info();
 
-  array<mixed> res(array_size{3, 0, true});
+  array<mixed> res(array_size{3, true});
   res[0] = sqlstate.val();
   res[1] = error_code == 0 ? mixed() : error_code;
   res[2] = strcmp(error_msg, "") == 0 ? mixed() : string{error_msg};

--- a/runtime/regexp.cpp
+++ b/runtime/regexp.cpp
@@ -721,7 +721,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, bool all_
   }
 
   if (all_matches) {
-    matches = array<mixed>(array_size(subpatterns_count, named_subpatterns_count, named_subpatterns_count == 0));
+    matches = array<mixed>(array_size(subpatterns_count + named_subpatterns_count, named_subpatterns_count == 0));
     for (int32_t i = 0; i < subpatterns_count; i++) {
       if (named_subpatterns_count && !subpattern_names[i].empty()) {
         matches.set_value(subpattern_names[i], array<mixed>());
@@ -780,7 +780,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, bool all_
         matches[i].push_back(match_str);
       }
     } else {
-      array<mixed> result_set(array_size(count, named_subpatterns_count, named_subpatterns_count == 0));
+      array<mixed> result_set(array_size(count + named_subpatterns_count, named_subpatterns_count == 0));
 
       if (named_subpatterns_count) {
         for (int64_t i = 0; i < count; i++) {
@@ -840,7 +840,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, int64_t f
   }
 
   if (pattern_order) {
-    matches = array<mixed>(array_size(subpatterns_count, named_subpatterns_count, named_subpatterns_count == 0));
+    matches = array<mixed>(array_size(subpatterns_count + named_subpatterns_count, named_subpatterns_count == 0));
     for (int32_t i = 0; i < subpatterns_count; i++) {
       if (named_subpatterns_count && !subpattern_names[i].empty()) {
         matches.set_value(subpattern_names[i], array<mixed>());
@@ -912,7 +912,7 @@ Optional<int64_t> regexp::match(const string &subject, mixed &matches, int64_t f
         }
       }
     } else {
-      array<mixed> result_set(array_size(count, named_subpatterns_count, named_subpatterns_count == 0));
+      array<mixed> result_set(array_size(count + named_subpatterns_count, named_subpatterns_count == 0));
 
       if (named_subpatterns_count) {
         for (int64_t i = 0; i < count; i++) {

--- a/runtime/regexp.h
+++ b/runtime/regexp.h
@@ -253,7 +253,7 @@ inline string regexp::get_replacement(const string &replace_val, const string &s
 
 template<class T>
 string regexp::get_replacement(const T &replace_val, const string &subject, const int64_t count) const {
-  array<string> result_set(array_size(count, named_subpatterns_count, named_subpatterns_count == 0));
+  array<string> result_set(array_size(count + named_subpatterns_count, named_subpatterns_count == 0));
 
   if (named_subpatterns_count) {
     for (int64_t i = 0; i < count; i++) {

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -1198,7 +1198,7 @@ bool f$rpc_mc_parse_raw_wildcard_with_flags_to_array(const string &raw_result, a
   if (cnt == 0) {
     return true;
   };
-  result.reserve(0, cnt + f$count(result), false);
+  result.reserve(cnt + f$count(result), false);
 
   for (int j = 0; j < cnt; ++j) {
     string key = f$fetch_string();

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -1352,7 +1352,7 @@ protected:
 public:
   explicit rpc_tl_query_result_resumable(const array<int64_t> &query_ids) :
     query_ids(query_ids),
-    tl_objects_unsorted(array_size(query_ids.count(), 0, false)),
+    tl_objects_unsorted(array_size(query_ids.count(), false)),
     queue_id(0),
     query_id(0) {
   }
@@ -1363,7 +1363,7 @@ array<array<mixed>> f$rpc_tl_query_result(const array<int64_t> &query_ids) {
 }
 
 array<array<mixed>> f$rpc_tl_query_result_synchronously(const array<int64_t> &query_ids) {
-  array<array<mixed>> tl_objects_unsorted(array_size(query_ids.count(), 0, false));
+  array<array<mixed>> tl_objects_unsorted(array_size(query_ids.count(), false));
   if (query_ids.count() == 1) {
     wait_without_result_synchronously_safe(query_ids.begin().get_value());
     tl_objects_unsorted[query_ids.begin().get_value()] = f$rpc_tl_query_result_one(query_ids.begin().get_value());

--- a/runtime/serialize-functions.cpp
+++ b/runtime/serialize-functions.cpp
@@ -153,9 +153,9 @@ int do_unserialize(const char *s, int s_len, mixed &out_var_value) noexcept {
           s += j + 2;
           s_len -= j + 4;
 
-          array_size size(0, len, false);
+          array_size size(len, false);
           if (s[0] == 'i') {//try to cheat
-            size = array_size(len, 0, s[1] == ':' && s[2] == '0' && s[3] == ';');
+            size = array_size(len, s[1] == ':' && s[2] == '0' && s[3] == ';');
           }
           array<mixed> res(size);
 

--- a/runtime/string.inl
+++ b/runtime/string.inl
@@ -270,6 +270,13 @@ string::string(double f) {
   }
 }
 
+string::string(ArrayBucketDummyStrTag) noexcept
+  : p(nullptr) {}
+
+bool string::is_dummy_string() const noexcept {
+  return p == nullptr;
+}
+
 string &string::operator=(const string &str) noexcept {
   return assign(str);
 }

--- a/runtime/string_decl.inl
+++ b/runtime/string_decl.inl
@@ -31,6 +31,8 @@ struct tmp_string {
   bool empty() const noexcept { return size == 0; }
 };
 
+struct ArrayBucketDummyStrTag;
+
 class string {
 public:
   using size_type = string_size_type;
@@ -101,8 +103,13 @@ public:
   inline explicit string(int32_t i): string(static_cast<int64_t>(i)) {}
   inline explicit string(double f);
 
-
   ~string() noexcept;
+
+  // Achtung! Do not use it!
+  // This constructor intended ONLY for usage inside array's bucket
+  // in order to being able to distinguish which key type is stored there
+  inline explicit string(ArrayBucketDummyStrTag) noexcept;
+  inline bool is_dummy_string() const noexcept;
 
   inline string &operator=(const string &str) noexcept;
   inline string &operator=(string &&str) noexcept;

--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -2326,12 +2326,12 @@ mixed f$str_ireplace(const mixed &search, const mixed &replace, const mixed &sub
 array<string> f$str_split(const string &str, int64_t split_length) {
   if (split_length <= 0) {
     php_warning ("Wrong parameter split_length = %" PRIi64 " in function str_split", split_length);
-    array<string> result(array_size(1, 0, true));
+    array<string> result(array_size(1, true));
     result.set_value(0, str);
     return result;
   }
 
-  array<string> result(array_size((str.size() + split_length - 1) / split_length, 0, true));
+  array<string> result(array_size((str.size() + split_length - 1) / split_length, true));
   string::size_type i = 0;
   for (i = 0; i + split_length <= str.size(); i += static_cast<string::size_type>(split_length)) {
     result.push_back(str.substr(i, static_cast<string::size_type>(split_length)));

--- a/runtime/tl/tl_builtins.h
+++ b/runtime/tl/tl_builtins.h
@@ -348,7 +348,7 @@ struct t_Vector {
       CurrentProcessingQuery::get().raise_fetching_error("Vector size is negative");
       return {};
     }
-    array<mixed> result(array_size(std::min(n, 10000), 0, true));
+    array<mixed> result(array_size(std::min(n, 10000), true));
     for (int i = 0; i < n; ++i) {
       fetch_magic_if_not_bare(inner_magic, "Incorrect magic of inner type of type Vector");
       const mixed &cur_elem = elem_state.fetch();
@@ -595,7 +595,7 @@ struct t_Tuple {
 
   array<mixed> fetch() {
     CHECK_EXCEPTION(return array<mixed>());
-    array<mixed> result(array_size(size, 0, true));
+    array<mixed> result(array_size(size, true));
     for (int64_t i = 0; i < size; ++i) {
       fetch_magic_if_not_bare(inner_magic, "Incorrect magic of inner type of type Tuple");
       result.push_back(elem_state.fetch());
@@ -666,7 +666,7 @@ struct tl_array {
   }
 
   array<mixed> fetch() {
-    array<mixed> result(array_size(size, 0, true));
+    array<mixed> result(array_size(size, true));
     CHECK_EXCEPTION(return result);
     for (int64_t i = 0; i < size; ++i) {
       fetch_magic_if_not_bare(inner_magic, "Incorrect magic of inner type of tl array");

--- a/runtime/tl/tl_builtins.h
+++ b/runtime/tl/tl_builtins.h
@@ -387,7 +387,7 @@ struct t_Vector {
       CurrentProcessingQuery::get().raise_fetching_error("Vector size is negative");
       return;
     }
-    out.reserve(n, 0, true);
+    out.reserve(n, true);
 
     if (std::is_same<T, t_Double>{} && inner_magic == 0) {
       fetch_raw_vector_T<typename T::PhpType>(out, n);
@@ -623,7 +623,7 @@ struct t_Tuple {
 
   void typed_fetch_to(PhpType &out) {
     CHECK_EXCEPTION(return);
-    out.reserve(size, 0, true);
+    out.reserve(size, true);
 
     if (std::is_same<T, t_Double>{} && inner_magic == 0) {
       fetch_raw_vector_T<typename T::PhpType>(out, size);
@@ -696,7 +696,7 @@ struct tl_array {
 
   void typed_fetch_to(PhpType &out) {
     CHECK_EXCEPTION(return);
-    out.reserve(size, 0, true);
+    out.reserve(size, true);
 
     if (std::is_same<T, t_Double>{} && inner_magic == 0) {
       fetch_raw_vector_T<typename T::PhpType>(out, size);

--- a/runtime/to-array-processor.h
+++ b/runtime/to-array-processor.h
@@ -89,7 +89,7 @@ private:
   template<class ...Args>
   void process_impl(const char *field_name, const std::tuple<Args...> &value) {
     ToArrayVisitor tuple_processor{with_class_names_};
-    tuple_processor.result_.reserve(sizeof...(Args), 0, true);
+    tuple_processor.result_.reserve(sizeof...(Args), true);
 
     process_tuple(value, tuple_processor, std::index_sequence_for<Args...>{});
     add_value(field_name, std::move(tuple_processor).flush_result());
@@ -98,7 +98,7 @@ private:
   template<size_t ...Is, typename ...T>
   void process_impl(const char *field_name, const shape<std::index_sequence<Is...>, T...> &value) {
     ToArrayVisitor shape_processor{with_class_names_};
-    shape_processor.result_.reserve(sizeof...(Is), 0, true);
+    shape_processor.result_.reserve(sizeof...(Is), true);
 
     process_shape(value, shape_processor);
     add_value(field_name, std::move(shape_processor).flush_result());

--- a/runtime/typed_rpc.cpp
+++ b/runtime/typed_rpc.cpp
@@ -93,7 +93,7 @@ class typed_rpc_tl_query_result_resumable : public Resumable {
 public:
   explicit typed_rpc_tl_query_result_resumable(const array<int64_t> &query_ids, const RpcErrorFactory &error_factory) :
     query_ids_(query_ids),
-    unsorted_results_(array_size(query_ids_.count(), 0, false)),
+    unsorted_results_(array_size(query_ids_.count(), false)),
     error_factory_(error_factory) {
   }
 
@@ -222,7 +222,7 @@ array<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_impl(const 
 
 array<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_synchronously_impl(const array<int64_t> &query_ids,
                                                                                         const RpcErrorFactory &error_factory) {
-  array<class_instance<C$VK$TL$RpcResponse>> unsorted_results(array_size(query_ids.count(), 0, false));
+  array<class_instance<C$VK$TL$RpcResponse>> unsorted_results(array_size(query_ids.count(), false));
 
   if (query_ids.count() == 1) {
     const int64_t query_id = query_ids.begin().get_value();

--- a/runtime/uber-h3.cpp
+++ b/runtime/uber-h3.cpp
@@ -38,7 +38,7 @@ inline int32_t check_resolution_param(int64_t resolution) noexcept {
 
 template<class T>
 array<T> make_zeros_vector(int64_t elements) noexcept {
-  array<T> elements_vector{array_size{elements, 0, true}};
+  array<T> elements_vector{array_size{elements, true}};
   if (elements) {
     elements_vector.fill_vector(elements, 0);
   }
@@ -62,8 +62,8 @@ class GeoPolygonOwner {
 public:
   GeoPolygonOwner(const array<std::tuple<double, double>> &polygon_boundary,
                   const array<array<std::tuple<double, double>>> &holes) noexcept:
-    polygon_boundary_(array_size{polygon_boundary.count(), 0, true}),
-    holes_(array_size{holes.count(), 0, true}) {
+    polygon_boundary_(array_size{polygon_boundary.count(), true}),
+    holes_(array_size{holes.count(), true}) {
     for (const auto &boundary_vertex : polygon_boundary) {
       polygon_boundary_.emplace_back(deg2coord(boundary_vertex.get_value()));
     }
@@ -123,7 +123,7 @@ std::tuple<double, double> f$UberH3$$h3ToGeo(int64_t h3_index) noexcept {
 array<std::tuple<double, double>> f$UberH3$$h3ToGeoBoundary(int64_t h3_index) noexcept {
   GeoBoundary boundary;
   h3ToGeoBoundary(h3_index, &boundary);
-  array<std::tuple<double, double>> result{array_size{boundary.numVerts, 0, true}};
+  array<std::tuple<double, double>> result{array_size{boundary.numVerts, true}};
   for (int i = 0; i < boundary.numVerts; ++i) {
     result.emplace_back(coord2deg(boundary.verts[i]));
   }
@@ -203,7 +203,7 @@ Optional<array<std::tuple<int64_t, int64_t>>> f$UberH3$$kRingDistances(int64_t h
   }
 
   const int32_t neighbors_count = maxKringSize(checked_k);
-  array<std::tuple<int64_t, int64_t>> result{array_size{neighbors_count, 0, true}};
+  array<std::tuple<int64_t, int64_t>> result{array_size{neighbors_count, true}};
   if (neighbors_count) {
     auto neighbor_indexes = make_zeros_vector<H3Index>(neighbors_count);
     auto neighbor_distances = make_zeros_vector<int32_t>(neighbors_count);
@@ -237,7 +237,7 @@ Optional<array<std::tuple<int64_t, int64_t>>> f$UberH3$$hexRangeDistances(int64_
   }
 
   const int32_t neighbors_count = maxKringSize(checked_k);
-  array<std::tuple<int64_t, int64_t>> result{array_size{neighbors_count, 0, true}};
+  array<std::tuple<int64_t, int64_t>> result{array_size{neighbors_count, true}};
   if (neighbors_count) {
     auto neighbor_indexes = make_zeros_vector<H3Index>(neighbors_count);
     auto neighbor_distances = make_zeros_vector<int32_t>(neighbors_count);
@@ -422,7 +422,7 @@ Optional<array<int64_t>> f$UberH3$$polyfill(const array<std::tuple<double, doubl
   for (const auto &element : hexagon_indexes) {
     indexes_count += element.get_value() ? 1 : 0;
   }
-  array<int64_t> result_array{array_size{indexes_count, 0, true}};
+  array<int64_t> result_array{array_size{indexes_count, true}};
   for (const auto &element : hexagon_indexes) {
     if (auto h3_index = element.get_value()) {
       result_array.emplace_back(h3_index);

--- a/runtime/uber-h3.cpp
+++ b/runtime/uber-h3.cpp
@@ -50,7 +50,7 @@ inline array<int64_t> indexes2vector(const array<int64_t> &h3_indexes, bool alwa
   if (h3_indexes.is_vector() && !always_deep_copy) {
     h3_vector = h3_indexes;
   } else {
-    h3_vector.reserve(h3_indexes.count(), 0, true);
+    h3_vector.reserve(h3_indexes.count(), true);
     for (const auto &h3_index : h3_indexes) {
       h3_vector.emplace_back(h3_index.get_value());
     }
@@ -76,7 +76,7 @@ public:
         .numVerts = static_cast<int32_t>(vertexes.count()),
         .verts = nullptr
       });
-      holes_vertexes_.reserve(holes_vertexes_.count() + vertexes.count(), 0, true);
+      holes_vertexes_.reserve(holes_vertexes_.count() + vertexes.count(), true);
       for (const auto &hole_vertex : vertexes) {
         holes_vertexes_.emplace_back(deg2coord(hole_vertex.get_value()));
       }

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -50,13 +50,13 @@ public:
     if (dot_pos != std::string::npos) {
       const auto dot_key = key.substr(0, dot_pos + 1);
       if (prev_key != dot_key) {
-        if (counter.int_size > 1) {
+        if (counter.size > 1) {
           size_hints_[prev_key] = counter;
         }
         prev_key = dot_key;
         counter = array_size{};
       }
-      ++counter.int_size;
+      ++counter.size;
 
     }
     return dot_pos;

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -50,18 +50,14 @@ public:
     if (dot_pos != std::string::npos) {
       const auto dot_key = key.substr(0, dot_pos + 1);
       if (prev_key != dot_key) {
-        if (counter.int_size + counter.string_size > 1) {
+        if (counter.int_size > 1) {
           size_hints_[prev_key] = counter;
         }
         prev_key = dot_key;
         counter = array_size{};
       }
-      const auto key_tail = key.substr(dot_pos + 1);
-      if (!key_tail.empty() && php_is_int(key_tail.data(), key_tail.size())) {
-        ++counter.int_size;
-      } else {
-        ++counter.string_size;
-      }
+      ++counter.int_size;
+
     }
     return dot_pos;
   }

--- a/tests/cpp/runtime/array-int-string-keys-collision-test.cpp
+++ b/tests/cpp/runtime/array-int-string-keys-collision-test.cpp
@@ -1,0 +1,112 @@
+#include <gtest/gtest.h>
+
+#include "runtime/array_functions.h"
+#include "runtime/kphp_core.h"
+
+class ArrayIntStringKeysCollision : public testing::Test {
+protected:
+  const string string_key{"my_key"};
+  const int64_t int_key{string_hash(string_key.c_str(), string_key.size())};
+};
+
+TEST_F(ArrayIntStringKeysCollision, string_int_collision) {
+  array<string> arr;
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_FALSE(arr.find_value(int_key));
+
+  arr.set_value(string_key, string{"string_key"});
+  ASSERT_TRUE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{"string_key"});
+  ASSERT_FALSE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{});
+
+  arr.set_value(int_key, string{"int_key"});
+  ASSERT_TRUE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{"string_key"});
+  ASSERT_TRUE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{"int_key"});
+}
+
+TEST_F(ArrayIntStringKeysCollision, int_string_collision) {
+  array<string> arr;
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_FALSE(arr.find_value(int_key));
+
+  arr.set_value(int_key, string{"int_key"});
+  ASSERT_TRUE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{"int_key"});
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{});
+
+  arr.set_value(string_key, string{"string_key"});
+  ASSERT_TRUE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{"int_key"});
+  ASSERT_TRUE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{"string_key"});
+}
+
+TEST_F(ArrayIntStringKeysCollision, unset_int_string_collision) {
+  array<string> arr;
+  arr.set_value(string_key, string{"string_key"});
+  arr.set_value(int_key, string{"int_key"});
+
+  ASSERT_EQ(arr.unset(int_key), string{"int_key"});
+  ASSERT_TRUE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{"string_key"});
+  ASSERT_FALSE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{});
+
+  ASSERT_EQ(arr.unset(string_key), string{"string_key"});
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{});
+  ASSERT_FALSE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{});
+}
+
+TEST_F(ArrayIntStringKeysCollision, unset_string_int_collision) {
+  array<string> arr;
+  arr.set_value(int_key, string{"int_key"});
+  arr.set_value(string_key, string{"string_key"});
+
+  ASSERT_EQ(arr.unset(string_key), string{"string_key"});
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{});
+  ASSERT_TRUE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{"int_key"});
+
+  ASSERT_EQ(arr.unset(int_key), string{"int_key"});
+  ASSERT_FALSE(arr.find_value(string_key));
+  ASSERT_EQ(arr.get_value(string_key), string{});
+  ASSERT_FALSE(arr.find_value(int_key));
+  ASSERT_EQ(arr.get_value(int_key), string{});
+}
+
+TEST_F(ArrayIntStringKeysCollision, ksort_int_string_collision) {
+  array<string> arr;
+  arr.set_value(int_key, string{"int_key"});
+  arr.set_value(string_key, string{"string_key"});
+
+  f$ksort(arr);
+
+  auto it = arr.begin();
+  ASSERT_TRUE(it.is_string_key());
+  ASSERT_EQ(it.get_string_key(), string_key);
+  ++it;
+  ASSERT_FALSE(it.is_string_key());
+  ASSERT_EQ(it.get_int_key(), int_key);
+}
+
+TEST_F(ArrayIntStringKeysCollision, ksort_string_int_collision) {
+  array<string> arr;
+  arr.set_value(string_key, string{"string_key"});
+  arr.set_value(int_key, string{"int_key"});
+
+  f$ksort(arr);
+
+  auto it = arr.begin();
+  ASSERT_TRUE(it.is_string_key());
+  ASSERT_EQ(it.get_string_key(), string_key);
+  ++it;
+  ASSERT_FALSE(it.is_string_key());
+  ASSERT_EQ(it.get_int_key(), int_key);
+}

--- a/tests/cpp/runtime/runtime-tests.cmake
+++ b/tests/cpp/runtime/runtime-tests.cmake
@@ -2,6 +2,7 @@ prepend(RUNTIME_TESTS_SOURCES ${BASE_DIR}/tests/cpp/runtime/
         _runtime-tests-env.cpp
         allocator-malloc-replacement-test.cpp
         array-test.cpp
+        array-int-string-keys-collision-test.cpp
         common-php-functions-test.cpp
         confdata-functions-test.cpp
         confdata-key-maker-test.cpp

--- a/tests/phpt/memory_usage/1_primitive_types.php
+++ b/tests/phpt/memory_usage/1_primitive_types.php
@@ -45,12 +45,12 @@ function test_string() {
 function test_array() {
 #ifndef KPHP
   var_dump(0);
-  var_dump(104);
+  var_dump(96);
   var_dump(0);
-  var_dump(72);
+  var_dump(64);
   var_dump(0);
-  var_dump(72);
-  var_dump(144);
+  var_dump(64);
+  var_dump(128);
   return;
 #endif
   $x = ["hello"];

--- a/tests/phpt/memory_usage/2_classes.php
+++ b/tests/phpt/memory_usage/2_classes.php
@@ -58,8 +58,8 @@ function test_class_with_dynamic_array() {
   } // total size = 16
 
 #ifndef KPHP
-  var_dump(248);
-  var_dump(16 + 248);
+  var_dump(240);
+  var_dump(16 + 240);
   return;
 #endif
   $instance = new MyClass2(10);

--- a/tests/phpt/memory_usage/4_interfaces.php
+++ b/tests/phpt/memory_usage/4_interfaces.php
@@ -46,7 +46,7 @@ function test_interfaces() {
   var_dump(24);
   var_dump(40);
   var_dump(0);
-  var_dump(16 + 16 + 40 + 8 + 8 + 80);
+  var_dump(16 + 24 + 40 + 80);
   return;
 #endif
   var_dump(estimate_memory_usage(new MyClass1()));

--- a/tests/phpt/memory_usage/5_polymorphic_classes.php
+++ b/tests/phpt/memory_usage/5_polymorphic_classes.php
@@ -63,7 +63,7 @@ function test_polymorphic_classes_in_array() {
   var_dump(24);
   var_dump(32);
   var_dump(0);
-  var_dump(16 + 16 + 32 + 24 + 32 + 8 + 96);
+  var_dump(16 + 16 + 32 + 24 + 32 + 96);
   return;
 #endif
   $ix = [new A(), new B1(), new B2(), new C1(), new C2(), null];

--- a/tests/phpt/memory_usage/6_get_global_vars_memory_stats.php
+++ b/tests/phpt/memory_usage/6_get_global_vars_memory_stats.php
@@ -95,9 +95,9 @@ function class_static_vars() {
 function test_get_global_vars_memory_stats() {
 #ifndef KPHP
   $greater_than_16 = [
-    "\$dynamic_array" => 72,
-    "static_vars::\$dynamic_array" => 72,
-    "ClassWithStaticVars::\$dynamic_array" => 72,
+    "\$dynamic_array" => 64,
+    "static_vars::\$dynamic_array" => 64,
+    "ClassWithStaticVars::\$dynamic_array" => 64,
     "ClassWithStaticVars::\$dynamic_string" => 19,
     "\$dynamic_string" => 19,
     "static_vars::\$dynamic_string" => 19


### PR DESCRIPTION
This patch introduces new logic regarding arrays' buckets. The main idea is to join buckets only for string keys (former `struct string_hash_entry`) with buckets only for int keys (former `struct int_hash_entry`) into one common bucket type now called `struct array_bucket` and being able to store any kind of keys. **The patch changes the logic only for hash part of php array**, the vector related part remains almost unchanged.

### Motivation
Imagine next code:
```
$arr = [];
$arr['foo'] = 'bar';
```
On second line array realizes that it must grow to contain the `foo` element. It chooses 11 as the number of buckets and allocates 11 buckets for string type keys and yet 11 for int one.
And here the problem appears - overall 22 buckets only for 1 element, that is too much.
Introduction universal buckets solved the issue, because there is no more difference between sting and int keys, and it's possible to allocate just 11 buckets.

### Measurements
Microbenchmarks showed different results depending on the case e.g:

- patch is extremely good for small arrays as shown above. We save almost a half of memory.
- small, almost negligible improvements for big arrays with string keys. We no longer need to make right shift on memory every time (in order to skip int buckets) to access string buckets.
- worsening for big arrays with int keys. The size of new universal bucket is bigger on 8 bytes for int keys.

So the final decision was up to measurements on production.
They show that e.g. for requests on two of the main urls we save ~23% of allocated memory (275Mb in master against 211Mb in patch for one url; and 227Mb against 175Mb for another). This makes up a significant part of total memory that is consumed for request processing. Saving such amount of memory even improve request time processing on several percents.

### Another changes
### 1. Avoid double allocations through reserves
Previously, for key with unknown type at compilation time compiler had to reserve space in array in both storages - because at runtime such a key may turn out to be either string or int.
```
function get_key($k) { return $k; }
$arr = [get_key(23) => 'foo', get_key('bar') => 'baz'];
```
Here function `get_key()` has `mixed` as return type, thus compiler must generate:
```
// in master; here reserved 2 buckets for int and 2 for strings
array< string > tmp_array = array< string > (array_size (2, 2, false));
// in patch; reserved only 2 buckets
array< string > tmp_array = array< string > (array_size (2, false));
```
The same effect takes place in function `array_unique()`, in internal function `mysql_query_callback()` and in internal autogenerated function `get_global_vars_memory_stats_impl()`

### 2. Avoid double loop in msgpack deserialization
Previously during deserialization msgpack object into php array we made 2 loops: at first loop we calculated numbers of string and int keys in msgpack object, made reserve on php array, and then actually filled php array with data at the second. Now we no longer need to make fist loop since the size of msgpack object is known and we can just make reserve and then fill php array with data in loop.
