### PR TITLE
maintained RpcReqError with headers in kphp

### DIFF
--- a/runtime/runtime.cmake
+++ b/runtime/runtime.cmake
@@ -108,6 +108,7 @@ prepend(KPHP_RUNTIME_SOURCES ${BASE_DIR}/runtime/
         string_buffer.cpp
         string_cache.cpp
         string_functions.cpp
+        tl/rpc_req_error.cpp
         tl/rpc_tl_query.cpp
         tl/rpc_response.cpp
         tl/rpc_server.cpp

--- a/runtime/tl/rpc_req_error.cpp
+++ b/runtime/tl/rpc_req_error.cpp
@@ -1,0 +1,27 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime/tl/rpc_req_error.h"
+
+#include "common/rpc-error-codes.h"
+#include "common/tl/constants/common.h"
+#include "runtime/rpc.h"
+
+bool RpcError::try_fetch() noexcept {
+  int op = rpc_lookup_int();
+  if (op != TL_RPC_REQ_ERROR) {
+    return false;
+  }
+  php_assert(tl_parse_int() == TL_RPC_REQ_ERROR);
+  tl_parse_long();
+  error_code = tl_parse_int();
+  error_msg = tl_parse_string();
+
+  if (!CurException.is_null()) {
+    error_code = TL_ERROR_SYNTAX;
+    error_msg = std::move(CurException->$message);
+    CurException = Optional<bool>{};
+  }
+  return true;
+}

--- a/runtime/tl/rpc_req_error.cpp
+++ b/runtime/tl/rpc_req_error.cpp
@@ -9,11 +9,18 @@
 #include "runtime/rpc.h"
 
 bool RpcError::try_fetch() noexcept {
-  int op = rpc_lookup_int();
+  int pos_backup = rpc_get_pos();
+  int op = tl_parse_int();
+  if (op == TL_REQ_RESULT_HEADER) {
+    int flags = tl_parse_int();
+    fetch_and_skip_header(flags);
+    op = tl_parse_int();
+  }
   if (op != TL_RPC_REQ_ERROR) {
+    rpc_set_pos(pos_backup);
     return false;
   }
-  php_assert(tl_parse_int() == TL_RPC_REQ_ERROR);
+
   tl_parse_long();
   error_code = tl_parse_int();
   error_msg = tl_parse_string();
@@ -24,4 +31,43 @@ bool RpcError::try_fetch() noexcept {
     CurException = Optional<bool>{};
   }
   return true;
+}
+
+void RpcError::fetch_and_skip_header(int flags) const noexcept {
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::binlog_pos) {
+    tl_parse_long();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::binlog_time) {
+    tl_parse_long();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::engine_pid) {
+    tl_parse_int();
+    tl_parse_int();
+    tl_parse_int();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::request_size) {
+    tl_parse_int();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::response_size) {
+    tl_parse_int();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::failed_subqueries) {
+    tl_parse_int();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::compression_version) {
+    tl_parse_int();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::stats) {
+    size_t n = tl_parse_int();
+    for (int i = 0; i < n; ++i) {
+      tl_parse_string();
+      tl_parse_string();
+    }
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::epoch_number) {
+    tl_parse_long();
+  }
+  if (flags & vk::tl::common::rpc_req_result_extra_flags::view_number) {
+    tl_parse_long();
+  }
 }

--- a/runtime/tl/rpc_req_error.h
+++ b/runtime/tl/rpc_req_error.h
@@ -11,4 +11,7 @@ struct RpcError {
   string error_msg = {};
 
   bool try_fetch() noexcept;
+
+private:
+  void fetch_and_skip_header(int flags) const noexcept;
 };

--- a/runtime/tl/rpc_req_error.h
+++ b/runtime/tl/rpc_req_error.h
@@ -1,0 +1,14 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2023 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/kphp_core.h"
+
+struct RpcError {
+  int error_code = 0;
+  string error_msg = {};
+
+  bool try_fetch() noexcept;
+};


### PR DESCRIPTION
## Changes
- Refactored RpcReqError fetching to get rid of copy-paste
- Maintained RpcReqError with headers. When it comes with headers they're just skipped and an error TL object is returned as usual.

relates to #915 