### PR TITLE
add json log for timeout in net

### DIFF
--- a/common/fast-backtrace.h
+++ b/common/fast-backtrace.h
@@ -15,5 +15,6 @@ extern char *stack_end;
 
 int fast_backtrace (void **buffer, int size) __attribute__ ((noinline));
 int fast_backtrace_without_recursions(void **buffer, int size) noexcept;
+int fast_backtrace_without_recursions_by_bp(void *bp, void *stack_end_, void **buffer, int size) noexcept;
 
 #endif

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -15,6 +15,7 @@
 #include "server/server-config.h"
 #include "server/json-logger.h"
 #include "server/php-engine-vars.h"
+#include "server/php-runner.h"
 
 namespace {
 
@@ -73,6 +74,30 @@ bool copy_raw_string(char *&out, size_t out_size, vk::string_view str) noexcept 
     }
   }
   return i == str.size();
+}
+
+int script_backtrace(void **buffer, int size) {
+  if (PhpScript::current_script == nullptr) {
+    return 0;
+  }
+  const ucontext_t_portable &context = PhpScript::current_script->run_context;
+#if defined(__APPLE__)
+#if defined(__arm64__)
+  void *rbp = reinterpret_cast<void *>(context.uc_mcontext->__ss.__fp);
+#else
+  void *rbp = reinterpret_cast<void *>(context.uc_mcontext->__ss.__rsp);
+#endif
+#elif defined(__x86_64__)
+  void *rbp = reinterpret_cast<void *>(context.uc_mcontext.gregs[REG_RBP]);
+#elif defined(__aarch64__) || defined(__arm64__)
+  void *rbp = reinterpret_cast<void *>(context.uc_mcontext.fp);
+#else
+  void *rbp = nullptr;
+  size = 0;
+#endif
+  char *stack_start = PhpScript::current_script->script_stack.get_stack_ptr();
+  char *stack_end = stack_start + PhpScript::current_script->script_stack.get_stack_size();
+  return fast_backtrace_without_recursions_by_bp(rbp, stack_end, buffer, size);
 }
 
 } // namespace
@@ -283,6 +308,14 @@ void JsonLogger::write_log_with_backtrace(vk::string_view message, int type) noe
   const int trace_size = backtrace(trace.data(), trace.size());
   write_log(message, type, time(nullptr), trace.data(), trace_size, true);
 }
+
+void JsonLogger::write_log_with_script_backtrace(vk::string_view message, int type) noexcept {
+  dl_assert(!PhpScript::in_script_context, "JsonLogger::write_log_with_script_backtrace must be called only in net context");
+  std::array<void *, 64> trace{};
+  const int trace_size = script_backtrace(trace.data(), trace.size());
+  vk::singleton<JsonLogger>::get().write_log(message, type, time(nullptr), trace.data(), trace_size, true);
+}
+
 
 void JsonLogger::write_stack_overflow_log(int type) noexcept {
   std::array<void *, 64> trace{};

--- a/server/json-logger.cpp
+++ b/server/json-logger.cpp
@@ -313,7 +313,7 @@ void JsonLogger::write_log_with_script_backtrace(vk::string_view message, int ty
   dl_assert(!PhpScript::in_script_context, "JsonLogger::write_log_with_script_backtrace must be called only in net context");
   std::array<void *, 64> trace{};
   const int trace_size = script_backtrace(trace.data(), trace.size());
-  vk::singleton<JsonLogger>::get().write_log(message, type, time(nullptr), trace.data(), trace_size, true);
+  write_log(message, type, time(nullptr), trace.data(), trace_size, true);
 }
 
 

--- a/server/json-logger.h
+++ b/server/json-logger.h
@@ -49,6 +49,8 @@ public:
   // todo: functions bellow use backtrace which isn't async-signal safety
   void write_log(vk::string_view message, int type, int64_t created_at, void *const *trace, int64_t trace_size, bool uncaught) noexcept;
   void write_log_with_backtrace(vk::string_view message, int type) noexcept;
+  void write_log_with_script_backtrace(vk::string_view message, int type) noexcept;
+
   void write_stack_overflow_log(int type) noexcept;
 
   void write_trace_line(const char *json_buf, size_t buf_len) noexcept;

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -66,7 +66,7 @@ int script_backtrace(void **buffer, int size) {
 
 void write_log_with_script_backtrace(vk::string_view message, int type) {
   std::array<void *, 64> trace{};
-  const int trace_size = script_backtrace(trace.data(), 64);
+  const int trace_size = script_backtrace(trace.data(), trace.size());
   vk::singleton<JsonLogger>::get().write_log(message, type, time(nullptr), trace.data(), trace_size, true);
 }
 

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -64,10 +64,10 @@ int script_backtrace(void **buffer, int size) {
   return fast_backtrace_without_recursions_by_bp(rbp, stack_end, buffer, size);
 }
 
-void write_log_with_script_backtrace() {
+void write_log_with_script_backtrace(vk::string_view message, int type) {
   std::array<void *, 64> trace{};
   const int trace_size = script_backtrace(trace.data(), 64);
-  vk::singleton<JsonLogger>::get().write_log("Maximum execution time exceeded", E_ERROR, time(nullptr), trace.data(), trace_size, true);
+  vk::singleton<JsonLogger>::get().write_log(message, type, time(nullptr), trace.data(), trace_size, true);
 }
 
 void default_sigalrm_handler(int signum) {
@@ -79,7 +79,7 @@ void default_sigalrm_handler(int signum) {
     PhpScript::time_limit_exceeded = true;
     if (!PhpScript::in_script_context) {
       if (is_json_log_on_timeout_enabled) {
-        write_log_with_script_backtrace();
+        write_log_with_script_backtrace("Maximum execution time exceeded", E_ERROR);
       }
     } else {
       if (is_json_log_on_timeout_enabled) {
@@ -99,7 +99,7 @@ void sigalrm_handler(int signum) {
       // log timeout event with script backtrace
       // save the timeout fact in order to process it in the script context
       if (is_json_log_on_timeout_enabled) {
-        write_log_with_script_backtrace();
+        write_log_with_script_backtrace("Maximum execution time exceeded", E_ERROR);
       }
       PhpScript::time_limit_exceeded = true;
     } else if (!PhpScript::time_limit_exceeded) {


### PR DESCRIPTION
General
-----------
Before this pr, all timeouts in net-context were ignored and not logged. Now alarm signals will be logged and write script backtrace