### PR TITLE
Fix runtime core flags

### DIFF
--- a/runtime-core/runtime-core.cmake
+++ b/runtime-core/runtime-core.cmake
@@ -29,4 +29,7 @@ endif()
 
 prepend(KPHP_CORE_SRC ${RUNTIME_CORE_DIR}/ "${KPHP_CORE_SRC}")
 vk_add_library(runtime-core OBJECT ${KPHP_CORE_SRC})
-target_compile_options(runtime-core PUBLIC -fPIC)
+
+if (COMPILE_RUNTIME_LIGHT)
+    target_compile_options(runtime-core PUBLIC -fPIC)
+endif()


### PR DESCRIPTION
Use `-fPIC` only with light runtime