### PR TITLE
Resolve classes from `export` methods in .modulite.yaml

### DIFF
--- a/compiler/pipes/collect-required-and-classes.cpp
+++ b/compiler/pipes/collect-required-and-classes.cpp
@@ -264,6 +264,10 @@ private:
         if (seems_like_classname) {
           require_class(modulite->modulite_namespace + e);
         }
+        size_t pos_classmember = e.find("::");
+        if (pos_classmember != std::string::npos) {
+          require_class(modulite->modulite_namespace + e.substr(0, pos_classmember));
+        }
       }
     }
   }

--- a/tests/phpt/modulite/010_mod_unreachable/Utils010/.modulite.yaml
+++ b/tests/phpt/modulite/010_mod_unreachable/Utils010/.modulite.yaml
@@ -5,6 +5,7 @@ export:
   - "Strings010"
   - "UnreachableClass010"
   - "UnreachableNs\\AnotherUn010"
+  - "UnreachableNs\\BnotherUn010::nothing()"
 
 require:
   

--- a/tests/phpt/modulite/010_mod_unreachable/Utils010/UnreachableNs/BnotherUn010.php
+++ b/tests/phpt/modulite/010_mod_unreachable/Utils010/UnreachableNs/BnotherUn010.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Utils010\UnreachableNs;
+
+class BnotherUn010 {
+    static public function nothing() {}
+}


### PR DESCRIPTION
Related to #1015.

When a modulite exports a method of a class, and the class itself is not reachable in any other ways, now it leads to a compilation error.

This PR fixes this. Resolving from classes in a modulite was earlier done, here I've just added resolving from methods.