### PR TITLE
[tlo-parsing] Fix typo in tlo schema parser

### DIFF
--- a/common/tlo-parsing/tlo-parser.cpp
+++ b/common/tlo-parsing/tlo-parser.cpp
@@ -81,7 +81,8 @@ std::unique_ptr<type_expr_base> tlo_parser::read_type_expr() {
 std::unique_ptr<nat_expr_base> tlo_parser::read_nat_expr() {
   auto magic = get_value<unsigned int>();
   switch (magic) {
-    case TL_TLS_EXPR_NAT: {
+    case TL_TLS_EXPR_NAT: // Legacy typo fix
+    case TL_TLS_NAT_CONST: {
       return std::make_unique<nat_const>(this);
     }
     case TL_TLS_NAT_VAR: {


### PR DESCRIPTION
Due to bug `tl-compiler` always generates `ExprNat` instead of `NatConst` for `NatExpr` case.
Correct .tlo format must fit this scheme:
https://github.com/VKCOM/kphp/blob/c8dc706e0bd125ae1aa9dea0e8f528bd8e146994/common/tl-files/tl.tl#L46 

Here's a fix to maintain correct .tlo format in `tlo-parser`.