### PR TITLE
Make master outlive confdata out of shared memory errors

### DIFF
--- a/runtime/array_decl.inl
+++ b/runtime/array_decl.inl
@@ -252,6 +252,10 @@ public:
   // we can create true vector
   bool has_no_string_keys() const noexcept;
 
+  static size_t estimate_size(int64_t n, bool is_vector) noexcept {
+    return array_inner::estimate_size(n, is_vector);
+  }
+
   T &operator[](int64_t int_key);
   T &operator[](int32_t key) { return (*this)[int64_t{key}]; }
   T &operator[](const string &s);

--- a/runtime/confdata-global-manager.cpp
+++ b/runtime/confdata-global-manager.cpp
@@ -95,11 +95,12 @@ ConfdataGlobalManager &ConfdataGlobalManager::get() noexcept {
 
 void ConfdataGlobalManager::init(size_t confdata_memory_limit,
                                  std::unordered_set<vk::string_view> &&predefined_wilrdcards,
-                                 std::unique_ptr<re2::RE2> &&blacklist_pattern) noexcept {
+                                 std::unique_ptr<re2::RE2> &&blacklist_pattern,
+                                 std::forward_list<vk::string_view> &&force_ignore_prefixes) noexcept {
   resource_.init(mmap_shared(confdata_memory_limit), confdata_memory_limit);
   confdata_samples_.init(resource_);
   predefined_wildcards_.set_wildcards(std::move(predefined_wilrdcards));
-  key_blacklist_.set_blacklist(std::move(blacklist_pattern));
+  key_blacklist_.set_blacklist(std::move(blacklist_pattern), std::move(force_ignore_prefixes));
 }
 
 ConfdataGlobalManager::~ConfdataGlobalManager() noexcept {

--- a/runtime/confdata-global-manager.h
+++ b/runtime/confdata-global-manager.h
@@ -51,8 +51,9 @@ public:
   static ConfdataGlobalManager &get() noexcept;
 
   void init(size_t confdata_memory_limit,
-    std::unordered_set<vk::string_view> &&predefined_wilrdcards,
-            std::unique_ptr<re2::RE2> &&blacklist_pattern) noexcept;
+            std::unordered_set<vk::string_view> &&predefined_wilrdcards,
+            std::unique_ptr<re2::RE2> &&blacklist_pattern,
+            std::forward_list<vk::string_view> &&force_ignore_prefixes) noexcept;
 
   void force_release_all_resources_acquired_by_this_proc_if_init() noexcept {
     if (is_initialized()) {

--- a/runtime/confdata-keys.cpp
+++ b/runtime/confdata-keys.cpp
@@ -131,3 +131,12 @@ void ConfdataKeyMaker::forcibly_change_first_key_wildcard_dots_from_two_to_one()
   second_key_ = string::make_const_string_on_memory(first_key_end, second_key_len, second_key_buffer_.data(), second_key_buffer_.size());
   first_key_type_ = ConfdataFirstKeyType::one_dot_wildcard;
 }
+
+bool ConfdataKeyBlacklist::is_key_forcibly_ignored_by_prefix(vk::string_view key) const noexcept {
+  for (const vk::string_view &prefix : force_ignore_prefixes_) {
+    if (key.starts_with(prefix)) {
+      return true;
+    }
+  }
+  return false;
+}

--- a/server/confdata-binlog-events.h
+++ b/server/confdata-binlog-events.h
@@ -90,6 +90,10 @@ public:
     return size <= 0 ? mixed{string{}} : mc_get_value(mem, size, get_flags());
   }
 
+  size_t get_data_size() const noexcept {
+    return BASE::data_len;
+  }
+
   vk::string_view get_value_as_string() const noexcept {
     const char *mem = BASE::data + BASE::key_len;
     const int size = BASE::data_len;

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -168,21 +168,20 @@ public:
 
     // disable the blacklist because we checked the keys during the previous step
     blacklist_enabled_ = false;
-    int ret_code = 0;
     for (int i = 0; i < nrecords; i++) {
       if (index_offset[i] >= 0) {
-        auto res = store_element(reinterpret_cast<const entry_type &>(index_binary_data[index_offset[i]]));
-        assert(res != OperationStatus::timed_out); // we don't set timeout on snapshot reading
-        if (current_memory_status() != MemoryStatus::NORMAL) {
-          ret_code = -1;
-          raise_confdata_oom_error("Can't read confdata snapshot on start");
-          break;
-        }
+        store_element(reinterpret_cast<const entry_type &>(index_binary_data[index_offset[i]]));
       }
     }
     blacklist_enabled_ = true;
     size_hints_.clear();
-    return ret_code;
+
+    if (current_memory_status() != MemoryStatus::NORMAL) {
+      raise_confdata_oom_error("Can't read confdata snapshot on start");
+      return -1;
+    }
+
+    return 0;
   }
 
   OperationStatus delete_element(const char *key, short key_len) noexcept {

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -462,19 +462,21 @@ private:
         ++event.throttled_out;
         ++event_counters_.throttled_out_total_events;
         break;
-      case OperationStatus::timed_out:
-        ++event_counters_.update_timeouts_total;
-        break;
       case OperationStatus::blacklisted:
         ++event.blacklisted;
         break;
       case OperationStatus::ttl_update_only:
         ++event.ttl_updated;
         break;
+      case OperationStatus::timed_out:
       case OperationStatus::full_update:
         break;
     }
-    if (current_memory_status() == MemoryStatus::HARD_OOM || status == OperationStatus::timed_out) {
+    if (current_memory_status() == MemoryStatus::HARD_OOM) {
+      return REPLAY_BINLOG_STOP_READING;
+    }
+    if (status == OperationStatus::timed_out) {
+      ++ConfdataStats::get().timed_out_updates;
       return REPLAY_BINLOG_STOP_READING;
     }
     ++event.total;

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -955,6 +955,6 @@ void write_confdata_stats_to(stats_t *stats) noexcept {
     auto &binlog_replayer = ConfdataBinlogReplayer::get();
     confdata_stats.elements_with_delay = binlog_replayer.get_elements_with_delay_count();
     confdata_stats.event_counters = binlog_replayer.get_event_counters();
-    confdata_stats.write_stats_to(stats, ConfdataGlobalManager::get().get_resource().get_memory_stats());
+    confdata_stats.write_stats_to(stats);
   }
 }

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -405,7 +405,7 @@ private:
       assert(wildcard_len <= std::numeric_limits<int16_t>::max());
       processing_key_.update_with_predefined_wildcard(key, key_len, static_cast<int16_t>(wildcard_len));
       const auto operation_status = operation();
-      if (operation_status == OperationStatus::throttled_out && get_memory_status() == MemoryStatus::HARD_OOM) {
+      if (operation_status == OperationStatus::throttled_out) {
         return OperationStatus::throttled_out;
       }
       assert(last_operation_status != OperationStatus::full_update || operation_status == OperationStatus::full_update);
@@ -419,14 +419,14 @@ private:
       const auto first_key_type = processing_key_.update(key, key_len);
       if (predefined_wildcard_lengths.empty() || first_key_type != ConfdataFirstKeyType::simple_key) {
         const auto operation_status = operation();
-        if (operation_status == OperationStatus::throttled_out && get_memory_status() == MemoryStatus::HARD_OOM) {
+        if (operation_status == OperationStatus::throttled_out) {
           return OperationStatus::throttled_out;
         }
         assert(last_operation_status != OperationStatus::full_update || operation_status == OperationStatus::full_update);
         if (operation_status == OperationStatus::full_update && first_key_type == ConfdataFirstKeyType::two_dots_wildcard) {
           processing_key_.forcibly_change_first_key_wildcard_dots_from_two_to_one();
           const auto should_be_full = operation();
-          if (operation_status == OperationStatus::throttled_out && get_memory_status() == MemoryStatus::HARD_OOM) {
+          if (operation_status == OperationStatus::throttled_out) {
             return OperationStatus::throttled_out;
           }
           assert(should_be_full == OperationStatus::full_update);

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -35,8 +35,8 @@ namespace {
 struct {
   const char *binlog_mask{nullptr};
   size_t memory_limit{2u * 1024u * 1024u * 1024u};
-  double soft_oom_threshold_ratio = 0.85;
-  double hard_oom_threshold_ratio = 0.95;
+  double soft_oom_threshold_ratio = CONFDATA_DEFAULT_SOFT_OOM_RATIO;
+  double hard_oom_threshold_ratio = CONFDATA_DEFAULT_HARD_OOM_RATIO;
   double confdata_update_timeout_sec = 0.3;
   std::unique_ptr<re2::RE2> key_blacklist_pattern;
   std::forward_list<vk::string_view> force_ignore_prefixes;
@@ -833,6 +833,10 @@ private:
 };
 
 } // namespace
+
+void set_confdata_soft_oom_ratio(double soft_oom_ratio) noexcept {
+  confdata_settings.soft_oom_threshold_ratio = soft_oom_ratio;
+}
 
 void set_confdata_binlog_mask(const char *mask) noexcept {
   confdata_settings.binlog_mask = mask;

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -604,7 +604,7 @@ private:
 
     // null is inserted by the default
     if (first_key_it->second.is_null()) {
-      if (memory_status == MemoryStatus::SOFT_OOM) {
+      if (memory_status == MemoryStatus::SOFT_OOM) { // todo: unreachable?
         first_key_it->second = array<mixed>{}; // to fit asserts that it's array
         return OperationStatus::throttled_out;
       }
@@ -1023,7 +1023,6 @@ bool update_confdata_state_from_binlog(bool is_initial_reading, double timeout_s
   bool ok = confdata_binlog_replayer.on_finish_update_cycle();
 
   if (!ok) {
-    // TODO: critical?
     log_server_warning("Confdata binlog %supdate timeout %f sec expired", is_initial_reading ? "initial " : "", timeout_sec);
   }
   return ok;

--- a/server/confdata-binlog-replay.h
+++ b/server/confdata-binlog-replay.h
@@ -13,6 +13,7 @@ void set_confdata_binlog_mask(const char *mask) noexcept;
 
 void set_confdata_memory_limit(size_t memory_limit) noexcept;
 void set_confdata_blacklist_pattern(std::unique_ptr<re2::RE2> &&key_blacklist_pattern) noexcept;
+void add_confdata_force_ignore_prefix(const char *key_ignore_prefix) noexcept;
 void add_confdata_predefined_wildcard(const char *wildcard) noexcept;
 void clear_confdata_predefined_wildcards() noexcept;
 

--- a/server/confdata-binlog-replay.h
+++ b/server/confdata-binlog-replay.h
@@ -9,6 +9,10 @@
 
 #include "runtime/allocator.h"
 
+static constexpr double CONFDATA_DEFAULT_SOFT_OOM_RATIO = 0.85;
+static constexpr double CONFDATA_DEFAULT_HARD_OOM_RATIO = 0.95;
+
+void set_confdata_soft_oom_ratio(double soft_oom_ratio) noexcept;
 void set_confdata_binlog_mask(const char *mask) noexcept;
 
 void set_confdata_memory_limit(size_t memory_limit) noexcept;

--- a/server/confdata-binlog-replay.h
+++ b/server/confdata-binlog-replay.h
@@ -13,6 +13,7 @@ void set_confdata_binlog_mask(const char *mask) noexcept;
 
 void set_confdata_memory_limit(size_t memory_limit) noexcept;
 void set_confdata_blacklist_pattern(std::unique_ptr<re2::RE2> &&key_blacklist_pattern) noexcept;
+void set_confdata_update_timeout(double timeout_sec) noexcept;
 void add_confdata_force_ignore_prefix(const char *key_ignore_prefix) noexcept;
 void add_confdata_predefined_wildcard(const char *wildcard) noexcept;
 void clear_confdata_predefined_wildcards() noexcept;
@@ -20,5 +21,6 @@ void clear_confdata_predefined_wildcards() noexcept;
 void init_confdata_binlog_reader() noexcept;
 
 void confdata_binlog_update_cron() noexcept;
+bool update_confdata_state_from_binlog(bool is_initial_reading, double timeout_sec) noexcept;
 
 void write_confdata_stats_to(stats_t *stats) noexcept;

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -92,6 +92,7 @@ void ConfdataStats::write_stats_to(stats_t *stats) const noexcept {
 
   stats->add_gauge_stat("confdata.updates.ignored", ignored_updates);
   stats->add_gauge_stat("confdata.updates.total", total_updates);
+  stats->add_gauge_stat("confdata.updates.timed_out", timed_out_updates);
 
   stats->add_gauge_stat("confdata.elements.total", total_elements);
 

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -36,6 +36,8 @@ void ConfdataStats::on_update(const confdata_sample_storage &new_confdata,
   two_dots_wildcard_elements = 0;
   predefined_wildcards = 0;
   predefined_wildcard_elements = 0;
+  heaviest_sections_by_count.clear();
+
   for (const auto &section: new_confdata) {
     const vk::string_view first_key{section.first.c_str(), section.first.size()};
     switch (confdata_predefined_wildcards.detect_first_key_type(first_key)) {
@@ -50,6 +52,7 @@ void ConfdataStats::on_update(const confdata_sample_storage &new_confdata,
         if (!confdata_predefined_wildcards.has_wildcard_for_key(first_key)) {
           total_elements += section.second.as_array().count();
         }
+        heaviest_sections_by_count.register_section(&section.first, section.second.as_array().count());
         break;
       }
       case ConfdataFirstKeyType::two_dots_wildcard:
@@ -70,11 +73,23 @@ void ConfdataStats::on_update(const confdata_sample_storage &new_confdata,
       }
     }
   }
+  // todo del
+  for (const auto &item : heaviest_sections_by_count.sorted_desc) {
+    if (item.first != nullptr) {
+      fprintf(stderr, "%s: %d\n", item.first->c_str(), (int)item.second);
+    }
+  }
 
   last_update_time_point = std::chrono::steady_clock::now();
 }
 
-void ConfdataStats::write_stats_to(stats_t *stats, const memory_resource::MemoryStats &memory_stats) const noexcept {
+const memory_resource::MemoryStats &ConfdataStats::get_memory_stats() const noexcept {
+  // both ConfdataStats and ConfdataGlobalManager are singletons
+  return ConfdataGlobalManager::get().get_resource().get_memory_stats();
+}
+
+void ConfdataStats::write_stats_to(stats_t *stats) const noexcept {
+  const auto &memory_stats = get_memory_stats();
   memory_stats.write_stats_to(stats, "confdata");
 
   stats->add_gauge_stat("confdata.initial_loading_duration", to_seconds(initial_loading_time));
@@ -129,4 +144,22 @@ void ConfdataStats::write_stats_to(stats_t *stats, const memory_resource::Memory
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "incr_tiny", event_counters.incr_tiny_events);
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "append", event_counters.append_events);
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "unsupported_total", event_counters.unsupported_total_events);
+}
+
+void ConfdataStats::HeaviestSections::clear() {
+  for (int i = 0; i < LEN; ++i) {
+    sorted_desc[i] = std::make_pair(nullptr, 0);
+  }
+}
+
+void ConfdataStats::HeaviestSections::register_section(const string *section_name, size_t size) {
+  for (int ins_pos = 0; ins_pos < LEN; ++ins_pos) {
+    if (size > sorted_desc[ins_pos].second) {
+      for (int shift_pos = LEN - 1; shift_pos >= ins_pos; --shift_pos) {
+        sorted_desc[shift_pos+1] = sorted_desc[shift_pos];
+      }
+      sorted_desc[ins_pos] = std::make_pair(section_name, size);
+      break;
+    }
+  }
 }

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -73,12 +73,6 @@ void ConfdataStats::on_update(const confdata_sample_storage &new_confdata,
       }
     }
   }
-  // todo del
-  for (const auto &item : heaviest_sections_by_count.sorted_desc) {
-    if (item.first != nullptr) {
-      fprintf(stderr, "%s: %d\n", item.first->c_str(), (int)item.second);
-    }
-  }
 
   last_update_time_point = std::chrono::steady_clock::now();
 }

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -138,6 +138,7 @@ void ConfdataStats::write_stats_to(stats_t *stats) const noexcept {
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "incr_tiny", event_counters.incr_tiny_events);
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "append", event_counters.append_events);
   stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "unsupported_total", event_counters.unsupported_total_events);
+  stats->add_gauge_stat_with_type_tag("confdata.binlog_events", "throttled_out_total", event_counters.throttled_out_total_events);
 }
 
 void ConfdataStats::HeaviestSections::clear() {

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -149,8 +149,8 @@ void ConfdataStats::HeaviestSections::clear() {
 void ConfdataStats::HeaviestSections::register_section(const string *section_name, size_t size) {
   for (int ins_pos = 0; ins_pos < LEN; ++ins_pos) {
     if (size > sorted_desc[ins_pos].second) {
-      for (int shift_pos = LEN - 1; shift_pos >= ins_pos; --shift_pos) {
-        sorted_desc[shift_pos+1] = sorted_desc[shift_pos];
+      for (int shift_pos = LEN - 1; shift_pos > ins_pos; --shift_pos) {
+        sorted_desc[shift_pos] = sorted_desc[shift_pos - 1];
       }
       sorted_desc[ins_pos] = std::make_pair(section_name, size);
       break;

--- a/server/confdata-stats.cpp
+++ b/server/confdata-stats.cpp
@@ -16,6 +16,7 @@ void write_event_stats(stats_t *stats, const char *name, const ConfdataStats::Ev
   stats->add_gauge_stat_with_type_tag(name, "total", event.total);
   stats->add_gauge_stat_with_type_tag(name, "blacklisted", event.blacklisted);
   stats->add_gauge_stat_with_type_tag(name, "ignored", event.ignored);
+  stats->add_gauge_stat_with_type_tag(name, "throttled_out", event.throttled_out);
   stats->add_gauge_stat_with_type_tag(name, "ttl_updated", event.ttl_updated);
 }
 

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -66,10 +66,26 @@ struct ConfdataStats : private vk::not_copyable {
     size_t throttled_out_total_events{0};
   } event_counters;
 
+  struct HeaviestSections {
+    static constexpr int LEN = 10;
+
+    // store pointers, not to copy strings when sorting (they point to array keys located in shared mem)
+    std::array<std::pair<const string *, size_t>, LEN> sorted_desc;
+
+    void clear();
+    void register_section(const string *section_name, size_t size);
+  };
+
+  HeaviestSections heaviest_sections_by_count;
+  // in the future, we may want distribution by estimate_memory_usage():
+  // HeaviestSections heaviest_sections_by_mem;
+
+  const memory_resource::MemoryStats &get_memory_stats() const noexcept;
+
   void on_update(const confdata_sample_storage &new_confdata,
                  size_t previous_garbage_size,
                  const ConfdataPredefinedWildcards &predefined_wildcards) noexcept;
-  void write_stats_to(stats_t *stats, const memory_resource::MemoryStats &memory_stats) const noexcept;
+  void write_stats_to(stats_t *stats) const noexcept;
 
 private:
   ConfdataStats() = default;

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -21,7 +21,7 @@ struct ConfdataStats : private vk::not_copyable {
 
   size_t total_updates{0};
   size_t ignored_updates{0};
-  size_t timed_out_updates;
+  size_t timed_out_updates{0};
 
   size_t last_garbage_size{0};
   std::array<size_t, 100> garbage_statistic_{{0}};

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -40,6 +40,7 @@ struct ConfdataStats : private vk::not_copyable {
       size_t total{0};
       size_t blacklisted{0};
       size_t ignored{0};
+      size_t throttled_out{0};
       size_t ttl_updated{0};
     };
 
@@ -62,6 +63,7 @@ struct ConfdataStats : private vk::not_copyable {
     size_t append_events{0};
 
     size_t unsupported_total_events{0};
+    size_t throttled_out_total_events{0};
   } event_counters;
 
   void on_update(const confdata_sample_storage &new_confdata,

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -64,6 +64,7 @@ struct ConfdataStats : private vk::not_copyable {
 
     size_t unsupported_total_events{0};
     size_t throttled_out_total_events{0};
+    size_t update_timeouts_total{0};
   } event_counters;
 
   struct HeaviestSections {

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -21,6 +21,7 @@ struct ConfdataStats : private vk::not_copyable {
 
   size_t total_updates{0};
   size_t ignored_updates{0};
+  size_t timed_out_updates;
 
   size_t last_garbage_size{0};
   std::array<size_t, 100> garbage_statistic_{{0}};
@@ -64,7 +65,6 @@ struct ConfdataStats : private vk::not_copyable {
 
     size_t unsupported_total_events{0};
     size_t throttled_out_total_events{0};
-    size_t update_timeouts_total{0};
   } event_counters;
 
   struct HeaviestSections {

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -22,6 +22,7 @@ double oom_handling_memory_ratio = 0.00;
 
 int worker_id = -1;
 int pid = -1;
+int master_pid = -1;
 
 ProcessType process_type = ProcessType::master;
 

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -32,6 +32,7 @@ extern double oom_handling_memory_ratio;
 
 extern int worker_id;
 extern int pid;
+extern int master_pid;
 
 extern ProcessType process_type;
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2221,6 +2221,12 @@ int main_args_handler(int i, const char *long_option) {
       set_confdata_update_timeout(timeout_sec);
       return res;
     }
+    case 2039: {
+      double soft_oom_ratio;
+      int res = read_option_to(long_option, 0.0, CONFDATA_DEFAULT_HARD_OOM_RATIO, soft_oom_ratio);
+      set_confdata_soft_oom_ratio(soft_oom_ratio);
+      return res;
+    }
     default:
       return -1;
   }
@@ -2333,6 +2339,8 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("confdata-force-ignore-keys-prefix", required_argument, 2037, "an emergency option, e.g. 'highload.vid*', to forcibly drop keys from snapshot/binlog; may be used multiple times");
   parse_option("confdata-update-timeout", required_argument, 2038, "cron confdata binlog replaying will be forcibly stopped after the specified timeout (default: 0.3 sec)"
                                                                    "Initial binlog is readed with x10 times larger timeout");
+  parse_option("confdata-soft-oom-ratio", required_argument, 2039, "Memory limit ratio to start ignoring new keys related events (default: 0.85)."
+                                                                   "Can't be > hard oom ratio (0.95)");
 
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1692,6 +1692,7 @@ void init_all() {
   auto end_time = std::chrono::steady_clock::now();
   uint64_t total_init_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
   StatsHouseManager::get().add_init_master_stats(total_init_ns, ConfdataStats::get().initial_loading_time.count());
+  StatsHouseManager::get().add_confdata_master_stats(ConfdataStats::get());
 }
 
 void init_logname(const char *src) {

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2215,6 +2215,12 @@ int main_args_handler(int i, const char *long_option) {
       add_confdata_force_ignore_prefix(optarg);
       return 0;
     }
+    case 2038: {
+      double timeout_sec;
+      int res = read_option_to(long_option, 0.0, std::numeric_limits<double>::max(), timeout_sec);
+      set_confdata_update_timeout(timeout_sec);
+      return res;
+    }
     default:
       return -1;
   }
@@ -2325,6 +2331,8 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("thread-pool-ratio", required_argument, 2035, "the thread pool size ratio of the overall cpu numbers");
   parse_option("thread-pool-size", required_argument, 2036, "the total threads num per worker");
   parse_option("confdata-force-ignore-keys-prefix", required_argument, 2037, "an emergency option, e.g. 'highload.vid*', to forcibly drop keys from snapshot/binlog; may be used multiple times");
+  parse_option("confdata-update-timeout", required_argument, 2038, "cron confdata binlog replaying will be forcibly stopped after the specified timeout (default: 0.3 sec)"
+                                                                   "Initial binlog is readed with x10 times larger timeout");
 
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2206,6 +2206,14 @@ int main_args_handler(int i, const char *long_option) {
     case 2036: {
       return read_option_to(long_option, 0U, 2048U, thread_pool_size);
     }
+    case 2037: {
+      if (!*optarg) {
+        kprintf("--%s option is empty\n", long_option);
+        return -1;
+      }
+      add_confdata_force_ignore_prefix(optarg);
+      return 0;
+    }
     default:
       return -1;
   }
@@ -2274,7 +2282,7 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("tasks-config", required_argument, 'S', "get lease worker settings from config file: mode and actor");
   parse_option("confdata-binlog", required_argument, 2004, "confdata binlog mask");
   parse_option("confdata-memory-limit", required_argument, 2005, "memory limit for confdata");
-  parse_option("confdata-blacklist", required_argument, 2006, "confdata key blacklist regex pattern");
+  parse_option("confdata-blacklist", required_argument, 2006, "confdata key blacklist regex pattern from PHP code, class KphpConfiguration");
   parse_option("confdata-predefined-wildcard", required_argument, 2007, "perdefine confdata wildcard for better performance");
   parse_option("php-version", no_argument, 2008, "show the compiled php code version and exit");
   parse_option("php-warnings-minimal-verbosity", required_argument, 2009, "set minimum verbosity level for php warnings");
@@ -2315,6 +2323,8 @@ void parse_main_args(int argc, char *argv[]) {
   parse_option("hard-time-limit", required_argument, 2034, "time limit for script termination after the main timeout has expired (default: 1 sec). Use 0 to disable");
   parse_option("thread-pool-ratio", required_argument, 2035, "the thread pool size ratio of the overall cpu numbers");
   parse_option("thread-pool-size", required_argument, 2036, "the total threads num per worker");
+  parse_option("confdata-force-ignore-keys-prefix", required_argument, 2037, "an emergency option, e.g. 'highload.vid*', to forcibly drop keys from snapshot/binlog; may be used multiple times");
+
   parse_engine_options_long(argc, argv, main_args_handler);
   parse_main_args_till_option(argc, argv);
   // TODO: remove it after successful migration from kphb.readyV2 to kphb.readyV3

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2360,6 +2360,7 @@ void init_default() {
   now = (int)time(nullptr);
 
   pid = getpid();
+  master_pid = getpid();
   // RPC part
   PID.port = (short)rpc_port;
 

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -54,7 +54,6 @@
 #include "runtime/instance-cache.h"
 #include "runtime/thread-pool.h"
 #include "server/confdata-binlog-replay.h"
-#include "server/confdata-stats.h"
 #include "server/http-server-context.h"
 #include "server/lease-rpc-client.h"
 #include "server/master-name.h"
@@ -1400,7 +1399,7 @@ static void master_cron() {
     // write stats at the beginning to avoid spikes in graphs
     send_data_to_statsd_with_prefix(vk::singleton<ServerConfig>::get().get_statsd_prefix(), stats_tag_kphp_server);
     const auto cpu_stats = server_stats.cpu[1].get_stat();
-    StatsHouseManager::get().add_common_master_stats(workers_stats, instance_cache_get_memory_stats(), ConfdataStats::get(), cpu_stats.cpu_s_usage, cpu_stats.cpu_u_usage,
+    StatsHouseManager::get().add_common_master_stats(workers_stats, instance_cache_get_memory_stats(), cpu_stats.cpu_s_usage, cpu_stats.cpu_u_usage,
                                                      instance_cache_memory_swaps_ok, instance_cache_memory_swaps_fail);
   }
   create_all_outbound_connections();

--- a/server/php-master.cpp
+++ b/server/php-master.cpp
@@ -54,6 +54,7 @@
 #include "runtime/instance-cache.h"
 #include "runtime/thread-pool.h"
 #include "server/confdata-binlog-replay.h"
+#include "server/confdata-stats.h"
 #include "server/http-server-context.h"
 #include "server/lease-rpc-client.h"
 #include "server/master-name.h"
@@ -1399,7 +1400,7 @@ static void master_cron() {
     // write stats at the beginning to avoid spikes in graphs
     send_data_to_statsd_with_prefix(vk::singleton<ServerConfig>::get().get_statsd_prefix(), stats_tag_kphp_server);
     const auto cpu_stats = server_stats.cpu[1].get_stat();
-    StatsHouseManager::get().add_common_master_stats(workers_stats, instance_cache_get_memory_stats(), cpu_stats.cpu_s_usage, cpu_stats.cpu_u_usage,
+    StatsHouseManager::get().add_common_master_stats(workers_stats, instance_cache_get_memory_stats(), ConfdataStats::get(), cpu_stats.cpu_s_usage, cpu_stats.cpu_u_usage,
                                                      instance_cache_memory_swaps_ok, instance_cache_memory_swaps_fail);
   }
   create_all_outbound_connections();

--- a/server/signal-handlers.cpp
+++ b/server/signal-handlers.cpp
@@ -217,7 +217,7 @@ void sigabrt_handler(int, siginfo_t *info, void *) {
   print_http_data();
   dl_print_backtrace(trace, trace_size);
   kill_workers();
-  if (static_cast<ExtraSignalAction>(info->si_value.sival_int) == ExtraSignalAction::GENERATE_COREDUMP) {
+  if (getpid() == master_pid || static_cast<ExtraSignalAction>(info->si_value.sival_int) == ExtraSignalAction::GENERATE_COREDUMP) {
     raise(SIGQUIT); // hack for generate core dump
   }
   _exit(EXIT_FAILURE);

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -322,7 +322,6 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   for (const auto &[section_name, size] : confdata_stats.heaviest_sections_by_count.sorted_desc) {
     if (section_name != nullptr && size > 0) { // section_name looks like "highload."
       client.metric("kphp_confdata_sections_by_count").tag(section_name->c_str()).write_value(size);
-      // fprintf(stderr, "%s: %d\n", section_name->c_str(), static_cast<int>(size));
     }
   }
 }

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -317,7 +317,8 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   client.metric("kphp_confdata_events").tag("delete").write_value(events.delete_events.total);
   client.metric("kphp_confdata_events").tag("delete_blacklisted").write_value(events.delete_events.blacklisted);
   client.metric("kphp_confdata_events").tag("throttled_out").write_value(events.throttled_out_total_events);
-  client.metric("kphp_confdata_events").tag("timed_out").write_value(events.update_timeouts_total);
+
+  client.metric("kphp_confdata_update_timeouts").write_value(events.update_timeouts_total);
 
   for (const auto &[section_name, size] : confdata_stats.heaviest_sections_by_count.sorted_desc) {
     if (section_name != nullptr && size > 0) { // section_name looks like "highload."

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -317,6 +317,7 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   client.metric("kphp_confdata_events").tag("delete").write_value(events.delete_events.total);
   client.metric("kphp_confdata_events").tag("delete_blacklisted").write_value(events.delete_events.blacklisted);
   client.metric("kphp_confdata_events").tag("throttled_out").write_value(events.throttled_out_total_events);
+  client.metric("kphp_confdata_events").tag("timed_out").write_value(events.update_timeouts_total);
 
   for (const auto &[section_name, size] : confdata_stats.heaviest_sections_by_count.sorted_desc) {
     if (section_name != nullptr && size > 0) { // section_name looks like "highload."

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -318,7 +318,8 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   client.metric("kphp_confdata_events").tag("delete_blacklisted").write_value(events.delete_events.blacklisted);
   client.metric("kphp_confdata_events").tag("throttled_out").write_value(events.throttled_out_total_events);
 
-  client.metric("kphp_confdata_update_timeouts").write_value(events.update_timeouts_total);
+  client.metric("kphp_confdata_update_fails").tag("ignored").write_value(confdata_stats.ignored_updates);
+  client.metric("kphp_confdata_update_fails").tag("timed_out").write_value(confdata_stats.timed_out_updates);
 
   for (const auto &[section_name, size] : confdata_stats.heaviest_sections_by_count.sorted_desc) {
     if (section_name != nullptr && size > 0) { // section_name looks like "highload."

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -19,6 +19,8 @@ using normalization_function = std::function<string(const string &)>;
 
 enum class script_error_t : uint8_t;
 
+struct ConfdataStats;
+
 class StatsHouseManager : vk::not_copyable {
 public:
   static void init(const std::string &ip, int port) {
@@ -69,7 +71,10 @@ public:
   /**
    * Must be called from master process only
    */
-  void add_common_master_stats(const workers_stats_t &workers_stats, const memory_resource::MemoryStats &memory_stats, double cpu_s_usage, double cpu_u_usage,
+  void add_common_master_stats(const workers_stats_t &workers_stats,
+                               const memory_resource::MemoryStats &instance_cache_memory_stats,
+                               const ConfdataStats &confdata_stats,
+                               double cpu_s_usage, double cpu_u_usage,
                                long long int instance_cache_memory_swaps_ok, long long int instance_cache_memory_swaps_fail);
 
   /**

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -73,7 +73,6 @@ public:
    */
   void add_common_master_stats(const workers_stats_t &workers_stats,
                                const memory_resource::MemoryStats &instance_cache_memory_stats,
-                               const ConfdataStats &confdata_stats,
                                double cpu_s_usage, double cpu_u_usage,
                                long long int instance_cache_memory_swaps_ok, long long int instance_cache_memory_swaps_fail);
 
@@ -86,6 +85,8 @@ public:
    * before calling the method, be sure to is_extended_instance_cache_stats_enabled() is true
    */
   void add_extended_instance_cache_stats(std::string_view type, std::string_view status, const string &key, uint64_t size = 0);
+
+  void add_confdata_master_stats(const ConfdataStats &confdata_stats);
 
 private:
   StatsHouseClient client;

--- a/tests/cpp/runtime/confdata-functions-test.cpp
+++ b/tests/cpp/runtime/confdata-functions-test.cpp
@@ -13,8 +13,9 @@ void init_global_confdata_confdata() {
   initiated = true;
 
   pid = 0;
+  std::forward_list<vk::string_view> force_ignore_prefixes;
   auto &global_manager = ConfdataGlobalManager::get();
-  global_manager.init(1024 * 1024 * 16, std::unordered_set<vk::string_view>{}, nullptr);
+  global_manager.init(1024 * 1024 * 16, std::unordered_set<vk::string_view>{}, nullptr, std::move(force_ignore_prefixes));
   auto confdata_sample_storage = global_manager.get_current().get_confdata();
 
   confdata_sample_storage[string{"_key_1"}] = string{"value_1"};

--- a/tests/python/lib/engine.py
+++ b/tests/python/lib/engine.py
@@ -115,11 +115,15 @@ class Engine:
         self._stats_receiver.start()
 
         cmd = [self._engine_bin]
-        for option, value in self._options.items():
-            if value is not None:
-                cmd.append(option)
-                if value is not True:
-                    cmd.append(str(value))
+        for option, value_raw in self._options.items():
+            if value_raw is not None:
+                value_list = value_raw
+                if type(value_raw) is not list:
+                    value_list = [value_raw]
+                for val in value_list:
+                    cmd.append(option)
+                    if val is not True:
+                        cmd.append(str(val))
 
         if self._binlog_path:
             cmd.append(self._binlog_path)

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -34,11 +34,11 @@ def search_kphp2cpp():
 
 
 def search_engine_bin(engine_name):
-    return _check_file("bin/" + engine_name, _ENGINE_INSTALL_PATH, _check_bin)
+    return _check_file("bin/" + engine_name, _ENGINE_INSTALL_PATH, _check_bin) if _ENGINE_INSTALL_PATH else engine_name
 
 
 def search_tl_client():
-    return _check_file("bin/tlclient", _ENGINE_INSTALL_PATH, _check_bin)
+    return _check_file("bin/tlclient", _ENGINE_INSTALL_PATH, _check_bin) if _ENGINE_INSTALL_PATH else "tlclient"
 
 
 def search_combined_tlo(working_dir):

--- a/tests/python/tests/json_logs/test_signals.py
+++ b/tests/python/tests/json_logs/test_signals.py
@@ -90,7 +90,9 @@ class TestJsonLogsSignals(KphpServerAutoTestCase):
 
     def test_master_sigabrt(self):
         self.kphp_server.send_signal(signal.SIGABRT)
-        self.kphp_server.restart()
+        with self.assertRaises(RuntimeError):
+            self.kphp_server.stop()
+        self.kphp_server.start()
         self.kphp_server.assert_json_log(
             expect=[{
                 "version": 0, "type": -1, "env": "", "msg": "SIGABRT terminating program",


### PR DESCRIPTION
Here're two new approaches:
## Events throttling
To prevent OOM errors on confdata overflows we start to throttle events, when too little shared memory left. There're two modes:
- Soft OOM (85%) - replay only existing keys related events until server restart. Ignore new keys.
- Hard OOM (95%) - replay nothing. Ignore all events, don't read binlog at all.

If server enters any OOM modes, it can't go back out of it. Manual server restart is needed for that.

## External preventive allocation heuristic checks
Before any action, that internally invokes allocations, we explicitly check that allocator has enough memory for that.
To achieve this we need to somehow calculate upper-bound for memory that will be required by the action in each particular case.
There're two 'kinds' of allocations:
1. Allocation made by our runtime (`array<mixed>::mutate_if_shared()`, etc..). It's not too complicated, because it's our own code and we can calculate it easily.
2. Allocation made by STL, out of `std::map<>` which uses our shared memory allocator.  To handle this we will use common sense, some knowledge about search trees internal structure and compile time upper-bound for tree node size from our allocator: https://github.com/VKCOM/kphp/blob/d685b6cce3cc351d48816d7bc982800c93b18d52/runtime/memory_resource/resource_allocator.h#L48

## New stats for confdata 

This PR also includes writing confdata metrics to statshouse:
- `kphp_confdata_memory` 
- `kphp_confdata_events`
- `kphp_confdata_sections_by_count`
- `kphp_confdata_update_fails`

## New option for blacklisting confdata events

`--confdata-force-ignore-keys-prefix` — an emergency option, e.g. 'highload.vid*', to forcibly drop keys from snapshot/binlog; may be used multiple times.

## Timeouts for reading binlog

To prevent master hanging in `master_cron()`, a timeout for reading a next binlog chunk is added, controlled by `--confdata-update-timeout`. Every second (every cron iteration) we allow binlog reader to consume next event no more than timeout seconds. That allows master to perform other work.

Note, that an option for reading binlog in a separate thread can't be implemented, since the master process is also fundamentally single-threaded (lots of globals, global allocator, global allocator switches between heap/shared memory, etc.).