### PR TITLE
TLS_NAT_CONST typo fixes

### DIFF
--- a/common/tl/compiler/tl-parser-new.cpp
+++ b/common/tl/compiler/tl-parser-new.cpp
@@ -2946,7 +2946,7 @@ void write_tree(struct tl_combinator_tree *T, int extra, tree_var_value_t **v, i
       write_args(T, v, last_var);
       break;
     case type_num_value:
-      wint(TLS_NAT_CONST);
+      wint(TLS_EXPR_NAT); // This is a typo. It must be TLS_NAT_CONST, but we have to maintain this for backward compatibility
       wint(T->type_flags);
       break;
     case type_num:

--- a/common/tl/compiler/tl-tl.h
+++ b/common/tl/compiler/tl-tl.h
@@ -27,7 +27,7 @@
 #define TLS_EXPR_TYPE 0xecc9da78
 #define TLS_EXPR_NAT 0xdcb49bd8
 
-#define TLS_NAT_CONST 0x8ce940b1
+#define TLS_NAT_CONST 0xdcb49bd8
 #define TLS_NAT_VAR 0x4e8a14f0
 #define TLS_TYPE_VAR 0x0142ceae
 #define TLS_ARRAY 0xd9fb20de

--- a/common/tl/compiler/tl-tl.h
+++ b/common/tl/compiler/tl-tl.h
@@ -27,7 +27,7 @@
 #define TLS_EXPR_TYPE 0xecc9da78
 #define TLS_EXPR_NAT 0xdcb49bd8
 
-#define TLS_NAT_CONST 0xdcb49bd8
+#define TLS_NAT_CONST 0x8ce940b1
 #define TLS_NAT_VAR 0x4e8a14f0
 #define TLS_TYPE_VAR 0x0142ceae
 #define TLS_ARRAY 0xd9fb20de

--- a/vkext/vkext-rpc-tl-serialization.cpp
+++ b/vkext/vkext-rpc-tl-serialization.cpp
@@ -4780,6 +4780,7 @@ struct tl_tree *read_nat_expr(int *var_num) {
     fprintf(stderr, "read_nat_expr: constructor = 0x%08x\n", x);
   }
   switch (x) {
+    case TLS_EXPR_NAT:  // because of legacy typo in TL compiler we must maintain this for backward compatibility
     case TLS_NAT_CONST:
       return read_num_const(var_num);
     case TLS_NAT_VAR:


### PR DESCRIPTION
- keep old _incorrect_ behaviour in `tl-compiler` for backward-compatibility
- maintain _correct_ and _incorrect_ tlo format in `vkext` just in case

relates to https://github.com/VKCOM/kphp/pull/913