### PR TITLE
prevent false-positive stack-buffer-overflow ASan detections on signal stack, attemp 2

### DIFF
--- a/server/signal-handlers.h
+++ b/server/signal-handlers.h
@@ -5,6 +5,9 @@
 #include "server/php-runner.h"
 #include "server/workers-control.h"
 
+// The size of buffer for alternative signal stack
+constexpr auto signal_stack_buffer_size = 65536;
+
 void perform_error_if_running(const char *msg, script_error_t error_type, const std::optional<int> &triggered_by_signal);
 
 void init_handlers();


### PR DESCRIPTION
`__sanitizer_start_switch_fiber` and ` __sanitizer_finish_switch_fiber` are not sufficient for informing ASan about the alternate signal stack. In our case, when a signal occurs, the activation of the alternate signal stack mislead ASan about current actual stack and leads to incorrect behavior of `__asan_handle_no_return`:
```
==15381==WARNING: ASan is ignoring requested __asan_handle_no_return: stack top: 0x7f98b59d0000; bottom 0x00000bb21000; size: 0x7f98a9eaf000 (140293662502912)
False positive error reports may follow
For details see https://github.com/google/sanitizers/issues/189
```
Need to use explicit signal stack unpoisoning instead. 

Fix of #1201
