### PR TITLE
Security update 2

### DIFF
--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -3,7 +3,7 @@ jsonschema==4.17.3
 portalocker==2.7.0
 psutil==5.9.5
 requests==2.31.0
-urllib3==1.26.12
+urllib3==1.26.18
 requests-toolbelt==0.9.1
 pytest==7.3.1
 pytest-mysql==2.3.1


### PR DESCRIPTION
# Change urllib from 1.26.12 to 1.26.18. Reason 1.
urllib3 previously wouldn't remove the HTTP request body when an HTTP redirect response using status 303 "See Other" after the request had its method changed from one that could accept a request body (like POST) to GET as is required by HTTP RFCs. Although the behavior of removing the request body is not specified in the section for redirects, it can be inferred by piecing together information from different sections and we have observed the behavior in other major HTTP client implementations like curl and web browsers.

From [RFC 9110 Section 9.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-get):

A client SHOULD NOT generate content in a GET request unless it is made directly to an origin server that has previously indicated, in or out of band, that such a request has a purpose and will be adequately supported.
Affected usages

Because the vulnerability requires a previously trusted service to become compromised in order to have an impact on confidentiality we believe the exploitability of this vulnerability is low. Additionally, many users aren't putting sensitive data in HTTP request bodies, if this is the case then this vulnerability isn't exploitable.

Both of the following conditions must be true to be affected by this vulnerability:

If you're using urllib3 and submitting sensitive information in the HTTP request body (such as form data or JSON)
The origin service is compromised and starts redirecting using 303 to a malicious peer or the redirected-to service becomes compromised.

# Change urllib from 1.26.12 to 1.26.18. Reason 2.
urllib3 doesn't treat the Cookie HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a Cookie header and unknowingly leak information via HTTP redirects to a different origin if that user doesn't disable redirects explicitly.

Users must handle redirects themselves instead of relying on urllib3's automatic redirects to achieve safe processing of the Cookie header, thus we decided to strip the header by default in order to further protect users who aren't using the correct approach.

Affected usages

We believe the number of usages affected by this advisory is low. It requires all of the following to be true to be exploited:

Using an affected version of urllib3 (patched in v1.26.17 and v2.0.6)
Using the Cookie header on requests, which is mostly typical for impersonating a browser.
Not disabling HTTP redirects
Either not using HTTPS or for the origin server to redirect to a malicious origin.