### PR TITLE
Add link -fno-lto option

### DIFF
--- a/cmake/init-compilation-flags.cmake
+++ b/cmake/init-compilation-flags.cmake
@@ -27,6 +27,9 @@ if(APPLE)
     else()
         message(FATAL_ERROR "unsupported arch: ${CMAKE_SYSTEM_PROCESSOR}")
     endif()
+else()
+    # Since Ubuntu 22.04 lto is enabled by default; breaks some builds
+    add_link_options(-fno-lto)
 endif()
 
 set(OPENSSL_USE_STATIC_LIBS TRUE)


### PR DESCRIPTION
Since Ubuntu 22.04, lto is enabled by default. It  breaks some builds, let's add `-fno-lto` link option in CMake  by default!