### PR TITLE
Fix compilation error for lambdas in unused functions

### DIFF
--- a/compiler/pipes/check-classes.cpp
+++ b/compiler/pipes/check-classes.cpp
@@ -72,7 +72,6 @@ inline void CheckClassesPass::check_static_fields_inited(ClassPtr klass) {
 }
 
 inline void CheckClassesPass::check_instance_fields_inited(ClassPtr klass) {
-  // TODO KPHP-221: the old code is kept for now (check for Unknown)
   klass->members.for_each([](const ClassMemberInstanceField &f) {
     PrimitiveType ptype = f.var->tinf_node.get_type()->get_real_ptype();
     kphp_error(ptype != tp_any,

--- a/compiler/pipes/filter-only-actually-used.cpp
+++ b/compiler/pipes/filter-only-actually-used.cpp
@@ -69,6 +69,9 @@ public:
         RemoveLambdaCallFromTypedCallablePass pass(lambda_class);
         run_function_pass(f_typed_invoke->root, &pass);
 
+        AnalyzeLambdasInUnusedFunctionPass self_pass(used_functions);
+        run_function_pass(f_lambda, &self_pass);
+
         used_functions[f_lambda] = {};
         used_functions[m_invoke->function] = {};
         used_functions[lambda_class->construct_function] = {};
@@ -333,7 +336,7 @@ void FilterOnlyActuallyUsedFunctionsF::on_finish(DataStream<FunctionPtr> &os) {
   // remove lambdas from unused functions, see comments above
   for (const auto &f_and_e : all) {
     FunctionPtr fun = f_and_e.first;
-    if (fun->has_lambdas_inside && !used_functions[fun]) {
+    if (fun->has_lambdas_inside && !fun->is_lambda() && !used_functions[fun]) {
       AnalyzeLambdasInUnusedFunctionPass pass(used_functions);
       run_function_pass(fun, &pass);
     }

--- a/compiler/pipes/generate-virtual-methods.cpp
+++ b/compiler/pipes/generate-virtual-methods.cpp
@@ -422,10 +422,6 @@ void generate_body_of_virtual_method(FunctionPtr virtual_function) {
       cases.emplace_back(v_case);
     }
   }
-  if (!cases.empty()) {
-    auto case_default_warn = generate_critical_error_call(fmt_format("call method({}) on null object", virtual_function->as_human_readable(false)));
-    cases.emplace_back(VertexAdaptor<op_default>::create(VertexAdaptor<op_seq>::create(case_default_warn)));
-  }
 
   if (cases.empty() && !stage::has_error()) {
     // when there are no inheritors of an interface, generate an empty body if possible —
@@ -436,7 +432,7 @@ void generate_body_of_virtual_method(FunctionPtr virtual_function) {
     auto call_get_hash = VertexAdaptor<op_func_call>::create(ClassData::gen_vertex_this({}));
     call_get_hash->str_val = "get_hash_of_class";
     call_get_hash->func_id = G->get_function(call_get_hash->str_val);
-    virtual_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(VertexUtil::create_switch_vertex(virtual_function, call_get_hash, std::move(cases)));
+    virtual_function->root->cmd_ref() = VertexAdaptor<op_seq>::create(VertexUtil::create_switch_vertex(virtual_function, call_get_hash, std::move(cases)), generate_critical_error_call(fmt_format("call method({}) on null object", virtual_function->as_human_readable(false))));
   }
 
   virtual_function->type = FunctionData::func_local;    // could be func_extern before, but now it has a body

--- a/tests/phpt/lambdas/020_uses_in_lambda.php
+++ b/tests/phpt/lambdas/020_uses_in_lambda.php
@@ -110,3 +110,43 @@ class WithFCapturingDeep {
 }
 (new WithFCapturingDeep)->l2();
 (new WithFCapturingDeep)->l2_modif();
+
+class Example020 {
+  static private function takeInt(int $i) { echo $i; }
+
+  public function unused_function(): void {
+    $tmp_var = "";
+    $this->call_function(function() use ($tmp_var): void {});
+    $int = 10;
+    $this->call_function(function() use ($int): void { self::takeInt($int); });
+  }
+
+  /** @param callable():void $fn */
+  public function call_function(callable $fn): void {
+    $fn();
+  }
+}
+
+(new Example020())->call_function(function(): void {});
+
+class Bxample020 {
+  /**
+   * @param callable(int):int $fn
+   */
+  public function unused_function(callable $fn): int {
+    return $this->test2(function () use ($fn) {
+      return $fn(1);
+    });
+  }
+
+  /**
+   * @param callable():int $fn
+   */
+  public function test2(callable $fn): int {
+    return $fn();
+  }
+}
+
+$bxample = new Bxample020();
+$bxample->test2(function() { return 0; });
+

--- a/tests/phpt/lambdas/020_uses_in_lambda.php
+++ b/tests/phpt/lambdas/020_uses_in_lambda.php
@@ -150,3 +150,24 @@ class Bxample020 {
 $bxample = new Bxample020();
 $bxample->test2(function() { return 0; });
 
+
+class Cxample {
+  public function unused_function(): void {
+    $tmp_var = "";
+    $this->call_function_first(function() use ($tmp_var): void {
+      $this->call_function_second(function() use ($tmp_var) {});
+    });
+  }
+
+  /** @param callable():void $fn */
+  public function call_function_first(callable $fn): void {
+    $fn();
+  }
+
+  /** @param callable():void $fn */
+  public function call_function_second(callable $fn): void {
+    $fn();
+  }
+}
+
+(new Cxample)->call_function_first(function():void{} );


### PR DESCRIPTION
Sometimes, one could face the following compilation error:
```
var Lambda$ufa6f526451637135_0::$tmp_var is declared but never written; please, provide a default value
```

That happened in such a scenario:
1. A lambda with `use` capturing was in an instance function 
2. That instance function was actually unused
3. That lambda was passed to a typed callable

The reason of an error was that a parent (instance) function was unused, but a lambda itself was used (from a typed callable switch-case dispatching). And since `use` capturing actually declares a field in a lambda class, a type of that field couldn't be inferred (since a type inferer never visits its parent function, it's unused).

The provided solution is to detect such cases (after marking used/unused functions) and to manually
1. Manually delete `case` of that lambda from a typed callable dispatching
2. Manually delete that lambda from reachable functions

Of course, this looks like a hack, but as of current compiler architecture (when generating virtual methods is performed prior to calculating used call graph, and instance functions are pre-marked used apriori), nothing could be done better.

Fixes #457
