### PR TITLE
Fix usage of resumable function with ArrayAccess methods

### DIFF
--- a/compiler/pipes/calc-bad-vars.cpp
+++ b/compiler/pipes/calc-bad-vars.cpp
@@ -585,6 +585,13 @@ class CalcBadVars {
     }
     for (const auto &func : call_graph.functions) {
       func->can_be_implicitly_interrupted_by_other_resumable = into_resumable[func];
+      if (unlikely(func->class_id && func->class_id->is_required_interface && into_resumable[func])) {
+        std::string func_name = func->name;
+        std::replace(func_name.begin(), func_name.end(), '$', ':');
+        std::vector<std::string> chain;
+        kphp_error(false, fmt_format("{} cannot call resumable inside({})", func_name, to_parents[func]->as_human_readable()).c_str());
+      }
+
       if (from_resumable[func] && into_resumable[func]) {
         func->is_resumable = true;
         func->fork_prev = from_parents[func];

--- a/tests/phpt/array_access/014_another_method_forked.php
+++ b/tests/phpt/array_access/014_another_method_forked.php
@@ -1,0 +1,34 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+function like_rpc_write() {
+    printf("log\n");
+    sched_yield(); // resumable
+}
+
+class A implements \ArrayAccess {
+    public function offsetSet($offset, $value) {}
+    /** @return bool */
+    public function offsetExists($offset) {return true;}
+    public function offsetUnset($offset) {}
+    /** @return mixed */
+    public function offsetGet($offset) {
+        return null;
+    }
+
+    public function to_be_forked() {
+        printf("in to_be_forked\n");
+        like_rpc_write();
+        return null;
+    }
+}
+
+function test() {
+    $x = new A();
+
+    $fut = fork($x->to_be_forked());
+    wait($fut);
+}
+
+test();

--- a/tests/phpt/array_access/103_calls_resumable.php
+++ b/tests/phpt/array_access/103_calls_resumable.php
@@ -1,0 +1,29 @@
+@kphp_should_fail
+/Function \[ArrayAccess::offsetGet\] is a method of ArrayAccess, it cannot call resumable functions/
+/Function transitively calls the resumable function along the following chain:/
+/ArrayAccess::offsetGet -> A::offsetGet -> like_rpc_write -> sched_yield/
+
+<?php
+
+function like_rpc_write() {
+    printf("log\n");
+    sched_yield(); // resumable
+}
+
+class A implements \ArrayAccess {
+    public function offsetSet($offset, $value) {}
+    /** @return bool */
+    public function offsetExists($offset) {return true;}
+    public function offsetUnset($offset) {}
+    /** @return mixed */
+    public function offsetGet($offset) {
+        like_rpc_write();
+        return null;
+    }
+}
+
+function test() {
+    $x = new A();
+}
+
+test();

--- a/tests/phpt/array_access/104_forked.php
+++ b/tests/phpt/array_access/104_forked.php
@@ -1,0 +1,24 @@
+@kphp_should_fail
+/Function \[ArrayAccess::offsetGet\] is a method of ArrayAccess, it cannot call resumable functions/
+/Function transitively calls the resumable function along the following chain:/
+/ArrayAccess::offsetGet -> A::offsetGet/
+
+<?php
+
+class A implements \ArrayAccess {
+    public function offsetSet($offset, $value) {}
+    /** @return bool */
+    public function offsetExists($offset) {return true;}
+    public function offsetUnset($offset) {}
+    /** @return mixed */
+    public function offsetGet($offset) {return null;}
+}
+
+function test() {
+    $x = new A();
+    $y = fork($x->offsetGet(42));
+
+    wait($y);
+}
+
+test();


### PR DESCRIPTION
Prohibit 2 things:
* Calling transitively resumable function
* Forking ArrayAccess methods

Previously, we had runtime problem in case of heavily using forks inside ArrayAccess methods.