### PR TITLE
Small improvements to light branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.16)
-set(CMAKE_CXX_STANDARD 20)
 project(kphplight)
 
 if ("${PROJECT_SOURCE_DIR}" STREQUAL "${PROJECT_BINARY_DIR}")

--- a/cmake/init-compilation-flags.cmake
+++ b/cmake/init-compilation-flags.cmake
@@ -87,7 +87,7 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
 endif()
 
 add_compile_options(-Wall -Wextra -Wunused-function -Wfloat-conversion -Wno-sign-compare
-                    -Wuninitialized -Wno-redundant-move -Wno-missing-field-initializers -Wno-vla-cxx-extension)
+                    -Wuninitialized -Wno-redundant-move -Wno-missing-field-initializers)
 
 if(NOT APPLE)
     check_cxx_compiler_flag(-gz=zlib DEBUG_COMPRESSION_IS_FOUND)

--- a/cmake/init-compilation-flags.cmake
+++ b/cmake/init-compilation-flags.cmake
@@ -8,10 +8,10 @@ elseif(CMAKE_CXX_COMPILER_ID MATCHES GNU)
     set(COMPILER_GCC True)
 endif()
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ standard to conform to")
+set(CMAKE_CXX_STANDARD 20 CACHE STRING "C++ standard to conform to")
 set(CMAKE_CXX_EXTENSIONS OFF)
-if (CMAKE_CXX_STANDARD LESS 17)
-    message(FATAL_ERROR "c++17 expected at least!")
+if (CMAKE_CXX_STANDARD LESS 20)
+    message(FATAL_ERROR "c++20 expected at least!")
 endif()
 cmake_print_variables(CMAKE_CXX_STANDARD)
 

--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -300,9 +300,7 @@ void CompilerSettings::init() {
   if (vk::contains(cxx.get(), "clang")) {
     ss << " -Wno-invalid-source-encoding";
   }
-  #if __cplusplus <= 201703L
-    ss << " -std=c++17";
-  #elif __cplusplus <= 202002L
+  #if __cplusplus <= 202002L
     ss << " -std=c++20";
   #else
     #error unsupported __cplusplus value

--- a/compiler/data/vertex-adaptor.h
+++ b/compiler/data/vertex-adaptor.h
@@ -39,15 +39,13 @@ public:
   explicit VertexAdaptor(vertex_inner<Op> *impl) noexcept
     : impl_(impl) {}
 
-  template<Operation FromOp>
+  template<Operation FromOp, typename = std::enable_if_t<op_type_is_base_of(Op, FromOp)>>
   VertexAdaptor(const VertexAdaptor<FromOp> &from) noexcept
     : impl_(static_cast<vertex_inner<Op> *>(from.impl_)) {
-    static_assert(op_type_is_base_of(Op, FromOp), "Strange cast to not base vertex");
   }
 
-  template<Operation FromOp>
+  template<Operation FromOp, typename = std::enable_if_t<op_type_is_base_of(Op, FromOp)>>
   VertexAdaptor<Op> &operator=(const VertexAdaptor<FromOp> &from) noexcept {
-    static_assert(op_type_is_base_of(Op, FromOp), "Strange assignment to not base vertex");
     impl_ = static_cast<vertex_inner<Op> *>(from.impl_);
     return *this;
   }

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -216,7 +216,7 @@ int main(int argc, char *argv[]) {
   parser.add("File with kphp runtime sha256 hash", settings->runtime_sha256_file,
              "runtime-sha256", "KPHP_RUNTIME_SHA256", "${KPHP_PATH}/objs/php_lib_version.sha256");
   parser.add("The output binary type: server, k2-component, cli or lib", settings->mode,
-             'M', "mode", "KPHP_MODE", "server", {"server", "k2-component", "cli", "lib"});
+             'M', "mode", "KPHP_MODE", "k2-component", {"server", "k2-component", "cli", "lib"});
   parser.add("A runtime library for building the output binary", settings->link_file,
              'l', "link-with", "KPHP_LINK_FILE");
   parser.add("Directory where php files will be searched", settings->includes,


### PR DESCRIPTION
There are small improvements:
* Fix machinery with C++ standard
* Change default mode as k2-component
* Remove useless compile option
* Fix Compile Error with `operator==` in VertexAdaptor