### PR TITLE
Refactor stream_functions to C++ style

### DIFF
--- a/runtime/files.h
+++ b/runtime/files.h
@@ -8,9 +8,60 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include "runtime/kphp_core.h"
+#include "runtime/stream_functions.h"
 
 extern const string LETTER_a;
+
+struct file_stream_functions : stream_functions {
+  file_stream_functions() {
+    name = string("file");
+    supported_functions.set_value(string("fopen"), true);
+    supported_functions.set_value(string("fwrite"), true);
+    supported_functions.set_value(string("fseek"), true);
+    supported_functions.set_value(string("ftell"), true);
+    supported_functions.set_value(string("fread"), true);
+    supported_functions.set_value(string("fgetc"), true);
+    supported_functions.set_value(string("fgets"), true);
+    supported_functions.set_value(string("fpassthru"), true);
+    supported_functions.set_value(string("fflush"), true);
+    supported_functions.set_value(string("feof"), true);
+    supported_functions.set_value(string("fclose"), true);
+    supported_functions.set_value(string("file_get_contents"), true);
+    supported_functions.set_value(string("file_put_contents"), true);
+    supported_functions.set_value(string("stream_socket_client"), false);
+    supported_functions.set_value(string("context_set_option"), false);
+    supported_functions.set_value(string("stream_set_option"), false);
+    supported_functions.set_value(string("get_fd"), false);
+  }
+
+  ~file_stream_functions() override = default;
+
+  Stream fopen(const string &stream, const string &mode) const override;
+
+  Optional<int64_t> fwrite(const Stream &stream, const string &data) const override;
+
+  int64_t fseek(const Stream &stream, int64_t offset, int64_t whence) const override;
+
+  Optional<int64_t> ftell(const Stream &stream) const override;
+
+  Optional<string> fread(const Stream &stream, int64_t length) const override;
+
+  Optional<string> fgetc(const Stream &stream) const override;
+
+  Optional<string> fgets(const Stream &stream, int64_t length) const override;
+
+  Optional<int64_t> fpassthru(const Stream &stream) const override;
+
+  bool fflush(const Stream &stream) const override;
+
+  bool feof(const Stream &stream) const override;
+
+  bool fclose(const Stream &stream) const override;
+
+  Optional<string> file_get_contents(const string &url) const override;
+
+  Optional<int64_t> file_put_contents(const string &url, const string &content, int64_t flags) const override;
+};
 
 
 int32_t close_safe(int32_t fd);

--- a/runtime/interface.h
+++ b/runtime/interface.h
@@ -9,14 +9,65 @@
 #include "common/wrappers/string_view.h"
 
 #include "runtime/critical_section.h"
-#include "runtime/kphp_core.h"
 #include "runtime/optional.h"
+#include "runtime/stream_functions.h"
 #include "server/php-query-data.h"
 #include "server/statshouse/statshouse-manager.h"
 #include "server/workers-control.h"
 
 extern string_buffer *coub;//TODO static
 using shutdown_function_type = std::function<void()>;
+
+struct php_stream_functions : stream_functions {
+  php_stream_functions() {
+    name = string("php");
+    supported_functions.set_value(string("fopen"), true);
+    supported_functions.set_value(string("fwrite"), true);
+    supported_functions.set_value(string("fseek"), true);
+    supported_functions.set_value(string("ftell"), true);
+    supported_functions.set_value(string("fread"), true);
+    supported_functions.set_value(string("fgetc"), true);
+    supported_functions.set_value(string("fgets"), true);
+    supported_functions.set_value(string("fpassthru"), true);
+    supported_functions.set_value(string("fflush"), true);
+    supported_functions.set_value(string("feof"), true);
+    supported_functions.set_value(string("fclose"), true);
+    supported_functions.set_value(string("file_get_contents"), true);
+    supported_functions.set_value(string("file_put_contents"), true);
+    supported_functions.set_value(string("stream_socket_client"), false);
+    supported_functions.set_value(string("context_set_option"), false);
+    supported_functions.set_value(string("stream_set_option"), false);
+    supported_functions.set_value(string("get_fd"), false);
+  }
+
+  ~php_stream_functions() override = default;
+
+  Stream fopen(const string &stream, const string &mode) const override;
+
+  Optional<int64_t> fwrite(const Stream &stream, const string &data) const override;
+
+  int64_t fseek(const Stream &stream, int64_t offset, int64_t whence) const override;
+
+  Optional<int64_t> ftell(const Stream &stream) const override;
+
+  Optional<string> fread(const Stream &stream, int64_t length) const override;
+
+  Optional<string> fgetc(const Stream &stream) const override;
+
+  Optional<string> fgets(const Stream &stream, int64_t length) const override;
+
+  Optional<int64_t> fpassthru(const Stream &stream) const override;
+
+  bool fflush(const Stream &stream) const override;
+
+  bool feof(const Stream &stream) const override;
+
+  bool fclose(const Stream &stream) const override;
+
+  Optional<string> file_get_contents(const string &url) const override;
+
+  Optional<int64_t> file_put_contents(const string &url, const string &content, int64_t flags) const override;
+};
 
 enum class shutdown_functions_status {
   not_executed,
@@ -219,7 +270,7 @@ void use_utf8();
  *
  */
 
-// for degug use only
+// for debug use only
 void f$raise_sigsegv();
 
 template<class T>

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -613,6 +613,7 @@ Optional<string> f$openssl_random_pseudo_bytes(int64_t length) {
   return std::move(buffer);
 }
 
+namespace {
 
 struct ssl_connection {
   int sock;
@@ -623,13 +624,15 @@ struct ssl_connection {
 };
 
 static char ssl_connections_storage[sizeof(array<ssl_connection>)];
-static array<ssl_connection> *ssl_connections = reinterpret_cast <array<ssl_connection> *> (ssl_connections_storage);
+static array<ssl_connection> *ssl_connections = reinterpret_cast<array<ssl_connection> *>(ssl_connections_storage);
 static long long ssl_connections_last_query_num = -1;
-
 
 const int DEFAULT_SOCKET_TIMEOUT = 60;
 
-static Stream ssl_stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags __attribute__((unused)), const mixed &options) {
+} // namespace
+
+Stream ssl_stream_functions::stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout,
+                                                  int64_t flags __attribute__((unused)), const mixed &options) const {
 #define RETURN(dump_error_stack)                        \
   if (dump_error_stack) {                               \
     php_warning ("%s: %s", error_description.c_str(),   \
@@ -880,7 +883,7 @@ static Stream ssl_stream_socket_client(const string &url, int64_t &error_number,
 #undef RETURN_ERROR_FORMAT
 }
 
-static bool ssl_context_set_option(mixed &context_ssl, const string &option, const mixed &value) {
+bool ssl_stream_functions::context_set_option(mixed &context_ssl, const string &option, const mixed &value) const {
   if (STRING_EQUALS(option, "verify_peer") ||
       STRING_EQUALS(option, "verify_depth") ||
       STRING_EQUALS(option, "cafile") ||
@@ -895,7 +898,7 @@ static bool ssl_context_set_option(mixed &context_ssl, const string &option, con
   return false;
 }
 
-ssl_connection *get_connection(const Stream &stream) {
+static ssl_connection *get_connection(const Stream &stream) {
   if (dl::query_num != ssl_connections_last_query_num || !ssl_connections->has_key(stream.to_string())) {
     php_warning("Connection to \"%s\" not found", stream.to_string().c_str());
     return nullptr;
@@ -974,7 +977,7 @@ static bool process_ssl_error(ssl_connection *c, int result) {
   }
 }
 
-static Optional<int64_t> ssl_fwrite(const Stream &stream, const string &data) {
+Optional<int64_t> ssl_stream_functions::fwrite(const Stream &stream, const string &data) const {
   ssl_connection *c = get_connection(stream);
   if (c == nullptr || c->sock == -1) {
     return false;
@@ -1009,7 +1012,7 @@ static Optional<int64_t> ssl_fwrite(const Stream &stream, const string &data) {
   }
 }
 
-static Optional<string> ssl_fread(const Stream &stream, int64_t length) {
+Optional<string> ssl_stream_functions::fread(const Stream &stream, int64_t length) const {
   if (length <= 0) {
     php_warning("Parameter length in function fread must be positive");
     return false;
@@ -1044,7 +1047,7 @@ static Optional<string> ssl_fread(const Stream &stream, int64_t length) {
   }
 }
 
-static bool ssl_feof(const Stream &stream) {
+bool ssl_stream_functions::feof(const Stream &stream) const {
   ssl_connection *c = get_connection(stream);
   if (c == nullptr || c->sock == -1) {
     return true;
@@ -1069,7 +1072,7 @@ static bool ssl_feof(const Stream &stream) {
   }
 }
 
-static bool ssl_fclose(const Stream &stream) {
+bool ssl_stream_functions::fclose(const Stream &stream) const {
   const string &stream_key = stream.to_string();
   if (dl::query_num != ssl_connections_last_query_num || !ssl_connections->has_key(stream_key)) {
     return false;
@@ -1081,7 +1084,7 @@ static bool ssl_fclose(const Stream &stream) {
   return true;
 }
 
-bool ssl_stream_set_option(const Stream &stream, int64_t option, int64_t value) {
+bool ssl_stream_functions::stream_set_option(const Stream &stream, int64_t option, int64_t value) const {
   ssl_connection *c = get_connection(stream);
   if (c == nullptr) {
     return false;
@@ -1114,7 +1117,7 @@ bool ssl_stream_set_option(const Stream &stream, int64_t option, int64_t value) 
   return false;
 }
 
-static int ssl_get_fd(const Stream &stream) {
+int ssl_stream_functions::get_fd(const Stream &stream) const {
   ssl_connection *c = get_connection(stream);
   if (c == nullptr) {
     return -1;
@@ -1127,30 +1130,8 @@ static int ssl_get_fd(const Stream &stream) {
 }
 
 void global_init_openssl_lib() {
-  static stream_functions ssl_stream_functions;
-
-  ssl_stream_functions.name = string("ssl", 3);
-  ssl_stream_functions.fopen = nullptr;
-  ssl_stream_functions.fwrite = ssl_fwrite;
-  ssl_stream_functions.fseek = nullptr;
-  ssl_stream_functions.ftell = nullptr;
-  ssl_stream_functions.fread = ssl_fread;
-  ssl_stream_functions.fgetc = nullptr;
-  ssl_stream_functions.fgets = nullptr;
-  ssl_stream_functions.fpassthru = nullptr;
-  ssl_stream_functions.fflush = nullptr;
-  ssl_stream_functions.feof = ssl_feof;
-  ssl_stream_functions.fclose = ssl_fclose;
-
-  ssl_stream_functions.file_get_contents = nullptr;
-  ssl_stream_functions.file_put_contents = nullptr;
-
-  ssl_stream_functions.stream_socket_client = ssl_stream_socket_client;
-  ssl_stream_functions.context_set_option = ssl_context_set_option;
-  ssl_stream_functions.stream_set_option = ssl_stream_set_option;
-  ssl_stream_functions.get_fd = ssl_get_fd;
-
-  register_stream_functions(&ssl_stream_functions, false);
+  static ssl_stream_functions ssl_stream_functions_v;
+  register_stream_functions(&ssl_stream_functions_v, false);
 
   OPENSSL_config(nullptr);
   SSL_library_init();
@@ -1183,7 +1164,7 @@ void x509_stack_info_free(STACK_OF(X509_INFO) *stack) {
   }
 }
 
-}
+} // namespace
 
 using BIO_ptr = vk::unique_ptr_with_delete_function<BIO, BIO_vfree>;
 using PKCS7_ptr = vk::unique_ptr_with_delete_function<PKCS7, PKCS7_free>;

--- a/runtime/openssl.h
+++ b/runtime/openssl.h
@@ -6,7 +6,48 @@
 
 #include <openssl/pkcs7.h>
 
-#include "runtime/kphp_core.h"
+#include "runtime/stream_functions.h"
+
+struct ssl_stream_functions : stream_functions {
+  ssl_stream_functions() {
+    name = string("ssl");
+    supported_functions.set_value(string("fopen"), false);
+    supported_functions.set_value(string("fwrite"), true);
+    supported_functions.set_value(string("fseek"), false);
+    supported_functions.set_value(string("ftell"), false);
+    supported_functions.set_value(string("fread"), true);
+    supported_functions.set_value(string("fgetc"), false);
+    supported_functions.set_value(string("fgets"), false);
+    supported_functions.set_value(string("fpassthru"), false);
+    supported_functions.set_value(string("fflush"), false);
+    supported_functions.set_value(string("feof"), true);
+    supported_functions.set_value(string("fclose"), true);
+    supported_functions.set_value(string("file_get_contents"), false);
+    supported_functions.set_value(string("file_put_contents"), false);
+    supported_functions.set_value(string("stream_socket_client"), true);
+    supported_functions.set_value(string("context_set_option"), true);
+    supported_functions.set_value(string("stream_set_option"), true);
+    supported_functions.set_value(string("get_fd"), true);
+  }
+
+  ~ssl_stream_functions() override = default;
+
+  Optional<int64_t> fwrite(const Stream &stream, const string &data) const override;
+
+  Optional<string> fread(const Stream &stream, int64_t length) const override;
+
+  bool feof(const Stream &stream) const override;
+
+  bool fclose(const Stream &stream) const override;
+
+  Stream stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context) const override;
+
+  bool context_set_option(mixed &context, const string &option, const mixed &value) const override;
+
+  bool stream_set_option(const Stream &stream, int64_t option, int64_t value) const override;
+
+  int32_t get_fd(const Stream &stream) const override;
+};
 
 enum openssl_algo {
   OPENSSL_ALGO_SHA1 = 1,

--- a/runtime/stream_functions.h
+++ b/runtime/stream_functions.h
@@ -21,71 +21,72 @@ struct stream_functions {
   string name;
   array<bool> supported_functions;
 
-  virtual Stream fopen(const string &stream, const string &mode) const {
+  virtual Stream fopen([[maybe_unused]] const string &stream, [[maybe_unused]] const string &mode) const {
     php_critical_error("Function \"fopen\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<int64_t> fwrite(const Stream &stream, const string &data) const {
+  virtual Optional<int64_t> fwrite([[maybe_unused]] const Stream &stream, [[maybe_unused]] const string &data) const {
     php_critical_error("Function \"fwrite\" is not supported for %s", name.c_str());
   }
 
-  virtual int64_t fseek(const Stream &stream, int64_t offset, int64_t whence) const {
+  virtual int64_t fseek([[maybe_unused]] const Stream &stream, [[maybe_unused]] int64_t offset, [[maybe_unused]] int64_t whence) const {
     php_critical_error("Function \"Stream\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<int64_t> ftell(const Stream &stream) const {
+  virtual Optional<int64_t> ftell([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"ftell\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<string> fread(const Stream &stream, int64_t length) const {
+  virtual Optional<string> fread([[maybe_unused]] const Stream &stream, [[maybe_unused]] int64_t length) const {
     php_critical_error("Function \"fread\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<string> fgetc(const Stream &stream) const {
+  virtual Optional<string> fgetc([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"fgetc\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<string> fgets(const Stream &stream, int64_t length) const {
+  virtual Optional<string> fgets([[maybe_unused]] const Stream &stream, [[maybe_unused]] int64_t length) const {
     php_critical_error("Function \"fgets\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<int64_t> fpassthru(const Stream &stream) const {
+  virtual Optional<int64_t> fpassthru([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"fpassthru\" is not supported for %s", name.c_str());
   }
 
-  virtual bool fflush(const Stream &stream) const {
+  virtual bool fflush([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"fflush\" is not supported for %s", name.c_str());
   }
 
-  virtual bool feof(const Stream &stream) const {
+  virtual bool feof([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"feof\" is not supported for %s", name.c_str());
   }
 
-  virtual bool fclose(const Stream &stream) const {
+  virtual bool fclose([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"fclose\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<string> file_get_contents(const string &url) const {
+  virtual Optional<string> file_get_contents([[maybe_unused]] const string &url) const {
     php_critical_error("Function \"file_get_contents\" is not supported for %s", name.c_str());
   }
 
-  virtual Optional<int64_t> file_put_contents(const string &url, const string &content, int64_t flags) const {
+  virtual Optional<int64_t> file_put_contents([[maybe_unused]] const string &url, [[maybe_unused]] const string &content, [[maybe_unused]] int64_t flags) const {
     php_critical_error("Function \"file_put_contents\" is not supported for %s", name.c_str());
   }
 
-  virtual Stream stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context) const {
+  virtual Stream stream_socket_client([[maybe_unused]] const string &url, [[maybe_unused]] int64_t &error_number, [[maybe_unused]] string &error_description,
+                                      [[maybe_unused]] double timeout, [[maybe_unused]] int64_t flags, [[maybe_unused]] const mixed &context) const {
     php_critical_error("Function \"stream_socket_client\" is not supported for %s", name.c_str());
   }
 
-  virtual bool context_set_option(mixed &context, const string &option, const mixed &value) const {
+  virtual bool context_set_option([[maybe_unused]] mixed &context, [[maybe_unused]] const string &option, [[maybe_unused]] const mixed &value) const {
     php_critical_error("Function \"context_set_option\" is not supported for %s", name.c_str());
   }
 
-  virtual bool stream_set_option(const Stream &stream, int64_t option, int64_t value) const {
+  virtual bool stream_set_option([[maybe_unused]] const Stream &stream, [[maybe_unused]] int64_t option, [[maybe_unused]] int64_t value) const {
     php_critical_error("Function \"stream_set_option\" is not supported for %s", name.c_str());
   }
 
-  virtual int32_t get_fd(const Stream &stream) const {
+  virtual int32_t get_fd([[maybe_unused]] const Stream &stream) const {
     php_critical_error("Function \"get_fd\" is not supported for %s", name.c_str());
   }
 };

--- a/runtime/stream_functions.h
+++ b/runtime/stream_functions.h
@@ -1,0 +1,91 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2020 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "runtime/kphp_core.h"
+
+using Stream = mixed;
+
+constexpr int64_t STREAM_SET_BLOCKING_OPTION = 0;
+constexpr int64_t STREAM_SET_WRITE_BUFFER_OPTION = 1;
+constexpr int64_t STREAM_SET_READ_BUFFER_OPTION = 2;
+
+constexpr int64_t FILE_APPEND = 1;
+
+struct stream_functions {
+  stream_functions() = default;
+  virtual ~stream_functions() = default;
+
+  string name;
+  array<bool> supported_functions;
+
+  virtual Stream fopen(const string &stream, const string &mode) const {
+    php_critical_error("Function \"fopen\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<int64_t> fwrite(const Stream &stream, const string &data) const {
+    php_critical_error("Function \"fwrite\" is not supported for %s", name.c_str());
+  }
+
+  virtual int64_t fseek(const Stream &stream, int64_t offset, int64_t whence) const {
+    php_critical_error("Function \"Stream\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<int64_t> ftell(const Stream &stream) const {
+    php_critical_error("Function \"ftell\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<string> fread(const Stream &stream, int64_t length) const {
+    php_critical_error("Function \"fread\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<string> fgetc(const Stream &stream) const {
+    php_critical_error("Function \"fgetc\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<string> fgets(const Stream &stream, int64_t length) const {
+    php_critical_error("Function \"fgets\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<int64_t> fpassthru(const Stream &stream) const {
+    php_critical_error("Function \"fpassthru\" is not supported for %s", name.c_str());
+  }
+
+  virtual bool fflush(const Stream &stream) const {
+    php_critical_error("Function \"fflush\" is not supported for %s", name.c_str());
+  }
+
+  virtual bool feof(const Stream &stream) const {
+    php_critical_error("Function \"feof\" is not supported for %s", name.c_str());
+  }
+
+  virtual bool fclose(const Stream &stream) const {
+    php_critical_error("Function \"fclose\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<string> file_get_contents(const string &url) const {
+    php_critical_error("Function \"file_get_contents\" is not supported for %s", name.c_str());
+  }
+
+  virtual Optional<int64_t> file_put_contents(const string &url, const string &content, int64_t flags) const {
+    php_critical_error("Function \"file_put_contents\" is not supported for %s", name.c_str());
+  }
+
+  virtual Stream stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context) const {
+    php_critical_error("Function \"stream_socket_client\" is not supported for %s", name.c_str());
+  }
+
+  virtual bool context_set_option(mixed &context, const string &option, const mixed &value) const {
+    php_critical_error("Function \"context_set_option\" is not supported for %s", name.c_str());
+  }
+
+  virtual bool stream_set_option(const Stream &stream, int64_t option, int64_t value) const {
+    php_critical_error("Function \"stream_set_option\" is not supported for %s", name.c_str());
+  }
+
+  virtual int32_t get_fd(const Stream &stream) const {
+    php_critical_error("Function \"get_fd\" is not supported for %s", name.c_str());
+  }
+};

--- a/runtime/streams.h
+++ b/runtime/streams.h
@@ -4,55 +4,7 @@
 
 #pragma once
 
-#include "runtime/kphp_core.h"
-
-using Stream =mixed;
-
-
-constexpr int64_t STREAM_SET_BLOCKING_OPTION = 0;
-constexpr int64_t STREAM_SET_WRITE_BUFFER_OPTION = 1;
-constexpr int64_t STREAM_SET_READ_BUFFER_OPTION = 2;
-
-constexpr int64_t FILE_APPEND = 1;
-
-
-struct stream_functions {
-  string name;
-
-  Stream (*fopen)(const string &stream, const string &mode);
-
-  Stream (*stream_socket_client)(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context);
-
-  Optional<int64_t> (*fwrite)(const Stream &stream, const string &data);
-
-  int64_t (*fseek)(const Stream &stream, int64_t offset, int64_t whence);
-
-  Optional<int64_t> (*ftell)(const Stream &stream);
-
-  Optional<string> (*fread)(const Stream &stream, int64_t length);
-
-  Optional<string> (*fgetc)(const Stream &stream);
-
-  Optional<string> (*fgets)(const Stream &stream, int64_t length);
-
-  Optional<int64_t> (*fpassthru)(const Stream &stream);
-
-  bool (*fflush)(const Stream &stream);
-
-  bool (*feof)(const Stream &stream);
-
-  bool (*fclose)(const Stream &stream);
-
-  Optional<string> (*file_get_contents)(const string &url);
-
-  Optional<int64_t> (*file_put_contents)(const string &url, const string &content, int64_t flags);
-
-  bool (*context_set_option)(mixed &context, const string &option, const mixed &value);
-
-  bool (*stream_set_option)(const Stream &stream, int64_t option, int64_t value);
-
-  int32_t (*get_fd)(const Stream &stream);
-};
+#include "runtime/stream_functions.h"
 
 
 void register_stream_functions(const stream_functions *functions, bool is_default);

--- a/runtime/tcp.h
+++ b/runtime/tcp.h
@@ -1,6 +1,49 @@
 #pragma once
 
-#include "runtime/kphp_core.h"
+#include "runtime/stream_functions.h"
+
+struct tcp_stream_functions : stream_functions {
+  tcp_stream_functions() {
+    name = string("tcp");
+    supported_functions.set_value(string("fopen"), false);
+    supported_functions.set_value(string("fwrite"), true);
+    supported_functions.set_value(string("fseek"), false);
+    supported_functions.set_value(string("ftell"), false);
+    supported_functions.set_value(string("fread"), true);
+    supported_functions.set_value(string("fgetc"), true);
+    supported_functions.set_value(string("fgets"), true);
+    supported_functions.set_value(string("fpassthru"), false);
+    supported_functions.set_value(string("fflush"), false);
+    supported_functions.set_value(string("feof"), true);
+    supported_functions.set_value(string("fclose"), true);
+    supported_functions.set_value(string("file_get_contents"), false);
+    supported_functions.set_value(string("file_put_contents"), false);
+    supported_functions.set_value(string("stream_socket_client"), true);
+    supported_functions.set_value(string("context_set_option"), false);
+    supported_functions.set_value(string("stream_set_option"), true);
+    supported_functions.set_value(string("get_fd"), true);
+  }
+
+  ~tcp_stream_functions() override = default;
+
+  Optional<int64_t> fwrite(const Stream &stream, const string &data) const override;
+
+  Optional<string> fread(const Stream &stream, int64_t length) const override;
+
+  Optional<string> fgetc(const Stream &stream) const override;
+
+  Optional<string> fgets(const Stream &stream, int64_t length) const override;
+
+  bool feof(const Stream &stream) const override;
+
+  bool fclose(const Stream &stream) const override;
+
+  Stream stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context) const override;
+
+  bool stream_set_option(const Stream &stream, int64_t option, int64_t value) const override;
+
+  int32_t get_fd(const Stream &stream) const override;
+};
 
 void global_init_tcp_lib();
 

--- a/runtime/udp.h
+++ b/runtime/udp.h
@@ -4,7 +4,40 @@
 
 #pragma once
 
-#include "runtime/kphp_core.h"
+#include "runtime/stream_functions.h"
+
+struct udp_stream_functions : stream_functions {
+  udp_stream_functions() {
+    name = string("udp");
+    supported_functions.set_value(string("fopen"), false);
+    supported_functions.set_value(string("fwrite"), true);
+    supported_functions.set_value(string("fseek"), false);
+    supported_functions.set_value(string("ftell"), false);
+    supported_functions.set_value(string("fread"), false);
+    supported_functions.set_value(string("fgetc"), false);
+    supported_functions.set_value(string("fgets"), false);
+    supported_functions.set_value(string("fpassthru"), false);
+    supported_functions.set_value(string("fflush"), false);
+    supported_functions.set_value(string("feof"), false);
+    supported_functions.set_value(string("fclose"), true);
+    supported_functions.set_value(string("file_get_contents"), false);
+    supported_functions.set_value(string("file_put_contents"), false);
+    supported_functions.set_value(string("stream_socket_client"), true);
+    supported_functions.set_value(string("context_set_option"), false);
+    supported_functions.set_value(string("stream_set_option"), false);
+    supported_functions.set_value(string("get_fd"), true);
+  }
+
+  ~udp_stream_functions() override = default;
+
+  Optional<int64_t> fwrite(const Stream &stream, const string &data) const override;
+
+  bool fclose(const Stream &stream) const override;
+
+  Stream stream_socket_client(const string &url, int64_t &error_number, string &error_description, double timeout, int64_t flags, const mixed &context) const override;
+
+  int32_t get_fd(const Stream &stream) const override;
+};
 
 void global_init_udp_lib();
 


### PR DESCRIPTION
In this PR `stream_functions` struct is refactored as a base class with virtual functions.

Classes derived from `stream_functions`:
- `php_stream_functions`
- `ssl_stream_functions`
- `tcp_stream_functions`
- `udp_stream_functions`
- `file_stream_functions`

Base class functions implementation just aborts KPHP - it is unexpected to call them.
Functions implementations in derived classes either do the same if corresponding protocol does not support particular function, or are valid implementations if the protocol supports it.
An `array<string, bool>` was added to the `stream_functions` struct to store supported functions and avoid throwing and handling exceptions.