### PR TITLE
Add "str_getcsv" builtin support

### DIFF
--- a/builtin-functions/kphp-full/_functions.txt
+++ b/builtin-functions/kphp-full/_functions.txt
@@ -739,6 +739,8 @@ function rtrim ($s ::: string, $what ::: string = " \n\r\t\v\0") ::: string;
 function xor_strings ($s ::: string, $t ::: string) ::: string;
 function similar_text ($first ::: string, $second ::: string, float &$percent = TODO) ::: int;
 
+function str_getcsv($str ::: string, string $delimiter = ",", string $enclosure = "\"", string $escape = "\\") ::: mixed[] | false;
+
 function extension_loaded(string $extension): bool;
 
 function ctype_alnum(mixed $text): bool;

--- a/runtime/streams.h
+++ b/runtime/streams.h
@@ -15,6 +15,7 @@ constexpr int64_t STREAM_SET_READ_BUFFER_OPTION = 2;
 
 constexpr int64_t FILE_APPEND = 1;
 
+constexpr int PHP_CSV_NO_ESCAPE = EOF;
 
 struct stream_functions {
   string name;
@@ -88,6 +89,8 @@ Optional<int64_t> f$vfprintf(const Stream &stream, const string &format, const a
 
 Optional<int64_t> f$fputcsv(const Stream &stream, const array<mixed> &fields, string delimiter = string(",", 1),
                             string enclosure = string("\"", 1), string escape_char = string("\\", 1));
+
+Optional<array<mixed>> getcsv(const Stream &stream, string buffer, char delimiter, char enclosure, char escape);
 
 Optional<array<mixed>> f$fgetcsv(const Stream &stream, int64_t length = 0, string delimiter = string(",", 1),
                               string enclosure = string("\"", 1), string escape_char = string("\\", 1));

--- a/runtime/string_functions.cpp
+++ b/runtime/string_functions.cpp
@@ -14,6 +14,9 @@
 #include "runtime/context/runtime-context.h"
 #include "runtime/interface.h"
 
+// For "f$str_getcsv" support
+#include "runtime/streams.h"
+
 const string COLON(",", 1);
 const string CP1251("cp1251");
 const string DOT(".", 1);
@@ -2949,4 +2952,30 @@ string str_concat(str_concat_arg s1, str_concat_arg s2, str_concat_arg s3, str_c
 string str_concat(str_concat_arg s1, str_concat_arg s2, str_concat_arg s3, str_concat_arg s4, str_concat_arg s5) {
   auto new_size = s1.size + s2.size + s3.size + s4.size + s5.size;
   return string(new_size, true).append_unsafe(s1.as_tmp_string()).append_unsafe(s2.as_tmp_string()).append_unsafe(s3.as_tmp_string()).append_unsafe(s4.as_tmp_string()).append_unsafe(s5.as_tmp_string()).finish_append();
+}
+
+// Based on `getcsv` from `streams`
+Optional<array<mixed>> f$str_getcsv(const string &str, const string &delimiter, const string &enclosure, const string &escape) {
+  /*
+   * By PHP Manual: delimiter, enclosure, escape -- one single-byte character only
+   * We make it a warning
+   * Since PHP 8.3.11 it should return false
+   */
+  if (delimiter.size() != 1) {
+    php_warning("Delimiter must be a single character");
+  }
+  char delimiter_char = delimiter[0];
+
+  if (enclosure.size() != 1) {
+    php_warning("Enclosure must be a single character");
+  }
+  char enclosure_char = enclosure[0];
+
+  if (escape.size() != 1) {
+    php_warning("Escape must be a single character");
+  }
+  // Empty string interprets as an indicator to disable escape mechanism
+  char escape_char = (escape.empty()) ? PHP_CSV_NO_ESCAPE : escape[0];
+
+  return getcsv(mixed() /* null */, str, delimiter_char, enclosure_char, escape_char);
 }

--- a/runtime/string_functions.h
+++ b/runtime/string_functions.h
@@ -263,6 +263,9 @@ string f$vsprintf(const string &format, const array<mixed> &args);
 
 string f$wordwrap(const string &str, int64_t width = 75, const string &brk = NEW_LINE, bool cut = false);
 
+Optional<array<mixed>> f$str_getcsv(const string &s, const string &delimiter = string(1, ','),
+                                    const string &enclosure = string(1, '\"'), const string &escape = string(1, '\\'));
+
 /*
  *
  *     IMPLEMENTATION

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -659,6 +659,8 @@ ext/standard/tests/strings/vsprintf_basic8.phpt
 ext/standard/tests/strings/vsprintf_basic9.phpt
 ext/standard/tests/strings/wordwrap_basic.phpt
 ext/standard/tests/strings/wordwrap_variation5.phpt
+ext/standard/tests/strings/str_getcsv_001.phpt
+ext/standard/tests/strings/str_getcsv_002.phpt
 ext/standard/tests/url/base64_decode_basic_001.phpt
 ext/standard/tests/url/base64_decode_basic_002.phpt
 ext/standard/tests/url/base64_encode_basic_001.phpt


### PR DESCRIPTION
Add compatible with PHP 7.4.0 support of [`str_getcsv`](https://www.php.net/manual/en/function.str-getcsv.php) builtin.
 
Related issues: KPHP-1856