### PR TITLE
Add support of 'random_int' and 'random_bytes' builtins

### DIFF
--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -451,6 +451,10 @@ function getrandmax() ::: int;
 function mt_srand ($seed ::: int = PHP_INT_MIN) ::: void;
 function mt_rand ($l ::: int = TODO_OVERLOAD, $r ::: int = TODO_OVERLOAD) ::: int;
 function mt_getrandmax() ::: int;
+/** @kphp-extern-func-info can_throw */
+function random_int($l ::: int, $r ::: int) ::: int;
+/** @kphp-extern-func-info can_throw */
+function random_bytes($length ::: int) ::: string;
 
 function hash_algos () ::: string[];
 function hash_hmac_algos () ::: string[];

--- a/builtin-functions/_functions.txt
+++ b/builtin-functions/_functions.txt
@@ -451,10 +451,8 @@ function getrandmax() ::: int;
 function mt_srand ($seed ::: int = PHP_INT_MIN) ::: void;
 function mt_rand ($l ::: int = TODO_OVERLOAD, $r ::: int = TODO_OVERLOAD) ::: int;
 function mt_getrandmax() ::: int;
-/** @kphp-extern-func-info can_throw */
-function random_int($l ::: int, $r ::: int) ::: int;
-/** @kphp-extern-func-info can_throw */
-function random_bytes($length ::: int) ::: string;
+function random_int($l ::: int, $r ::: int) ::: int | false;
+function random_bytes($length ::: int) ::: string | false;
 
 function hash_algos () ::: string[];
 function hash_hmac_algos () ::: string[];

--- a/builtin-functions/spl.txt
+++ b/builtin-functions/spl.txt
@@ -25,6 +25,8 @@ class RangeException extends RuntimeException {}
 class UnderflowException extends RuntimeException {}
 class UnexpectedValueException extends RuntimeException {}
 
+class Random\RandomException extends Exception {}
+
 // https://www.php.net/manual/en/class.arrayiterator.php
 // TODO: make it work with T[] arrays when generic classes are available.
 // For now, it only supports mixed[].

--- a/runtime/exception.cpp
+++ b/runtime/exception.cpp
@@ -85,7 +85,6 @@ Exception new_Exception(const string &file, int64_t line, const string &message,
   return f$_exception_set_location(f$Exception$$__construct(Exception().alloc(), message, code), file, line);
 }
 
-
 Exception f$err(const string &file, int64_t line, const string &code, const string &desc) {
   return new_Exception(file, line, (static_SB.clean() << "ERR_" << code << ": " << desc).str(), 0);
 }

--- a/runtime/exception.h
+++ b/runtime/exception.h
@@ -281,3 +281,7 @@ struct C$UnderflowException : public C$RuntimeException {
 struct C$UnexpectedValueException : public C$RuntimeException {
   const char *get_class() const noexcept override { return "UnexpectedValueException"; }
 };
+
+struct C$Random$RandomException : public C$Exception {
+  const char *get_class() const noexcept override { return "Random\\RandomException"; }
+};

--- a/runtime/exception.h
+++ b/runtime/exception.h
@@ -157,6 +157,22 @@ Exception new_Exception(const string &file, int64_t line, const string &message 
 
 Exception f$err(const string &file, int64_t line, const string &code, const string &desc = string());
 
+template <typename T>
+inline class_instance<T> make_throwable(const string &file, int64_t line, int64_t code, const string &desc) noexcept {
+  static_assert(
+    std::is_base_of_v<C$Throwable, T>,
+    "Template argument must be a subtype of C$Throwable");
+
+  auto ci = make_instance<T>();
+
+  auto *ins_ptr = ci.get();
+  ins_ptr->$file = file;
+  ins_ptr->$line = line;
+  ins_ptr->$code = code;
+  ins_ptr->$message = desc;
+
+  return ci;
+}
 
 string f$Exception$$getMessage(const Exception &e);
 string f$Error$$getMessage(const Error &e);

--- a/runtime/exception.h
+++ b/runtime/exception.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include "common/algorithms/hashes.h"
 #include "common/wrappers/string_view.h"
 #include "runtime/dummy-visitor-methods.h"

--- a/runtime/math_functions.cpp
+++ b/runtime/math_functions.cpp
@@ -219,11 +219,10 @@ int64_t f$getrandmax() noexcept {
   return f$mt_getrandmax();
 }
 
-int64_t f$random_int(int64_t l, int64_t r) noexcept {
+Optional<int64_t> f$random_int(int64_t l, int64_t r) noexcept {
   if (unlikely(l > r)) {
-    string errMsg{"Argument #1 ($min) must be less than or equal to argument #2 ($max)"};
-    THROW_EXCEPTION(make_throwable<C$ValueError>(string(__FILE__), __LINE__, 0, errMsg));
-    return {};
+    php_warning("Argument #1 ($min) must be less than or equal to argument #2 ($max)");
+    return false;
   }
 
   if (unlikely(l == r)) {
@@ -236,27 +235,24 @@ int64_t f$random_int(int64_t l, int64_t r) noexcept {
 
     return dist(rd);
   } catch (const std::exception &e) {
-    string errMsg{"Source of randomness cannot be found"};
-    THROW_EXCEPTION(make_throwable<C$Random$RandomException>(string(__FILE__), __LINE__, 0, errMsg));
-    return -1;
+    php_warning("Source of randomness cannot be found");
+    return false;
   } catch (...) {
     php_critical_error("Unhandled exception");
   }
 }
 
-string f$random_bytes(int64_t length) noexcept {
+Optional<string> f$random_bytes(int64_t length) noexcept {
   if (unlikely(length < 1)) {
-    string errMsg{"Argument #1 ($length) must be greater than 0"};
-    THROW_EXCEPTION(make_throwable<C$ValueError>(string(__FILE__), __LINE__, 0, errMsg));
-    return {};
+    php_warning("Argument #1 ($length) must be greater than 0");
+    return false;
   }
 
-  string str{static_cast<string::size_type>(length), true};
+  string str{static_cast<string::size_type>(length), false};
 
   if (secure_rand_buf(str.buffer(), static_cast<size_t>(length)) == -1) {
-    string errMsg{"Source of randomness cannot be found"};
-    THROW_EXCEPTION(make_throwable<C$Random$RandomException>(string(__FILE__), __LINE__, 0, errMsg));
-    return {};
+    php_warning("Source of randomness cannot be found");
+    return false;
   }
 
   return str;

--- a/runtime/math_functions.cpp
+++ b/runtime/math_functions.cpp
@@ -8,8 +8,14 @@
 #include <random>
 #include <sys/time.h>
 
+#if defined(__APPLE__)
+#include <stdlib.h>
+#else
+#include <sys/random.h>
+#endif
+
 #include "common/cycleclock.h"
-#include "exception.h"
+#include "runtime/exception.h"
 #include "runtime/critical_section.h"
 #include "runtime/string_functions.h"
 #include "server/php-engine-vars.h"

--- a/runtime/math_functions.cpp
+++ b/runtime/math_functions.cpp
@@ -2,10 +2,10 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
-#include "runtime/math_functions.h"
-
 #include <chrono>
 #include <random>
+#include <cstring>
+#include <cerrno>
 #include <sys/time.h>
 
 #if defined(__APPLE__)
@@ -15,6 +15,7 @@
 #endif
 
 #include "common/cycleclock.h"
+#include "runtime/math_functions.h"
 #include "runtime/exception.h"
 #include "runtime/critical_section.h"
 #include "runtime/string_functions.h"
@@ -241,7 +242,7 @@ Optional<int64_t> f$random_int(int64_t l, int64_t r) noexcept {
 
     return dist(rd);
   } catch (const std::exception &e) {
-    php_warning("Source of randomness cannot be found");
+    php_warning("Source of randomness cannot be found: %s", e.what());
     return false;
   } catch (...) {
     php_critical_error("Unhandled exception");
@@ -257,7 +258,7 @@ Optional<string> f$random_bytes(int64_t length) noexcept {
   string str{static_cast<string::size_type>(length), false};
 
   if (secure_rand_buf(str.buffer(), static_cast<size_t>(length)) == -1) {
-    php_warning("Source of randomness cannot be found");
+    php_warning("Source of randomness cannot be found: %s", std::strerror(errno));
     return false;
   }
 

--- a/runtime/math_functions.h
+++ b/runtime/math_functions.h
@@ -40,9 +40,9 @@ int64_t f$rand() noexcept;
 
 int64_t f$getrandmax() noexcept;
 
-int64_t f$random_int(int64_t l, int64_t r) noexcept;
+Optional<int64_t> f$random_int(int64_t l, int64_t r) noexcept;
 
-string f$random_bytes(int64_t length) noexcept;
+Optional<string> f$random_bytes(int64_t length) noexcept;
 
 
 template<class T>

--- a/runtime/math_functions.h
+++ b/runtime/math_functions.h
@@ -4,6 +4,12 @@
 
 #pragma once
 
+#if defined(__APPLE__)
+#include "stdlib.h"
+#else
+#include <sys/random.h>
+#endif
+
 #include "runtime/kphp_core.h"
 
 int64_t f$bindec(const string &number) noexcept;
@@ -33,6 +39,10 @@ int64_t f$rand(int64_t l, int64_t r) noexcept;
 int64_t f$rand() noexcept;
 
 int64_t f$getrandmax() noexcept;
+
+int64_t f$random_int(int64_t l, int64_t r) noexcept;
+
+string f$random_bytes(int64_t length) noexcept;
 
 
 template<class T>

--- a/runtime/math_functions.h
+++ b/runtime/math_functions.h
@@ -4,12 +4,6 @@
 
 #pragma once
 
-#if defined(__APPLE__)
-#include "stdlib.h"
-#else
-#include <sys/random.h>
-#endif
-
 #include "runtime/kphp_core.h"
 
 int64_t f$bindec(const string &number) noexcept;

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -23,6 +23,7 @@ class TestFile:
         self.env_vars = env_vars
         self.out_regexps = out_regexps
         self.forbidden_regexps = forbidden_regexps
+        self.php_version = next((tag for tag in tags if tag.startswith("php")), "php7.4")
 
     def is_ok(self):
         return "ok" in self.tags
@@ -43,7 +44,7 @@ class TestFile:
         return "kphp_runtime_should_not_warn" in self.tags
 
     def is_php8(self):
-        return "php8" in self.tags
+        return self.php_version.startswith("php8")
 
     def make_kphp_once_runner(self, use_nocc, cxx_name):
         tester_dir = os.path.abspath(os.path.dirname(__file__))
@@ -51,7 +52,7 @@ class TestFile:
             php_script_path=self.file_path,
             working_dir=os.path.abspath(os.path.join(self.test_tmp_dir, "working_dir")),
             artifacts_dir=os.path.abspath(os.path.join(self.test_tmp_dir, "artifacts")),
-            php_bin=search_php_bin(php8_require=self.is_php8()),
+            php_bin=search_php_bin(self.php_version),
             extra_include_dirs=[os.path.join(tester_dir, "php_include")],
             vkext_dir=os.path.abspath(os.path.join(tester_dir, os.path.pardir, "objs", "vkext")),
             use_nocc=use_nocc,

--- a/tests/kphp_tester.py
+++ b/tests/kphp_tester.py
@@ -52,7 +52,7 @@ class TestFile:
             php_script_path=self.file_path,
             working_dir=os.path.abspath(os.path.join(self.test_tmp_dir, "working_dir")),
             artifacts_dir=os.path.abspath(os.path.join(self.test_tmp_dir, "artifacts")),
-            php_bin=search_php_bin(self.php_version),
+            php_bin=search_php_bin(php_version=self.php_version),
             extra_include_dirs=[os.path.join(tester_dir, "php_include")],
             vkext_dir=os.path.abspath(os.path.join(tester_dir, os.path.pardir, "objs", "vkext")),
             use_nocc=use_nocc,

--- a/tests/phpt/dl/385_random_bytes.php
+++ b/tests/phpt/dl/385_random_bytes.php
@@ -1,0 +1,10 @@
+@ok php8
+<?php
+
+function test_random_bytes() {
+  for ($i = 1; $i < 50; $i += 1) {
+    var_dump(strlen(random_bytes($i)));
+  }
+}
+
+test_random_bytes();

--- a/tests/phpt/dl/386_random_int.php
+++ b/tests/phpt/dl/386_random_int.php
@@ -1,0 +1,33 @@
+@ok php8
+<?php
+
+function test_random_int() {
+  $x = random_int(100, 500);
+  var_dump($x >= 100 && $x <= 500);
+
+  $x = random_int(-450, -200);
+  var_dump($x >= -450 && $x <= -200);
+
+  $x = random_int(-124, 107);
+  var_dump($x >= -124 && $x <= 107);
+
+  $x = random_int(0, PHP_INT_MAX);
+  var_dump($x >= 0 && $x <= PHP_INT_MAX);
+
+  $x = random_int(-PHP_INT_MAX - 1, 0);
+  var_dump($x >= -PHP_INT_MAX - 1 && $x <= 0);
+
+  $x = random_int(-PHP_INT_MAX - 1, PHP_INT_MAX);
+  var_dump($x >= (-PHP_INT_MAX - 1) && $x <= PHP_INT_MAX);
+
+  var_dump(random_int(0, 0));
+  var_dump(random_int(1, 1));
+  var_dump(random_int(-4, -4));
+  var_dump(random_int(9287167122323, 9287167122323));
+  var_dump(random_int(-8548276162, -8548276162));
+
+  var_dump(random_int(PHP_INT_MAX, PHP_INT_MAX));
+  var_dump(random_int(-PHP_INT_MAX - 1, -PHP_INT_MAX - 1));
+}
+
+test_random_int();

--- a/tests/phpt/exceptions/spl/02_builtin_exceptions.php
+++ b/tests/phpt/exceptions/spl/02_builtin_exceptions.php
@@ -1,4 +1,4 @@
-@ok
+@ok php8
 KPHP_REQUIRE_FUNCTIONS_TYPING=1
 <?php
 
@@ -16,6 +16,7 @@ KPHP_REQUIRE_FUNCTIONS_TYPING=1
         RangeException
         UnderflowException
         UnexpectedValueException
+    Random\RandomException (extends Exception)
 */
 
 function fmt_throwable(Throwable $e): string {
@@ -67,5 +68,28 @@ function test_runtime_exception() {
   }
 }
 
+function test_random_exception() {
+  $to_throw = new Random\RandomException(__FUNCTION__, __LINE__ + 1);
+
+  try {
+    throw $to_throw;
+  } catch (LogicException $e) {
+    var_dump([__LINE__ => 'unreachable']);
+  } catch (RuntimeException $e) {
+    var_dump([__LINE__ => 'unreachable']);
+  } catch (Exception $e) {
+    var_dump([__LINE__ => fmt_throwable($e)]);
+    var_dump([__LINE__ => $e->getMessage()]);
+  }
+
+  try {
+    throw $to_throw;
+  } catch (Random\RandomException $e) {
+    var_dump([__LINE__ => fmt_throwable($e)]);
+    var_dump([__LINE__ => $e->getMessage()]);
+  }
+}
+
 test_logic_exception();
 test_runtime_exception();
+test_random_exception();

--- a/tests/phpt/exceptions/spl/02_builtin_exceptions.php
+++ b/tests/phpt/exceptions/spl/02_builtin_exceptions.php
@@ -1,4 +1,4 @@
-@ok php8
+@ok
 KPHP_REQUIRE_FUNCTIONS_TYPING=1
 <?php
 
@@ -68,28 +68,5 @@ function test_runtime_exception() {
   }
 }
 
-function test_random_exception() {
-  $to_throw = new Random\RandomException(__FUNCTION__, __LINE__ + 1);
-
-  try {
-    throw $to_throw;
-  } catch (LogicException $e) {
-    var_dump([__LINE__ => 'unreachable']);
-  } catch (RuntimeException $e) {
-    var_dump([__LINE__ => 'unreachable']);
-  } catch (Exception $e) {
-    var_dump([__LINE__ => fmt_throwable($e)]);
-    var_dump([__LINE__ => $e->getMessage()]);
-  }
-
-  try {
-    throw $to_throw;
-  } catch (Random\RandomException $e) {
-    var_dump([__LINE__ => fmt_throwable($e)]);
-    var_dump([__LINE__ => $e->getMessage()]);
-  }
-}
-
 test_logic_exception();
 test_runtime_exception();
-test_random_exception();

--- a/tests/phpt/exceptions/spl/02_builtin_exceptions.php
+++ b/tests/phpt/exceptions/spl/02_builtin_exceptions.php
@@ -16,7 +16,6 @@ KPHP_REQUIRE_FUNCTIONS_TYPING=1
         RangeException
         UnderflowException
         UnexpectedValueException
-    Random\RandomException (extends Exception)
 */
 
 function fmt_throwable(Throwable $e): string {

--- a/tests/phpt/exceptions/spl/02_builtin_exceptions_1.php
+++ b/tests/phpt/exceptions/spl/02_builtin_exceptions_1.php
@@ -1,0 +1,35 @@
+@ok php8.2
+KPHP_REQUIRE_FUNCTIONS_TYPING=1
+<?php
+
+/*
+    Random\RandomException (extends Exception)
+*/
+
+function fmt_throwable(Throwable $e): string {
+  return get_class($e) . ":{$e->getLine()}:{$e->getMessage()}:{$e->getCode()}";
+}
+
+function test_random_exception() {
+  $to_throw = new Random\RandomException(__FUNCTION__, __LINE__ + 1);
+
+  try {
+    throw $to_throw;
+  } catch (LogicException $e) {
+    var_dump([__LINE__ => 'unreachable']);
+  } catch (RuntimeException $e) {
+    var_dump([__LINE__ => 'unreachable']);
+  } catch (Exception $e) {
+    var_dump([__LINE__ => fmt_throwable($e)]);
+    var_dump([__LINE__ => $e->getMessage()]);
+  }
+
+  try {
+    throw $to_throw;
+  } catch (Random\RandomException $e) {
+    var_dump([__LINE__ => fmt_throwable($e)]);
+    var_dump([__LINE__ => $e->getMessage()]);
+  }
+}
+
+test_random_exception();

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -109,10 +109,10 @@ def search_php_bin(php_version: str):
     if sys.platform == "darwin":
         return shutil.which("php")
 
-    # checking from newest to oldest versions
-    for spv in sorted(_SUPPORTED_PHP_VERSIONS, reverse=True):
+    # checking from oldest to newest versions
+    for spv in sorted(_SUPPORTED_PHP_VERSIONS):
         if spv < php_version:
-            break
+            continue
 
         exe_path = shutil.which(spv)
         if exe_path is not None:

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -113,4 +113,5 @@ def search_php_bin(php8_require=False):
             exe_path = shutil.which(spv)
             if exe_path is not None:
                 return exe_path
+        return None
     return shutil.which("php7.4")

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -4,6 +4,8 @@ import re
 import sys
 import shutil
 
+_SUPPORTED_PHP_VERSIONS = ["php7.4", "php8", "php8.1", "php8.2", "php8.3"]
+
 
 def _check_file(file_name, file_dir, file_checker):
     file_path = os.path.join(file_dir, file_name)
@@ -103,15 +105,17 @@ def can_ignore_sanitizer_log(sanitizer_log_file):
     return ignore_sanitizer
 
 
-def search_php_bin(php8_require=False):
+def search_php_bin(php_version: str):
     if sys.platform == "darwin":
         return shutil.which("php")
-    if php8_require:
-        supported_php8_versions = ["php8", "php8.1", "php8.2", "php8.3"]
-        # checking from newest to oldest versions
-        for spv in sorted(supported_php8_versions, reverse=True):
-            exe_path = shutil.which(spv)
-            if exe_path is not None:
-                return exe_path
-        return None
-    return shutil.which("php7.4")
+
+    # checking from newest to oldest versions
+    for spv in sorted(SUPPORTED_PHP_VERSIONS, reverse=True):
+        if spv < php_version:
+            break
+
+        exe_path = shutil.which(spv)
+        if exe_path is not None:
+            return exe_path
+
+    return None

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -110,7 +110,7 @@ def search_php_bin(php_version: str):
         return shutil.which("php")
 
     # checking from newest to oldest versions
-    for spv in sorted(SUPPORTED_PHP_VERSIONS, reverse=True):
+    for spv in sorted(_SUPPORTED_PHP_VERSIONS, reverse=True):
         if spv < php_version:
             break
 

--- a/tests/python/lib/file_utils.py
+++ b/tests/python/lib/file_utils.py
@@ -107,5 +107,10 @@ def search_php_bin(php8_require=False):
     if sys.platform == "darwin":
         return shutil.which("php")
     if php8_require:
-        return shutil.which("php8.1") or shutil.which("php8")
+        supported_php8_versions = ["php8", "php8.1", "php8.2", "php8.3"]
+        # checking from newest to oldest versions
+        for spv in sorted(supported_php8_versions, reverse=True):
+            exe_path = shutil.which(spv)
+            if exe_path is not None:
+                return exe_path
     return shutil.which("php7.4")

--- a/tests/python/lib/testcase.py
+++ b/tests/python/lib/testcase.py
@@ -280,7 +280,7 @@ class KphpCompilerAutoTestCase(BaseTestCase):
 
     def __init__(self, method_name):
         super().__init__(method_name)
-        self.require_php8 = False
+        self.php_version = "php7.4"
 
     @classmethod
     def extra_class_setup(cls):
@@ -318,7 +318,7 @@ class KphpCompilerAutoTestCase(BaseTestCase):
             php_script_path=os.path.join(self.test_dir, php_script_path),
             artifacts_dir=self.kphp_server_working_dir,
             working_dir=self.kphp_build_working_dir,
-            php_bin=search_php_bin("php7.4"),
+            php_bin=search_php_bin(php_version=self.php_version),
             use_nocc=self.should_use_nocc(),
         )
         self.once_runner_trash_bin.append(once_runner)

--- a/tests/python/lib/testcase.py
+++ b/tests/python/lib/testcase.py
@@ -318,7 +318,7 @@ class KphpCompilerAutoTestCase(BaseTestCase):
             php_script_path=os.path.join(self.test_dir, php_script_path),
             artifacts_dir=self.kphp_server_working_dir,
             working_dir=self.kphp_build_working_dir,
-            php_bin=search_php_bin(php8_require=self.require_php8),
+            php_bin=search_php_bin("php7.4"),
             use_nocc=self.should_use_nocc(),
         )
         self.once_runner_trash_bin.append(once_runner)


### PR DESCRIPTION
This PR adds support of `random_int` and `random_bytes` functions added in `PHP8`. Also, it adds `Random\RandomException` class into runtime.