### PR TITLE
fix ub on process termination

### DIFF
--- a/compiler/code-gen/files/const-vars-init.cpp
+++ b/compiler/code-gen/files/const-vars-init.cpp
@@ -113,7 +113,7 @@ void ConstVarsInit::compile_const_init_part(CodeGenerator &W, const ConstantsBat
     for (VarPtr var: other_const_vars.vars_by_dep_level(dep_level)) {
       W << InitConstVar(var);
       const TypeData *type_data = var->tinf_node.get_type();
-      if (vk::any_of_equal(type_data->ptype(), tp_array, tp_mixed, tp_string)) {
+      if (vk::any_of_equal(type_data->ptype(), tp_array, tp_mixed, tp_string, tp_Class)) {
         W << var->name;
         if (type_data->use_optional()) {
           W << ".val()";


### PR DESCRIPTION
General
-----------

Now for this example
```php
<?php

class B {
    public int $value;
    public function __construct(int $x) {
        // B::$static_int += 1;  // accessing globals in constructor in const classes crashes const_init; todo how to detect it in the future?
        $this->value = $x;
    }
    public function getValue() {
        return $this->value;
    }
}

const b = new B(42);
echo b->value;
```
Generated initialization looks like this 
```c++
void const_init_level1_file0() noexcept {
  c_obj$2ad134878d768207 = f$B$$__construct(class_instance<C$B>().alloc(), 42_i64);
}
```
Since `c_obj...` has no reference counter equal to `ExtraRefCnt::for_global_const` its destructor is called during process termination. It leads to UB in runtime and to sigsegv in runtime-light.

This pr improve initialization to 
```c++
void const_init_level1_file0() noexcept {
  c_obj$2ad134878d768207 = f$B$$__construct(class_instance<C$B>().alloc(), 42_i64);
  c_obj$2ad134878d768207.set_reference_counter_to(ExtraRefCnt::for_global_const);
}
```