### PR TITLE
Make RPC in light runtime more robust

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 .DS_Store
 
 .idea
+.vscode
 build
 *.iml
 /cmake-build-*

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <optional>
 #include <utility>
 
@@ -350,19 +351,15 @@ bool f$store_string(const string &v) noexcept { // TODO: support large strings
   string::size_type string_len{v.size()};
   string::size_type size_len{};
   if (string_len <= rpc_impl_::SMALL_STRING_MAX_LEN) {
-    buffer << static_cast<uint8_t>(string_len);
+    buffer << static_cast<char>(string_len);
     size_len = 1;
   } else if (string_len <= rpc_impl_::MEDIUM_STRING_MAX_LEN) {
-    buffer << static_cast<uint8_t>(rpc_impl_::MEDIUM_STRING_MAGIC) << static_cast<uint8_t>(string_len & 0xff) << static_cast<uint8_t>((string_len >> 8) & 0xff)
-           << static_cast<uint8_t>((string_len >> 16) & 0xff);
+    buffer << static_cast<char>(rpc_impl_::MEDIUM_STRING_MAGIC) << static_cast<char>(string_len & 0xff) << static_cast<char>((string_len >> 8) & 0xff)
+           << static_cast<char>((string_len >> 16) & 0xff);
     size_len = 4;
   } else {
-    buffer << static_cast<uint8_t>(rpc_impl_::LARGE_STRING_MAGIC) << static_cast<uint8_t>(string_len & 0xff) << static_cast<uint8_t>((string_len >> 8) & 0xff)
-           << static_cast<uint8_t>((string_len >> 16) & 0xff) << static_cast<uint8_t>((string_len >> 24) & 0xff);
-//    buffer << static_cast<uint8_t>(rpc_impl_::LARGE_STRING_MAGIC) << static_cast<uint8_t>(string_len & 0xff) << static_cast<uint8_t>((string_len >> 8) & 0xff)
-//           << static_cast<uint8_t>((string_len >> 16) & 0xff) << static_cast<uint8_t>((string_len >> 24) & 0xff)
-//           << static_cast<uint8_t>((string_len >> 32) & 0xff) << static_cast<uint8_t>((string_len >> 40) & 0xff)
-//           << static_cast<uint8_t>((string_len >> 48) & 0xff);
+    buffer << static_cast<char>(rpc_impl_::LARGE_STRING_MAGIC) << static_cast<char>(string_len & 0xff) << static_cast<char>((string_len >> 8) & 0xff)
+           << static_cast<char>((string_len >> 16) & 0xff) << static_cast<char>((string_len >> 24) & 0xff);
     size_len = 8;
   }
   buffer.append(v.c_str(), static_cast<size_t>(string_len));

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -6,14 +6,13 @@
 
 #include <array>
 #include <chrono>
-#include <coroutine>
 #include <cstddef>
 #include <optional>
 #include <utility>
 
 #include "common/algorithms/find.h"
 #include "common/rpc-error-codes.h"
-#include "common/tl/constants/common.h"
+#include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/allocator/allocator.h"
 #include "runtime-light/stdlib/rpc/rpc-context.h"
 #include "runtime-light/stdlib/rpc/rpc-extra-headers.h"

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -15,10 +15,10 @@
 #include "common/rpc-error-codes.h"
 #include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/allocator/allocator.h"
+#include "runtime-light/stdlib/rpc/rpc-buffer.h"
 #include "runtime-light/stdlib/rpc/rpc-context.h"
 #include "runtime-light/stdlib/rpc/rpc-extra-headers.h"
 #include "runtime-light/streams/interface.h"
-#include "runtime-light/utils/concepts.h"
 
 namespace rpc_impl_ {
 
@@ -46,27 +46,11 @@ mixed mixed_array_get_value(const mixed &arr, const string &str_key, int64_t num
   return {};
 }
 
-bool rpc_fetch_remaining_enough(size_t len) noexcept {
-  return RpcComponentContext::get().fetch_state.remaining() >= len;
-}
-
 array<mixed> make_fetch_error(string &&error_msg, int32_t error_code) {
   array<mixed> res;
   res.set_value(string{"__error", 7}, std::move(error_msg));
   res.set_value(string{"__error_code", 12}, error_code);
   return res;
-}
-
-template<standard_layout T>
-std::optional<T> fetch_trivial() noexcept {
-  if (!rpc_fetch_remaining_enough(sizeof(T))) {
-    return {}; // TODO: error handling
-  }
-
-  auto &rpc_ctx{RpcComponentContext::get()};
-  const auto v{*reinterpret_cast<const T *>(rpc_ctx.buffer.c_str() + rpc_ctx.fetch_state.pos())};
-  rpc_ctx.fetch_state.adjust(sizeof(T));
-  return v;
 }
 
 array<mixed> fetch_function_untyped(const class_instance<RpcTlQuery> &rpc_query) noexcept {
@@ -94,12 +78,6 @@ class_instance<C$VK$TL$RpcResponse> fetch_function_typed(const class_instance<Rp
   return res;
 }
 
-template<standard_layout T>
-bool store_trivial(T v) noexcept {
-  RpcComponentContext::get().buffer.append(reinterpret_cast<const char *>(&v), sizeof(T));
-  return true;
-}
-
 class_instance<RpcTlQuery> store_function(const mixed &tl_object) noexcept {
   auto &cur_query{CurrentTlQuery::get()};
   const auto &rpc_image_state{RpcImageState::get()};
@@ -121,26 +99,25 @@ class_instance<RpcTlQuery> store_function(const mixed &tl_object) noexcept {
 }
 
 task_t<RpcQueryInfo> rpc_send_impl(const string &actor, double timeout, bool ignore_answer) noexcept {
-  auto &rpc_ctx = RpcComponentContext::get();
-
   if (timeout <= 0 || timeout > MAX_TIMEOUT_S) { // TODO: handle timeouts
     //    timeout = conn.get()->timeout_ms * 0.001;
   }
 
+  auto &rpc_ctx = RpcComponentContext::get();
   string request_buf{};
-  size_t request_size{rpc_ctx.buffer.size()};
+  size_t request_size{rpc_ctx.rpc_buffer.size()};
 
   // 'request_buf' will look like this:
   //    [ RpcExtraHeaders (optional) ] [ payload ]
-  if (const auto [opt_new_extra_header, cur_extra_header_size]{regularize_extra_headers(rpc_ctx.buffer.c_str(), ignore_answer)}; opt_new_extra_header) {
+  if (const auto [opt_new_extra_header, cur_extra_header_size]{regularize_extra_headers(rpc_ctx.rpc_buffer.data(), ignore_answer)}; opt_new_extra_header) {
     const auto new_extra_header{opt_new_extra_header.value()};
     const auto new_extra_header_size{sizeof(std::decay_t<decltype(new_extra_header)>)};
     request_size = request_size - cur_extra_header_size + new_extra_header_size;
 
     request_buf.append(reinterpret_cast<const char *>(&new_extra_header), new_extra_header_size);
-    request_buf.append(rpc_ctx.buffer.c_str() + cur_extra_header_size, rpc_ctx.buffer.size() - cur_extra_header_size);
+    request_buf.append(rpc_ctx.rpc_buffer.data() + cur_extra_header_size, rpc_ctx.rpc_buffer.size() - cur_extra_header_size);
   } else {
-    request_buf.append(rpc_ctx.buffer.c_str(), request_size);
+    request_buf.append(rpc_ctx.rpc_buffer.data(), request_size);
   }
 
   // get timestamp before co_await to also count the time we were waiting for runtime to resume this coroutine
@@ -168,7 +145,7 @@ task_t<RpcQueryInfo> rpc_tl_query_one_impl(const string &actor, mixed tl_object,
     co_return RpcQueryInfo{};
   }
 
-  rpc_ctx.buffer.clean();
+  rpc_ctx.rpc_buffer.clean();
   auto rpc_tl_query{store_function(tl_object)}; // TODO: exception handling
   if (rpc_tl_query.is_null()) {
     co_return RpcQueryInfo{};
@@ -195,7 +172,7 @@ task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(const string &actor, const RpcR
     co_return RpcQueryInfo{};
   }
 
-  rpc_ctx.buffer.clean();
+  rpc_ctx.rpc_buffer.clean();
   auto fetcher{rpc_request.store_request()};
   if (!static_cast<bool>(fetcher)) {
     rpc_ctx.current_query.raise_storing_error("could not store rpc request");
@@ -263,9 +240,8 @@ task_t<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) noexcept {
     it_response_extra_info->second.first = rpc_response_extra_info_status_t::READY;
   }
 
-  rpc_ctx.fetch_state.reset(0, data.size());
-  rpc_ctx.buffer.clean();
-  rpc_ctx.buffer.append(data.c_str(), data.size());
+  rpc_ctx.rpc_buffer.clean();
+  rpc_ctx.rpc_buffer.store(data.c_str(), data.size());
 
   co_return fetch_function_untyped(rpc_query);
 }
@@ -315,9 +291,8 @@ task_t<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(i
     it_response_extra_info->second.first = rpc_response_extra_info_status_t::READY;
   }
 
-  rpc_ctx.fetch_state.reset(0, data.size());
-  rpc_ctx.buffer.clean();
-  rpc_ctx.buffer.append(data.c_str(), data.size());
+  rpc_ctx.rpc_buffer.clean();
+  rpc_ctx.rpc_buffer.store(data.c_str(), data.size());
 
   co_return fetch_function_typed(rpc_query, error_factory);
 }
@@ -330,74 +305,84 @@ bool f$store_int(int64_t v) noexcept {
   if (unlikely(is_int32_overflow(v))) {
     php_warning("Got int32 overflow on storing '%" PRIi64 "', the value will be casted to '%d'", v, static_cast<int32_t>(v));
   }
-  return rpc_impl_::store_trivial(static_cast<int32_t>(v));
+  RpcComponentContext::get().rpc_buffer.store_trivial(static_cast<int32_t>(v));
+  return true;
 }
 
 bool f$store_long(int64_t v) noexcept {
-  return rpc_impl_::store_trivial(v);
+  RpcComponentContext::get().rpc_buffer.store_trivial(v);
+  return true;
 }
 
 bool f$store_float(double v) noexcept {
-  return rpc_impl_::store_trivial(static_cast<float>(v));
+  RpcComponentContext::get().rpc_buffer.store_trivial(static_cast<float>(v));
+  return true;
 }
 
 bool f$store_double(double v) noexcept {
-  return rpc_impl_::store_trivial(v);
+  RpcComponentContext::get().rpc_buffer.store_trivial(v);
+  return true;
 }
 
 bool f$store_string(const string &v) noexcept { // TODO: support large strings
-  auto &buffer{RpcComponentContext::get().buffer};
+  auto &rpc_buf{RpcComponentContext::get().rpc_buffer};
 
   string::size_type string_len{v.size()};
   string::size_type size_len{};
   if (string_len <= rpc_impl_::SMALL_STRING_MAX_LEN) {
-    buffer << static_cast<char>(string_len);
     size_len = 1;
+    rpc_buf.store_trivial(static_cast<uint8_t>(string_len));
   } else if (string_len <= rpc_impl_::MEDIUM_STRING_MAX_LEN) {
-    buffer << static_cast<char>(rpc_impl_::MEDIUM_STRING_MAGIC) << static_cast<char>(string_len & 0xff) << static_cast<char>((string_len >> 8) & 0xff)
-           << static_cast<char>((string_len >> 16) & 0xff);
     size_len = 4;
+    rpc_buf.store_trivial(static_cast<uint8_t>(rpc_impl_::MEDIUM_STRING_MAGIC));
+    rpc_buf.store_trivial(static_cast<uint8_t>(string_len & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
   } else {
-    buffer << static_cast<char>(rpc_impl_::LARGE_STRING_MAGIC) << static_cast<char>(string_len & 0xff) << static_cast<char>((string_len >> 8) & 0xff)
-           << static_cast<char>((string_len >> 16) & 0xff) << static_cast<char>((string_len >> 24) & 0xff);
     size_len = 8;
+    rpc_buf.store_trivial(static_cast<uint8_t>(rpc_impl_::LARGE_STRING_MAGIC));
+    rpc_buf.store_trivial(static_cast<uint8_t>(string_len & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 24) & 0xff));
+    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 32) & 0xff));
+    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 40) & 0xff));
+    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 48) & 0xff));
   }
-  buffer.append(v.c_str(), static_cast<size_t>(string_len));
+  rpc_buf.store(v.c_str(), string_len);
 
   const auto total_len{size_len + string_len};
   const auto total_len_with_padding{(total_len + 3) & ~static_cast<string::size_type>(3)};
   const auto padding{total_len_with_padding - total_len};
 
   std::array padding_array{'\0', '\0', '\0', '\0'};
-  buffer.append(padding_array.data(), padding);
+  rpc_buf.store(padding_array.data(), padding);
   return true;
 }
 
 // === Rpc Fetch ==================================================================================
 
 int64_t f$fetch_int() noexcept {
-  const auto opt{rpc_impl_::fetch_trivial<int32_t>()};
-  return opt.value_or(0);
+  return static_cast<int64_t>(RpcComponentContext::get().rpc_buffer.fetch_trivial<int32_t>().value_or(0));
 }
 
 int64_t f$fetch_long() noexcept {
-  const auto opt{rpc_impl_::fetch_trivial<int64_t>()};
-  return opt.value_or(0);
+  return RpcComponentContext::get().rpc_buffer.fetch_trivial<int64_t>().value_or(0);
 }
 
 double f$fetch_double() noexcept {
-  const auto opt{rpc_impl_::fetch_trivial<double>()};
-  return opt.value_or(0.0);
+  return RpcComponentContext::get().rpc_buffer.fetch_trivial<double>().value_or(0.0);
 }
 
 double f$fetch_float() noexcept {
-  const auto opt{rpc_impl_::fetch_trivial<float>()};
-  return static_cast<double>(opt.value_or(0.0));
+  return static_cast<double>(RpcComponentContext::get().rpc_buffer.fetch_trivial<float>().value_or(0.0));
 }
 
 string f$fetch_string() noexcept {
+  auto &rpc_buf{RpcComponentContext::get().rpc_buffer};
+
   uint8_t first_byte{};
-  if (const auto opt_first_byte{rpc_impl_::fetch_trivial<uint8_t>()}; opt_first_byte) {
+  if (const auto opt_first_byte{rpc_buf.fetch_trivial<uint8_t>()}; opt_first_byte) {
     first_byte = opt_first_byte.value();
   } else {
     return {}; // TODO: error handling
@@ -408,16 +393,16 @@ string f$fetch_string() noexcept {
   switch (first_byte) {
     case rpc_impl_::LARGE_STRING_MAGIC: { // next 7 bytes are string's length // TODO: support large strings
       // static_assert(sizeof(string::size_type) >= 8, "string's length doesn't fit platform size");
-      if (!rpc_impl_::rpc_fetch_remaining_enough(7)) {
+      if (rpc_buf.remaining() < 7) {
         return {}; // TODO: error handling
       }
-      const auto first{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value())};
-      const auto second{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 8};
-      const auto third{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 16};
-      const auto fourth{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 24};
-      const auto fifth{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 32};
-      const auto sixth{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 40};
-      const auto seventh{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 48};
+      const auto first{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value())};
+      const auto second{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 8};
+      const auto third{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 16};
+      const auto fourth{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 24};
+      const auto fifth{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 32};
+      const auto sixth{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 40};
+      const auto seventh{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 48};
       string_len = first | second | third | fourth | fifth | sixth | seventh;
       if (string_len < (1 << 24)) {
         php_warning("long string's length is less than 1 << 24");
@@ -425,12 +410,12 @@ string f$fetch_string() noexcept {
       size_len = 8;
     }
     case rpc_impl_::MEDIUM_STRING_MAGIC: { // next 3 bytes are string's length
-      if (!rpc_impl_::rpc_fetch_remaining_enough(3)) {
+      if (rpc_buf.remaining() < 3) {
         return {}; // TODO: error handling
       }
-      const auto first{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value())};
-      const auto second{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 8};
-      const auto third{static_cast<uint64_t>(rpc_impl_::fetch_trivial<uint8_t>().value()) << 16};
+      const auto first{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value())};
+      const auto second{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 8};
+      const auto third{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 16};
       string_len = first | second | third;
       if (string_len <= 253) {
         php_warning("long string's length is less than 254");
@@ -443,13 +428,12 @@ string f$fetch_string() noexcept {
   }
 
   const auto total_len_with_padding{(size_len + string_len + 3) & ~static_cast<string::size_type>(3)};
-  if (!rpc_impl_::rpc_fetch_remaining_enough(total_len_with_padding - size_len)) {
+  if (rpc_buf.remaining() < total_len_with_padding - size_len) {
     return {}; // TODO: error handling
   }
 
-  auto &rpc_ctx{RpcComponentContext::get()};
-  string res{rpc_ctx.buffer.c_str() + rpc_ctx.fetch_state.pos(), string_len};
-  rpc_ctx.fetch_state.adjust(total_len_with_padding - size_len);
+  string res{rpc_buf.data() + rpc_buf.pos(), string_len};
+  rpc_buf.adjust(total_len_with_padding - size_len);
   return res;
 }
 
@@ -488,9 +472,7 @@ task_t<array<array<mixed>>> f$rpc_tl_query_result(array<int64_t> query_ids) noex
 // === Rpc Misc ==================================================================================
 
 void f$rpc_clean() noexcept {
-  auto &rpc_ctx{RpcComponentContext::get()};
-  rpc_ctx.buffer.clean();
-  rpc_ctx.fetch_state.reset(0, 0);
+  RpcComponentContext::get().rpc_buffer.clean();
 }
 
 // === Misc =======================================================================================
@@ -504,15 +486,15 @@ bool is_int32_overflow(int64_t v) noexcept {
 }
 
 void store_raw_vector_double(const array<double> &vector) noexcept { // TODO: didn't we forget vector's length?
-  RpcComponentContext::get().buffer.append(reinterpret_cast<const char *>(vector.get_const_vector_pointer()), sizeof(double) * vector.count());
+  RpcComponentContext::get().rpc_buffer.store(reinterpret_cast<const char *>(vector.get_const_vector_pointer()), sizeof(double) * vector.count());
 }
 
 void fetch_raw_vector_double(array<double> &vector, int64_t num_elems) noexcept {
+  auto &rpc_buf{RpcComponentContext::get().rpc_buffer};
   const auto len_bytes{sizeof(double) * num_elems};
-  if (!rpc_impl_::rpc_fetch_remaining_enough(len_bytes)) {
+  if (rpc_buf.remaining() < len_bytes) {
     return; // TODO: error handling
   }
-  auto &rpc_ctx{RpcComponentContext::get()};
-  vector.memcpy_vector(num_elems, rpc_ctx.buffer.c_str() + rpc_ctx.fetch_state.pos());
-  rpc_ctx.fetch_state.adjust(len_bytes);
+  vector.memcpy_vector(num_elems, rpc_buf.data() + rpc_buf.pos());
+  rpc_buf.adjust(len_bytes);
 }

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -98,7 +98,7 @@ class_instance<RpcTlQuery> store_function(const mixed &tl_object) noexcept {
   return rpc_tl_query;
 }
 
-task_t<RpcQueryInfo> rpc_send_impl(const string &actor, double timeout, bool ignore_answer) noexcept {
+task_t<RpcQueryInfo> rpc_send_impl(string actor, double timeout, bool ignore_answer) noexcept {
   if (timeout <= 0 || timeout > MAX_TIMEOUT_S) { // TODO: handle timeouts
     //    timeout = conn.get()->timeout_ms * 0.001;
   }
@@ -137,7 +137,7 @@ task_t<RpcQueryInfo> rpc_send_impl(const string &actor, double timeout, bool ign
   co_return RpcQueryInfo{.id = query_id, .request_size = request_size, .timestamp = timestamp};
 }
 
-task_t<RpcQueryInfo> rpc_tl_query_one_impl(const string &actor, mixed tl_object, double timeout, bool collect_resp_extra_info, bool ignore_answer) noexcept {
+task_t<RpcQueryInfo> rpc_tl_query_one_impl(string actor, mixed tl_object, double timeout, bool collect_resp_extra_info, bool ignore_answer) noexcept {
   auto &rpc_ctx{RpcComponentContext::get()};
 
   if (!tl_object.is_array()) {
@@ -163,7 +163,7 @@ task_t<RpcQueryInfo> rpc_tl_query_one_impl(const string &actor, mixed tl_object,
   co_return query_info;
 }
 
-task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(const string &actor, const RpcRequest &rpc_request, double timeout, bool collect_responses_extra_info,
+task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(string actor, const RpcRequest &rpc_request, double timeout, bool collect_responses_extra_info,
                                                  bool ignore_answer) noexcept {
   auto &rpc_ctx{RpcComponentContext::get()};
 

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -6,7 +6,6 @@
 
 #include <concepts>
 #include <cstdint>
-#include <memory>
 
 #include "runtime-core/runtime-core.h"
 #include "runtime-light/coroutine/task.h"

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -26,7 +26,7 @@ struct RpcQueryInfo {
   double timestamp{0.0};
 };
 
-task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(const string &actor, const RpcRequest &rpc_request, double timeout, bool collect_responses_extra_info,
+task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(string actor, const RpcRequest &rpc_request, double timeout, bool collect_responses_extra_info,
                                                  bool ignore_answer) noexcept;
 
 task_t<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(int64_t query_id, const RpcErrorFactory &error_factory) noexcept;

--- a/runtime-light/stdlib/rpc/rpc-buffer.h
+++ b/runtime-light/stdlib/rpc/rpc-buffer.h
@@ -1,0 +1,78 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2024 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <cstddef>
+#include <optional>
+
+#include "common/mixin/not_copyable.h"
+#include "runtime-core/runtime-core.h"
+#include "runtime-core/utils/kphp-assert-core.h"
+#include "runtime-light/utils/concepts.h"
+
+class RpcBuffer : private vk::not_copyable {
+  string_buffer m_buffer;
+  size_t m_pos{0};
+  size_t m_remaining{0};
+
+public:
+  RpcBuffer() = default;
+
+  const char *data() const noexcept {
+    return m_buffer.buffer();
+  }
+
+  size_t size() const noexcept {
+    return static_cast<size_t>(m_buffer.size());
+  }
+
+  size_t remaining() const noexcept {
+    return m_remaining;
+  }
+
+  size_t pos() const noexcept {
+    return m_pos;
+  }
+
+  void clean() noexcept {
+    m_buffer.clean();
+    m_pos = 0;
+    m_remaining = 0;
+  }
+
+  void reset(size_t pos) noexcept {
+    php_assert(pos >= 0 && pos <= size());
+    m_pos = pos;
+    m_remaining = size() - m_pos;
+  }
+
+  void adjust(size_t len) noexcept {
+    php_assert(m_pos + len <= size());
+    m_pos += len;
+    m_remaining -= len;
+  }
+
+  void store(const char *src, size_t len) noexcept {
+    m_buffer.append(src, len);
+    m_remaining += len;
+  }
+
+  template<standard_layout T>
+  void store_trivial(const T &t) noexcept {
+    store(reinterpret_cast<const char *>(&t), sizeof(T));
+  }
+
+  template<standard_layout T>
+  std::optional<T> fetch_trivial() noexcept {
+    if (m_remaining < sizeof(T)) {
+      return std::nullopt;
+    }
+
+    const auto t{*reinterpret_cast<const T *>(m_buffer.c_str() + m_pos)};
+    m_pos += sizeof(T);
+    m_remaining -= sizeof(T);
+    return t;
+  }
+};

--- a/runtime-light/stdlib/rpc/rpc-context.h
+++ b/runtime-light/stdlib/rpc/rpc-context.h
@@ -10,43 +10,17 @@
 #include "common/mixin/not_copyable.h"
 #include "runtime-core/memory-resource/resource_allocator.h"
 #include "runtime-core/runtime-core.h"
+#include "runtime-light/stdlib/rpc/rpc-buffer.h"
 #include "runtime-light/stdlib/rpc/rpc-extra-info.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-defs.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-query.h"
 #include "runtime-light/streams/component-stream.h"
 
 struct RpcComponentContext final : private vk::not_copyable {
-  class FetchState {
-    size_t m_pos{0};
-    size_t m_remaining{0};
-
-  public:
-    constexpr FetchState() = default;
-
-    constexpr size_t remaining() const noexcept {
-      return m_remaining;
-    }
-
-    constexpr size_t pos() const noexcept {
-      return m_pos;
-    }
-
-    constexpr void reset(size_t pos, size_t len) noexcept {
-      m_pos = pos;
-      m_remaining = len;
-    }
-
-    constexpr void adjust(size_t len) noexcept {
-      m_pos += len;
-      m_remaining -= len;
-    }
-  };
-
   template<typename Key, typename Value>
   using unordered_map = memory_resource::stl::unordered_map<Key, Value, memory_resource::unsynchronized_pool_resource>;
 
-  string_buffer buffer;
-  FetchState fetch_state;
+  RpcBuffer rpc_buffer;
   int64_t current_query_id{0};
   CurrentTlQuery current_query;
   unordered_map<int64_t, class_instance<C$ComponentQuery>> pending_component_queries;
@@ -57,6 +31,8 @@ struct RpcComponentContext final : private vk::not_copyable {
 
   static RpcComponentContext &get() noexcept;
 };
+
+// ================================================================================================
 
 struct RpcImageState final : private vk::not_copyable {
   array<tl_storer_ptr> tl_storers_ht;

--- a/runtime-light/stdlib/rpc/rpc-extra-headers.cpp
+++ b/runtime-light/stdlib/rpc/rpc-extra-headers.cpp
@@ -8,7 +8,7 @@
 
 #include "common/algorithms/find.h"
 #include "common/tl/constants/common.h"
-#include "runtime-light/utils/php_assert.h"
+#include "runtime-core/utils/kphp-assert-core.h"
 
 namespace {
 

--- a/runtime-light/stdlib/rpc/rpc-extra-info.cpp
+++ b/runtime-light/stdlib/rpc/rpc-extra-info.cpp
@@ -4,6 +4,8 @@
 
 #include "runtime-light/stdlib/rpc/rpc-extra-info.h"
 
+#include "common/algorithms/hashes.h"
+#include "common/wrappers/string_view.h"
 #include "runtime-light/stdlib/rpc/rpc-context.h"
 
 const char *C$KphpRpcRequestsExtraInfo::get_class() const noexcept {

--- a/runtime-light/stdlib/rpc/rpc-extra-info.h
+++ b/runtime-light/stdlib/rpc/rpc-extra-info.h
@@ -7,8 +7,6 @@
 #include <cstdint>
 #include <tuple>
 
-#include "common/algorithms/hashes.h"
-#include "common/wrappers/string_view.h"
 #include "runtime-core/class-instance/refcountable-php-classes.h"
 #include "runtime-core/runtime-core.h"
 

--- a/runtime-light/stdlib/rpc/rpc-tl-defs.h
+++ b/runtime-light/stdlib/rpc/rpc-tl-defs.h
@@ -7,9 +7,9 @@
 #include <memory>
 
 #include "runtime-core/runtime-core.h"
+#include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-func-base.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-function.h"
-#include "runtime-light/utils/php_assert.h"
 
 using tl_undefined_php_type = std::nullptr_t;
 using tl_storer_ptr = std::unique_ptr<tl_func_base> (*)(const mixed &);

--- a/runtime-light/stdlib/rpc/rpc-tl-query.cpp
+++ b/runtime-light/stdlib/rpc/rpc-tl-query.cpp
@@ -6,8 +6,8 @@
 
 #include <array>
 
+#include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/stdlib/rpc/rpc-context.h"
-#include "runtime-light/utils/php_assert.h"
 
 void CurrentTlQuery::reset() noexcept {
   current_tl_function_name = string{};

--- a/runtime-light/stdlib/rpc/rpc-tl-request.cpp
+++ b/runtime-light/stdlib/rpc/rpc-tl-request.cpp
@@ -4,7 +4,7 @@
 
 #include "runtime-light/stdlib/rpc/rpc-tl-request.h"
 
-#include "runtime-light/utils/php_assert.h"
+#include "runtime-core/utils/kphp-assert-core.h"
 
 RpcRequestResult::RpcRequestResult(bool is_typed, std::unique_ptr<tl_func_base> &&result_fetcher)
   : is_typed(is_typed)

--- a/runtime-light/tl/tl-builtins.cpp
+++ b/runtime-light/tl/tl-builtins.cpp
@@ -11,15 +11,15 @@ void register_tl_storers_table_and_fetcher(const array<tl_storer_ptr> &gen$ht, t
 }
 
 int32_t tl_parse_save_pos() {
-  return static_cast<int32_t>(RpcComponentContext::get().fetch_state.pos());
+  return static_cast<int32_t>(RpcComponentContext::get().rpc_buffer.pos());
 }
 
 bool tl_parse_restore_pos(int32_t pos) {
-  auto &rpc_ctx{RpcComponentContext::get()};
-  if (pos < 0 || pos > rpc_ctx.fetch_state.pos()) {
+  auto &rpc_buf{RpcComponentContext::get().rpc_buffer};
+  if (pos < 0 || pos > rpc_buf.pos()) {
     return false;
   }
-  rpc_ctx.fetch_state.reset(static_cast<size_t>(pos), rpc_ctx.fetch_state.remaining() + rpc_ctx.fetch_state.pos() - pos);
+  rpc_buf.reset(pos);
   return true;
 }
 

--- a/runtime-light/tl/tl-builtins.h
+++ b/runtime-light/tl/tl-builtins.h
@@ -10,12 +10,9 @@
 #include "common/php-functions.h"
 #include "common/tl/constants/common.h"
 #include "runtime-core/runtime-core.h"
+#include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/stdlib/rpc/rpc-api.h"
-#include "runtime-light/stdlib/rpc/rpc-context.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-defs.h"
-#include "runtime-light/stdlib/rpc/rpc-tl-function.h"
-#include "runtime-light/stdlib/rpc/rpc-tl-kphp-request.h"
-#include "runtime-light/utils/php_assert.h"
 
 // TODO: get rid of it here
 #define CHECK_EXCEPTION(action)

--- a/tests/k2-components/scheme.tl
+++ b/tests/k2-components/scheme.tl
@@ -1,0 +1,12 @@
+// MemCache
+
+memcache.not_found#32c42422 = memcache.Value;
+memcache.strvalue#a6bebb1a value:string flags:int = memcache.Value;
+
+---functions---
+
+// MemCache
+
+@read memcache.get#d33b13ae key:string = memcache.Value;
+
+@write memcache.set#eeeb54c4 key:string flags:int delay:int value:string = Bool;

--- a/tests/k2-components/test_rpc_memcached.php
+++ b/tests/k2-components/test_rpc_memcached.php
@@ -1,0 +1,36 @@
+<?php
+
+function do_untyped_rpc() {
+  $ids = rpc_tl_query("mc_main", [["_" => "memcache.get", "key" => "xxx"]]);
+  $response = rpc_tl_query_result($ids)[0];
+  $result = $response["result"];
+  if ($result["_"] !== "memcache.not_found") {
+    warning("memcache.not_found expected");
+    return false;
+  }
+
+  $ids = rpc_tl_query("mc_main", [["_" => "memcache.set", "key" => "foo", "flags" => 0, "delay" => 0, "value" => "bar"]]);
+  $response = rpc_tl_query_result($ids)[0];
+  $result = $response["result"];
+  if ($result !== true) {
+    warning("true expected");
+    return false;
+  }
+  
+  $ids = rpc_tl_query("mc_main", [["_" => "memcache.get", "key" => "foo"]]);
+  $response = rpc_tl_query_result($ids)[0];
+  $result = $response["result"];
+  if ($result["_"] !== "memcache.strvalue" || $result["value"] !== "bar") {
+    warning("\"bar\" expected");
+    return false;
+  }
+
+  return true;
+}
+
+component_server_get_query();
+if (do_untyped_rpc()) {
+  component_server_send_result("OK");
+} else {
+  component_server_send_result("FAIL");
+}


### PR DESCRIPTION
Fix a bug in store_string caused by incorrect usage of string_buffer.

Add RpcBuffer class that prevents us from similar bugs in the future.