### PR TITLE
fixed mac os http server

### DIFF
--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1460,6 +1460,13 @@ void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_port) n
     case WorkerType::general_worker: {
       const auto &http_server_ctx = vk::singleton<HttpServerContext>::get();
 
+#if defined(__APPLE__)
+      /*
+         * this is a hack, for more information, see https://github.com/VKCOM/kphp/issues/986
+       */
+      socket(AF_LOCAL, SOCK_DGRAM, 0);
+#endif
+
       if (http_server_ctx.http_server_enabled()) {
         http_port = http_server_ctx.worker_http_port();
         http_sfd = http_server_ctx.worker_http_socket_fd();


### PR DESCRIPTION
The problem was related to using epoll-shim, which relies on the kqueue() function. If you review the [documentation](https://www.opennet.ru/man.shtml?topic=kqueue&category=2) for kqueue(), you will see that it states the following: "The kqueue() system call creates a new kernel event queue and returns a descriptor. The queue is not inherited by a child created with fork(2)". It is easy to verify this using the following code:
```
#include <iostream>
#include <sys/event.h>
#include <sys/socket.h>
#include <unistd.h>

int main() {
  int kfd = kqueue();
  std::cout << "kfd: " << kfd << std::endl;
  pid_t child = fork();
  if (child == 0) {
    int sfd;
    if (sfd = socket(AF_INET, SOCK_STREAM, 0); sfd < 0) {
      exit(-1);
    }
    std::cout << "from child kfd: " << kfd << ", sfd: " << sfd << std::endl;
  } else {
    int sfd;
    if (sfd = socket(AF_INET, SOCK_STREAM, 0); sfd < 0) {
      exit(-1);
    }
    std::cout << "from parent kfd: " << kfd << ", sfd: " << sfd << std::endl;
  }

  return 0;
}
```
Output:
> kfd: 3
> from parent kfd: 3, sfd: 4
> from child kfd: 3, sfd: 3

It is worth noting that in KPHP, we use the prefork model. In this model, the main process, or master, first creates all necessary resources, such as file descriptors. Then, the process calls the fork function to create several child processes, controlled by the "-f" flag. The resulting file descriptor numbers are used as indexes for the "Targets" array, which stores references to event handler functions. This means that when the accept() call is made in the worker process, it cannot find the desired function in the "Targets" array because all workers have different file descriptor offsets.



I understand that this may not be the most elegant solution, but it is simple and effective.