### PR TITLE
Enhance K2 TL

### DIFF
--- a/runtime-core/memory-resource/resource_allocator.h
+++ b/runtime-core/memory-resource/resource_allocator.h
@@ -9,9 +9,9 @@
 #include <queue>
 #include <unordered_map>
 #include <unordered_set>
+#include <vector>
 
 #include "common/wrappers/likely.h"
-
 #include "runtime-core/utils/kphp-assert-core.h"
 
 namespace memory_resource {
@@ -79,6 +79,9 @@ using deque = std::deque<T, resource_allocator<T, Resource>>;
 
 template<class T, class Resource>
 using queue = std::queue<T, std::deque<T, resource_allocator<T, Resource>>>;
+
+template<class T, class Resource>
+using vector = std::vector<T, resource_allocator<T, Resource>>;
 } // namespace stl
 
 } // namespace memory_resource

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-const string CRYPTO_COMPONENT = string("crypto");
+constexpr const char *CRYPTO_COMPONENT_NAME = "crypto";
 
 } // namespace
 
@@ -31,7 +31,7 @@ task_t<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length) noexcept 
   string request_buf;
   request_buf.append(buffer.data(), buffer.size());
 
-  auto query = f$component_client_send_request(CRYPTO_COMPONENT, string{buffer.data(), static_cast<string::size_type>(buffer.size())});
+  auto query = f$component_client_send_request(string{CRYPTO_COMPONENT_NAME}, string{buffer.data(), static_cast<string::size_type>(buffer.size())});
   string resp = co_await f$component_client_fetch_response(co_await query);
 
   buffer.clean();
@@ -55,7 +55,7 @@ task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool sho
   string request_buf;
   request_buf.append(buffer.data(), buffer.size());
 
-  auto query = f$component_client_send_request(CRYPTO_COMPONENT, request_buf);
+  auto query = f$component_client_send_request(string{CRYPTO_COMPONENT_NAME}, request_buf);
   string resp_from_platform = co_await f$component_client_fetch_response(co_await query);
 
   buffer.clean();
@@ -75,7 +75,7 @@ task_t<bool> f$openssl_sign(const string &data, string &signature, const string 
   tl::TLBuffer buffer;
   request.store(buffer);
 
-  auto query = f$component_client_send_request(CRYPTO_COMPONENT, string(buffer.data(), buffer.size()));
+  auto query = f$component_client_send_request(string{CRYPTO_COMPONENT_NAME}, string(buffer.data(), buffer.size()));
   string resp_from_platform = co_await f$component_client_fetch_response(co_await query);
 
   buffer.clean();
@@ -98,7 +98,7 @@ task_t<int64_t> f$openssl_verify(const string &data, const string &signature, co
   tl::TLBuffer buffer;
   request.store(buffer);
 
-  auto query = f$component_client_send_request(CRYPTO_COMPONENT, string(buffer.data(), buffer.size()));
+  auto query = f$component_client_send_request(string{CRYPTO_COMPONENT_NAME}, string(buffer.data(), buffer.size()));
   string resp_from_platform = co_await f$component_client_fetch_response(co_await query);
 
   buffer.clean();

--- a/runtime-light/tl/tl-core.cpp
+++ b/runtime-light/tl/tl-core.cpp
@@ -5,6 +5,7 @@
 #include "runtime-light/tl/tl-core.h"
 
 namespace tl {
+
 void TLBuffer::store_string(std::string_view str) noexcept {
   const char *str_buf{str.data()};
   size_t str_len{str.size()};
@@ -94,4 +95,5 @@ std::string_view TLBuffer::fetch_string() noexcept {
   adjust(total_len_with_padding - size_len);
   return response;
 }
+
 } // namespace tl

--- a/runtime-light/tl/tl-core.h
+++ b/runtime-light/tl/tl-core.h
@@ -101,6 +101,10 @@ public:
 template<typename T>
 concept tl_serializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
   { t.store(tlb) } noexcept -> std::same_as<void>;
+};
+
+template<typename T>
+concept tl_deserializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
   { t.fetch(tlb) } noexcept -> std::convertible_to<bool>;
 };
 

--- a/runtime-light/tl/tl-functions.h
+++ b/runtime-light/tl/tl-functions.h
@@ -36,7 +36,6 @@ inline constexpr uint32_t GET_PEM_CERT_INFO_MAGIC = 0xa50c'fd6c;
 inline constexpr uint32_t DIGEST_SIGN_MAGIC = 0xd345'f658;
 inline constexpr uint32_t DIGEST_VERIFY_MAGIC = 0x5760'bd0e;
 
-
 struct GetCryptosecurePseudorandomBytes final {
   int32_t size{};
 
@@ -63,6 +62,23 @@ struct DigestVerify final {
   string public_key;
   DigestAlgorithm algorithm;
   string signature;
+
+  void store(TLBuffer &tlb) const noexcept;
+};
+
+// ===== CONFDATA =====
+
+inline constexpr uint32_t CONFDATA_GET_MAGIC = 0xf0eb'cd89;
+inline constexpr uint32_t CONFDATA_GET_WILDCARD_MAGIC = 0x5759'bd9e;
+
+struct ConfdataGet final {
+  string key;
+
+  void store(TLBuffer &tlb) const noexcept;
+};
+
+struct ConfdataGetWildcard final {
+  string wildcard;
 
   void store(TLBuffer &tlb) const noexcept;
 };

--- a/runtime-light/tl/tl-types.cpp
+++ b/runtime-light/tl/tl-types.cpp
@@ -149,11 +149,4 @@ bool ConfdataValue::fetch(TLBuffer &tlb) noexcept {
   return true;
 }
 
-void ConfdataValue::store(TLBuffer &tlb) const noexcept {
-  tlb.store_trivial<uint32_t>(CONFDATA_VALUE_MAGIC);
-  tlb.store_string({value.c_str(), static_cast<size_t>(value.size())});
-  Bool{.value = is_php_serialized}.store(tlb);
-  Bool{.value = is_json_serialized}.store(tlb);
-}
-
 } // namespace tl

--- a/runtime-light/tl/tl-types.cpp
+++ b/runtime-light/tl/tl-types.cpp
@@ -4,6 +4,7 @@
 
 #include "runtime-light/tl/tl-types.h"
 
+#include <cstddef>
 #include <cstdint>
 #include <string_view>
 #include <tuple>
@@ -13,27 +14,28 @@
 
 namespace {
 
-// magic + flags + job_id + minimum string size length
-constexpr auto K2_JOB_WORKER_RESPONSE_MIN_SIZE = sizeof(uint32_t) + sizeof(uint32_t) + sizeof(int64_t) + tl::SMALL_STRING_SIZE_LEN;
+enum CertInfoItem : uint32_t { LONG_MAGIC = 0x533f'f89f, STR_MAGIC = 0xc427'feef, DICT_MAGIC = 0x1ea8'a774 };
 
-enum CertInfoItem : uint32_t {
-  LONG_MAGIC = 0x533f'f89f,
-  STR_MAGIC = 0xc427'feef,
-  DICT_MAGIC = 0x1ea8'a774
-};
+constexpr uint32_t K2_JOB_WORKER_RESPONSE_MAGIC = 0x3afb'3a08;
+constexpr uint32_t CONFDATA_VALUE_MAGIC = 0x3eaa'910b;
 
 } // namespace
 
 namespace tl {
 
 bool K2JobWorkerResponse::fetch(TLBuffer &tlb) noexcept {
-  if (tlb.size() < K2_JOB_WORKER_RESPONSE_MIN_SIZE || *tlb.fetch_trivial<uint32_t>() != K2_JOB_WORKER_RESPONSE_MAGIC) {
+  if (tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) != K2_JOB_WORKER_RESPONSE_MAGIC) {
     return false;
   }
 
   std::ignore = tlb.fetch_trivial<uint32_t>(); // ignore flags
-  job_id = *tlb.fetch_trivial<int64_t>();
-  const std::string_view body_view{tlb.fetch_string()};
+  const auto opt_job_id{tlb.fetch_trivial<int64_t>()};
+  if (!opt_job_id.has_value()) {
+    return false;
+  }
+  const auto body_view{tlb.fetch_string()};
+
+  job_id = *opt_job_id;
   body = string{body_view.data(), static_cast<string::size_type>(body_view.size())};
   return true;
 }
@@ -128,6 +130,30 @@ bool GetPemCertInfoResponse::fetch(TLBuffer &tlb) noexcept {
 
   data = std::move(response);
   return true;
+}
+
+bool ConfdataValue::fetch(TLBuffer &tlb) noexcept {
+  if (tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) != CONFDATA_VALUE_MAGIC) {
+    return false;
+  }
+  const auto value_view{tlb.fetch_string()};
+  Bool is_php_serialized_{};
+  Bool is_json_serialized_{};
+  if (!(is_php_serialized_.fetch(tlb) && is_json_serialized_.fetch(tlb))) {
+    return false;
+  }
+
+  value = {value_view.data(), static_cast<string::size_type>(value_view.size())};
+  is_php_serialized = is_php_serialized_.value;
+  is_json_serialized = is_json_serialized_.value;
+  return true;
+}
+
+void ConfdataValue::store(TLBuffer &tlb) const noexcept {
+  tlb.store_trivial<uint32_t>(CONFDATA_VALUE_MAGIC);
+  tlb.store_string({value.c_str(), static_cast<size_t>(value.size())});
+  Bool{.value = is_php_serialized}.store(tlb);
+  Bool{.value = is_json_serialized}.store(tlb);
 }
 
 } // namespace tl

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -276,8 +276,6 @@ struct ConfdataValue final {
   bool is_json_serialized{};
 
   bool fetch(TLBuffer &tlb) noexcept;
-
-  void store(TLBuffer &tlb) const noexcept;
 };
 
 } // namespace tl

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -4,16 +4,237 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstddef>
 #include <cstdint>
+#include <optional>
 
+#include "common/tl/constants/common.h"
+#include "runtime-core/allocator/runtime-allocator.h"
+#include "runtime-core/memory-resource/resource_allocator.h"
+#include "runtime-core/memory-resource/unsynchronized_pool_resource.h"
 #include "runtime-core/runtime-core.h"
 #include "runtime-light/tl/tl-core.h"
 
 namespace tl {
 
-// ===== JOB WORKERS =====
+// ===== GENERAL =====
 
-inline constexpr uint32_t K2_JOB_WORKER_RESPONSE_MAGIC = 0x3afb'3a08;
+struct Bool final {
+  bool value{};
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    const auto magic{tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO)};
+    value = magic == TL_BOOL_TRUE;
+    return magic == TL_BOOL_TRUE || magic == TL_BOOL_FALSE;
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(value ? TL_BOOL_TRUE : TL_BOOL_FALSE);
+  }
+};
+
+template<tl_serializable T>
+struct Maybe final {
+  std::optional<T> opt_value{};
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    const auto magic{tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO)};
+    if (magic == TL_MAYBE_TRUE) {
+      opt_value.emplace();
+      return (*opt_value).fetch(tlb);
+    } else if (magic == TL_MAYBE_FALSE) {
+      opt_value = std::nullopt;
+      return true;
+    }
+    return false;
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    if (opt_value.has_value()) {
+      tlb.store_trivial<uint32_t>(TL_MAYBE_TRUE);
+      (*opt_value).store(tlb);
+    } else {
+      tlb.store_trivial<uint32_t>(TL_MAYBE_FALSE);
+    }
+  }
+};
+
+template<tl_serializable T>
+struct vector final {
+  using vector_t = memory_resource::stl::vector<T, memory_resource::unsynchronized_pool_resource>;
+  vector_t data{typename vector_t::allocator_type(RuntimeAllocator::current().memory_resource)};
+
+  using iterator = vector_t::iterator;
+  using const_iterator = vector_t::const_iterator;
+
+  iterator begin() noexcept {
+    return data.begin();
+  }
+  iterator end() noexcept {
+    return data.end();
+  }
+  const_iterator begin() const noexcept {
+    return data.begin();
+  }
+  const_iterator end() const noexcept {
+    return data.end();
+  }
+  const_iterator cbegin() const noexcept {
+    return data.cbegin();
+  }
+  const_iterator cend() const noexcept {
+    return data.cend();
+  }
+
+  size_t size() const noexcept {
+    return data.size();
+  }
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    int64_t size{};
+    if (const auto opt_size{tlb.fetch_trivial<uint32_t>()}; opt_size.has_value()) {
+      size = *opt_size;
+    } else {
+      return false;
+    }
+
+    data.clear();
+    data.reserve(static_cast<size_t>(size));
+    for (auto i = 0; i < size; ++i) {
+      T t{};
+      if (!t.fetch(tlb)) {
+        return false;
+      }
+      data.emplace_back(std::move(t));
+    }
+
+    return true;
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(static_cast<uint32_t>(data.size()));
+    std::for_each(data.cbegin(), data.cend(), [&tlb](auto &&elem) { std::forward<decltype(elem)>(elem).store(tlb); });
+  }
+};
+
+template<tl_serializable T>
+struct Vector final {
+  vector<T> data{};
+
+  using iterator = vector<T>::iterator;
+  using const_iterator = vector<T>::const_iterator;
+
+  iterator begin() noexcept {
+    return data.begin();
+  }
+  iterator end() noexcept {
+    return data.end();
+  }
+  const_iterator begin() const noexcept {
+    return data.begin();
+  }
+  const_iterator end() const noexcept {
+    return data.end();
+  }
+  const_iterator cbegin() const noexcept {
+    return data.cbegin();
+  }
+  const_iterator cend() const noexcept {
+    return data.cend();
+  }
+
+  size_t size() const noexcept {
+    return data.size();
+  }
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    if (tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) != TL_VECTOR) {
+      return false;
+    }
+    return data.fetch(tlb);
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(TL_VECTOR);
+    data.store(tlb);
+  }
+};
+
+template<tl_serializable T>
+struct dictionaryField final {
+  string key;
+  T value{};
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    const auto key_view{tlb.fetch_string()};
+    key = {key_view.data(), static_cast<string::size_type>(key_view.size())};
+    return !value.fetch(tlb);
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    tlb.store_string({key.c_str(), static_cast<size_t>(key.size())});
+    value.store(tlb);
+  }
+};
+
+template<tl_serializable T>
+struct dictionary final {
+  vector<dictionaryField<T>> data{};
+
+  using iterator = vector<dictionaryField<T>>::iterator;
+  using const_iterator = vector<dictionaryField<T>>::const_iterator;
+
+  iterator begin() noexcept {
+    return data.begin();
+  }
+  iterator end() noexcept {
+    return data.end();
+  }
+  const_iterator begin() const noexcept {
+    return data.begin();
+  }
+  const_iterator end() const noexcept {
+    return data.end();
+  }
+  const_iterator cbegin() const noexcept {
+    return data.cbegin();
+  }
+  const_iterator cend() const noexcept {
+    return data.cend();
+  }
+
+  size_t size() const noexcept {
+    return data.size();
+  }
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    return data.fetch(tlb);
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    data.store(tlb);
+  }
+};
+
+template<tl_serializable T>
+struct Dictionary final {
+  dictionary<T> data{};
+
+  bool fetch(TLBuffer &tlb) noexcept {
+    if (tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) != TL_DICTIONARY) {
+      return false;
+    }
+    return data.fetch(tlb);
+  }
+
+  void store(TLBuffer &tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(TL_DICTIONARY);
+    data.store(tlb);
+  }
+};
+
+// ===== JOB WORKERS =====
 
 struct K2JobWorkerResponse final {
   int64_t job_id{};
@@ -28,7 +249,7 @@ struct K2JobWorkerResponse final {
 
 // Actually it's "Maybe (Dictionary CertInfoItem)"
 // But I now want to have this logic separately
-struct GetPemCertInfoResponse {
+struct GetPemCertInfoResponse final {
   array<mixed> data;
 
   bool fetch(TLBuffer &tlb) noexcept;
@@ -45,6 +266,18 @@ enum DigestAlgorithm : uint32_t {
   MD5 = 0x257d'df13,
   MD4 = 0x317f'e3d1,
   MD2 = 0x5aca'6998,
+};
+
+// ===== CONFDATA =====
+
+struct ConfdataValue final {
+  string value;
+  bool is_php_serialized{};
+  bool is_json_serialized{};
+
+  bool fetch(TLBuffer &tlb) noexcept;
+
+  void store(TLBuffer &tlb) const noexcept;
 };
 
 } // namespace tl


### PR DESCRIPTION
This PR adds following changes:

1. enhances TL primitives for K2 job workers;
2. adds support for some general TL types, e.g., vector, dictionary, etc;
3. adds TL primitives for K2 confdata.