### PR TITLE
increasing the maximum length of an rpc query in vkext

### DIFF
--- a/vkext/vkext-rpc.h
+++ b/vkext/vkext-rpc.h
@@ -12,7 +12,7 @@
 #define RPC_BUF_SIZE (1 << 12)
 #define RPC_SERVER_MAGIC 0x8940303d
 #define RPC_BUFFER_MAGIC 0x8fa0da0c
-#define RPC_MAX_QUERY_LEN (1 << 20)
+#define RPC_MAX_QUERY_LEN (1 << 24)
 
 #define RPC_SKIP 0
 


### PR DESCRIPTION
For history :)
The code to reproduce the problem:
tl scheme:
```
---types---
kphp.testResponse
 elements:(%Vector int) = kphp.TestResponse;

---functions---
@kphp
kphp.testQuery count: int = kphp.TestResponse;
```

simple server (build by kphp2cpp and run with -r port arg):
```
<?php

try {
  /** @var \VK\TL\RpcFunction */
  $request = rpc_server_fetch_request();

  if ($request instanceof \VK\TL\kphp\Functions\kphp_testQuery) {
    $value = array_fill(0, $request->count, 7);
    $response = \VK\TL\kphp\Functions\kphp_testQuery::createRpcServerResponse($value);
    rpc_server_store_response($response);
  } else {
    store_error(-2001, "Unsupported function");
  }
} catch (Exception $e) {
  warning('Fatal error: ' . $e->getMessage());
  store_error(-2002, $e->getMessage());
}
```

client (run like php script):
```
<?php
  $count = 262136 + 1; // 4 bytes = 1 int, 1 mb = ((1 << 20) / 4) ints = 262 144 ints (+ 32 bytes request header, -8 ints)
  $connection = new_rpc_connection('127.0.0.1', 8091, 0);
  $query = ['kphp.testQuery', $count];

  $query_ids = rpc_tl_query($connection, [$query]);
  $results = rpc_tl_query_result($query_ids);
  var_dump($results);
```

Output:
```
array(1) {
  [0] =>
  array(2) {
    '__error' =>
    string(38) "Response not found, probably timed out"
    '__error_code' =>
    int(-4102)
  }
}
```

But after merging these changes, we can use 16 mb in the response body.