### PR TITLE
Disable RPC fetch of large strings

### DIFF
--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -342,15 +342,10 @@ bool f$store_string(const string &v) noexcept {
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
   } else {
-    size_len = rpc_impl_::LARGE_STRING_SIZE_LEN + 1;
-    rpc_buf.store_trivial(static_cast<uint8_t>(rpc_impl_::LARGE_STRING_MAGIC));
-    rpc_buf.store_trivial(static_cast<uint8_t>(string_len & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 24) & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 32) & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 40) & 0xff));
-    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 48) & 0xff));
+    php_warning("large strings aren't supported");
+    size_len = rpc_impl_::SMALL_STRING_SIZE_LEN;
+    string_len = 0;
+    rpc_buf.store_trivial(static_cast<uint8_t>(string_len));
   }
   rpc_buf.store(v.c_str(), string_len);
 
@@ -410,7 +405,7 @@ string f$fetch_string() noexcept {
 
       const auto total_len_with_padding{(size_len + string_len + 3) & ~static_cast<uint64_t>(3)};
       rpc_buf.adjust(total_len_with_padding - size_len);
-      php_warning("fetch of large strings is not supported");
+      php_warning("large strings aren't supported");
       return {};
     }
     case rpc_impl_::MEDIUM_STRING_MAGIC: {

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -24,7 +24,10 @@ namespace rpc_impl_ {
 
 constexpr int32_t MAX_TIMEOUT_S = 86400;
 
-// TODO: change uint64_t to string::size_type after moving it from uint32_t to uint64_t
+constexpr auto SMALL_STRING_SIZE_LEN = 1;
+constexpr auto MEIDUM_STRING_SIZE_LEN = 3;
+constexpr auto LARGE_STRING_SIZE_LEN = 7;
+
 constexpr uint64_t SMALL_STRING_MAX_LEN = 253;
 constexpr uint64_t MEDIUM_STRING_MAX_LEN = (static_cast<uint64_t>(1) << 24) - 1;
 [[maybe_unused]] constexpr uint64_t LARGE_STRING_MAX_LEN = (static_cast<uint64_t>(1) << 56) - 1;
@@ -324,30 +327,30 @@ bool f$store_double(double v) noexcept {
   return true;
 }
 
-bool f$store_string(const string &v) noexcept { // TODO: support large strings
+bool f$store_string(const string &v) noexcept {
   auto &rpc_buf{RpcComponentContext::get().rpc_buffer};
 
-  string::size_type string_len{v.size()};
-  string::size_type size_len{};
+  uint8_t size_len{};
+  uint64_t string_len{v.size()};
   if (string_len <= rpc_impl_::SMALL_STRING_MAX_LEN) {
-    size_len = 1;
+    size_len = rpc_impl_::SMALL_STRING_SIZE_LEN;
     rpc_buf.store_trivial(static_cast<uint8_t>(string_len));
   } else if (string_len <= rpc_impl_::MEDIUM_STRING_MAX_LEN) {
-    size_len = 4;
+    size_len = rpc_impl_::MEIDUM_STRING_SIZE_LEN + 1;
     rpc_buf.store_trivial(static_cast<uint8_t>(rpc_impl_::MEDIUM_STRING_MAGIC));
     rpc_buf.store_trivial(static_cast<uint8_t>(string_len & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
   } else {
-    size_len = 8;
+    size_len = rpc_impl_::LARGE_STRING_SIZE_LEN + 1;
     rpc_buf.store_trivial(static_cast<uint8_t>(rpc_impl_::LARGE_STRING_MAGIC));
     rpc_buf.store_trivial(static_cast<uint8_t>(string_len & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 8) & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 16) & 0xff));
     rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 24) & 0xff));
-    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 32) & 0xff));
-    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 40) & 0xff));
-    // rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 48) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 32) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 40) & 0xff));
+    rpc_buf.store_trivial(static_cast<uint8_t>((string_len >> 48) & 0xff));
   }
   rpc_buf.store(v.c_str(), string_len);
 
@@ -388,14 +391,14 @@ string f$fetch_string() noexcept {
     return {}; // TODO: error handling
   }
 
-  string::size_type string_len{};
-  string::size_type size_len{};
+  uint8_t size_len{};
+  uint64_t string_len{};
   switch (first_byte) {
-    case rpc_impl_::LARGE_STRING_MAGIC: { // next 7 bytes are string's length // TODO: support large strings
-      // static_assert(sizeof(string::size_type) >= 8, "string's length doesn't fit platform size");
-      if (rpc_buf.remaining() < 7) {
+    case rpc_impl_::LARGE_STRING_MAGIC: {
+      if (rpc_buf.remaining() < rpc_impl_::LARGE_STRING_SIZE_LEN) {
         return {}; // TODO: error handling
       }
+      size_len = rpc_impl_::LARGE_STRING_SIZE_LEN + 1;
       const auto first{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value())};
       const auto second{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 8};
       const auto third{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 16};
@@ -404,35 +407,40 @@ string f$fetch_string() noexcept {
       const auto sixth{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 40};
       const auto seventh{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 48};
       string_len = first | second | third | fourth | fifth | sixth | seventh;
-      if (string_len < (1 << 24)) {
-        php_warning("long string's length is less than 1 << 24");
-      }
-      size_len = 8;
+
+      const auto total_len_with_padding{(size_len + string_len + 3) & ~static_cast<uint64_t>(3)};
+      rpc_buf.adjust(total_len_with_padding - size_len);
+      php_warning("fetch of large strings is not supported");
+      return {};
     }
-    case rpc_impl_::MEDIUM_STRING_MAGIC: { // next 3 bytes are string's length
-      if (rpc_buf.remaining() < 3) {
+    case rpc_impl_::MEDIUM_STRING_MAGIC: {
+      if (rpc_buf.remaining() < rpc_impl_::MEIDUM_STRING_SIZE_LEN) {
         return {}; // TODO: error handling
       }
+      size_len = rpc_impl_::MEIDUM_STRING_SIZE_LEN + 1;
       const auto first{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value())};
       const auto second{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 8};
       const auto third{static_cast<uint64_t>(rpc_buf.fetch_trivial<uint8_t>().value()) << 16};
       string_len = first | second | third;
-      if (string_len <= 253) {
+
+      if (string_len <= rpc_impl_::SMALL_STRING_MAX_LEN) {
         php_warning("long string's length is less than 254");
       }
-      size_len = 4;
+      break;
     }
-    default:
-      string_len = static_cast<string::size_type>(first_byte);
-      size_len = 1;
+    default: {
+      size_len = rpc_impl_::SMALL_STRING_SIZE_LEN;
+      string_len = static_cast<uint64_t>(first_byte);
+      break;
+    }
   }
 
-  const auto total_len_with_padding{(size_len + string_len + 3) & ~static_cast<string::size_type>(3)};
+  const auto total_len_with_padding{(size_len + string_len + 3) & ~static_cast<uint64_t>(3)};
   if (rpc_buf.remaining() < total_len_with_padding - size_len) {
     return {}; // TODO: error handling
   }
 
-  string res{rpc_buf.data() + rpc_buf.pos(), string_len};
+  string res{rpc_buf.data() + rpc_buf.pos(), static_cast<string::size_type>(string_len)};
   rpc_buf.adjust(total_len_with_padding - size_len);
   return res;
 }

--- a/runtime-light/streams/interface.cpp
+++ b/runtime-light/streams/interface.cpp
@@ -21,7 +21,7 @@ task_t<void> f$component_get_http_query() {
 task_t<class_instance<C$ComponentQuery>> f$component_client_send_query(const string &name, const string &message) {
   class_instance<C$ComponentQuery> query;
   const PlatformCtx &ptx = *get_platform_context();
-  uint64_t stream_d;
+  uint64_t stream_d{};
   OpenStreamResult res = ptx.open(name.size(), name.c_str(), &stream_d);
   if (res != OpenStreamOk) {
     php_warning("cannot open stream");
@@ -94,7 +94,7 @@ class_instance<C$ComponentStream> f$component_open_stream(const string &name) {
   class_instance<C$ComponentStream> query;
   const PlatformCtx &ptx = *get_platform_context();
   ComponentState &ctx = *get_component_context();
-  uint64_t stream_d;
+  uint64_t stream_d{};
   OpenStreamResult res = ptx.open(name.size(), name.c_str(), &stream_d);
   if (res != OpenStreamOk) {
     php_warning("cannot open stream");

--- a/runtime-light/streams/interface.h
+++ b/runtime-light/streams/interface.h
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "runtime-light/coroutine/task.h"
 #include "runtime-light/streams/component-stream.h"
 


### PR DESCRIPTION
Remove RPC fetch and store of large TL strings since it requires support of large strings in runtime.