### PR TITLE
add `str_getcsv` builtin support

### DIFF
--- a/builtin-functions/kphp-full/_functions.txt
+++ b/builtin-functions/kphp-full/_functions.txt
@@ -739,6 +739,8 @@ function rtrim ($s ::: string, $what ::: string = " \n\r\t\v\0") ::: string;
 function xor_strings ($s ::: string, $t ::: string) ::: string;
 function similar_text ($first ::: string, $second ::: string, float &$percent = TODO) ::: int;
 
+function str_getcsv($str ::: string, string $delimiter ::: string = ",", string $enclosure ::: string = "\"", string $escape ::: string = "\\") ::: mixed[] | false;
+
 function extension_loaded(string $extension): bool;
 
 function ctype_alnum(mixed $text): bool;

--- a/runtime/streams.h
+++ b/runtime/streams.h
@@ -15,6 +15,7 @@ constexpr int64_t STREAM_SET_READ_BUFFER_OPTION = 2;
 
 constexpr int64_t FILE_APPEND = 1;
 
+constexpr int PHP_CSV_NO_ESCAPE = EOF;
 
 struct stream_functions {
   string name;
@@ -88,6 +89,8 @@ Optional<int64_t> f$vfprintf(const Stream &stream, const string &format, const a
 
 Optional<int64_t> f$fputcsv(const Stream &stream, const array<mixed> &fields, string delimiter = string(",", 1),
                             string enclosure = string("\"", 1), string escape_char = string("\\", 1));
+
+Optional<array<mixed>> getcsv(const Stream &stream, string buffer, char delimiter, char enclosure, char escape);
 
 Optional<array<mixed>> f$fgetcsv(const Stream &stream, int64_t length = 0, string delimiter = string(",", 1),
                               string enclosure = string("\"", 1), string escape_char = string("\\", 1));

--- a/runtime/string_functions.h
+++ b/runtime/string_functions.h
@@ -263,6 +263,9 @@ string f$vsprintf(const string &format, const array<mixed> &args);
 
 string f$wordwrap(const string &str, int64_t width = 75, const string &brk = NEW_LINE, bool cut = false);
 
+Optional<array<mixed>> f$str_getcsv(const string &s, const string &delimiter = string(1, ','),
+                                    const string &enclosure = string(1, '\"'), const string &escape = string(1, '\\'));
+
 /*
  *
  *     IMPLEMENTATION

--- a/tests/phpt/string_functions/011_str_getcsv.php
+++ b/tests/phpt/string_functions/011_str_getcsv.php
@@ -1,0 +1,27 @@
+@ok
+<?php
+
+$s1 = <<<_STR
+"a","b","c"
+_STR;
+
+$s2 = <<<_STR
+*a*,*b*,*\*c*
+_STR;
+
+
+// In php empty delimiter and enclosure args leads to the same behavior as omitted args
+var_dump(str_getcsv($s1));
+var_dump(str_getcsv($s1, ""));
+
+var_dump(str_getcsv($s1, ","));
+var_dump(str_getcsv($s1, ",", ""));
+
+// But empty escape symbol has same semantics as one backslash ("\")
+// 1 <=> 2
+// not 1 <=> 3
+var_dump(str_getcsv($s2, ",", "*"));        // 1
+var_dump(str_getcsv($s2, ",", "*", "\\"));  // 2
+var_dump(str_getcsv($s2, ",", "*", ""));    // 3
+
+

--- a/tests/zend-test-list
+++ b/tests/zend-test-list
@@ -659,6 +659,9 @@ ext/standard/tests/strings/vsprintf_basic8.phpt
 ext/standard/tests/strings/vsprintf_basic9.phpt
 ext/standard/tests/strings/wordwrap_basic.phpt
 ext/standard/tests/strings/wordwrap_variation5.phpt
+ext/standard/tests/strings/str_getcsv_001.phpt
+ext/standard/tests/strings/str_getcsv_002.phpt
+ext/standard/tests/strings/bug55674.phpt
 ext/standard/tests/url/base64_decode_basic_001.phpt
 ext/standard/tests/url/base64_decode_basic_002.phpt
 ext/standard/tests/url/base64_encode_basic_001.phpt


### PR DESCRIPTION
Add compatible with PHP 7.4.0 support of [`str_getcsv`](https://www.php.net/manual/en/function.str-getcsv.php) builtin.
 
Related issues: `KPHP-1856`