### PR TITLE
Do not remove empty default values for string and array respectively

### DIFF
--- a/compiler/data/kphp-json-tags.cpp
+++ b/compiler/data/kphp-json-tags.cpp
@@ -403,7 +403,7 @@ FieldJsonSettings merge_and_inherit_json_tags(const ClassMemberInstanceField &fi
 
   // for 'public int $id;' — no default and non-nullable type — set 'required' so that decode() would fire unless exists
   // it could be overridden with `@kphp-json required = false`
-  if (field.type_hint && !field.var->init_val && !does_type_hint_allow_null(field.type_hint)) {
+  if (field.type_hint && !field.var->init_val && !field.var->had_user_assigned_val && !does_type_hint_allow_null(field.type_hint)) {
     s.required = true;
   }
 

--- a/compiler/data/var-data.h
+++ b/compiler/data/var-data.h
@@ -32,6 +32,7 @@ public:
   std::string name;
   tinf::VarNode tinf_node;
   VertexPtr init_val;
+  bool had_user_assigned_val = false;
   FunctionPtr holder_func;
   ClassPtr class_id;
   std::unordered_set<VarPtr> *bad_vars = nullptr;

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -358,6 +358,7 @@ void OptimizationPass::on_finish() {
 
         if (can_init_value_be_removed(class_field.var->init_val, class_field.var)) {
           class_field.var->init_val = {};
+          class_field.var->had_user_assigned_val = true;
         } else {
           explicit_cast_array_type(class_field.var->init_val, tinf::get_type(class_field.var));
         }

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -28,16 +28,7 @@ bool can_init_value_be_removed(VertexPtr init_value, const VarPtr &variable) {
     return false;
   }
 
-  switch (init_type->ptype()) {
-    case tp_string: {
-      const auto *init_string = VertexUtil::get_constexpr_string(init_value);
-      return init_string && init_string->empty();
-    }
-    case tp_array:
-      return init_type->lookup_at_any_key()->get_real_ptype() == tp_any;
-    default:
-      return false;
-  }
+  return false;
 }
 
 VarPtr cast_const_array_type(VertexPtr &type_acceptor, const TypeData *required_type) noexcept {

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -28,7 +28,16 @@ bool can_init_value_be_removed(VertexPtr init_value, const VarPtr &variable) {
     return false;
   }
 
-  return false;
+  switch (init_type->ptype()) {
+    case tp_string: {
+      const auto *init_string = VertexUtil::get_constexpr_string(init_value);
+      return init_string && init_string->empty();
+    }
+    case tp_array:
+      return init_type->lookup_at_any_key()->get_real_ptype() == tp_any;
+    default:
+      return false;
+  }
 }
 
 VarPtr cast_const_array_type(VertexPtr &type_acceptor, const TypeData *required_type) noexcept {

--- a/tests/phpt/json/38_optimized_init_val.php
+++ b/tests/phpt/json/38_optimized_init_val.php
@@ -1,0 +1,22 @@
+<?php
+
+class User {
+  public string $name = '';
+  public string $password = '';
+}
+
+function test_optimized_init_value(): void {
+  $raw = '{"name": "user"}';
+
+  $user = JsonEncoder::decode($raw, User::class);
+
+  $error = JsonEncoder::getLastError();
+  if (!empty($error)) {
+    echo "Error: " . $error;
+    exit();
+  }
+
+  var_dump(instance_to_array($user));
+}
+
+test_optimized_init_value();

--- a/tests/phpt/json/38_optimized_init_val.php
+++ b/tests/phpt/json/38_optimized_init_val.php
@@ -1,3 +1,4 @@
+@ok
 <?php
 
 class User {


### PR DESCRIPTION
Before this PR empty values are eliminated for string and arrays, so 

```php
class User {
  public string $name = '';
  public string $password = '';
}
``` 
and 
```php
class User {
  public string $name;
  public string $password;
}
```
are treated as same.

While it is true technically, this lead to unwanted consequences. Value absence marks such fields as `required` during JSON deserialization. Removed default value changes class semantics and has strong implication of `string` having default value of `''`.

Suggested changes are about storing fact user provided value was optimized and eliminated.
But the fact it was there is used by later steps to correctly process values.