### PR TITLE
Change exit codes

### DIFF
--- a/common/exit-codes.h
+++ b/common/exit-codes.h
@@ -1,0 +1,11 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2024 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+enum class ExitCode {
+  KPHP_TO_CPP_STAGE = 100,
+  CPP_TO_OBJS_STAGE = 101,
+  OBJS_TO_BINARY_STAGE = 102,
+  SIGNAL_OFFSET = 128
+};

--- a/common/exit-codes.h
+++ b/common/exit-codes.h
@@ -3,6 +3,11 @@
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #pragma once
+
+// The exit codes were selected according to https://tldp.org/LDP/abs/html/exitcodes.html
+// 100, 101, and 102 are free for statuses defined by the programmer and they look pretty
+// If the app is going to exit because of a signal, then the return code is 128 + %signal_code%,
+// which is also a common practice
 enum class ExitCode {
   KPHP_TO_CPP_STAGE = 100,
   CPP_TO_OBJS_STAGE = 101,

--- a/common/server/signals.h
+++ b/common/server/signals.h
@@ -15,7 +15,7 @@ extern int daemonize;
 void print_backtrace();
 void ksignal(int sig, void (*handler)(int));
 void ksignal_intr(int sig, void (*handler)(int));
-void set_debug_handlers();
+void set_debug_handlers(bool save_signal_in_exit_code = false);
 void setup_delayed_handlers();
 int is_signal_pending(int sig);
 

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -200,7 +200,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   init_version_string("kphp2cpp");
-  set_debug_handlers();
+  set_debug_handlers(true);
 
   auto settings = std::make_unique<CompilerSettings>();
 

--- a/compiler/make/make.cpp
+++ b/compiler/make/make.cpp
@@ -419,7 +419,7 @@ void run_make() {
     stage::die_if_global_errors();
   }
   stage::set_name("Make");
-  stage::set_exit_code(stage::CXX_STAGE_ERROR);
+  stage::set_exit_code(ExitCode::CPP_TO_OBJS_STAGE);
 
   Index obj_index;
 
@@ -443,7 +443,7 @@ void run_make() {
   stage::die_if_global_errors();
 
   const std::string build_stage{output_mode == OutputMode::lib ? "Compiling" : "Linking"};
-  stage::set_exit_code(output_mode == OutputMode::lib ? stage::CXX_STAGE_ERROR : stage::LINKING_STAGE_ERROR);
+  stage::set_exit_code(output_mode == OutputMode::lib ? ExitCode::CPP_TO_OBJS_STAGE : ExitCode::OBJS_TO_BINARY_STAGE);
   AutoProfiler profiler{get_profiler(build_stage)};
 
   bool ok = make.make_target(&bin_file, build_stage, settings.jobs_count.get());

--- a/compiler/make/make.cpp
+++ b/compiler/make/make.cpp
@@ -419,6 +419,7 @@ void run_make() {
     stage::die_if_global_errors();
   }
   stage::set_name("Make");
+  stage::set_exit_code(stage::CXX_STAGE_ERROR);
 
   Index obj_index;
 
@@ -442,6 +443,7 @@ void run_make() {
   stage::die_if_global_errors();
 
   const std::string build_stage{output_mode == OutputMode::lib ? "Compiling" : "Linking"};
+  stage::set_exit_code(output_mode == OutputMode::lib ? stage::CXX_STAGE_ERROR : stage::LINKING_STAGE_ERROR);
   AutoProfiler profiler{get_profiler(build_stage)};
 
   bool ok = make.make_target(&bin_file, build_stage, settings.jobs_count.get());

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -59,6 +59,7 @@ void on_compilation_error(const char *description __attribute__((unused)), const
     fmt_fprintf(file, "Compilation failed.\n"
                       "It is probably happened due to incorrect or unsupported PHP input.\n"
                       "But it is still bug in compiler.\n");
+  // TODO should we just call exit() with specific return code ot leave it as is?
 #ifdef __arm64__
     __builtin_debugtrap();  // for easier debugging kphp_assert / kphp_fail
 #endif
@@ -167,6 +168,10 @@ stage::StageInfo *stage::get_stage_info_ptr() {
   return &*stage_info;
 }
 
+void stage::set_exit_code(int code) {
+  get_stage_info_ptr()->exit_code = code;
+}
+
 void stage::set_name(std::string &&name) {
   get_stage_info_ptr()->name = std::move(name);
   get_stage_info_ptr()->cnt_errors = 0;
@@ -193,12 +198,16 @@ bool stage::has_global_error() {
 void stage::die_if_global_errors() {
   if (stage::has_global_error()) {
     fmt_print("Compilation terminated due to errors\n");
-    exit(1);
+    exit(stage::get_exit_code());
   }
 }
 
 const std::string &stage::get_name() {
   return get_stage_info_ptr()->name;
+}
+
+int stage::get_exit_code() {
+  return get_stage_info_ptr()->exit_code;
 }
 
 Location *stage::get_location_ptr() {

--- a/compiler/stage.cpp
+++ b/compiler/stage.cpp
@@ -59,7 +59,6 @@ void on_compilation_error(const char *description __attribute__((unused)), const
     fmt_fprintf(file, "Compilation failed.\n"
                       "It is probably happened due to incorrect or unsupported PHP input.\n"
                       "But it is still bug in compiler.\n");
-  // TODO should we just call exit() with specific return code ot leave it as is?
 #ifdef __arm64__
     __builtin_debugtrap();  // for easier debugging kphp_assert / kphp_fail
 #endif
@@ -168,7 +167,7 @@ stage::StageInfo *stage::get_stage_info_ptr() {
   return &*stage_info;
 }
 
-void stage::set_exit_code(int code) {
+void stage::set_exit_code(ExitCode code) {
   get_stage_info_ptr()->exit_code = code;
 }
 
@@ -198,7 +197,7 @@ bool stage::has_global_error() {
 void stage::die_if_global_errors() {
   if (stage::has_global_error()) {
     fmt_print("Compilation terminated due to errors\n");
-    exit(stage::get_exit_code());
+    exit(static_cast<int>(stage::get_exit_code()));
   }
 }
 
@@ -206,7 +205,7 @@ const std::string &stage::get_name() {
   return get_stage_info_ptr()->name;
 }
 
-int stage::get_exit_code() {
+ExitCode stage::get_exit_code() {
   return get_stage_info_ptr()->exit_code;
 }
 

--- a/compiler/stage.h
+++ b/compiler/stage.h
@@ -19,11 +19,17 @@ namespace stage {
 
 void set_warning_file(FILE *file) noexcept;
 
+// TODO think about values
+constexpr size_t KPHP_STAGE_ERROR = 101;
+constexpr size_t CXX_STAGE_ERROR = 102;
+constexpr size_t LINKING_STAGE_ERROR = 103;
+
 struct StageInfo {
   std::string name;
   Location location;
   bool global_error_flag{false};
   uint32_t cnt_errors{0};
+  int exit_code = KPHP_STAGE_ERROR;
 };
 
 StageInfo *get_stage_info_ptr();
@@ -41,6 +47,9 @@ void print_current_location_on_error(FILE *f);
 
 void set_name(std::string &&name);
 const std::string &get_name();
+
+void set_exit_code(int code);
+int get_exit_code();
 
 void set_file(SrcFilePtr file);
 void set_function(FunctionPtr function);

--- a/compiler/stage.h
+++ b/compiler/stage.h
@@ -7,6 +7,8 @@
 #include <cstdint>
 #include <unistd.h>
 
+#include "common/exit-codes.h"
+
 #include "compiler/data/data_ptr.h"
 #include "compiler/kphp_assert.h"
 #include "compiler/location.h"
@@ -19,17 +21,12 @@ namespace stage {
 
 void set_warning_file(FILE *file) noexcept;
 
-// TODO think about values
-constexpr size_t KPHP_STAGE_ERROR = 101;
-constexpr size_t CXX_STAGE_ERROR = 102;
-constexpr size_t LINKING_STAGE_ERROR = 103;
-
 struct StageInfo {
   std::string name;
   Location location;
   bool global_error_flag{false};
   uint32_t cnt_errors{0};
-  int exit_code = KPHP_STAGE_ERROR;
+  ExitCode exit_code = ExitCode::KPHP_TO_CPP_STAGE;
 };
 
 StageInfo *get_stage_info_ptr();
@@ -48,8 +45,8 @@ void print_current_location_on_error(FILE *f);
 void set_name(std::string &&name);
 const std::string &get_name();
 
-void set_exit_code(int code);
-int get_exit_code();
+void set_exit_code(ExitCode code);
+ExitCode get_exit_code();
 
 void set_file(SrcFilePtr file);
 void set_function(FunctionPtr function);


### PR DESCRIPTION
Introduce special exit codes for` PHP -> CPP`, `CPP -> Object files` and `Object files -> binary` stages.

Let's discuss values of exit codes and whether should we do something different from `abort()` for compiler asserts.