### PR TITLE
Fix SIGSEGV in openssl_random_pseudo_bytes

### DIFF
--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -601,7 +601,7 @@ Optional<string> f$openssl_random_pseudo_bytes(int64_t length) {
   if (length <= 0 || length > string::max_size()) {
     return false;
   }
-  string buffer(static_cast<string::size_type>(length), ' ');
+  string buffer{static_cast<string::size_type>(length), false};
   timeval tv{};
   gettimeofday(&tv, nullptr);
 
@@ -610,7 +610,7 @@ Optional<string> f$openssl_random_pseudo_bytes(int64_t length) {
   if (RAND_bytes(reinterpret_cast<unsigned char *>(buffer.buffer()), static_cast<int32_t>(length)) <= 0) {
     return false;
   }
-  return std::move(buffer);
+  return buffer;
 }
 
 

--- a/runtime/string_decl.inl
+++ b/runtime/string_decl.inl
@@ -74,6 +74,8 @@ private:
   inline void set_size(size_type new_size);
 
   inline static char *create(const char *beg, const char *end);
+  // IMPORTANT: this function may return read-only strings for n == 0 and n == 1.
+  // Use it unless you have to manually write something into the buffer.
   inline static char *create(size_type req, char c);
   inline static char *create(size_type req, bool b);
 
@@ -97,6 +99,8 @@ public:
   inline string(string &&str) noexcept;
   inline string(const char *s, size_type n);
   inline explicit string(const char *s);
+  // IMPORTANT: this constructor may return read-only strings for n == 0 and n == 1.
+  // Use it unless you have to manually operate with string's internal buffer.
   inline string(size_type n, char c);
   inline string(size_type n, bool b);
   inline explicit string(int64_t i);

--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -2844,7 +2844,7 @@ string f$wordwrap(const string &str, int64_t width, const string &brk, bool cut)
 
 string f$xor_strings(const string &s, const string &t) {
   string::size_type length = min(s.size(), t.size());
-  string result(length, ' ');
+  string result{length, false};
   const char *s_str = s.c_str();
   const char *t_str = t.c_str();
   char *res_str = result.buffer();

--- a/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
+++ b/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
@@ -1,26 +1,33 @@
 @ok
 <?php
 
+function is_kphp() {
+#ifndef KPHP
+    return false;
+#endif
+    return true;
+}
+
 function test_openssl_random_pseudo_bytes() {
   for ($i = -300; $i < 2048; $i += 273) {
-  /** @var string */
-  $res = "";
-#ifndef KPHP
-    try {
+    $res = "";
+
+    if (is_kphp()) {
       $res = openssl_random_pseudo_bytes($i);
-    } catch (Exception $e) {
-      if ($i < 1) {
+      if ($res === false && $i < 1) {
         print("error");
-      } else {
-        critical_error("unexpected exception");
+      }
+    } else {
+      try {
+        $res = openssl_random_pseudo_bytes($i);
+      } catch (Exception $e) {
+        if ($i < 1) {
+          print("error");
+        } else {
+          critical_error("unexpected exception");
+        }
       }
     }
-#else
-    $res = openssl_random_pseudo_bytes($i);
-    if ($res === false && $i < 1) {
-      print("error");
-    }
-#endif
     var_dump($res);
   }
 }

--- a/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
+++ b/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
@@ -1,0 +1,12 @@
+@ok
+<?php
+
+function test_openssl_random_pseudo_bytes() {
+  $length = 1;
+  $str = openssl_random_pseudo_bytes($length);
+  var_dump(strlen($str));
+
+  $length = 2048;
+  $str = openssl_random_pseudo_bytes($length);
+  var_dump(strlen($str));
+}

--- a/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
+++ b/tests/phpt/openssl/9_openssl_random_pseudo_bytes.php
@@ -2,11 +2,25 @@
 <?php
 
 function test_openssl_random_pseudo_bytes() {
-  $length = 1;
-  $str = openssl_random_pseudo_bytes($length);
-  var_dump(strlen($str));
-
-  $length = 2048;
-  $str = openssl_random_pseudo_bytes($length);
-  var_dump(strlen($str));
+  for ($i = -300; $i < 2048; $i += 273) {
+  /** @var string */
+  $res = "";
+#ifndef KPHP
+    try {
+      $res = openssl_random_pseudo_bytes($i);
+    } catch (Exception $e) {
+      if ($i < 1) {
+        print("error");
+      } else {
+        critical_error("unexpected exception");
+      }
+    }
+#else
+    $res = openssl_random_pseudo_bytes($i);
+    if ($res === false && $i < 1) {
+      print("error");
+    }
+#endif
+    var_dump($res);
+  }
 }

--- a/tests/phpt/string_functions/010_xor_strings.php
+++ b/tests/phpt/string_functions/010_xor_strings.php
@@ -1,18 +1,24 @@
 @ok
 <?php
 
+function is_kphp() {
+#ifndef KPHP
+    return false;
+#endif
+    return true;
+}
+
 function test_xor_strings() {
   $strings = ["handling and manipulating", "ings, take a look", "ctory Access Protocol", "0000000dwxasd", "1111sadsd11"];
 
   foreach ($strings as $str1) {
     foreach($strings as $str2) {
-#ifndef KPHP
-        $res = $str1 ^ $str2;
-#else
+      if (is_kphp()) {
         $res = xor_strings($str1, $str2);
-#endif
-
-        var_dump($res);
+      } else {
+        $res = $str1 ^ $str2;
+      }
+      var_dump($res);
     }
   }
 }

--- a/tests/phpt/string_functions/010_xor_strings.php
+++ b/tests/phpt/string_functions/010_xor_strings.php
@@ -9,7 +9,7 @@ function is_kphp() {
 }
 
 function test_xor_strings() {
-  $strings = ["handling and manipulating", "ings, take a look", "ctory Access Protocol", "0000000dwxasd", "1111sadsd11"];
+  $strings = ["handling and manipulating", "ings, take a look", "ctory Access Protocol", "0000000dwxasd", "1111sadsd11", "a", "-"];
 
   foreach ($strings as $str1) {
     foreach($strings as $str2) {

--- a/tests/phpt/string_functions/010_xor_strings.php
+++ b/tests/phpt/string_functions/010_xor_strings.php
@@ -1,0 +1,18 @@
+@ok
+<?php
+
+function test_xor_strings() {
+  $strings = ["handling and manipulating", "ings, take a look", "ctory Access Protocol", "0000000dwxasd", "1111sadsd11"];
+
+  foreach ($strings as $str1) {
+    foreach($strings as $str2) {
+#ifndef KPHP
+        $res = $str1 ^ $str2;
+#else
+        $res = xor_strings($str1, $str2);
+#endif
+
+        var_dump($res);
+    }
+  }
+}


### PR DESCRIPTION
SIGSEGV was caused by using wrong string's constructor. The constructor we used is an optimization for single-character strings.