### PR TITLE
add `kphp_request_script_time_max_running_interval` mertric collecting

### DIFF
--- a/server/php-runner.h
+++ b/server/php-runner.h
@@ -88,6 +88,7 @@ class PhpScript {
   double net_time{0};
   double script_time{0};
   double last_net_time_delta{0};
+  double script_max_running_interval{0};
   int queries_cnt{0};
   int long_queries_cnt{0};
 

--- a/server/server-stats.cpp
+++ b/server/server-stats.cpp
@@ -638,11 +638,12 @@ void ServerStats::after_fork(pid_t worker_pid, uint64_t active_connections, uint
   last_update_aggr_stats = std::chrono::steady_clock::now();
 }
 
-void ServerStats::add_request_stats(double script_time_sec, double net_time_sec, double script_init_time_sec, double connection_process_time_sec,
+void ServerStats::add_request_stats(double script_time_sec, double net_time_sec, double script_max_running_interval_sec, double script_init_time_sec, double connection_process_time_sec,
                                     int64_t script_queries, int64_t long_script_queries, const memory_resource::MemoryStats &script_memory_stats, int64_t curl_total_allocated, process_rusage_t script_rusage, script_error_t error) noexcept {
   auto &stats = worker_type_ == WorkerType::job_worker ? shared_stats_->job_workers : shared_stats_->general_workers;
   const auto script_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(script_time_sec));
   const auto net_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(net_time_sec));
+  const auto script_max_running_interval = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(script_max_running_interval_sec));
   const auto script_init_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(script_init_time_sec));
   const auto http_connection_process_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(connection_process_time_sec));
   const auto script_user_time = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(script_rusage.user_time));
@@ -656,7 +657,7 @@ void ServerStats::add_request_stats(double script_time_sec, double net_time_sec,
   stats.add_request_stats(queries_stat, error, script_memory_stats, curl_total_allocated);
   shared_stats_->workers.add_worker_stats(queries_stat, worker_process_id_);
 
-  StatsHouseManager::get().add_request_stats(script_time.count(), net_time.count(), error, script_memory_stats, script_queries, long_script_queries,
+  StatsHouseManager::get().add_request_stats(script_time.count(), net_time.count(), script_max_running_interval.count(), error, script_memory_stats, script_queries, long_script_queries,
                                              script_user_time.count(), script_system_time.count(),
                                              script_init_time.count(), http_connection_process_time.count(),
                                              script_rusage.voluntary_context_switches, script_rusage.involuntary_context_switches);

--- a/server/server-stats.h
+++ b/server/server-stats.h
@@ -20,7 +20,7 @@ class ServerStats : vk::not_copyable {
 public:
   void init() noexcept;
 
-  void add_request_stats(double script_time_sec, double net_time_sec, double script_init_time_sec, double connection_process_time_sec,
+  void add_request_stats(double script_time_sec, double net_time_sec, double script_max_running_interval_sec, double script_init_time_sec, double connection_process_time_sec,
                          int64_t script_queries, int64_t long_script_queries,
                          const memory_resource::MemoryStats &script_memory_stats, int64_t curl_total_allocated,
                          process_rusage_t script_rusage, script_error_t error) noexcept;

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -100,7 +100,7 @@ void StatsHouseManager::generic_cron_check_if_tag_host_needed() {
   }
 }
 
-void StatsHouseManager::add_request_stats(uint64_t script_time_ns, uint64_t net_time_ns, script_error_t error,
+void StatsHouseManager::add_request_stats(uint64_t script_time_ns, uint64_t net_time_ns, uint64_t script_max_running_interval_ns,  script_error_t error,
                                           const memory_resource::MemoryStats &script_memory_stats, uint64_t script_queries, uint64_t long_script_queries,
                                           uint64_t script_user_time_ns, uint64_t script_system_time_ns,
                                           uint64_t script_init_time, uint64_t http_connection_process_time,
@@ -110,6 +110,7 @@ void StatsHouseManager::add_request_stats(uint64_t script_time_ns, uint64_t net_
 
   client.metric("kphp_request_time").tag("script").tag(worker_type).tag(status).write_value(script_time_ns);
   client.metric("kphp_request_time").tag("net").tag(worker_type).tag(status).write_value(net_time_ns);
+  client.metric("kphp_request_script_time_max_running_interval").tag(worker_type).tag(status).write_value(script_max_running_interval_ns);
   client.metric("kphp_request_cpu_time").tag("user").tag(worker_type).tag(status).write_value(script_user_time_ns);
   client.metric("kphp_request_cpu_time").tag("system").tag(worker_type).tag(status).write_value(script_system_time_ns);
   client.metric("kphp_request_init_time").tag(worker_type).tag(status).write_value(script_init_time);

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -55,7 +55,7 @@ public:
     return this->instance_cache_key_normalization_function != nullptr;
   }
 
-  void add_request_stats(uint64_t script_time_ns, uint64_t net_time_ns, script_error_t error, const memory_resource::MemoryStats &script_memory_stats,
+  void add_request_stats(uint64_t script_time_ns, uint64_t net_time_ns, uint64_t script_max_running_interval_ns, script_error_t error, const memory_resource::MemoryStats &script_memory_stats,
                          uint64_t script_queries, uint64_t long_script_queries,
                          uint64_t script_user_time_ns, uint64_t script_system_time_ns,
                          uint64_t script_init_time, uint64_t http_connection_process_time,


### PR DESCRIPTION
New metric represents a duration of maximum running interval when worker in script context 

Related issues: KPHP-1939