### PR TITLE
Resolve classes from `@param` phpdoc

### DIFF
--- a/tests/phpt/cl/030_resolve_from_phpdoc.php
+++ b/tests/phpt/cl/030_resolve_from_phpdoc.php
@@ -26,6 +26,14 @@ function f2() {
     else echo "a null\n";
 }
 
+/**
+ * @param ?\Classes\Z3Infer $b
+ */
+function f3($b) {
+  if ($b) $b->thisHasInfer(1,2);
+}
+
 f1(null);
 f2();
+f3(null);
 (new BB)->f();


### PR DESCRIPTION
Purpose: when a class occurs only in `@param` and is actually never created, resolve it in `CollectRequiredPass`.
Previously, `@param` weren't analyzed there, because phpdocs haven't been parsed up to that execution point, and I didn't want to perform parsing twice.

Unfortunately, the only way to reach the goal is to do parsing twice :( Considering current vkcom codebase. It's very ugly, since parsing is quite a heavy operation.

Ideally, types in phpdoc should be parsed once in gentree, but actually, vkcom has so much syntax-invalid phpdocs, that it's unavailable. (that "invalid" functions aren't reachable in fact, they just exist in a dead codebase, so their phpdocs aren't analyzed later, but trying to parse them in gentree leads to 10k errors)