### PR TITLE
Change deb.debian.org on archive.debian.org

### DIFF
--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -5,7 +5,7 @@ COPY tests/python/requirements.txt /tmp/
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
-    echo "deb https://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \ 
+    echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     wget -qO /etc/apt/trusted.gpg.d/vkpartner.asc https://artifactory-external.vkpartner.ru/artifactory/api/gpg/key/public && \
     echo "deb https://artifactory-external.vkpartner.ru/artifactory/kphp buster main" >> /etc/apt/sources.list && \
     wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \

--- a/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
+++ b/docs/kphp-internals/developing-and-extending-kphp/compiling-kphp-from-sources.md
@@ -33,7 +33,7 @@ apt-get update
 # utils for adding repositories
 apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release
 # for newest cmake package
-echo "deb https://deb.debian.org/debian buster-backports main" >> /etc/apt/sources.list
+echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list
 # for curl-kphp-vk, libuber-h3-dev packages and kphp-timelib
 wget -qO /etc/apt/trusted.gpg.d/vkpartner.asc https://artifactory-external.vkpartner.ru/artifactory/api/gpg/key/public
 echo "deb https://artifactory-external.vkpartner.ru/artifactory/kphp buster main" >> /etc/apt/sources.list 


### PR DESCRIPTION
Previously had an error "The repository 'https://deb.debian.org/debian buster-backports Release' does not have a Release file."

For example: https://github.com/VKCOM/kphp/actions/runs/8739653713/job/23981827080?pr=983.

This PR fixes it.