### PR TITLE
Cache uname syscall invocation

### DIFF
--- a/common/kernel-version.cpp
+++ b/common/kernel-version.cpp
@@ -4,12 +4,10 @@
 
 #include "common/kernel-version.h"
 
-#include <sys/utsname.h>
-
 #include "common/kprintf.h"
 #include "common/stats/provider.h"
 
-static struct utsname* cached_uname() {
+utsname* cached_uname() {
   static struct utsname kernel_version;
   static int got_kernel_version = 0;
   if (got_kernel_version == 0) {

--- a/common/kernel-version.h
+++ b/common/kernel-version.h
@@ -5,7 +5,8 @@
 #pragma once
 
 #include <sys/cdefs.h>
+#include <sys/utsname.h>
 
+utsname* cached_uname();
 int epoll_exclusive_supported();
 int madvise_madv_free_supported();
-

--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -13,6 +13,7 @@
 
 #undef basename
 
+#include "common/kernel-version.h"
 #include "common/macos-ports.h"
 #include "common/wrappers/mkdir_recursive.h"
 
@@ -361,13 +362,11 @@ bool f$mkdir(const string &name, int64_t mode, bool recursive) {
 }
 
 string f$php_uname(const string &name) {
-  utsname res;
-  dl::enter_critical_section();//OK
-  if (uname(&res)) {
-    dl::leave_critical_section();
+  const auto *uname = cached_uname();
+  if (uname == nullptr) {
     return {};
   }
-  dl::leave_critical_section();
+  const auto &res = *uname;
 
   char mode = name[0];
   switch (mode) {

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -26,6 +26,7 @@
 #include "common/crc32c.h"
 #include "common/cycleclock.h"
 #include "common/dl-utils-lite.h"
+#include "common/kernel-version.h"
 #include "common/kprintf.h"
 #include "common/macos-ports.h"
 #include "common/options.h"
@@ -1667,6 +1668,7 @@ void init_all() {
     log_server_warning(deprecation_warning);
   }
   StatsHouseManager::get().set_common_tags();
+  cached_uname(); // invoke uname syscall only once on master start
 
   global_init_runtime_libs();
   global_init_php_scripts();


### PR DESCRIPTION
Now we invoke uname syscall only once on master start and cache it for the next usages.