### PR TITLE
Added GNUInstallDirs CMake module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ include(CMakePrintHelpers)
 include(CheckCXXCompilerFlag)
 include(AddFileDependencies)
 include(FetchContent)
+include(GNUInstallDirs)
 
 # Global includes must be before all other includes/add_subdirectories
 include(cmake/utils.cmake)

--- a/common/tl/tl.cmake
+++ b/common/tl/tl.cmake
@@ -4,7 +4,7 @@ include(${COMMON_DIR}/tl2php/tl2php.cmake)
 
 install(TARGETS tl-compiler tl2php
         COMPONENT TL_TOOLS
-        RUNTIME DESTINATION bin)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 install(DIRECTORY ${COMMON_DIR}/tl-files
         COMPONENT TL_TOOLS

--- a/common/tlo-parsing/tlo-parsing.cmake
+++ b/common/tlo-parsing/tlo-parsing.cmake
@@ -25,8 +25,8 @@ set_target_properties(tlo_parsing_static PROPERTIES
 
 install(TARGETS tlo_parsing_static
         COMPONENT TLO_PARSING_DEV
-        ARCHIVE DESTINATION lib
-        PUBLIC_HEADER DESTINATION usr/include/tlo-parsing)
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        PUBLIC_HEADER DESTINATION /usr/${CMAKE_INSTALL_INCLUDEDIR}/tlo-parsing)
 
 vk_add_library(tlo_parsing_shared SHARED $<TARGET_OBJECTS:tlo_parsing_src>)
 set_target_properties(tlo_parsing_shared PROPERTIES OUTPUT_NAME tlo_parsing)
@@ -37,7 +37,7 @@ endif()
 
 install(TARGETS tlo_parsing_shared
         COMPONENT TLO_PARSING
-        LIBRARY DESTINATION lib)
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 set(CPACK_DEBIAN_TLO_PARSING_PACKAGE_NAME "libtlo-parsing")
 set(CPACK_DEBIAN_TLO_PARSING_DESCRIPTION "Library files for the tlo parsing")

--- a/flex/flex.cmake
+++ b/flex/flex.cmake
@@ -35,8 +35,8 @@ set_target_properties(flex_data_shared flex_data_static
 
 install(TARGETS flex_data_shared flex_data_static
         COMPONENT FLEX
-        LIBRARY DESTINATION usr/lib
-        ARCHIVE DESTINATION usr/lib)
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 set(CPACK_DEBIAN_FLEX_PACKAGE_BREAKS "engine-kphp-runtime (<< 20190917), php5-vkext (<< 20190917), php7-vkext (<< 20190917)")
 set(CPACK_DEBIAN_FLEX_PACKAGE_NAME "vk-flex-data")


### PR DESCRIPTION
The problem I'm trying to solve is described in the corresponding issue #997.

The patch replaces hardcoded installation paths with paths from GNUInstallDirs. This should help ensure cross-distribution builds, at least at the directory compatibility level.