### PR TITLE
Add cacheline-alignment to compiler/threading and switch from volatile to std::atomic

### DIFF
--- a/common/cacheline.h
+++ b/common/cacheline.h
@@ -7,7 +7,11 @@
 
 #include <stdint.h>
 
+#if defined(__ARM_ARCH_7A__) || defined(__aarch64__)
+#define KDB_CACHELINE_SIZE 128
+#else
 #define KDB_CACHELINE_SIZE 64
+#endif // __ARM_ARCH_7A__ || __aarch64__
 #define KDB_CACHELINE_ALIGNED __attribute__((aligned(KDB_CACHELINE_SIZE)))
 
 #endif // KDB_COMMON_CACHELINE_H

--- a/compiler/scheduler/scheduler-base.cpp
+++ b/compiler/scheduler/scheduler-base.cpp
@@ -11,17 +11,17 @@ std::atomic<int> tasks_before_sync_node;
 static SchedulerBase *scheduler;
 
 void set_scheduler(SchedulerBase *new_scheduler) {
-  assert (scheduler == nullptr);
+  assert(scheduler == nullptr);
   scheduler = new_scheduler;
 }
 
 void unset_scheduler(SchedulerBase *old_scheduler) {
-  assert (scheduler == old_scheduler);
+  assert(scheduler == old_scheduler);
   scheduler = nullptr;
 }
 
 SchedulerBase *get_scheduler() {
-  assert (scheduler != nullptr);
+  assert(scheduler != nullptr);
   return scheduler;
 }
 

--- a/compiler/scheduler/scheduler-base.cpp
+++ b/compiler/scheduler/scheduler-base.cpp
@@ -6,7 +6,7 @@
 
 #include <cassert>
 
-volatile int tasks_before_sync_node;
+std::atomic<int> tasks_before_sync_node;
 
 static SchedulerBase *scheduler;
 

--- a/compiler/scheduler/scheduler-base.h
+++ b/compiler/scheduler/scheduler-base.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <atomic>
+
 class Node;
 
 class Task;
@@ -22,7 +24,7 @@ SchedulerBase *get_scheduler();
 void set_scheduler(SchedulerBase *new_scheduler);
 void unset_scheduler(SchedulerBase *old_scheduler);
 
-extern volatile int tasks_before_sync_node;
+extern std::atomic<int> tasks_before_sync_node;
 
 inline void register_async_task(Task *task) {
   get_scheduler()->add_task(task);

--- a/compiler/scheduler/scheduler.cpp
+++ b/compiler/scheduler/scheduler.cpp
@@ -67,7 +67,7 @@ void Scheduler::execute() {
   }
 
   while (true) {
-    if (tasks_before_sync_node > 0) {
+    if (tasks_before_sync_node.load(std::memory_order_acquire) > 0) {
       usleep(250);
       continue;
     }
@@ -101,7 +101,7 @@ bool Scheduler::thread_process_node(Node *node) {
   }
   task->execute();
   delete task;
-  __sync_fetch_and_sub(&tasks_before_sync_node, 1);
+  tasks_before_sync_node.fetch_sub(1, std::memory_order_release);
   return true;
 }
 

--- a/compiler/scheduler/scheduler.cpp
+++ b/compiler/scheduler/scheduler.cpp
@@ -21,15 +21,14 @@ public:
   bool run_flag;
 };
 
-
 void *scheduler_thread_execute(void *arg) {
   auto *tls = (ThreadContext *)arg;
   tls->scheduler->thread_execute(tls);
   return nullptr;
 }
 
-Scheduler::Scheduler() :
-  threads_count(-1) {
+Scheduler::Scheduler()
+  : threads_count(-1) {
   task_pull = new TaskPull();
 }
 
@@ -46,7 +45,7 @@ void Scheduler::add_sync_node(Node *node) {
 }
 
 void Scheduler::add_task(Task *task) {
-  assert (task_pull != nullptr);
+  assert(task_pull != nullptr);
   task_pull->add_task(task);
 }
 
@@ -55,7 +54,7 @@ void Scheduler::execute() {
   set_thread_id(0);
   std::vector<ThreadContext> threads(threads_count + 1);
 
-  assert ((int)one_thread_nodes.size() < threads_count);
+  assert((int)one_thread_nodes.size() < threads_count);
   for (int i = 1; i <= threads_count; i++) {
     threads[i].thread_id = i;
     threads[i].scheduler = this;
@@ -90,7 +89,7 @@ void Scheduler::execute() {
 }
 
 void Scheduler::set_threads_count(int new_threads_count) {
-  assert (1 <= new_threads_count && new_threads_count <= MAX_THREADS_COUNT);
+  assert(1 <= new_threads_count && new_threads_count <= MAX_THREADS_COUNT);
   threads_count = new_threads_count;
 }
 

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -29,7 +29,7 @@ const char *get_assert_level_desc(AssertLevelT assert_level) {
     case FATAL_ASSERT_LEVEL:
       return "Fatal error";
     default:
-      assert (0);
+      assert(0);
   }
 }
 
@@ -43,8 +43,8 @@ void stage::set_warning_file(FILE *file) noexcept {
   warning_file = file;
 }
 
-void on_compilation_error(const char *description __attribute__((unused)), const char *file_name, int line_number,
-                          const char *full_description, AssertLevelT assert_level) {
+void on_compilation_error(const char *description __attribute__((unused)), const char *file_name, int line_number, const char *full_description,
+                          AssertLevelT assert_level) {
 
   AutoLocker<std::atomic<int> *> locker(&ce_locker);
   FILE *file = stdout;
@@ -62,7 +62,7 @@ void on_compilation_error(const char *description __attribute__((unused)), const
                       "It is probably happened due to incorrect or unsupported PHP input.\n"
                       "But it is still bug in compiler.\n");
 #ifdef __arm64__
-    __builtin_debugtrap();  // for easier debugging kphp_assert / kphp_fail
+    __builtin_debugtrap(); // for easier debugging kphp_assert / kphp_fail
 #endif
     abort();
   }
@@ -74,7 +74,6 @@ void on_compilation_error(const char *description __attribute__((unused)), const
   }
   fflush(file);
 }
-
 
 void Location::set_file(SrcFilePtr new_file) {
   file = new_file;
@@ -94,10 +93,10 @@ void Location::set_line(int new_line) {
   line = new_line;
 }
 
-Location::Location(const SrcFilePtr &file, const FunctionPtr &function, int line) :
-  file(file),
-  function(function),
-  line(line) {}
+Location::Location(const SrcFilePtr &file, const FunctionPtr &function, int line)
+  : file(file)
+  , function(function)
+  , line(line) {}
 
 // return a location in the format: "{file}:{line}  in {function}"
 std::string Location::as_human_readable() const {
@@ -251,8 +250,9 @@ const std::string &stage::get_function_name() {
   return function->name;
 }
 
-bool stage::should_be_colored(FILE *f)  {
-  if (!G) return TermStringFormat::is_terminal(f);
+bool stage::should_be_colored(FILE *f) {
+  if (!G)
+    return TermStringFormat::is_terminal(f);
   switch (G->settings().get_color_settings()) {
     case CompilerSettings::colored:
       return true;

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -2,6 +2,8 @@
 // Copyright (c) 2020 LLC «V Kontakte»
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
+#include <atomic>
+
 #include "compiler/stage.h"
 
 #include "common/termformat/termformat.h"
@@ -31,7 +33,7 @@ const char *get_assert_level_desc(AssertLevelT assert_level) {
   }
 }
 
-volatile int ce_locker;
+std::atomic<int> ce_locker;
 
 namespace {
 FILE *warning_file{nullptr};
@@ -44,7 +46,7 @@ void stage::set_warning_file(FILE *file) noexcept {
 void on_compilation_error(const char *description __attribute__((unused)), const char *file_name, int line_number,
                           const char *full_description, AssertLevelT assert_level) {
 
-  AutoLocker<volatile int *> locker(&ce_locker);
+  AutoLocker<std::atomic<int> *> locker(&ce_locker);
   FILE *file = stdout;
   if (assert_level == WRN_ASSERT_LEVEL && warning_file) {
     file = warning_file;

--- a/compiler/threading/data-stream.h
+++ b/compiler/threading/data-stream.h
@@ -38,7 +38,7 @@ public:
 
   void operator<<(DataType input) {
     if (!is_sink_mode_) {
-      __sync_fetch_and_add(&tasks_before_sync_node, 1);
+      tasks_before_sync_node.fetch_add(1, std::memory_order_release);
     }
     std::lock_guard<std::mutex> lock{mutex_};
     queue_.push_front(std::move(input));

--- a/compiler/threading/data-stream.h
+++ b/compiler/threading/data-stream.h
@@ -21,10 +21,8 @@ public:
   template<size_t data_id>
   using NthDataType = DataType;
 
-  explicit DataStream(bool is_sink = false) :
-    is_sink_mode_(is_sink)
-  {
-  }
+  explicit DataStream(bool is_sink = false)
+    : is_sink_mode_(is_sink) {}
 
   bool get(DataType &result) {
     std::lock_guard<std::mutex> lock{mutex_};
@@ -60,13 +58,12 @@ private:
   const bool is_sink_mode_;
 };
 
-
 struct EmptyStream {
   template<size_t stream_id>
   using NthDataType = EmptyStream;
 };
 
-template<class ...DataTypes>
+template<class... DataTypes>
 class MultipleDataStreams {
 private:
   std::tuple<DataStream<DataTypes> *...> streams_;

--- a/compiler/threading/hash-table.h
+++ b/compiler/threading/hash-table.h
@@ -43,7 +43,7 @@ public:
       }
       unsigned long long expected = 0;
       if (nodes[i].hash.load(std::memory_order_acquire) == 0 
-        && nodes[i].hash.compare_exchange_weak(expected, hash, std::memory_order_acq_rel)) {
+        && !nodes[i].hash.compare_exchange_strong(expected, hash, std::memory_order_acq_rel)) {
         int id = used_size.fetch_add(1, std::memory_order_release);
         assert(id * 2 < N);
         continue;

--- a/compiler/threading/hash-table.h
+++ b/compiler/threading/hash-table.h
@@ -16,34 +16,31 @@ public:
     std::atomic<unsigned long long> hash;
     T data;
 
-    HTNode() :
-      hash(0),
-      data() {
-    }
+    HTNode()
+      : hash(0)
+      , data() {}
   };
 
 private:
   HTNode *nodes;
   std::atomic<int> used_size;
+
 public:
-  TSHashTable() :
-    nodes(new HTNode[N]),
-    used_size(0) {
-  }
+  TSHashTable()
+    : nodes(new HTNode[N])
+    , used_size(0) {}
 
   HTNode *at(unsigned long long hash) {
     int i = (unsigned)hash % (unsigned)N;
     while (true) {
-      while (nodes[i].hash.load(std::memory_order_acquire) != 0 
-        && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
+      while (nodes[i].hash.load(std::memory_order_acquire) != 0 && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
         i++;
         if (i == N) {
           i = 0;
         }
       }
       unsigned long long expected = 0;
-      if (nodes[i].hash.load(std::memory_order_acquire) == 0 
-        && !nodes[i].hash.compare_exchange_strong(expected, hash, std::memory_order_acq_rel)) {
+      if (nodes[i].hash.load(std::memory_order_acquire) == 0 && !nodes[i].hash.compare_exchange_strong(expected, hash, std::memory_order_acq_rel)) {
         int id = used_size.fetch_add(1, std::memory_order_release);
         assert(id * 2 < N);
         continue;
@@ -55,8 +52,7 @@ public:
 
   const T *find(unsigned long long hash) {
     int i = (unsigned)hash % (unsigned)N;
-    while (nodes[i].hash.load(std::memory_order_acquire) != 0 
-      && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
+    while (nodes[i].hash.load(std::memory_order_acquire) != 0 && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
       i++;
       if (i == N) {
         i = 0;

--- a/compiler/threading/hash-table.h
+++ b/compiler/threading/hash-table.h
@@ -13,7 +13,7 @@ template<class T, int N = 1000000>
 class TSHashTable {
 public:
   struct HTNode : Lockable {
-    unsigned long long hash;
+    std::atomic<unsigned long long> hash;
     T data;
 
     HTNode() :
@@ -24,7 +24,7 @@ public:
 
 private:
   HTNode *nodes;
-  int used_size;
+  std::atomic<int> used_size;
 public:
   TSHashTable() :
     nodes(new HTNode[N]),
@@ -34,14 +34,17 @@ public:
   HTNode *at(unsigned long long hash) {
     int i = (unsigned)hash % (unsigned)N;
     while (true) {
-      while (nodes[i].hash != 0 && nodes[i].hash != hash) {
+      while (nodes[i].hash.load(std::memory_order_acquire) != 0 
+        && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
         i++;
         if (i == N) {
           i = 0;
         }
       }
-      if (nodes[i].hash == 0 && !__sync_bool_compare_and_swap(&nodes[i].hash, 0, hash)) {
-        int id = __sync_fetch_and_add(&used_size, 1);
+      unsigned long long expected = 0;
+      if (nodes[i].hash.load(std::memory_order_acquire) == 0 
+        && nodes[i].hash.compare_exchange_weak(expected, hash, std::memory_order_acq_rel)) {
+        int id = used_size.fetch_add(1, std::memory_order_release);
         assert(id * 2 < N);
         continue;
       }
@@ -52,20 +55,21 @@ public:
 
   const T *find(unsigned long long hash) {
     int i = (unsigned)hash % (unsigned)N;
-    while (nodes[i].hash != 0 && nodes[i].hash != hash) {
+    while (nodes[i].hash.load(std::memory_order_acquire) != 0 
+      && nodes[i].hash.load(std::memory_order_relaxed) != hash) {
       i++;
       if (i == N) {
         i = 0;
       }
     }
 
-    return nodes[i].hash == hash ? &nodes[i].data : nullptr;
+    return nodes[i].hash.load(std::memory_order_acquire) == hash ? &nodes[i].data : nullptr;
   }
 
   std::vector<T> get_all() {
     std::vector<T> res;
     for (int i = 0; i < N; i++) {
-      if (nodes[i].hash != 0) {
+      if (nodes[i].hash.load(std::memory_order_acquire) != 0) {
         res.push_back(nodes[i].data);
       }
     }
@@ -76,7 +80,7 @@ public:
   std::vector<T> get_all_if(const CondF &callbackF) {
     std::vector<T> res;
     for (int i = 0; i < N; i++) {
-      if (nodes[i].hash != 0 && callbackF(nodes[i].data)) {
+      if (nodes[i].hash.load(std::memory_order_acquire) != 0 && callbackF(nodes[i].data)) {
         res.push_back(nodes[i].data);
       }
     }

--- a/compiler/threading/locks.h
+++ b/compiler/threading/locks.h
@@ -48,6 +48,19 @@ public:
   Lockable() :
     x(0) {}
 
+  Lockable(const Lockable& other) noexcept : 
+    x{other.x.load(std::memory_order_relaxed)} {}
+  Lockable(Lockable&& other) noexcept : 
+    x{other.x.load(std::memory_order_relaxed)} {}
+  Lockable& operator=(const Lockable& other) noexcept {
+    x = other.x.load(std::memory_order_relaxed);
+    return *this;
+  }
+  Lockable& operator=(Lockable&& other) noexcept {
+    x = other.x.load(std::memory_order_relaxed);
+    return *this;
+  }
+
   virtual ~Lockable() = default;
 
   void lock() {

--- a/compiler/threading/locks.h
+++ b/compiler/threading/locks.h
@@ -44,19 +44,20 @@ inline void unlock(std::atomic<int> *locker) {
 class KDB_CACHELINE_ALIGNED Lockable {
 private:
   std::atomic<int> x;
-public:
-  Lockable() :
-    x(0) {}
 
-  Lockable(const Lockable& other) noexcept : 
-    x{other.x.load(std::memory_order_relaxed)} {}
-  Lockable(Lockable&& other) noexcept : 
-    x{other.x.load(std::memory_order_relaxed)} {}
-  Lockable& operator=(const Lockable& other) noexcept {
+public:
+  Lockable()
+    : x(0) {}
+
+  Lockable(const Lockable &other) noexcept
+    : x{other.x.load(std::memory_order_relaxed)} {}
+  Lockable(Lockable &&other) noexcept
+    : x{other.x.load(std::memory_order_relaxed)} {}
+  Lockable &operator=(const Lockable &other) noexcept {
     x = other.x.load(std::memory_order_relaxed);
     return *this;
   }
-  Lockable& operator=(Lockable&& other) noexcept {
+  Lockable &operator=(Lockable &&other) noexcept {
     x = other.x.load(std::memory_order_relaxed);
     return *this;
   }
@@ -76,9 +77,10 @@ template<class DataT>
 class AutoLocker {
 private:
   DataT ptr;
+
 public:
-  explicit AutoLocker(DataT ptr) :
-    ptr(ptr) {
+  explicit AutoLocker(DataT ptr)
+    : ptr(ptr) {
     lock(ptr);
   }
 

--- a/compiler/threading/thread-id.cpp
+++ b/compiler/threading/thread-id.cpp
@@ -4,7 +4,7 @@
 
 #include "compiler/threading/thread-id.h"
 
-static __thread int bicycle_thread_id;
+static thread_local int bicycle_thread_id;
 
 int get_thread_id() {
   return bicycle_thread_id;

--- a/compiler/threading/tls.h
+++ b/compiler/threading/tls.h
@@ -8,6 +8,8 @@
 #include <cassert>
 #include <thread>
 
+#include "common/cacheline.h"
+
 #include "compiler/threading/locks.h"
 #include "compiler/threading/thread-id.h"
 
@@ -23,10 +25,10 @@ inline uint32_t get_default_threads_count() noexcept {
 template<class T>
 struct TLS {
 private:
-  struct TLSRaw {
+  struct KDB_CACHELINE_ALIGNED TLSRaw {
     T data{};
-    volatile int locker = 0;
-    char dummy[4096];
+    std::atomic<int> locker = UNLOCKED;
+    char dummy[KDB_CACHELINE_SIZE];
   };
 
   // The thread with thread_id = 0 is the main thread in which the scheduler's master code is executed.

--- a/compiler/threading/tls.h
+++ b/compiler/threading/tls.h
@@ -47,10 +47,8 @@ private:
   }
 
 public:
-  TLS() :
-    arr() {
-  }
-
+  TLS()
+    : arr() {}
 
   T &get() {
     return get_raw()->data;

--- a/runtime/critical_section.cpp
+++ b/runtime/critical_section.cpp
@@ -9,10 +9,10 @@
 
 #include "runtime/php_assert.h"
 
-void check_stack_overflow() __attribute__ ((weak));
+void check_stack_overflow() __attribute__((weak));
 
 void check_stack_overflow() {
-  //pass;
+  // pass;
 }
 
 namespace dl {
@@ -22,13 +22,13 @@ volatile long long pending_signals;
 
 void enter_critical_section() noexcept {
   check_stack_overflow();
-  php_assert (in_critical_section.load(std::memory_order_relaxed) >= 0);
+  php_assert(in_critical_section.load(std::memory_order_relaxed) >= 0);
   in_critical_section.fetch_add(1, std::memory_order_release);
 }
 
 void leave_critical_section() noexcept {
   in_critical_section.fetch_sub(1, std::memory_order_release);
-  php_assert (in_critical_section.load(std::memory_order_relaxed) >= 0);
+  php_assert(in_critical_section.load(std::memory_order_relaxed) >= 0);
   if (pending_signals && in_critical_section.load(std::memory_order_acquire) <= 0) {
     for (int i = 0; i < sizeof(pending_signals) * 8; i++) {
       if ((pending_signals >> i) & 1) {

--- a/runtime/critical_section.h
+++ b/runtime/critical_section.h
@@ -4,13 +4,14 @@
 
 #pragma once
 
+#include <atomic>
 #include <utility>
 
 #include "common/mixin/not_copyable.h"
 
 namespace dl {
 
-extern volatile int in_critical_section;
+extern std::atomic<int> in_critical_section;
 extern volatile long long pending_signals;
 
 void enter_critical_section() noexcept;

--- a/runtime/critical_section.h
+++ b/runtime/critical_section.h
@@ -20,13 +20,21 @@ void leave_critical_section() noexcept;
 // leaves the critical section until the destructor is executed;
 // it is implied that this object is constructed somewhere inside the critical section
 struct NonCriticalSectionGuard : private vk::not_copyable {
-  NonCriticalSectionGuard() noexcept { leave_critical_section(); }
-  ~NonCriticalSectionGuard() noexcept { enter_critical_section(); }
+  NonCriticalSectionGuard() noexcept {
+    leave_critical_section();
+  }
+  ~NonCriticalSectionGuard() noexcept {
+    enter_critical_section();
+  }
 };
 
 struct CriticalSectionGuard : private vk::not_copyable {
-  CriticalSectionGuard() noexcept { enter_critical_section(); }
-  ~CriticalSectionGuard() noexcept { leave_critical_section(); }
+  CriticalSectionGuard() noexcept {
+    enter_critical_section();
+  }
+  ~CriticalSectionGuard() noexcept {
+    leave_critical_section();
+  }
 };
 
 class CriticalSectionSmartGuard : private vk::not_copyable {
@@ -57,8 +65,8 @@ private:
   bool in_critical_section_{false};
 };
 
-template<class F, class ...Args>
-auto critical_section_call(F &&f, Args &&...args) noexcept {
+template<class F, class... Args>
+auto critical_section_call(F &&f, Args &&... args) noexcept {
   CriticalSectionGuard critical_section;
   return f(std::forward<Args>(args)...);
 }


### PR DESCRIPTION
Refactor compiler/threading:
* Switch to `std::atomic` instead of `volatile`
* Use `alignas` to cache-align shared structs
* Use proper memory orderings instead of default seq_cst