### PR TITLE
Make K2 RPC asynchronous

### DIFF
--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -849,7 +849,7 @@ void compile_func_call(VertexAdaptor<op_func_call> root, CodeGenerator &W, func_
 
     if (mode == func_call_mode::fork_call) {
       if (func->is_interruptible) {
-        W << "(co_await start_fork_and_reschedule_t{" << FunctionName(func);
+        W << "(co_await start_fork_t{" << FunctionName(func);
       } else {
         W << FunctionForkName(func);
       }
@@ -883,7 +883,7 @@ void compile_func_call(VertexAdaptor<op_func_call> root, CodeGenerator &W, func_
   W << ")";
   if (func->is_interruptible) {
     if (mode == func_call_mode::fork_call) {
-      W << "})";
+      W << ", start_fork_t::execution::fork})";
     } else if (func->is_k2_fork) { // k2 fork's return type is 'task_t<fork_result>' so we need to unpack actual result from fork_result
       W << ").get_result<" << TypeName(tinf::get_type(root)) << ">()";
     } else {

--- a/runtime-core/utils/hash.h
+++ b/runtime-core/utils/hash.h
@@ -1,0 +1,13 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2024 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include <cstddef>
+#include <functional>
+
+// from boost
+// see https://www.boost.org/doc/libs/1_55_0/doc/html/hash/reference.html#boost.hash_combine
+template<typename T>
+void hash_combine(size_t &seed, const T &v) noexcept {
+  seed ^= std::hash<T>{}(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -200,7 +200,7 @@ public:
       cancel();
     }
     if (timer_d != INVALID_PLATFORM_DESCRIPTOR) {
-      get_platform_context()->free_descriptor(timer_d);
+      get_component_context()->release_stream(timer_d);
     }
   }
 
@@ -215,9 +215,7 @@ public:
     CoroutineScheduler::get().suspend(suspend_token);
   }
 
-  void await_resume() const noexcept {
-    get_component_context()->release_stream(timer_d);
-  }
+  constexpr void await_resume() const noexcept {}
 
   bool done() const noexcept {
     return was_suspended && !CoroutineScheduler::get().contains(suspend_token);

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -9,9 +9,10 @@
 #include <coroutine>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <type_traits>
 #include <utility>
 
-#include "runtime-core/core-types/decl/optional.h"
 #include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/component/component.h"
 #include "runtime-light/coroutine/task.h"
@@ -28,6 +29,13 @@ concept Awaitable = requires(T awaitable, const T const_awaitable, std::coroutin
   { awaitable.await_resume() } noexcept;
 };
 
+template<class T>
+concept CancellableAwaitable = Awaitable<T> && requires(T awaitable, const T const_awaitable) {
+  // the result of 'done' is only valid after a call to awaitable's 'await_suspend'
+  { const_awaitable.done() } noexcept -> std::convertible_to<bool>;
+  { awaitable.cancel() } noexcept -> std::same_as<void>;
+};
+
 // === Awaitables =================================================================================
 
 class wait_for_update_t {
@@ -38,6 +46,20 @@ public:
   explicit wait_for_update_t(uint64_t stream_d_) noexcept
     : stream_d(stream_d_)
     , suspend_token(std::noop_coroutine(), WaitEvent::UpdateOnStream{.stream_d = stream_d}) {}
+
+  wait_for_update_t(wait_for_update_t &&other) noexcept
+    : stream_d(std::exchange(other.stream_d, INVALID_PLATFORM_DESCRIPTOR))
+    , suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))) {};
+
+  wait_for_update_t(const wait_for_update_t &) = delete;
+  wait_for_update_t &operator=(const wait_for_update_t &) = delete;
+  wait_for_update_t &operator=(wait_for_update_t &&) = delete;
+
+  ~wait_for_update_t() {
+    if (!done()) {
+      cancel();
+    }
+  }
 
   bool await_ready() const noexcept {
     return get_component_context()->stream_updated(stream_d);
@@ -50,6 +72,10 @@ public:
 
   constexpr void await_resume() const noexcept {}
 
+  bool done() const noexcept {
+    return !CoroutineScheduler::get().contains(suspend_token);
+  }
+
   void cancel() const noexcept {
     CoroutineScheduler::get().cancel(suspend_token);
   }
@@ -61,6 +87,21 @@ class wait_for_incoming_stream_t {
   SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::IncomingStream{}};
 
 public:
+  wait_for_incoming_stream_t() noexcept = default;
+
+  wait_for_incoming_stream_t(wait_for_incoming_stream_t &&other) noexcept
+    : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))) {};
+
+  wait_for_incoming_stream_t(const wait_for_incoming_stream_t &) = delete;
+  wait_for_incoming_stream_t &operator=(const wait_for_incoming_stream_t &) = delete;
+  wait_for_incoming_stream_t &operator=(wait_for_incoming_stream_t &&) = delete;
+
+  ~wait_for_incoming_stream_t() {
+    if (!done()) {
+      cancel();
+    }
+  }
+
   bool await_ready() const noexcept {
     return !get_component_context()->incoming_streams().empty();
   }
@@ -76,6 +117,10 @@ public:
     return incoming_stream_d;
   }
 
+  bool done() const noexcept {
+    return !CoroutineScheduler::get().contains(suspend_token);
+  }
+
   void cancel() const noexcept {
     CoroutineScheduler::get().cancel(suspend_token);
   }
@@ -87,6 +132,21 @@ class wait_for_reschedule_t {
   SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::Rechedule{}};
 
 public:
+  wait_for_reschedule_t() noexcept = default;
+
+  wait_for_reschedule_t(wait_for_reschedule_t &&other) noexcept
+    : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))) {};
+
+  wait_for_reschedule_t(const wait_for_reschedule_t &) = delete;
+  wait_for_reschedule_t &operator=(const wait_for_reschedule_t &) = delete;
+  wait_for_reschedule_t &operator=(wait_for_reschedule_t &&) = delete;
+
+  ~wait_for_reschedule_t() {
+    if (!done()) {
+      cancel();
+    }
+  }
+
   constexpr bool await_ready() const noexcept {
     return false;
   }
@@ -97,6 +157,10 @@ public:
   }
 
   constexpr void await_resume() const noexcept {}
+
+  bool done() const noexcept {
+    return !CoroutineScheduler::get().contains(suspend_token);
+  }
 
   void cancel() const noexcept {
     CoroutineScheduler::get().cancel(suspend_token);
@@ -114,6 +178,23 @@ public:
     : timer_d(get_component_context()->set_timer(duration))
     , suspend_token(std::noop_coroutine(), WaitEvent::UpdateOnTimer{.timer_d = timer_d}) {}
 
+  wait_for_timer_t(wait_for_timer_t &&other) noexcept
+    : timer_d(std::exchange(other.timer_d, INVALID_PLATFORM_DESCRIPTOR))
+    , suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))) {}
+
+  wait_for_timer_t(const wait_for_timer_t &) = delete;
+  wait_for_timer_t &operator=(const wait_for_timer_t &) = delete;
+  wait_for_timer_t &operator=(wait_for_timer_t &&) = delete;
+
+  ~wait_for_timer_t() {
+    if (!done()) {
+      cancel();
+    }
+    if (timer_d != INVALID_PLATFORM_DESCRIPTOR) {
+      get_platform_context()->free_descriptor(timer_d);
+    }
+  }
+
   bool await_ready() const noexcept {
     TimePoint tp{};
     return timer_d == INVALID_PLATFORM_DESCRIPTOR || get_platform_context()->get_timer_status(timer_d, std::addressof(tp)) == TimerStatus::TimerStatusElapsed;
@@ -128,8 +209,11 @@ public:
     get_component_context()->release_stream(timer_d);
   }
 
+  bool done() const noexcept {
+    return !CoroutineScheduler::get().contains(suspend_token);
+  }
+
   void cancel() const noexcept {
-    get_component_context()->release_stream(timer_d);
     CoroutineScheduler::get().cancel(suspend_token);
   }
 };
@@ -189,31 +273,111 @@ public:
 template<typename T>
 class wait_fork_t {
   int64_t fork_id;
+  task_t<fork_result> fork_task;
   task_t<fork_result>::awaiter_t fork_awaiter;
-  wait_for_timer_t timer_awaiter;
 
 public:
-  wait_fork_t(int64_t fork_id_, std::chrono::nanoseconds timeout) noexcept
+  explicit wait_fork_t(int64_t fork_id_) noexcept
     : fork_id(fork_id_)
-    , fork_awaiter(std::addressof(ForkComponentContext::get().get_fork(fork_id)))
-    , timer_awaiter(timeout) {}
+    , fork_task(ForkComponentContext::get().pop_fork(fork_id))
+    , fork_awaiter(std::addressof(fork_task)) {}
+
+  wait_fork_t(wait_fork_t &&other) noexcept
+    : fork_id(std::exchange(other.fork_id, INVALID_FORK_ID))
+    , fork_task(std::move(other.fork_task))
+    , fork_awaiter(std::addressof(fork_task)) {}
+
+  wait_fork_t(const wait_fork_t &) = delete;
+  wait_fork_t &operator=(const wait_fork_t &) = delete;
+  wait_fork_t &operator=(wait_fork_t &&) = delete;
+  ~wait_fork_t() = default;
 
   bool await_ready() const noexcept {
-    return ForkComponentContext::get().get_fork(fork_id).done();
+    return fork_awaiter.done();
   }
 
-  void await_suspend(std::coroutine_handle<> coro) noexcept {
+  constexpr void await_suspend(std::coroutine_handle<> coro) noexcept {
     fork_awaiter.await_suspend(coro);
-    timer_awaiter.await_suspend(coro);
   }
 
-  Optional<T> await_resume() noexcept {
-    if (ForkComponentContext::get().get_fork(fork_id).done()) {
-      timer_awaiter.cancel();
-      return {fork_awaiter.await_resume().get_result<T>()};
+  T await_resume() noexcept {
+    return fork_awaiter.await_resume().get_result<T>();
+  }
+
+  constexpr bool done() const noexcept {
+    return fork_awaiter.done();
+  }
+
+  constexpr void cancel() const noexcept {
+    fork_awaiter.cancel();
+  }
+};
+
+// ================================================================================================
+
+template<CancellableAwaitable T>
+class wait_with_timeout_t {
+  T awaitable;
+  wait_for_timer_t timer_awaitable;
+
+  static_assert(CancellableAwaitable<wait_for_timer_t>);
+  static_assert(std::is_void_v<decltype(timer_awaitable.await_suspend(std::coroutine_handle<>{}))>);
+  using awaitable_suspend_t = decltype(awaitable.await_suspend(std::coroutine_handle<>{}));
+  using await_suspend_return_t = awaitable_suspend_t;
+  using awaitable_resume_t = decltype(awaitable.await_resume());
+  using await_resume_return_t = std::conditional_t<std::is_void_v<awaitable_resume_t>, void, std::optional<awaitable_resume_t>>;
+
+public:
+  wait_with_timeout_t(T &&awaitable_, std::chrono::nanoseconds timeout) noexcept
+    : awaitable(std::move(awaitable_))
+    , timer_awaitable(timeout) {}
+
+  wait_with_timeout_t(wait_with_timeout_t &&other) noexcept
+    : awaitable(std::move(other.awaitable))
+    , timer_awaitable(std::move(other.timer_awaitable)) {}
+
+  wait_with_timeout_t(const wait_with_timeout_t &) = delete;
+  wait_with_timeout_t &operator=(const wait_with_timeout_t &) = delete;
+  wait_with_timeout_t &operator=(wait_with_timeout_t &&) = delete;
+  ~wait_with_timeout_t() = default;
+
+  constexpr bool await_ready() const noexcept {
+    return awaitable.await_ready() || timer_awaitable.await_ready();
+  }
+
+  // according to C++ standard, there can be 3 possible cases:
+  // 1. await_suspend returns void;
+  // 2. await_suspend returns bool;
+  // 3. await_suspend returns std::coroutine_handle<>.
+  // we must guarantee that 'co_await wait_with_timeout_t{awaitable, timeout}' behaves like 'co_await awaitable' except
+  // it may cancel 'co_await awaitable' if the timeout has elapsed.
+  await_suspend_return_t await_suspend(std::coroutine_handle<> coro) noexcept {
+    // as we don't rely on coroutine scheduler implementation, let's always suspend awaitable first. in case of some smart scheduler
+    // it won't have any effect, but it will have an effect if our scheduler is quite simple.
+    if constexpr (std::is_void_v<await_suspend_return_t>) {
+      awaitable.await_suspend(coro);
+      timer_awaitable.await_suspend(coro);
     } else {
-      fork_awaiter.cancel();
-      return {};
+      const auto awaitable_suspend_res{awaitable.await_suspend(coro)};
+      timer_awaitable.await_suspend(coro);
+      return awaitable_suspend_res;
+    }
+  }
+
+  await_resume_return_t await_resume() noexcept {
+    if (awaitable.done()) {
+      timer_awaitable.cancel();
+      if constexpr (!std::is_void_v<await_resume_return_t>) {
+        return awaitable.await_resume();
+      }
+    } else {
+      awaitable.cancel();
+      if constexpr (!std::is_void_v<await_resume_return_t>) {
+        return std::nullopt;
+      }
     }
   }
 };
+
+template<class T>
+wait_with_timeout_t(T &&, std::chrono::nanoseconds) -> wait_with_timeout_t<T>;

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -249,6 +249,17 @@ public:
     , fork_coro(task_.get_handle())
     , fork_id(ForkComponentContext::get().push_fork(std::move(task_))) {}
 
+  start_fork_t(start_fork_t &&other) noexcept
+    : exec_policy(other.exec_policy)
+    , fork_coro(std::exchange(other.fork_coro, std::noop_coroutine()))
+    , fork_id(std::exchange(other.fork_id, INVALID_FORK_ID))
+    , suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))) {}
+
+  start_fork_t(const start_fork_t &) = delete;
+  start_fork_t &operator=(const start_fork_t &) = delete;
+  start_fork_t &operator=(start_fork_t &&) = delete;
+  ~start_fork_t() = default;
+
   constexpr bool await_ready() const noexcept {
     return false;
   }

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -39,6 +39,9 @@ concept CancellableAwaitable = Awaitable<T> && requires(T awaitable, const T con
 };
 
 // === Awaitables =================================================================================
+//
+// ***Important***
+// Below awaitables are not supposed to be co_awaited on more than once.
 
 class wait_for_update_t {
   uint64_t stream_d;
@@ -279,6 +282,9 @@ public:
       }
     }
     CoroutineScheduler::get().suspend(suspend_token);
+    // reset fork_coro and suspend_token to guarantee that the same fork will be started only once
+    fork_coro = std::noop_coroutine();
+    suspend_token = std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{});
     return continuation;
   }
 

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -31,7 +31,10 @@ concept Awaitable = requires(T awaitable, const T const_awaitable, std::coroutin
 
 template<class T>
 concept CancellableAwaitable = Awaitable<T> && requires(T awaitable, const T const_awaitable) {
+  // semantics: awaitable has really done its job, e.g. timer suspended and resumed, task finished etc
   { const_awaitable.done() } noexcept -> std::convertible_to<bool>;
+  // semantics: following resume of the awaitable should not have any effect on the awaiter.
+  // semantics (optional): stop useless calculations.
   { awaitable.cancel() } noexcept -> std::same_as<void>;
 };
 

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -207,7 +207,7 @@ struct task_t : public task_base_t {
       return task->get_result();
     }
 
-    bool done() const noexcept {
+    bool resumable() const noexcept {
       return task->done();
     }
 

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -52,8 +52,8 @@ protected:
 
 /**
  * Please, read following documents before trying to understand what's going on here:
- * 1. C++20 coroutines — https://en.cppreference.com/w/cpp/language/coroutines;
- * 2. C++ coroutines — understanding symmetric stransfer - https://lewissbaker.github.io/2020/05/11/understanding_symmetric_transfer.
+ * 1. C++20 coroutines — https://en.cppreference.com/w/cpp/language/coroutines
+ * 2. C++ coroutines: understanding symmetric stransfer — https://lewissbaker.github.io/2020/05/11/understanding_symmetric_transfer
  */
 template<typename T>
 struct task_t : public task_base_t {

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -50,6 +50,11 @@ protected:
   void *handle_address{nullptr};
 };
 
+/**
+ * Please, read following documents before trying to understand what's going on here:
+ * 1. C++20 coroutines — https://en.cppreference.com/w/cpp/language/coroutines;
+ * 2. C++ coroutines — understanding symmetric stransfer - https://lewissbaker.github.io/2020/05/11/understanding_symmetric_transfer.
+ */
 template<typename T>
 struct task_t : public task_base_t {
   template<std::same_as<T> F>

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -202,6 +202,10 @@ struct task_t : public task_base_t {
       return task->get_result();
     }
 
+    bool done() const noexcept {
+      return task->done();
+    }
+
     void cancel() const noexcept {
       task->get_handle().promise().next = nullptr;
     }

--- a/runtime-light/scheduler/scheduler.cpp
+++ b/runtime-light/scheduler/scheduler.cpp
@@ -113,9 +113,15 @@ void SimpleCoroutineScheduler::cancel(SuspendToken token) noexcept {
     [this, token](auto &&event) noexcept {
       using event_t = std::remove_cvref_t<decltype(event)>;
       if constexpr (std::is_same_v<event_t, WaitEvent::Rechedule>) {
-        yield_tokens.erase(std::find(yield_tokens.cbegin(), yield_tokens.cend(), token));
+        const auto it_token{std::find(yield_tokens.cbegin(), yield_tokens.cend(), token)};
+        if (it_token != yield_tokens.cend()) {
+          yield_tokens.erase(it_token);
+        }
       } else if constexpr (std::is_same_v<event_t, WaitEvent::IncomingStream>) {
-        awaiting_for_stream_tokens.erase(std::find(awaiting_for_stream_tokens.cbegin(), awaiting_for_stream_tokens.cend(), token));
+        const auto it_token{std::find(awaiting_for_stream_tokens.cbegin(), awaiting_for_stream_tokens.cend(), token)};
+        if (it_token != awaiting_for_stream_tokens.cend()) {
+          awaiting_for_stream_tokens.erase(it_token);
+        }
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnStream>) {
         awaiting_for_update_tokens.erase(event.stream_d);
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnTimer>) {

--- a/runtime-light/scheduler/scheduler.cpp
+++ b/runtime-light/scheduler/scheduler.cpp
@@ -21,35 +21,35 @@ SimpleCoroutineScheduler &SimpleCoroutineScheduler::get() noexcept {
 }
 
 ScheduleStatus SimpleCoroutineScheduler::scheduleOnNoEvent() noexcept {
-  if (yield_coros.empty()) {
+  if (yield_tokens.empty()) {
     return ScheduleStatus::Skipped;
   }
-  const auto coro{yield_coros.front()};
-  yield_coros.pop_front();
-  suspend_tokens.erase(std::make_pair(coro, WaitEvent::Rechedule{}));
-  coro.resume();
+  const auto token{yield_tokens.front()};
+  yield_tokens.pop_front();
+  suspend_tokens.erase(token);
+  token.first.resume();
   return ScheduleStatus::Resumed;
 }
 
 ScheduleStatus SimpleCoroutineScheduler::scheduleOnIncomingStream() noexcept {
-  if (awaiting_for_stream_coros.empty()) {
+  if (awaiting_for_stream_tokens.empty()) {
     return ScheduleStatus::Skipped;
   }
-  const auto coro{awaiting_for_stream_coros.front()};
-  awaiting_for_stream_coros.pop_front();
-  suspend_tokens.erase(std::make_pair(coro, WaitEvent::IncomingStream{}));
-  coro.resume();
+  const auto token{awaiting_for_stream_tokens.front()};
+  awaiting_for_stream_tokens.pop_front();
+  suspend_tokens.erase(token);
+  token.first.resume();
   return ScheduleStatus::Resumed;
 }
 
 ScheduleStatus SimpleCoroutineScheduler::scheduleOnStreamUpdate(uint64_t stream_d) noexcept {
   if (stream_d == INVALID_PLATFORM_DESCRIPTOR) {
     return ScheduleStatus::Error;
-  } else if (const auto it_coro{awaiting_for_update_coros.find(stream_d)}; it_coro != awaiting_for_update_coros.cend()) {
-    const auto coro{it_coro->second};
-    awaiting_for_update_coros.erase(it_coro);
-    suspend_tokens.erase(std::make_pair(coro, WaitEvent::UpdateOnStream{.stream_d = stream_d}));
-    coro.resume();
+  } else if (const auto it_token{awaiting_for_update_tokens.find(stream_d)}; it_token != awaiting_for_update_tokens.cend()) {
+    const auto token{it_token->second};
+    awaiting_for_update_tokens.erase(it_token);
+    suspend_tokens.erase(token);
+    token.first.resume();
     return ScheduleStatus::Resumed;
   } else {
     return ScheduleStatus::Skipped;
@@ -83,48 +83,46 @@ ScheduleStatus SimpleCoroutineScheduler::schedule(ScheduleEvent::EventT event) n
 
 void SimpleCoroutineScheduler::suspend(SuspendToken token) noexcept {
   suspend_tokens.emplace(token);
-  const auto [coro, event]{token};
   std::visit(
-    [this, coro](auto &&event) noexcept {
+    [this, token](auto &&event) noexcept {
       using event_t = std::remove_cvref_t<decltype(event)>;
       if constexpr (std::is_same_v<event_t, WaitEvent::Rechedule>) {
-        yield_coros.push_back(coro);
+        yield_tokens.push_back(token);
       } else if constexpr (std::is_same_v<event_t, WaitEvent::IncomingStream>) {
-        awaiting_for_stream_coros.push_back(coro);
+        awaiting_for_stream_tokens.push_back(token);
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnStream>) {
         if (event.stream_d == INVALID_PLATFORM_DESCRIPTOR) {
           return;
         }
-        awaiting_for_update_coros.emplace(event.stream_d, coro);
+        awaiting_for_update_tokens.emplace(event.stream_d, token);
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnTimer>) {
         if (event.timer_d == INVALID_PLATFORM_DESCRIPTOR) {
           return;
         }
-        awaiting_for_update_coros.emplace(event.timer_d, coro);
+        awaiting_for_update_tokens.emplace(event.timer_d, token);
       } else {
         static_assert(false, "non-exhaustive visitor");
       }
     },
-    event);
+    token.second);
 }
 
 void SimpleCoroutineScheduler::cancel(SuspendToken token) noexcept {
   suspend_tokens.erase(token);
-  const auto [coro, event]{token};
   std::visit(
-    [this, coro](auto &&event) noexcept {
+    [this, token](auto &&event) noexcept {
       using event_t = std::remove_cvref_t<decltype(event)>;
       if constexpr (std::is_same_v<event_t, WaitEvent::Rechedule>) {
-        yield_coros.erase(std::find(yield_coros.cbegin(), yield_coros.cend(), coro));
+        yield_tokens.erase(std::find(yield_tokens.cbegin(), yield_tokens.cend(), token));
       } else if constexpr (std::is_same_v<event_t, WaitEvent::IncomingStream>) {
-        awaiting_for_stream_coros.erase(std::find(awaiting_for_stream_coros.cbegin(), awaiting_for_stream_coros.cend(), coro));
+        awaiting_for_stream_tokens.erase(std::find(awaiting_for_stream_tokens.cbegin(), awaiting_for_stream_tokens.cend(), token));
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnStream>) {
-        awaiting_for_update_coros.erase(event.stream_d);
+        awaiting_for_update_tokens.erase(event.stream_d);
       } else if constexpr (std::is_same_v<event_t, WaitEvent::UpdateOnTimer>) {
-        awaiting_for_update_coros.erase(event.timer_d);
+        awaiting_for_update_tokens.erase(event.timer_d);
       } else {
         static_assert(false, "non-exhaustive visitor");
       }
     },
-    event);
+    token.second);
 }

--- a/runtime-light/scheduler/scheduler.h
+++ b/runtime-light/scheduler/scheduler.h
@@ -161,6 +161,8 @@ concept CoroutineSchedulerConcept = std::constructible_from<scheduler_t, memory_
 
 // === SimpleCoroutineScheduler ===================================================================
 
+// This scheduler doesn't support waiting for the same event from multiple coroutines.
+// We need to finalize our decision whether we allow to do it from PHP code or not.
 class SimpleCoroutineScheduler {
   template<hashable Key, typename Value>
   using unordered_map = memory_resource::stl::unordered_map<Key, Value, memory_resource::unsynchronized_pool_resource>;

--- a/runtime-light/scheduler/scheduler.h
+++ b/runtime-light/scheduler/scheduler.h
@@ -171,10 +171,9 @@ class SimpleCoroutineScheduler {
   template<typename T>
   using deque = memory_resource::stl::deque<T, memory_resource::unsynchronized_pool_resource>;
 
-  deque<std::coroutine_handle<>> yield_coros;
-  deque<std::coroutine_handle<>> awaiting_for_stream_coros;
-  unordered_map<uint64_t, std::coroutine_handle<>> awaiting_for_update_coros;
-
+  deque<SuspendToken> yield_tokens;
+  deque<SuspendToken> awaiting_for_stream_tokens;
+  unordered_map<uint64_t, SuspendToken> awaiting_for_update_tokens;
   unordered_set<SuspendToken> suspend_tokens;
 
   ScheduleStatus scheduleOnNoEvent() noexcept;
@@ -184,9 +183,9 @@ class SimpleCoroutineScheduler {
 
 public:
   explicit SimpleCoroutineScheduler(memory_resource::unsynchronized_pool_resource &memory_resource) noexcept
-    : yield_coros(deque<std::coroutine_handle<>>::allocator_type{memory_resource})
-    , awaiting_for_stream_coros(deque<std::coroutine_handle<>>::allocator_type{memory_resource})
-    , awaiting_for_update_coros(unordered_map<uint64_t, std::coroutine_handle<>>::allocator_type{memory_resource})
+    : yield_tokens(deque<SuspendToken>::allocator_type{memory_resource})
+    , awaiting_for_stream_tokens(deque<SuspendToken>::allocator_type{memory_resource})
+    , awaiting_for_update_tokens(unordered_map<uint64_t, SuspendToken>::allocator_type{memory_resource})
     , suspend_tokens(unordered_set<SuspendToken>::allocator_type{memory_resource}) {}
 
   static SimpleCoroutineScheduler &get() noexcept;

--- a/runtime-light/scheduler/scheduler.h
+++ b/runtime-light/scheduler/scheduler.h
@@ -84,8 +84,9 @@ using SuspendToken = std::pair<std::coroutine_handle<>, WaitEvent::EventT>;
  * 2. have static `get` function that returns a reference to scheduler instance;
  * 3. have `done` method that returns whether scheduler's scheduled all coroutines;
  * 4. have `schedule` method that takes an event and schedules coroutines for execution;
- * 5. have `suspend` method that suspends specified coroutine;
- * 6. have `cancel` method that cancels specified SuspendToken.
+ * 5. have `contains` method returns whether specified SuspendToken is in schedule queue;
+ * 6. have `suspend` method that suspends specified coroutine;
+ * 7. have `cancel` method that cancels specified SuspendToken.
  */
 template<class scheduler_t>
 concept CoroutineSchedulerConcept = std::constructible_from<scheduler_t, memory_resource::unsynchronized_pool_resource &>
@@ -93,6 +94,7 @@ concept CoroutineSchedulerConcept = std::constructible_from<scheduler_t, memory_
   { scheduler_t::get() } noexcept -> std::same_as<scheduler_t &>;
   { s.done() } noexcept -> std::convertible_to<bool>;
   { s.schedule(schedule_event) } noexcept -> std::same_as<ScheduleStatus>;
+  { s.contains(token) } noexcept -> std::convertible_to<bool>;
   { s.suspend(token) } noexcept -> std::same_as<void>;
   { s.cancel(token) } noexcept -> std::same_as<void>;
 };
@@ -128,6 +130,7 @@ public:
   }
 
   ScheduleStatus schedule(ScheduleEvent::EventT) noexcept;
+  bool contains(SuspendToken) const noexcept;
   void suspend(SuspendToken) noexcept;
   void cancel(SuspendToken) noexcept;
 };

--- a/runtime-light/stdlib/fork/fork-api.h
+++ b/runtime-light/stdlib/fork/fork-api.h
@@ -24,15 +24,16 @@ constexpr auto DEFAULT_TIMEOUT_NS = std::chrono::duration_cast<std::chrono::nano
 
 template<typename T>
 requires(is_optional<T>::value) task_t<T> f$wait(int64_t fork_id, double timeout = -1.0) noexcept {
-  if (!ForkComponentContext::get().contains(fork_id)) {
+  auto &fork_ctx{ForkComponentContext::get()};
+  if (!fork_ctx.contains(fork_id)) {
     php_warning("can't find fork %" PRId64, fork_id);
-    co_return T{};
+    co_return internal_optional_type_t<T>{};
   }
   // normalize timeout
   const auto timeout_ns{timeout > 0 && timeout <= fork_api_impl_::MAX_TIMEOUT_S
                           ? std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{timeout})
                           : fork_api_impl_::DEFAULT_TIMEOUT_NS};
-  co_return co_await wait_fork_t<internal_optional_type_t<T>>{fork_id, timeout_ns};
+  co_return(co_await wait_with_timeout_t{wait_fork_t<internal_optional_type_t<T>>{fork_id}, timeout_ns}).value_or(internal_optional_type_t<T>{});
 }
 
 template<typename T>

--- a/runtime-light/stdlib/fork/fork-api.h
+++ b/runtime-light/stdlib/fork/fork-api.h
@@ -19,20 +19,17 @@ constexpr double WAIT_FORK_MAX_TIMEOUT = 86400.0;
 
 } // namespace fork_api_impl_
 
-constexpr int64_t INVALID_FORK_ID = -1;
-
 template<typename T>
 requires(is_optional<T>::value) task_t<T> f$wait(int64_t fork_id, double timeout = -1.0) noexcept {
   if (timeout < 0.0) {
     timeout = fork_api_impl_::WAIT_FORK_MAX_TIMEOUT;
   }
-  auto task_opt{ForkComponentContext::get().pop_fork(fork_id)};
-  if (!task_opt.has_value()) {
+  if (!ForkComponentContext::get().contains(fork_id)) {
     php_warning("can't find fork %" PRId64, fork_id);
     co_return T{};
   }
   const auto timeout_ns{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{timeout})};
-  co_return co_await wait_fork_t<internal_optional_type_t<T>>{*std::move(task_opt), timeout_ns};
+  co_return co_await wait_fork_t<internal_optional_type_t<T>>{fork_id, timeout_ns};
 }
 
 template<typename T>

--- a/runtime-light/stdlib/fork/fork-context.h
+++ b/runtime-light/stdlib/fork/fork-context.h
@@ -5,7 +5,6 @@
 #pragma once
 
 #include <cstdint>
-#include <optional>
 
 #include "runtime-core/memory-resource/unsynchronized_pool_resource.h"
 #include "runtime-core/utils/kphp-assert-core.h"
@@ -13,35 +12,42 @@
 #include "runtime-light/stdlib/fork/fork.h"
 #include "runtime-light/utils/concepts.h"
 
+constexpr int64_t INVALID_FORK_ID = -1;
+
 class ForkComponentContext {
   template<hashable Key, typename Value>
   using unordered_map = memory_resource::stl::unordered_map<Key, Value, memory_resource::unsynchronized_pool_resource>;
 
   static constexpr auto FORK_ID_INIT = 1;
 
-  unordered_map<int64_t, task_t<fork_result>> forks_;
-  int64_t next_fork_id_{FORK_ID_INIT};
+  unordered_map<int64_t, task_t<fork_result>> forks;
+  int64_t next_fork_id{FORK_ID_INIT};
 
 public:
   explicit ForkComponentContext(memory_resource::unsynchronized_pool_resource &memory_resource) noexcept
-    : forks_(unordered_map<int64_t, task_t<fork_result>>::allocator_type{memory_resource}) {}
+    : forks(unordered_map<int64_t, task_t<fork_result>>::allocator_type{memory_resource}) {}
 
   static ForkComponentContext &get() noexcept;
 
+  bool contains(int64_t fork_id) const noexcept {
+    return forks.contains(fork_id);
+  }
+
   int64_t push_fork(task_t<fork_result> &&task) noexcept {
-    const auto fork_id{next_fork_id_++};
-    forks_.emplace(fork_id, std::move(task));
-    php_debug("ForkComponentContext: push fork %" PRId64, fork_id);
+    const auto fork_id{next_fork_id++};
+    forks.emplace(fork_id, std::move(task));
     return fork_id;
   }
 
-  std::optional<task_t<fork_result>> pop_fork(int64_t fork_id) noexcept {
-    if (const auto it_fork{forks_.find(fork_id)}; it_fork != forks_.cend()) {
-      php_debug("ForkComponentContext: pop fork %" PRId64, fork_id);
-      auto fork{std::move(it_fork->second)};
-      forks_.erase(it_fork);
-      return {std::move(fork)};
+  task_t<fork_result> &get_fork(int64_t fork_id) noexcept {
+    const auto it_fork{forks.find(fork_id)};
+    if (it_fork == forks.end()) {
+      php_critical_error("can't find fork %" PRId64, fork_id);
     }
-    return std::nullopt;
+    return it_fork->second;
+  }
+
+  void pop_fork(int64_t fork_id) noexcept {
+    forks.erase(fork_id);
   }
 };

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -135,8 +135,7 @@ task_t<RpcQueryInfo> rpc_send_impl(string actor, double timeout, bool ignore_ans
                                                        co_return co_await f$component_client_get_result(std::move(comp_query));
                                                      }(std::move(comp_query)),
                                                      start_fork_t::execution::self}};
-    auto response_opt{co_await wait_fork_t<string>{fetcher_fork_id, timeout}};
-    const auto response{response_opt.has_value() ? std::move(response_opt.val()) : string{}};
+    const auto response{(co_await wait_fork_t<string>{fetcher_fork_id, timeout}).val()};
     // update response extra info if needed
     if (collect_responses_extra_info) {
       auto &extra_info_map{RpcComponentContext::get().rpc_responses_extra_info};
@@ -246,8 +245,7 @@ task_t<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) noexcept {
   }
 
   const auto timeout{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{MAX_TIMEOUT_S})};
-  auto data_opt{co_await wait_fork_t<string>{response_waiter_fork_id, timeout}};
-  const auto data{data_opt.has_value() ? std::move(data_opt.val()) : string{}};
+  const auto data{(co_await wait_fork_t<string>{response_waiter_fork_id, timeout}).val()};
   if (data.empty()) {
     co_return make_fetch_error(string{"rpc response timeout"}, TL_ERROR_QUERY_TIMEOUT);
   }
@@ -296,8 +294,7 @@ task_t<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(i
   }
 
   const auto timeout{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{MAX_TIMEOUT_S})};
-  auto data_opt{co_await wait_fork_t<string>{response_waiter_fork_id, timeout}};
-  const auto data{data_opt.has_value() ? std::move(data_opt.val()) : string{}};
+  const auto data{(co_await wait_fork_t<string>{response_waiter_fork_id, timeout}).val()};
   if (data.empty()) {
     co_return error_factory.make_error(string{"rpc response timeout"}, TL_ERROR_QUERY_TIMEOUT);
   }

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -7,21 +7,26 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
-#include <optional>
+#include <memory>
 #include <utility>
 
 #include "common/algorithms/find.h"
 #include "common/rpc-error-codes.h"
+#include "runtime-core/runtime-core.h"
 #include "runtime-core/utils/kphp-assert-core.h"
 #include "runtime-light/allocator/allocator.h"
+#include "runtime-light/coroutine/awaitable.h"
+#include "runtime-light/coroutine/task.h"
 #include "runtime-light/stdlib/rpc/rpc-context.h"
 #include "runtime-light/stdlib/rpc/rpc-extra-headers.h"
+#include "runtime-light/stdlib/rpc/rpc-extra-info.h"
 #include "runtime-light/streams/interface.h"
 #include "runtime-light/tl/tl-core.h"
 
 namespace rpc_impl_ {
 
-constexpr int32_t MAX_TIMEOUT_S = 86400;
+constexpr double MAX_TIMEOUT_S = 86400.0;
+constexpr double DEFAULT_TIMEOUT_S = 0.4;
 
 mixed mixed_array_get_value(const mixed &arr, const string &str_key, int64_t num_key) noexcept {
   if (!arr.is_array()) {
@@ -89,42 +94,68 @@ class_instance<RpcTlQuery> store_function(const mixed &tl_object) noexcept {
   return rpc_tl_query;
 }
 
-task_t<RpcQueryInfo> rpc_send_impl(string actor, double timeout, bool ignore_answer) noexcept {
-  if (timeout <= 0 || timeout > MAX_TIMEOUT_S) { // TODO: handle timeouts
-    //    timeout = conn.get()->timeout_ms * 0.001;
-  }
-
-  auto &rpc_ctx = RpcComponentContext::get();
+task_t<RpcQueryInfo> rpc_send_impl(string actor, double timeout, bool ignore_answer, bool collect_responses_extra_info) noexcept {
+  auto &rpc_ctx{RpcComponentContext::get()};
+  // prepare RPC request
   string request_buf{};
   size_t request_size{rpc_ctx.rpc_buffer.size()};
-
   // 'request_buf' will look like this:
   //    [ RpcExtraHeaders (optional) ] [ payload ]
   if (const auto [opt_new_extra_header, cur_extra_header_size]{regularize_extra_headers(rpc_ctx.rpc_buffer.data(), ignore_answer)}; opt_new_extra_header) {
     const auto new_extra_header{opt_new_extra_header.value()};
-    const auto new_extra_header_size{sizeof(std::decay_t<decltype(new_extra_header)>)};
+    const auto new_extra_header_size{sizeof(std::remove_cvref_t<decltype(new_extra_header)>)};
     request_size = request_size - cur_extra_header_size + new_extra_header_size;
 
-    request_buf.append(reinterpret_cast<const char *>(&new_extra_header), new_extra_header_size);
+    request_buf.reserve_at_least(request_size);
+    request_buf.append(reinterpret_cast<const char *>(std::addressof(new_extra_header)), new_extra_header_size);
     request_buf.append(rpc_ctx.rpc_buffer.data() + cur_extra_header_size, rpc_ctx.rpc_buffer.size() - cur_extra_header_size);
   } else {
     request_buf.append(rpc_ctx.rpc_buffer.data(), request_size);
   }
-
-  // get timestamp before co_await to also count the time we were waiting for runtime to resume this coroutine
+  // send RPC request
+  const auto query_id{rpc_ctx.current_query_id++};
   const auto timestamp{std::chrono::duration<double>{std::chrono::system_clock::now().time_since_epoch()}.count()};
-
   auto comp_query{co_await f$component_client_send_query(actor, request_buf)};
   if (comp_query.is_null()) {
-    php_error("could not send rpc query to %s", actor.c_str());
+    php_error("can't send rpc query to %s", actor.c_str());
     co_return RpcQueryInfo{.id = RPC_INVALID_QUERY_ID, .request_size = request_size, .timestamp = timestamp};
   }
 
-  if (ignore_answer) { // TODO: wait for answer in a separate coroutine and keep returning RPC_IGNORED_ANSWER_QUERY_ID
+  // create response extra info
+  if (collect_responses_extra_info) {
+    rpc_ctx.rpc_responses_extra_info.emplace(query_id, std::make_pair(rpc_response_extra_info_status_t::NOT_READY, rpc_response_extra_info_t{0, timestamp}));
+  }
+  // normalize timeout
+  timeout = timeout > 0 && timeout <= MAX_TIMEOUT_S ? timeout : DEFAULT_TIMEOUT_S;
+  const auto timeout_ns{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{timeout})};
+  // create fork to wait for RPC response. we need to do it even if 'ignore_answer' is 'true' to make sure
+  // that the stream will not be closed too early. otherwise, platform may even not send RPC request
+  auto waiter_task{[](int64_t query_id, auto comp_query, std::chrono::nanoseconds timeout, bool collect_responses_extra_info) noexcept -> task_t<fork_result> {
+    const auto fetcher_fork_id{co_await start_fork_t{[](auto comp_query) noexcept -> task_t<fork_result> {
+                                                       co_return co_await f$component_client_get_result(std::move(comp_query));
+                                                     }(std::move(comp_query)),
+                                                     start_fork_t::execution::self}};
+    auto response_opt{co_await wait_fork_t<string>{fetcher_fork_id, timeout}};
+    const auto response{response_opt.has_value() ? std::move(response_opt.val()) : string{}};
+    // update response extra info if needed
+    if (collect_responses_extra_info) {
+      auto &extra_info_map{RpcComponentContext::get().rpc_responses_extra_info};
+      if (const auto it_extra_info{extra_info_map.find(query_id)}; it_extra_info != extra_info_map.end()) {
+        const auto timestamp{std::chrono::duration<double>{std::chrono::system_clock::now().time_since_epoch()}.count()};
+        it_extra_info->second.second = std::make_tuple(response.size(), timestamp - std::get<1>(it_extra_info->second.second));
+        it_extra_info->second.first = rpc_response_extra_info_status_t::READY;
+      } else {
+        php_warning("can't find extra info for RPC query %" PRId64, query_id);
+      }
+    }
+    co_return response;
+  }(query_id, std::move(comp_query), timeout_ns, collect_responses_extra_info)};
+  const auto waiter_fork_id{co_await start_fork_t{std::move(waiter_task), start_fork_t::execution::self}};
+
+  if (ignore_answer) {
     co_return RpcQueryInfo{.id = RPC_IGNORED_ANSWER_QUERY_ID, .request_size = request_size, .timestamp = timestamp};
   }
-  const auto query_id{rpc_ctx.current_query_id++};
-  rpc_ctx.pending_component_queries.emplace(query_id, std::move(comp_query));
+  rpc_ctx.response_waiters_forks.emplace(query_id, waiter_fork_id);
   co_return RpcQueryInfo{.id = query_id, .request_size = request_size, .timestamp = timestamp};
 }
 
@@ -142,15 +173,10 @@ task_t<RpcQueryInfo> rpc_tl_query_one_impl(string actor, mixed tl_object, double
     co_return RpcQueryInfo{};
   }
 
-  const auto query_info{co_await rpc_send_impl(actor, timeout, ignore_answer)};
+  const auto query_info{co_await rpc_send_impl(actor, timeout, ignore_answer, collect_resp_extra_info)};
   if (!ignore_answer) {
-    rpc_ctx.pending_rpc_queries.emplace(query_info.id, std::move(rpc_tl_query));
+    rpc_ctx.response_fetcher_instances.emplace(query_info.id, std::move(rpc_tl_query));
   }
-  if (collect_resp_extra_info) {
-    rpc_ctx.rpc_responses_extra_info.emplace(query_info.id,
-                                             std::make_pair(rpc_response_extra_info_status_t::NOT_READY, rpc_response_extra_info_t{0, query_info.timestamp}));
-  }
-
   co_return query_info;
 }
 
@@ -170,19 +196,14 @@ task_t<RpcQueryInfo> typed_rpc_tl_query_one_impl(string actor, const RpcRequest 
     co_return RpcQueryInfo{};
   }
 
-  const auto query_info{co_await rpc_send_impl(actor, timeout, ignore_answer)};
+  const auto query_info{co_await rpc_send_impl(actor, timeout, ignore_answer, collect_responses_extra_info)};
   if (!ignore_answer) {
     auto rpc_tl_query{make_instance<RpcTlQuery>()};
     rpc_tl_query.get()->result_fetcher = std::move(fetcher);
     rpc_tl_query.get()->tl_function_name = rpc_request.tl_function_name();
 
-    rpc_ctx.pending_rpc_queries.emplace(query_info.id, std::move(rpc_tl_query));
+    rpc_ctx.response_fetcher_instances.emplace(query_info.id, std::move(rpc_tl_query));
   }
-  if (collect_responses_extra_info) {
-    rpc_ctx.rpc_responses_extra_info.emplace(query_info.id,
-                                             std::make_pair(rpc_response_extra_info_status_t::NOT_READY, rpc_response_extra_info_t{0, query_info.timestamp}));
-  }
-
   co_return query_info;
 }
 
@@ -193,22 +214,22 @@ task_t<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) noexcept {
 
   auto &rpc_ctx{RpcComponentContext::get()};
   class_instance<RpcTlQuery> rpc_query{};
-  class_instance<C$ComponentQuery> component_query{};
+  int64_t response_waiter_fork_id{INVALID_FORK_ID};
 
   {
-    const auto it_rpc_query{rpc_ctx.pending_rpc_queries.find(query_id)};
-    const auto it_component_query{rpc_ctx.pending_component_queries.find(query_id)};
+    const auto it_rpc_query{rpc_ctx.response_fetcher_instances.find(query_id)};
+    const auto it_response_fetcher_fork_id{rpc_ctx.response_waiters_forks.find(query_id)};
 
-    vk::final_action finalizer{[&rpc_ctx, it_rpc_query, it_component_query]() {
-      rpc_ctx.pending_rpc_queries.erase(it_rpc_query);
-      rpc_ctx.pending_component_queries.erase(it_component_query);
+    vk::final_action finalizer{[&rpc_ctx, it_rpc_query, it_response_fetcher_fork_id]() {
+      rpc_ctx.response_fetcher_instances.erase(it_rpc_query);
+      rpc_ctx.response_waiters_forks.erase(it_response_fetcher_fork_id);
     }};
 
-    if (it_rpc_query == rpc_ctx.pending_rpc_queries.end() || it_component_query == rpc_ctx.pending_component_queries.end()) {
+    if (it_rpc_query == rpc_ctx.response_fetcher_instances.end() || it_response_fetcher_fork_id == rpc_ctx.response_waiters_forks.end()) {
       co_return make_fetch_error(string{"unexpectedly could not find query in pending queries"}, TL_ERROR_INTERNAL);
     }
     rpc_query = std::move(it_rpc_query->second);
-    component_query = std::move(it_component_query->second);
+    response_waiter_fork_id = it_response_fetcher_fork_id->second;
   }
 
   if (rpc_query.is_null()) {
@@ -220,20 +241,19 @@ task_t<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) noexcept {
   if (rpc_query.get()->result_fetcher->is_typed) {
     co_return make_fetch_error(string{"can't get untyped result from typed TL query. Use consistent API for that"}, TL_ERROR_INTERNAL);
   }
+  if (response_waiter_fork_id == INVALID_FORK_ID) {
+    co_return make_fetch_error(string{"can't find fetcher fork"}, TL_ERROR_INTERNAL);
+  }
 
-  const auto data{co_await f$component_client_get_result(component_query)};
-
-  // TODO: subscribe to rpc response event?
-  // update rpc response extra info
-  if (const auto it_response_extra_info{rpc_ctx.rpc_responses_extra_info.find(query_id)}; it_response_extra_info != rpc_ctx.rpc_responses_extra_info.end()) {
-    const auto timestamp{std::chrono::duration<double>{std::chrono::system_clock::now().time_since_epoch()}.count()};
-    it_response_extra_info->second.second = {data.size(), timestamp - std::get<1>(it_response_extra_info->second.second)};
-    it_response_extra_info->second.first = rpc_response_extra_info_status_t::READY;
+  const auto timeout{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{MAX_TIMEOUT_S})};
+  auto data_opt{co_await wait_fork_t<string>{response_waiter_fork_id, timeout}};
+  const auto data{data_opt.has_value() ? std::move(data_opt.val()) : string{}};
+  if (data.empty()) {
+    co_return make_fetch_error(string{"rpc response timeout"}, TL_ERROR_QUERY_TIMEOUT);
   }
 
   rpc_ctx.rpc_buffer.clean();
   rpc_ctx.rpc_buffer.store_bytes(data.c_str(), data.size());
-
   co_return fetch_function_untyped(rpc_query);
 }
 
@@ -244,22 +264,22 @@ task_t<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(i
 
   auto &rpc_ctx{RpcComponentContext::get()};
   class_instance<RpcTlQuery> rpc_query{};
-  class_instance<C$ComponentQuery> component_query{};
+  int64_t response_waiter_fork_id{INVALID_FORK_ID};
 
   {
-    const auto it_rpc_query{rpc_ctx.pending_rpc_queries.find(query_id)};
-    const auto it_component_query{rpc_ctx.pending_component_queries.find(query_id)};
+    const auto it_rpc_query{rpc_ctx.response_fetcher_instances.find(query_id)};
+    const auto it_response_fetcher_fork_id{rpc_ctx.response_waiters_forks.find(query_id)};
 
-    vk::final_action finalizer{[&rpc_ctx, it_rpc_query, it_component_query]() {
-      rpc_ctx.pending_rpc_queries.erase(it_rpc_query);
-      rpc_ctx.pending_component_queries.erase(it_component_query);
+    vk::final_action finalizer{[&rpc_ctx, it_rpc_query, it_response_fetcher_fork_id]() {
+      rpc_ctx.response_fetcher_instances.erase(it_rpc_query);
+      rpc_ctx.response_waiters_forks.erase(it_response_fetcher_fork_id);
     }};
 
-    if (it_rpc_query == rpc_ctx.pending_rpc_queries.end() || it_component_query == rpc_ctx.pending_component_queries.end()) {
+    if (it_rpc_query == rpc_ctx.response_fetcher_instances.end() || it_response_fetcher_fork_id == rpc_ctx.response_waiters_forks.end()) {
       co_return error_factory.make_error(string{"unexpectedly could not find query in pending queries"}, TL_ERROR_INTERNAL);
     }
     rpc_query = std::move(it_rpc_query->second);
-    component_query = std::move(it_component_query->second);
+    response_waiter_fork_id = it_response_fetcher_fork_id->second;
   }
 
   if (rpc_query.is_null()) {
@@ -271,20 +291,19 @@ task_t<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(i
   if (!rpc_query.get()->result_fetcher->is_typed) {
     co_return error_factory.make_error(string{"can't get typed result from untyped TL query. Use consistent API for that"}, TL_ERROR_INTERNAL);
   }
+  if (response_waiter_fork_id == INVALID_FORK_ID) {
+    co_return error_factory.make_error(string{"can't find fetcher fork"}, TL_ERROR_INTERNAL);
+  }
 
-  const auto data{co_await f$component_client_get_result(component_query)};
-
-  // TODO: subscribe to rpc response event?
-  // update rpc response extra info
-  if (const auto it_response_extra_info{rpc_ctx.rpc_responses_extra_info.find(query_id)}; it_response_extra_info != rpc_ctx.rpc_responses_extra_info.end()) {
-    const auto timestamp{std::chrono::duration<double>{std::chrono::system_clock::now().time_since_epoch()}.count()};
-    it_response_extra_info->second.second = {data.size(), timestamp - std::get<1>(it_response_extra_info->second.second)};
-    it_response_extra_info->second.first = rpc_response_extra_info_status_t::READY;
+  const auto timeout{std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{MAX_TIMEOUT_S})};
+  auto data_opt{co_await wait_fork_t<string>{response_waiter_fork_id, timeout}};
+  const auto data{data_opt.has_value() ? std::move(data_opt.val()) : string{}};
+  if (data.empty()) {
+    co_return error_factory.make_error(string{"rpc response timeout"}, TL_ERROR_QUERY_TIMEOUT);
   }
 
   rpc_ctx.rpc_buffer.clean();
   rpc_ctx.rpc_buffer.store_bytes(data.c_str(), data.size());
-
   co_return fetch_function_typed(rpc_query, error_factory);
 }
 

--- a/runtime-light/stdlib/rpc/rpc-context.cpp
+++ b/runtime-light/stdlib/rpc/rpc-context.cpp
@@ -8,12 +8,6 @@
 #include "runtime-light/component/image.h"
 #include "runtime-light/utils/context.h"
 
-RpcComponentContext::RpcComponentContext(memory_resource::unsynchronized_pool_resource &memory_resource)
-  : current_query()
-  , pending_component_queries(unordered_map<int64_t, class_instance<C$ComponentQuery>>::allocator_type{memory_resource})
-  , pending_rpc_queries(unordered_map<int64_t, class_instance<RpcTlQuery>>::allocator_type{memory_resource})
-  , rpc_responses_extra_info(unordered_map<int64_t, std::pair<rpc_response_extra_info_status_t, rpc_response_extra_info_t>>::allocator_type{memory_resource}) {}
-
 RpcComponentContext &RpcComponentContext::get() noexcept {
   return get_component_context()->rpc_component_context;
 }

--- a/runtime-light/stdlib/rpc/rpc-context.h
+++ b/runtime-light/stdlib/rpc/rpc-context.h
@@ -13,7 +13,6 @@
 #include "runtime-light/stdlib/rpc/rpc-extra-info.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-defs.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-query.h"
-#include "runtime-light/streams/component-stream.h"
 #include "runtime-light/tl/tl-core.h"
 
 struct RpcComponentContext final : private vk::not_copyable {
@@ -23,11 +22,16 @@ struct RpcComponentContext final : private vk::not_copyable {
   tl::TLBuffer rpc_buffer;
   int64_t current_query_id{0};
   CurrentTlQuery current_query;
-  unordered_map<int64_t, class_instance<C$ComponentQuery>> pending_component_queries;
-  unordered_map<int64_t, class_instance<RpcTlQuery>> pending_rpc_queries;
+  unordered_map<int64_t, int64_t> response_waiters_forks;
+  unordered_map<int64_t, class_instance<RpcTlQuery>> response_fetcher_instances;
   unordered_map<int64_t, std::pair<rpc_response_extra_info_status_t, rpc_response_extra_info_t>> rpc_responses_extra_info;
 
-  explicit RpcComponentContext(memory_resource::unsynchronized_pool_resource &memory_resource);
+  explicit RpcComponentContext(memory_resource::unsynchronized_pool_resource &memory_resource) noexcept
+    : current_query()
+    , response_waiters_forks(unordered_map<int64_t, int64_t>::allocator_type{memory_resource})
+    , response_fetcher_instances(unordered_map<int64_t, class_instance<RpcTlQuery>>::allocator_type{memory_resource})
+    , rpc_responses_extra_info(
+        unordered_map<int64_t, std::pair<rpc_response_extra_info_status_t, rpc_response_extra_info_t>>::allocator_type{memory_resource}) {}
 
   static RpcComponentContext &get() noexcept;
 };

--- a/runtime-light/stdlib/rpc/rpc-context.h
+++ b/runtime-light/stdlib/rpc/rpc-context.h
@@ -22,13 +22,13 @@ struct RpcComponentContext final : private vk::not_copyable {
   tl::TLBuffer rpc_buffer;
   int64_t current_query_id{0};
   CurrentTlQuery current_query;
-  unordered_map<int64_t, int64_t> response_waiters_forks;
+  unordered_map<int64_t, int64_t> response_waiter_forks;
   unordered_map<int64_t, class_instance<RpcTlQuery>> response_fetcher_instances;
   unordered_map<int64_t, std::pair<rpc_response_extra_info_status_t, rpc_response_extra_info_t>> rpc_responses_extra_info;
 
   explicit RpcComponentContext(memory_resource::unsynchronized_pool_resource &memory_resource) noexcept
     : current_query()
-    , response_waiters_forks(unordered_map<int64_t, int64_t>::allocator_type{memory_resource})
+    , response_waiter_forks(unordered_map<int64_t, int64_t>::allocator_type{memory_resource})
     , response_fetcher_instances(unordered_map<int64_t, class_instance<RpcTlQuery>>::allocator_type{memory_resource})
     , rpc_responses_extra_info(
         unordered_map<int64_t, std::pair<rpc_response_extra_info_status_t, rpc_response_extra_info_t>>::allocator_type{memory_resource}) {}

--- a/runtime-light/stdlib/timer/timer.h
+++ b/runtime-light/stdlib/timer/timer.h
@@ -25,5 +25,6 @@ task_t<void> f$set_timer(int64_t timeout_ms, T &&on_timer_callback) noexcept {
     co_return 0;
   }}; // TODO: someone should pop that fork from ForkComponentContext since it will stay there unless we perform f$wait on fork
   const auto duration_ms{std::chrono::milliseconds{static_cast<uint64_t>(timeout_ms)}};
-  co_await start_fork_and_reschedule_t(fork_f(std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::forward<T>(on_timer_callback)));
+  co_await start_fork_t{fork_f(std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::forward<T>(on_timer_callback)),
+                        start_fork_t::execution::fork};
 }

--- a/runtime-light/streams/interface.cpp
+++ b/runtime-light/streams/interface.cpp
@@ -46,9 +46,9 @@ task_t<string> f$component_client_get_result(class_instance<C$ComponentQuery> qu
   const auto [buffer, size]{co_await read_all_from_stream(stream_d)};
   string result{buffer, static_cast<string::size_type>(size)};
   get_platform_context()->allocator.free(buffer);
+  php_debug("read %d bytes from stream %" PRIu64, size, stream_d);
   get_component_context()->release_stream(stream_d);
   query.get()->stream_d = INVALID_PLATFORM_DESCRIPTOR;
-  php_debug("read %d bytes from stream %" PRIu64, size, stream_d);
   co_return result;
 }
 

--- a/runtime-light/streams/interface.h
+++ b/runtime-light/streams/interface.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 
+#include "runtime-core/runtime-core.h"
 #include "runtime-light/coroutine/task.h"
 #include "runtime-light/streams/component-stream.h"
 


### PR DESCRIPTION
Now RPC in K2 runtime uses forks for:

1. waiting for RPC response;
2. updating RPC response extra info.

Also, this PR adds:

1. execution policy to `start_fork_t` which makes it possible to choose whether we want to run fork immediately or not;
2. cancellable awaitables.