### PR TITLE
Moving options -Wall before extra_cxx_flags to resolve conflicting -Wno-XXX options for clang

### DIFF
--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -284,11 +284,13 @@ void CompilerSettings::init() {
 
   remove_extra_spaces(extra_cxx_flags.value_);
   std::stringstream ss;
-  ss << extra_cxx_flags.get();
-  ss << " -iquote" << kphp_src_path.get()
-     << " -iquote " << kphp_src_path.get() << "objs/generated/auto/runtime";
-  ss << " -Wall -fwrapv -Wno-parentheses -Wno-trigraphs";
-  ss << " -fno-strict-aliasing -fno-omit-frame-pointer";
+  ss << "-Wall "
+     << extra_cxx_flags.get()
+     << " -iquote" << kphp_src_path.get()
+     << " -iquote " << kphp_src_path.get()
+     << "objs/generated/auto/runtime"
+     << " -fwrapv -Wno-parentheses -Wno-trigraphs"
+     << " -fno-strict-aliasing -fno-omit-frame-pointer";
 #ifdef __x86_64__
   ss << " -march=sandybridge";
 #elif __aarch64__


### PR DESCRIPTION
Example:
```
int main() {
  int a = 7;
  int b;
  b = 10;
  return 0;
}
```
Output with _-Wall_:

> $clang++-16 main.cpp -Wall
> main.cpp:4:7: warning: unused variable 'a' [-Wunused-variable]
>   int a = 7;
>       ^
> main.cpp:5:7: warning: variable 'b' set but not used [-Wunused-but-set-variable]
>   int b;
>       ^
> 2 warnings generated.


Output with _-Wno-XXX_ and _-Wall_ at the end:

> $clang++-16 main.cpp -Wno-unused-variable -Wno-unused-but-set-variable -Wall
> main.cpp:4:7: warning: unused variable 'a' [-Wunused-variable]
>   int a = 7;
>       ^
> main.cpp:5:7: warning: variable 'b' set but not used [-Wunused-but-set-variable]
>   int b;
>       ^
> 2 warnings generated.
> 

But if _-Wall_ is before the other _-Wno-XXX_ arguments, everything is compiled successfully