### PR TITLE
Fix KPHP_GLOBAL_SPLIT_CNT option

### DIFF
--- a/compiler/code-gen/files/vars-cpp.cpp
+++ b/compiler/code-gen/files/vars-cpp.cpp
@@ -165,7 +165,7 @@ static void compile_vars_part(CodeGenerator &W, const std::vector<VarPtr> &vars,
 VarsCpp::VarsCpp(std::vector<int> &&max_dep_levels, size_t parts_cnt)
   : max_dep_levels_(std::move(max_dep_levels))
   , parts_cnt_(parts_cnt) {
-  kphp_assert (1 <= parts_cnt_ && parts_cnt_ <= 1024);
+  kphp_assert (1 <= parts_cnt_ && parts_cnt_ <= G->settings().globals_split_count.get());
 }
 
 void VarsCpp::compile(CodeGenerator &W) const {

--- a/compiler/code-gen/files/vars-cpp.cpp
+++ b/compiler/code-gen/files/vars-cpp.cpp
@@ -165,7 +165,10 @@ static void compile_vars_part(CodeGenerator &W, const std::vector<VarPtr> &vars,
 VarsCpp::VarsCpp(std::vector<int> &&max_dep_levels, size_t parts_cnt)
   : max_dep_levels_(std::move(max_dep_levels))
   , parts_cnt_(parts_cnt) {
-  kphp_assert (1 <= parts_cnt_ && parts_cnt_ <= G->settings().globals_split_count.get());
+  kphp_assert(1 <= parts_cnt_);
+  kphp_error(parts_cnt_ <= G->settings().globals_split_count.get(),
+             fmt_format("Too many globals initialization .cpp files({}) for the specified globals_split_count({})", parts_cnt_,
+                        G->settings().globals_split_count.get()));
 }
 
 void VarsCpp::compile(CodeGenerator &W) const {

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -236,7 +236,7 @@ int main(int argc, char *argv[]) {
   parser.add("Threads number for the transpilation", settings->threads_count,
              't', "threads-count", "KPHP_THREADS_COUNT", std::to_string(get_default_threads_count()));
   parser.add("Count of global variables per dedicated .cpp file. Lowering it could decrease compilation time", settings->globals_split_count,
-             "globals-split-count", "KPHP_GLOBALS_SPLIT_COUNT", "1024");
+             "globals-split-count", "KPHP_GLOBALS_SPLIT_COUNT", "1536");
   parser.add("Builtin tl schema. Incompatible with lib mode", settings->tl_schema_file,
              'T', "tl-schema", "KPHP_TL_SCHEMA");
   parser.add("Generate storers and fetchers for internal tl functions", settings->gen_tl_internals,


### PR DESCRIPTION
* Increase default KPHP_GLOBAL_SPLIT_CNT
* Fix assert: number of file with global variables definitions less or equal than KPHP_GLOBAL_SPLIT_CNT