### PR TITLE
prevent false-positive `stack-buffer-overflow` ASan detections on signal stack 

### DIFF
--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -101,6 +101,13 @@ void PhpScript::error(const char *error_message, script_error_t error_type, [[ma
   }
 #endif
 #if ASAN_ENABLED
+  // AddressSanitizer relies on normal function call and return patterns to maintain its internal stack of
+  // function calls, known as the "shadow stack," which helps it detect stack-related issues like "buffer overflows".
+  // Functions that do not return, e.g. using setcontext() functionality, can interfere with this, causing ASan to lose track of the actual state of the call stack.
+  // By calling __asan_handle_no_return(), we explicitly notify ASan that the current stack frame will not return
+  // as expected, allowing it to clean up and adjust its "shadow stack" correctly and avoid false-positive detections.
+  __asan_handle_no_return();
+
   __sanitizer_start_switch_fiber(nullptr, main_thread_stack, main_thread_stacksize);
 #endif
   setcontext_portable(&exit_context);

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -91,11 +91,11 @@ void PhpScript::error(const char *error_message, script_error_t error_type, [[ma
   stack_end = reinterpret_cast<char *>(get_context_stack_ptr_portable(exit_context)) + get_context_stack_size_portable(exit_context);
 
 #if defined(__linux__) && defined(__x86_64__) || defined(__APPLE__) && (__aarch64__)
-  // The PhpScript::error may be produced in process of signal handling. The default behavior on Linux-based platforms
-  // consider to block a signal during handler execution and unblock after handler ending.
-  // For x86_64 arch we have context replacement implementation where the signals manipulations is omitted by design,
-  // e.g. we do not save signals state in context replacement.
-  // Therefore, we need manual control for signal state, especially, we have to unblock blocked signals at logical end of handler.
+  // The PhpScript::error function may be invoked during signal handling. The default behavior on Linux-based platforms
+  // is to block a signal during the execution of its handler and unblock it after the handler completes.
+  // For the x86_64 architecture, we have a context replacement implementation where signal manipulation is omitted by design;
+  // for example, we do not save the signal state during context replacement.
+  // Therefore, we need manual control over the signal state. Specifically, we must unblock any blocked signals at the logical end of the handler.
   if (triggered_by_signal.has_value()) {
     dl_unblock_signal(triggered_by_signal.value());
   }

--- a/tests/python/tests/http_server/test_oom_handler.py
+++ b/tests/python/tests/http_server/test_oom_handler.py
@@ -1,6 +1,5 @@
 import requests.exceptions
 from python.lib.testcase import KphpServerAutoTestCase
-import unittest
 
 
 class TestOomHandler(KphpServerAutoTestCase):

--- a/tests/python/tests/http_server/test_oom_handler.py
+++ b/tests/python/tests/http_server/test_oom_handler.py
@@ -47,12 +47,10 @@ class TestOomHandler(KphpServerAutoTestCase):
         self._generic_test("test_case=script_memory_realloc")
         self.kphp_server.assert_log(["realloc_allocations_cnt=1,realloc_mem_allocated=[1-9]\\d*"], timeout=5)
 
-    @unittest.skip("Temporary disabled until KPHP-1990 will be resolved")
     def test_with_job_request(self):
         self._generic_test("test_case=with_job_request")
         self.kphp_server.assert_log(["job_request_succeeded=1"], timeout=5)
 
-    @unittest.skip("Temporary disabled until KPHP-1990 will be resolved")
     def test_with_instance_cache(self):
         self._generic_test("test_case=with_instance_cache")
         self.kphp_server.assert_log(["instance_cache_store_succeeded=1"], timeout=5)


### PR DESCRIPTION
During the execution of OOM tests with AddressSanitizer enabled, we encountered an error like this:
```
==2123325==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x00000b72af0f at pc 0x000000e831ae bp 0x00000b72ade0 sp 0x00000b72add0
WRITE of size 1 at 0x00000b72af0f thread T0
    #0 0xe831ad in kwrite_print_int /home/p-shumilov/Projects/kphp/common/kprintf.cpp:112
    #1 0xe834f3 in kwrite(int, void const*, int) /home/p-shumilov/Projects/kphp/common/kprintf.cpp:131
    #2 0xdaf788 in kwrite_str /home/p-shumilov/Projects/kphp/server/signal-handlers.cpp:23
    #3 0xdb06d4 in sigusr2_handler /home/p-shumilov/Projects/kphp/server/signal-handlers.cpp:103
    #4 0x79bd8244251f  (/lib/x86_64-linux-gnu/libc.so.6+0x4251f)
    #5 0x79bd824969fb in __pthread_kill_implementation nptl/pthread_kill.c:43
    #6 0x79bd824969fb in __pthread_kill_internal nptl/pthread_kill.c:78
    #7 0x79bd824969fb in __GI___pthread_kill nptl/pthread_kill.c:89
    #8 0x79bd82442475 in __GI_raise ../sysdeps/posix/raise.c:26
    #9 0x7f6357 in memory_resource::monotonic_buffer_resource::raise_oom(unsigned long) const /home/p-shumilov/Projects/kphp/runtime/memory_resource_impl/monotonic_runtime_buffer_resource.cpp:66
    #10 0x8945a7 in memory_resource::monotonic_buffer_resource::get_from_pool(unsigned long, bool) /home/p-shumilov/Projects/kphp/./runtime-common/core/memory-resource/monotonic_buffer_resource.h:114
    #11 0x8949d5 in memory_resource::unsynchronized_pool_resource::allocate_huge_piece(unsigned long, bool) /home/p-shumilov/Projects/kphp/./runtime-common/core/memory-resource/unsynchronized_pool_resource.h:114
    #12 0xe0c9ed in memory_resource::unsynchronized_pool_resource::perform_defragmentation_and_allocate_huge_piece(unsigned long) /home/p-shumilov/Projects/kphp/runtime-common/core/memory-resource/unsynchronized_pool_resource.cpp:105
    #13 0x8946a2 in memory_resource::unsynchronized_pool_resource::allocate(unsigned long) /home/p-shumilov/Projects/kphp/./runtime-common/core/memory-resource/unsynchronized_pool_resource.h:41
    #14 0x8955d1 in dl::allocate(unsigned long) (/home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/artifacts/tmp_test_oom_handler/255810/2123305/kphp_server+0x8955d1)
    #15 0x896e87 in RuntimeAllocator::alloc_script_memory(unsigned long) /home/p-shumilov/Projects/kphp/runtime/context/runtime-core-allocator.cpp:21
    #16 0x7d12ab in array<long>::array_inner::create(long, bool) /home/p-shumilov/Projects/kphp/./runtime-common/core/core-types/definition/array.inl:256
    #17 0x897c93 in array<long>::mutate_to_size_if_vector_shared(long) /home/p-shumilov/Projects/kphp/./runtime-common/core/core-types/definition/array.inl:679
    #18 0x897dd8 in array<long>::mutate_to_size(long) /home/p-shumilov/Projects/kphp/./runtime-common/core/core-types/definition/array.inl:728
    #19 0x8a6c62 in array<long>::reserve(long, bool) /home/p-shumilov/Projects/kphp/./runtime-common/core/core-types/definition/array.inl:778
    #20 0x72fd83 in void f$array_reserve_vector<long>(array<long>&, long) /home/p-shumilov/Projects/kphp/runtime-common/stdlib/array/array-functions.h:345
    #21 0x72fd83 in f$make_array_of_volume(long) /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/o_50/make_array_of_volume.cpp:27
    #22 0x740273 in f$make_oom_error() /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/o_50/make_oom_error.h:13
    #23 0x72f05b in f$main() /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/o_50/main.cpp:72
    #24 0x73f124 in f$src_test_oom_handlera65caa425796796a() /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/o_50/src_test_oom_handlera65caa425796796a.cpp:44
    #25 0x7648e9 in f$src_indexbccbb8a09559268e() /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/o_6/src_indexbccbb8a09559268e.cpp:946
    #26 0x721c7c in f$src_indexbccbb8a09559268e$run() /home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/working_dir/kphp_build/kphp/init_php_scripts.cpp:33
    #27 0xd7dae5 in PhpScript::run() /home/p-shumilov/Projects/kphp/server/php-runner.cpp:470
    #28 0xd7e5e0 in PhpScript::script_context_entrypoint() /home/p-shumilov/Projects/kphp/server/php-runner.cpp:577
    #29 0xeda5cf in _GLOBAL__sub_I_00099_1__Z21tl_fetch_query_headerP17tl_query_header_t (/home/p-shumilov/Projects/kphp/tests/python/_tmp/http_server/artifacts/tmp_test_oom_handler/255810/2123305/kphp_server+0xeda5cf)

0x00000b72af0f is located 61999 bytes inside of global variable 'buffer' defined in '/home/p-shumilov/Projects/kphp/server/signal-handlers.cpp:241:44' (0xb71bce0) of size 65536
SUMMARY: AddressSanitizer: stack-buffer-overflow /home/p-shumilov/Projects/kphp/common/kprintf.cpp:112 in kwrite_print_int
Shadow bytes around the buggy address:
  0x0000816dd590: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000816dd5a0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000816dd5b0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000816dd5c0: 00 00 00 00 00 00 00 00 00 00 f1 f1 f1 f1 00 f2
  0x0000816dd5d0: f2 f2 f2 f2 f2 f2 00 00 00 00 00 00 f1 f1 f1 f1
=>0x0000816dd5e0: 04[f2]04 f2 f2 f2 f3 f3 f3 f3 f2 f2 f2 f2 f2 f2
  0x0000816dd5f0: 00 f2 f2 f2 f2 f2 f1 f1 f1 f1 04 f2 f2 f2 f2 f2
  0x0000816dd600: f2 f2 00 f2 f2 f2 f3 f3 f3 f3 00 00 00 00 00 00
  0x0000816dd610: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000816dd620: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0000816dd630: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==2123325==ABORTING
```
Following PR fix this false-positive detections.

Related issue: KPHP-1990