### PR TITLE
Add toggle to disable confdata soft OOM degradation mode

### DIFF
--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -851,6 +851,10 @@ void set_confdata_soft_oom_ratio(double soft_oom_ratio) noexcept {
   confdata_settings.soft_oom_threshold_ratio = soft_oom_ratio;
 }
 
+void set_confdata_hard_oom_ratio(double hard_oom_ratio) noexcept {
+  confdata_settings.hard_oom_threshold_ratio = hard_oom_ratio;
+}
+
 void set_confdata_binlog_mask(const char *mask) noexcept {
   confdata_settings.binlog_mask = mask;
 }

--- a/server/confdata-binlog-replay.h
+++ b/server/confdata-binlog-replay.h
@@ -13,6 +13,7 @@ static constexpr double CONFDATA_DEFAULT_SOFT_OOM_RATIO = 0.85;
 static constexpr double CONFDATA_DEFAULT_HARD_OOM_RATIO = 0.95;
 
 void set_confdata_soft_oom_ratio(double soft_oom_ratio) noexcept;
+void set_confdata_hard_oom_ratio(double hard_oom_ratio) noexcept;
 void set_confdata_binlog_mask(const char *mask) noexcept;
 
 void set_confdata_memory_limit(size_t memory_limit) noexcept;

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2227,8 +2227,14 @@ int main_args_handler(int i, const char *long_option) {
     }
     case 2039: {
       double soft_oom_ratio;
-      int res = read_option_to(long_option, 0.0, CONFDATA_DEFAULT_HARD_OOM_RATIO, soft_oom_ratio);
-      set_confdata_soft_oom_ratio(soft_oom_ratio);
+      int res = read_option_to(long_option, 0.0, 1.0, soft_oom_ratio);
+      if (soft_oom_ratio < CONFDATA_DEFAULT_HARD_OOM_RATIO) {
+        set_confdata_soft_oom_ratio(soft_oom_ratio);
+      } else {
+        kprintf("Confdata soft OOM degradation mode disabled\n");
+        set_confdata_soft_oom_ratio(1.0);
+        set_confdata_hard_oom_ratio(1.0);
+      }
       return res;
     }
     default:


### PR DESCRIPTION
Now it's possible to disable confdata degradation mode (see #946) by specifiying `--confdata-soft-oom-ratio 1.0` start option