### PR TITLE
Fix jammy installing from deb package

### DIFF
--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -182,7 +182,7 @@ std::string get_default_extra_cxxflags() noexcept {
 }
 
 std::string get_default_extra_ldflags() noexcept {
-  std::string flags{"-L${KPHP_PATH}/objs/flex -ggdb"};
+  std::string flags{"-L${KPHP_PATH}/objs/flex -ggdb -fno-lto"};
 #ifdef KPHP_HAS_NO_PIE
   flags += " " KPHP_HAS_NO_PIE;
 #endif


### PR DESCRIPTION
Started from ubuntu 21.04 there is default LTO optimisation for all installing deb package include kphp. It's causes errors then kphp transpiling php script. Fix is just flag to disable LTO. 