### PR TITLE
Add support for JSON serialized confdata values

### DIFF
--- a/runtime/memcache.cpp
+++ b/runtime/memcache.cpp
@@ -164,8 +164,8 @@ mixed mc_get_value(const char *result_str, int32_t result_str_len, int64_t flags
   if (flags & MEMCACHE_SERIALIZED) {
     flags ^= MEMCACHE_SERIALIZED;
     result = unserialize_raw(result_str, result_str_len);
-  } else if (flags & MEMCACHE_JSON_SERIALZIED) {
-    flags ^= MEMCACHE_JSON_SERIALZIED;
+  } else if (flags & MEMCACHE_JSON_SERIALIZED) {
+    flags ^= MEMCACHE_JSON_SERIALIZED;
     result = json_decode({result_str, static_cast<string::size_type>(result_str_len)}).first;
   } else {
     result = string(result_str, result_str_len);

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -23,7 +23,7 @@ bool mc_is_immediate_query(const string &key);
 
 constexpr inline auto MEMCACHE_SERIALIZED = static_cast<int64_t>(1U << 0U);
 constexpr inline auto MEMCACHE_COMPRESSED = static_cast<int64_t>(1U << 1U);
-constexpr inline auto MEMCACHE_JSON_SERIALZIED = static_cast<int64_t>(1U << 3U);
+constexpr inline auto MEMCACHE_JSON_SERIALZIED = static_cast<int64_t>(1U << 4U);
 
 struct C$Memcache : public abstract_refcountable_php_interface {
 public:

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -23,7 +23,7 @@ bool mc_is_immediate_query(const string &key);
 
 inline constexpr int64_t MEMCACHE_SERIALIZED = 1U << 0U;
 inline constexpr int64_t MEMCACHE_COMPRESSED = 1U << 1U;
-inline constexpr int64_t MEMCACHE_JSON_SERIALZIED = 1U << 4U;
+inline constexpr int64_t MEMCACHE_JSON_SERIALIZED = 1U << 4U;
 
 struct C$Memcache : public abstract_refcountable_php_interface {
 public:

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -21,9 +21,9 @@ mixed mc_get_value(const char *result_str, int32_t result_str_len, int64_t flags
 
 bool mc_is_immediate_query(const string &key);
 
-constexpr inline auto MEMCACHE_SERIALIZED = static_cast<int64_t>(1U << 0U);
-constexpr inline auto MEMCACHE_COMPRESSED = static_cast<int64_t>(1U << 1U);
-constexpr inline auto MEMCACHE_JSON_SERIALZIED = static_cast<int64_t>(1U << 4U);
+constexpr inline int64_t MEMCACHE_SERIALIZED = 1U << 0U;
+constexpr inline int64_t MEMCACHE_COMPRESSED = 1U << 1U;
+constexpr inline int64_t MEMCACHE_JSON_SERIALZIED = 1U << 4U;
 
 struct C$Memcache : public abstract_refcountable_php_interface {
 public:

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -21,9 +21,9 @@ mixed mc_get_value(const char *result_str, int32_t result_str_len, int64_t flags
 
 bool mc_is_immediate_query(const string &key);
 
-constexpr inline int64_t MEMCACHE_SERIALIZED = 1U << 0U;
-constexpr inline int64_t MEMCACHE_COMPRESSED = 1U << 1U;
-constexpr inline int64_t MEMCACHE_JSON_SERIALZIED = 1U << 4U;
+inline constexpr int64_t MEMCACHE_SERIALIZED = 1U << 0U;
+inline constexpr int64_t MEMCACHE_COMPRESSED = 1U << 1U;
+inline constexpr int64_t MEMCACHE_JSON_SERIALZIED = 1U << 4U;
 
 struct C$Memcache : public abstract_refcountable_php_interface {
 public:

--- a/runtime/memcache.h
+++ b/runtime/memcache.h
@@ -4,17 +4,13 @@
 
 #pragma once
 
-#include <utility>
+#include <cstdint>
 
 #include "common/algorithms/hashes.h"
 #include "common/wrappers/string_view.h"
 #include "runtime-core/runtime-core.h"
 #include "runtime/dummy-visitor-methods.h"
-#include "runtime/exception.h"
 #include "runtime/memory_usage.h"
-#include "runtime/net_events.h"
-#include "runtime/resumable.h"
-#include "runtime/rpc.h"
 
 void init_memcache_lib();
 void free_memcache_lib();
@@ -25,9 +21,9 @@ mixed mc_get_value(const char *result_str, int32_t result_str_len, int64_t flags
 
 bool mc_is_immediate_query(const string &key);
 
-
-constexpr int64_t MEMCACHE_SERIALIZED = 1;
-constexpr int64_t MEMCACHE_COMPRESSED = 2;
+constexpr inline auto MEMCACHE_SERIALIZED = static_cast<int64_t>(1U << 0U);
+constexpr inline auto MEMCACHE_COMPRESSED = static_cast<int64_t>(1U << 1U);
+constexpr inline auto MEMCACHE_JSON_SERIALZIED = static_cast<int64_t>(1U << 3U);
 
 struct C$Memcache : public abstract_refcountable_php_interface {
 public:


### PR DESCRIPTION
This PR adds new `MEMCACHE_JSON_SERIALIZED` flag that means that a value we got from MC is serialized in JSON format, so we need to deserialize it accordingly.