### PR TITLE
Fix `kphp2cpp` assertion failure when using thread count is equal to `MAX_THREADS_COUNT`

### DIFF
--- a/compiler/threading/tls.h
+++ b/compiler/threading/tls.h
@@ -29,10 +29,14 @@ private:
     char dummy[4096];
   };
 
-  TLSRaw arr[MAX_THREADS_COUNT + 1];
+  // The thread with thread_id = 0 is the main thread in which the scheduler's master code is executed.
+  // Threads with thread_id values in the range [1, MAX_THREADS_CNT] can be used as worker threads.
+  // An additional thread with thread_id = MAX_THREADS_CNT + 1 can be used to work with the CppDestDirInitializer.
+  // Therefore, the system requires a total of MAX_THREADS_CNT + 2 threads to be available.
+  TLSRaw arr[MAX_THREADS_COUNT + 2];
 
   TLSRaw *get_raw(int id) {
-    assert(0 <= id && id <= MAX_THREADS_COUNT);
+    assert(0 <= id && id <= 1 + MAX_THREADS_COUNT);
     return &arr[id];
   }
 


### PR DESCRIPTION
Previously, we had failing `assert` when forces compiler to use 102 threads, meanwhile 102 equals `MAX_THREADS_COUNT`.
Example:
```
$ ./objs/bin/kphp2cpp dev_kphp/echo.php -t 102 -o a
Starting php to cpp transpiling...
dl_assert failed [tls.h:35: TLS<T>::TLSRaw* TLS<T>::get_raw(int) [with T = ZAllocatorRaw]]: 0 <= id && id <= MAX_THREADS_COUNT
[pid 38283] [time 1714728309] SIGSEGV caught, terminating program
```

 It was because TLS storage does not consider an additional thread that is reserved for `CppDestDirInitializer`. This PR adds comment in the code and fixes the problem.