### PR TITLE
Implement hash builtins for K2

### DIFF
--- a/builtin-functions/kphp-light/crypto.txt
+++ b/builtin-functions/kphp-light/crypto.txt
@@ -42,7 +42,19 @@ function openssl_encrypt($data ::: string, $method ::: string, $key ::: string, 
 function openssl_decrypt($data ::: string, $method ::: string, $key ::: string, $options ::: int = 0, $iv ::: string  = '',
                         $tag ::: string = '', $aad ::: string = '') ::: string | false;
 
+function hash_algos () ::: string[];
+function hash_hmac_algos () ::: string[];
+
+/** @kphp-extern-func-info interruptible */
+function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
+/** @kphp-extern-func-info interruptible */
+function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
+
+/** @kphp-extern-func-info interruptible */
+function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
 function md5 ($s ::: string, $raw_output ::: bool = false): string;
+
+function hash_equals(string $known_string, string $user_string) ::: bool;
 
 // ===== UNSUPPORTED =====
 

--- a/builtin-functions/kphp-light/hash.txt
+++ b/builtin-functions/kphp-light/hash.txt
@@ -10,14 +10,6 @@ function gzcompress ($str ::: string, $level ::: int = -1): string;
 
 function gzuncompress ($str ::: string): string;
 
-function hash_algos () ::: string[];
-function hash_hmac_algos () ::: string[];
-function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
-function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
-function hash_equals(string $known_string, string $user_string) ::: bool;
-function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
-function md5 ($s ::: string, $raw_output ::: bool = false) ::: string;
-
 // ===== UNSUPPORTED =====
 
 /** @kphp-extern-func-info generate-stub */

--- a/builtin-functions/kphp-light/hash.txt
+++ b/builtin-functions/kphp-light/hash.txt
@@ -10,6 +10,14 @@ function gzcompress ($str ::: string, $level ::: int = -1): string;
 
 function gzuncompress ($str ::: string): string;
 
+function hash_algos () ::: string[];
+function hash_hmac_algos () ::: string[];
+function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
+function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
+function hash_equals(string $known_string, string $user_string) ::: bool;
+function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
+function md5 ($s ::: string, $raw_output ::: bool = false) ::: string;
+
 // ===== UNSUPPORTED =====
 
 /** @kphp-extern-func-info generate-stub */
@@ -21,19 +29,8 @@ function gzdeflate ($str ::: string, $level ::: int = -1) ::: string;
 /** @kphp-extern-func-info generate-stub */
 function gzinflate ($str ::: string) ::: string;
 
-
-/** @kphp-extern-func-info generate-stub */
-function hash_hmac_algos () ::: string[];
-/** @kphp-extern-func-info generate-stub */
-function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
-/** @kphp-extern-func-info generate-stub */
-function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
-/** @kphp-extern-func-info generate-stub */
-function hash_equals(string $known_string, string $user_string) ::: bool;
 /** @kphp-extern-func-info generate-stub */
 function md5_file ($s ::: string, $raw_output ::: bool = false) ::: string | false;
-/** @kphp-extern-func-info generate-stub */
-function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
 
 define('ZLIB_NO_FLUSH', 0);
 define('ZLIB_PARTIAL_FLUSH', 1);

--- a/runtime-common/stdlib/hash/hash-functions.cpp
+++ b/runtime-common/stdlib/hash/hash-functions.cpp
@@ -1,0 +1,19 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime-common/stdlib/hash/hash-functions.h"
+
+bool f$hash_equals(const string &known_string, const string &user_string) noexcept {
+  if (known_string.size() != user_string.size()) {
+    return false;
+  }
+  int result = 0;
+  // This is security sensitive code. Do not optimize this for speed
+  // Compares two strings using the same time whether they're equal or not
+  // A difference in length will leak
+  for (int i = 0; i != known_string.size(); ++i) {
+    result |= known_string[i] ^ user_string[i];
+  }
+  return !result;
+}

--- a/runtime-common/stdlib/hash/hash-functions.h
+++ b/runtime-common/stdlib/hash/hash-functions.h
@@ -1,0 +1,7 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime-common/core/runtime-core.h"
+
+bool f$hash_equals(const string &known_string, const string &user_string) noexcept;

--- a/runtime-common/stdlib/stdlib.cmake
+++ b/runtime-common/stdlib/stdlib.cmake
@@ -1,4 +1,5 @@
 prepend(STDLIB_ARRAY stdlib/array/ array-functions.cpp)
+prepend(STDLIB_HASH stdlib/hash/ hash-functions.cpp)
 prepend(STDLIB_MATH stdlib/math/ math-functions.cpp
         bcmath-functions.cpp math-context.cpp)
 prepend(STDLIB_SERIALIZATION stdlib/serialization/ json-functions.cpp
@@ -13,5 +14,5 @@ if(COMPILER_CLANG)
     set_source_files_properties(${RUNTIME_COMMON_DIR}/stdlib/vkext/string-processing.cpp PROPERTIES COMPILE_FLAGS -Wno-invalid-source-encoding)
 endif()
 
-set(STDLIB_SRC ${STDLIB_ARRAY} ${STDLIB_MATH} ${STDLIB_SERIALIZATION}
+set(STDLIB_SRC ${STDLIB_ARRAY} ${STDLIB_HASH} ${STDLIB_MATH} ${STDLIB_SERIALIZATION}
                ${STDLIB_STRING} ${STDLIB_SERVER} ${STDLIB_VKEXT})

--- a/runtime-common/stdlib/string/string-functions.h
+++ b/runtime-common/stdlib/string/string-functions.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <string_view>
 
 #include "runtime-common/core/runtime-core.h"
 #include "runtime-common/core/utils/kphp-assert-core.h"
@@ -18,7 +19,7 @@ string f$addslashes(const string &str) noexcept;
 
 string f$hex2bin(const string &str) noexcept;
 
-inline string f$bin2hex(const string &str) noexcept {
+inline string bin2hex_impl(std::string_view str) noexcept {
   int len = str.size();
   string result(2 * len, false);
 
@@ -28,6 +29,10 @@ inline string f$bin2hex(const string &str) noexcept {
   }
 
   return result;
+}
+
+inline string f$bin2hex(const string &str) noexcept {
+  return bin2hex_impl(std::string_view{str.c_str(), str.size()});
 }
 
 string f$convert_cyr_string(const string &str, const string &from_s, const string &to_s) noexcept;

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -100,7 +100,7 @@ task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool sho
 task_t<bool> f$openssl_sign(const string &data, string &signature, const string &private_key, int64_t algo) noexcept {
   tl::DigestSign request{.data = {.value = {data.c_str(), data.size()}},
                          .private_key = {.value = {private_key.c_str(), private_key.size()}},
-                         .algorithm = static_cast<tl::DigestAlgorithm>(algo)};
+                         .algorithm = static_cast<tl::HashAlgorithm>(algo)};
 
   tl::TLBuffer buffer;
   request.store(buffer);
@@ -127,7 +127,7 @@ task_t<bool> f$openssl_sign(const string &data, string &signature, const string 
 task_t<int64_t> f$openssl_verify(const string &data, const string &signature, const string &pub_key, int64_t algo) noexcept {
   tl::DigestVerify request{.data = {.value = {data.c_str(), data.size()}},
                            .public_key = {.value = {pub_key.c_str(), pub_key.size()}},
-                           .algorithm = static_cast<tl::DigestAlgorithm>(algo),
+                           .algorithm = static_cast<tl::HashAlgorithm>(algo),
                            .signature = {.value = {signature.c_str(), signature.size()}}};
 
   tl::TLBuffer buffer;

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -343,3 +343,17 @@ task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, co
   }
   co_return string{response.inner.value.data(), static_cast<string::size_type>(response.inner.value.size())};
 }
+
+array<string> f$hash_algos() noexcept {
+  static constexpr const char *algos[] = {"md5", "sha1", "sha224", "sha256", "sha384", "sha512"};
+  array<string> response;
+  response.reserve(std::size(algos), true);
+  for (const char *algo : algos) {
+    response.push_back(string(algo));
+  }
+  return response;
+}
+
+array<string> f$hash_hmac_algos() noexcept {
+  return f$hash_algos();
+}

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -4,11 +4,14 @@
 
 #include "runtime-light/stdlib/crypto/crypto-functions.h"
 
+#include <algorithm>
 #include <cstddef>
 #include <string_view>
 
 #include "common/tl/constants/common.h"
+#include "runtime-common/core/utils/kphp-assert-core.h"
 #include "runtime-common/stdlib/server/url-functions.h"
+#include "runtime-common/stdlib/string/string-functions.h"
 #include "runtime-light/stdlib/component/component-api.h"
 #include "runtime-light/tl/tl-core.h"
 #include "runtime-light/tl/tl-functions.h"
@@ -155,7 +158,7 @@ namespace {
 constexpr std::string_view AES_128_CBC = "aes-128-cbc";
 constexpr std::string_view AES_256_CBC = "aes-256-cbc";
 
-std::optional<tl::CipherAlgorithm> parse_algorithm(const string &method) noexcept {
+std::optional<tl::CipherAlgorithm> parse_cipher_algorithm(const string &method) noexcept {
   using namespace std::string_view_literals;
   std::string_view method_sv{method.c_str(), method.size()};
 
@@ -237,7 +240,7 @@ array<string> f$openssl_get_cipher_methods([[maybe_unused]] bool aliases) noexce
 }
 
 Optional<int64_t> f$openssl_cipher_iv_length(const string &method) noexcept {
-  auto algorithm = parse_algorithm(method);
+  auto algorithm = parse_cipher_algorithm(method);
   if (!algorithm.has_value()) {
     php_warning("Unknown cipher algorithm");
     return false;
@@ -247,7 +250,7 @@ Optional<int64_t> f$openssl_cipher_iv_length(const string &method) noexcept {
 
 task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &method, const string &source_key, int64_t options, const string &source_iv,
                                            string &tag, const string &aad, int64_t tag_length __attribute__((unused))) noexcept {
-  auto algorithm = parse_algorithm(method);
+  auto algorithm = parse_cipher_algorithm(method);
   if (!algorithm.has_value()) {
     php_warning("Unknown cipher algorithm");
     co_return false;
@@ -303,7 +306,7 @@ task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, co
     data = std::move(decoding_data.val());
   }
 
-  auto algorithm = parse_algorithm(method);
+  auto algorithm = parse_cipher_algorithm(method);
   if (!algorithm.has_value()) {
     php_warning("Unknown cipher algorithm");
     co_return false;
@@ -344,16 +347,92 @@ task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, co
   co_return string{response.inner.value.data(), static_cast<string::size_type>(response.inner.value.size())};
 }
 
+namespace {
+constexpr std::pair<const char *, tl::HashAlgorithm> HASH_ALGOS[] = {{"md5", tl::HashAlgorithm::MD5},       {"sha1", tl::HashAlgorithm::SHA1},
+                                                                     {"sha224", tl::HashAlgorithm::SHA224}, {"sha256", tl::HashAlgorithm::SHA256},
+                                                                     {"sha384", tl::HashAlgorithm::SHA384}, {"sha512", tl::HashAlgorithm::SHA512}};
+
+std::optional<tl::HashAlgorithm> parse_hash_algorithm(const string &algo_str) noexcept {
+  std::string_view algo_sv{algo_str.c_str(), algo_str.size()};
+
+  const auto ichar_equals = [](char a, char b) { return std::tolower(a) == std::tolower(b); };
+
+  const auto *it = std::find_if(std::begin(HASH_ALGOS), std::end(HASH_ALGOS),
+                                [&](auto pair) { return std::ranges::equal(algo_sv, std::string_view{pair.first}, ichar_equals); });
+
+  if (it == std::end(HASH_ALGOS)) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+task_t<string> send_and_get_string(tl::TLBuffer &&buffer, bool raw_output) {
+  auto query = f$component_client_send_request(string{CRYPTO_COMPONENT_NAME.data(), static_cast<string::size_type>(CRYPTO_COMPONENT_NAME.size())},
+                                               string{buffer.data(), static_cast<string::size_type>(buffer.size())});
+  string resp = co_await f$component_client_fetch_response(co_await query);
+
+  buffer.clean();
+  buffer.store_bytes({resp.c_str(), static_cast<size_t>(resp.size())});
+
+  tl::String response{};
+  // TODO: parse error?
+  if (!response.fetch(buffer)) {
+    co_return string("");
+  }
+
+  if (!raw_output) {
+    co_return bin2hex_impl(response.inner.value);
+  }
+
+  // Important to pass size because response.inner.value is binary so
+  // it may contain zero in any position, not only in the end
+  co_return string(response.inner.value.data(), response.inner.value.size());
+}
+
+task_t<string> hash_impl(tl::HashAlgorithm algo, const string &s, bool raw_output) noexcept {
+  tl::Hash request{.algorithm = algo, .data = {.value = {s.c_str(), s.size()}}};
+  tl::TLBuffer buffer;
+  request.store(buffer);
+
+  co_return co_await send_and_get_string(std::move(buffer), raw_output);
+}
+
+} // namespace
+
 array<string> f$hash_algos() noexcept {
-  static constexpr const char *algos[] = {"md5", "sha1", "sha224", "sha256", "sha384", "sha512"};
   array<string> response;
-  response.reserve(std::size(algos), true);
-  for (const char *algo : algos) {
-    response.push_back(string(algo));
+  response.reserve(std::size(HASH_ALGOS), true);
+  for (auto [algo_name, _] : HASH_ALGOS) {
+    response.push_back(string(algo_name));
   }
   return response;
 }
 
 array<string> f$hash_hmac_algos() noexcept {
   return f$hash_algos();
+}
+
+task_t<string> f$hash(const string &algo_str, const string &s, bool raw_output) noexcept {
+  const auto algo = parse_hash_algorithm(algo_str);
+  if (!algo.has_value()) {
+    php_critical_error("algo %s not supported in function hash", algo_str.c_str());
+  }
+  co_return co_await hash_impl(*algo, s, raw_output);
+}
+
+task_t<string> f$hash_hmac(const string &algo_str, const string &s, const string &key, bool raw_output) noexcept {
+  const auto algo = parse_hash_algorithm(algo_str);
+  if (!algo.has_value()) {
+    php_critical_error("algo %s not supported in function hash", algo_str.c_str());
+  }
+
+  tl::HashHmac request{.algorithm = *algo, .data = {.value = {s.c_str(), s.size()}}, .secret_key = {.value = {key.c_str(), key.size()}}};
+  tl::TLBuffer buffer;
+  request.store(buffer);
+
+  co_return co_await send_and_get_string(std::move(buffer), raw_output);
+}
+
+task_t<string> f$sha1(const string &s, bool raw_output) noexcept {
+  co_return co_await hash_impl(tl::HashAlgorithm::SHA1, s, raw_output);
 }

--- a/runtime-light/stdlib/crypto/crypto-functions.h
+++ b/runtime-light/stdlib/crypto/crypto-functions.h
@@ -31,17 +31,11 @@ task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &met
 task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, const string &key, int64_t options = 0, const string &iv = string{},
                                            string tag = string{}, const string &aad = string{}) noexcept;
 
-
 array<string> f$hash_algos() noexcept;
 array<string> f$hash_hmac_algos() noexcept;
-
-// function hash_algos () ::: string[];
-// function hash_hmac_algos () ::: string[];
-// function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
-// function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
-// function hash_equals(string $known_string, string $user_string) ::: bool;
-// function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
-
+task_t<string> f$hash(const string &algo_str, const string &s, bool raw_output = false) noexcept;
+task_t<string> f$hash_hmac(const string &algo_str, const string &s, const string &key, bool raw_output = false) noexcept;
+task_t<string> f$sha1(const string &s, bool raw_output = false) noexcept;
 inline string f$md5(const string &str, bool binary = false) noexcept {
   constexpr auto MD5_HASH_LEN = 16;
   string output{static_cast<string::size_type>(MD5_HASH_LEN * (binary ? 1 : 2)), false};
@@ -55,4 +49,3 @@ inline string f$md5(const string &str, bool binary = false) noexcept {
   }
   return output;
 }
-

--- a/runtime-light/stdlib/crypto/crypto-functions.h
+++ b/runtime-light/stdlib/crypto/crypto-functions.h
@@ -17,9 +17,9 @@ task_t<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length) noexcept;
 
 task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool shortnames = true) noexcept;
 
-task_t<bool> f$openssl_sign(const string &data, string &signature, const string &private_key, int64_t algo = tl::DigestAlgorithm::SHA1) noexcept;
+task_t<bool> f$openssl_sign(const string &data, string &signature, const string &private_key, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
 
-task_t<int64_t> f$openssl_verify(const string &data, const string &signature, const string &pub_key_id, int64_t algo = tl::DigestAlgorithm::SHA1) noexcept;
+task_t<int64_t> f$openssl_verify(const string &data, const string &signature, const string &pub_key_id, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
 
 array<string> f$openssl_get_cipher_methods(bool aliases = false) noexcept;
 

--- a/runtime-light/stdlib/crypto/crypto-functions.h
+++ b/runtime-light/stdlib/crypto/crypto-functions.h
@@ -13,20 +13,6 @@
 #include "runtime-light/stdlib/string/string-state.h"
 #include "runtime-light/tl/tl-types.h"
 
-inline string f$md5(const string &str, bool binary = false) noexcept {
-  constexpr auto MD5_HASH_LEN = 16;
-  string output{static_cast<string::size_type>(MD5_HASH_LEN * (binary ? 1 : 2)), false};
-  md5(reinterpret_cast<const unsigned char *>(str.c_str()), static_cast<int32_t>(str.size()), reinterpret_cast<unsigned char *>(output.buffer()));
-  if (!binary) {
-    const auto &lhex_digits{StringImageState::get().lhex_digits};
-    for (int64_t i = MD5_HASH_LEN - 1; i >= 0; --i) {
-      output[2 * i + 1] = lhex_digits[output[i] & 0x0F];
-      output[2 * i] = lhex_digits[(output[i] >> 4) & 0x0F];
-    }
-  }
-  return output;
-}
-
 task_t<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length) noexcept;
 
 task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool shortnames = true) noexcept;
@@ -44,3 +30,29 @@ task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &met
                                            int64_t tag_length = 16) noexcept;
 task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, const string &key, int64_t options = 0, const string &iv = string{},
                                            string tag = string{}, const string &aad = string{}) noexcept;
+
+
+array<string> f$hash_algos() noexcept;
+array<string> f$hash_hmac_algos() noexcept;
+
+// function hash_algos () ::: string[];
+// function hash_hmac_algos () ::: string[];
+// function hash ($algo ::: string, $data ::: string, $raw_output ::: bool = false) ::: string;
+// function hash_hmac ($algo ::: string, $data ::: string, $key ::: string, $raw_output ::: bool = false) ::: string;
+// function hash_equals(string $known_string, string $user_string) ::: bool;
+// function sha1 ($s ::: string, $raw_output ::: bool = false) ::: string;
+
+inline string f$md5(const string &str, bool binary = false) noexcept {
+  constexpr auto MD5_HASH_LEN = 16;
+  string output{static_cast<string::size_type>(MD5_HASH_LEN * (binary ? 1 : 2)), false};
+  md5(reinterpret_cast<const unsigned char *>(str.c_str()), static_cast<int32_t>(str.size()), reinterpret_cast<unsigned char *>(output.buffer()));
+  if (!binary) {
+    const auto &lhex_digits{StringImageState::get().lhex_digits};
+    for (int64_t i = MD5_HASH_LEN - 1; i >= 0; --i) {
+      output[2 * i + 1] = lhex_digits[output[i] & 0x0F];
+      output[2 * i] = lhex_digits[(output[i] >> 4) & 0x0F];
+    }
+  }
+  return output;
+}
+

--- a/runtime-light/stdlib/crypto/crypto_schema.tl
+++ b/runtime-light/stdlib/crypto/crypto_schema.tl
@@ -9,7 +9,7 @@ resultFalse#27930a7b {t:Type} = Maybe t;
 resultTrue#3f9c8ef8 {t:Type} result:t = Maybe t;
 
 // Vector
-vector#1cb5c415 {t:Type} # [t] = Vector t;
+vector#1cb5c415 {t:Type} # [t] = Vector t
 
 // Tuple
 tuple#9770768a {t:Type} {n:#} [t] = Tuple t n;
@@ -22,16 +22,16 @@ certInfoItemLong#533ff89f l:long = CertInfoItem;
 certInfoItemStr#c427feef s:string = CertInfoItem;
 certInfoItemDict#1ea8a774 d: %(Dictionary string) = CertInfoItem;
 
-digestAlgorithmDSS1#f572d6b6 = DigestAlgorithm; // DSA digest + with SHA1 hash function
-digestAlgorithmSHA1#215fb97d = DigestAlgorithm;
-digestAlgorithmSHA224#8bce55e9 = DigestAlgorithm;
-digestAlgorithmSHA256#6c977f8c = DigestAlgorithm;
-digestAlgorithmSHA384#f54c2608 = DigestAlgorithm;
-digestAlgorithmSHA512#225df2b6 = DigestAlgorithm;
-digestAlgorithmRMD160#1887e6b4 = DigestAlgorithm;
-digestAlgorithmMD5#257ddf13 = DigestAlgorithm;
-digestAlgorithmMD4#317fe3d1 = DigestAlgorithm;
-digestAlgorithmMD2#5aca6998 = DigestAlgorithm;
+hashAlgorithmDSS1#f572d6b6 = HashAlgorithm; // DSA digest + with SHA1 hash function
+hashAlgorithmSHA1#215fb97d = HashAlgorithm;
+hashAlgorithmSHA224#8bce55e9 = HashAlgorithm;
+hashAlgorithmSHA256#6c977f8c = HashAlgorithm;
+hashAlgorithmSHA384#f54c2608 = HashAlgorithm;
+hashAlgorithmSHA512#225df2b6 = HashAlgorithm;
+hashAlgorithmRMD160#1887e6b4 = HashAlgorithm;
+hashAlgorithmMD5#257ddf13 = HashAlgorithm;
+hashAlgorithmMD4#317fe3d1 = HashAlgorithm;
+hashAlgorithmMD2#5aca6998 = HashAlgorithm;
 
 cipherAlgorithmAes128#e627c460 = CipherAlgorithm;
 cipherAlgorithmAes256#4c98c1f9 = CipherAlgorithm;
@@ -52,13 +52,13 @@ getPemCertInfo#a50cfd6c
 digestSign#d345f658
     data         : string
     private_key  : string
-    algorithm    : DigestAlgorithm
+    algorithm    : HashAlgorithm
     = Maybe string;
 
 digestVerify#5760bd0e
     data        : string
     private_key : string
-    algorithm   : DigestAlgorithm
+    algorithm   : HashAlgorithm
     signature   : string
     = Bool;
 
@@ -77,3 +77,14 @@ cbcEncrypt#6d4ee36a
    iv           : string
    data         : string
    = String;
+
+hash#50732a27
+    algorithm : HashAlgorithm
+    data      : string
+    = String;
+
+hashHmac#8dcb3d9d
+    algorithm  : HashAlgorithm
+    data       : string
+    secret_key : string
+    = String;

--- a/runtime-light/tl/tl-functions.cpp
+++ b/runtime-light/tl/tl-functions.cpp
@@ -90,6 +90,19 @@ void CbcEncrypt::store(TLBuffer &tlb) const noexcept {
   data.store(tlb);
 }
 
+void Hash::store(TLBuffer &tlb) const noexcept {
+  tlb.store_trivial<uint32_t>(HASH_MAGIC);
+  tlb.store_trivial<uint32_t>(algorithm);
+  data.store(tlb);
+}
+
+void HashHmac::store(TLBuffer &tlb) const noexcept {
+  tlb.store_trivial<uint32_t>(HASH_HMAC_MAGIC);
+  tlb.store_trivial<uint32_t>(algorithm);
+  data.store(tlb);
+  secret_key.store(tlb);
+}
+
 // ===== CONFDATA =====
 
 void ConfdataGet::store(TLBuffer &tlb) const noexcept {

--- a/runtime-light/tl/tl-functions.h
+++ b/runtime-light/tl/tl-functions.h
@@ -56,7 +56,7 @@ struct GetPemCertInfo final {
 struct DigestSign final {
   string data;
   string private_key;
-  DigestAlgorithm algorithm{};
+  HashAlgorithm algorithm{};
 
   void store(TLBuffer &tlb) const noexcept;
 };
@@ -64,7 +64,7 @@ struct DigestSign final {
 struct DigestVerify final {
   string data;
   string public_key;
-  DigestAlgorithm algorithm{};
+  HashAlgorithm algorithm{};
   string signature;
 
   void store(TLBuffer &tlb) const noexcept;

--- a/runtime-light/tl/tl-functions.h
+++ b/runtime-light/tl/tl-functions.h
@@ -39,6 +39,8 @@ inline constexpr uint32_t DIGEST_SIGN_MAGIC = 0xd345'f658;
 inline constexpr uint32_t DIGEST_VERIFY_MAGIC = 0x5760'bd0e;
 inline constexpr uint32_t CBC_DECRYPT_MAGIC = 0x7f2e'e1e4;
 inline constexpr uint32_t CBC_ENCRYPT_MAGIC = 0x6d4e'e36a;
+inline constexpr uint32_t HASH_MAGIC = 0x5073'2a27;
+inline constexpr uint32_t HASH_HMAC_MAGIC = 0x8dcb'3d9d;
 
 struct GetCryptosecurePseudorandomBytes final {
   int32_t size{};
@@ -86,6 +88,21 @@ struct CbcEncrypt final {
   string passphrase;
   string iv;
   string data;
+
+  void store(TLBuffer &tlb) const noexcept;
+};
+
+struct Hash final {
+  HashAlgorithm algorithm{};
+  string data;
+
+  void store(TLBuffer &tlb) const noexcept;
+};
+
+struct HashHmac final {
+  HashAlgorithm algorithm{};
+  string data;
+  string secret_key;
 
   void store(TLBuffer &tlb) const noexcept;
 };

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -313,7 +313,7 @@ public:
   };
 };
 
-enum DigestAlgorithm : uint32_t {
+enum HashAlgorithm : uint32_t {
   DSS1 = 0xf572'd6b6,
   SHA1 = 0x215f'b97d,
   SHA224 = 0x8bce'55e9,

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -239,20 +239,6 @@ int64_t f$crc32_file(const string &file_name) {
   return res ^ std::numeric_limits<uint32_t>::max();
 }
 
-bool f$hash_equals(const string &known_string, const string &user_string) noexcept {
-  if (known_string.size() != user_string.size()) {
-    return false;
-  }
-  int result = 0;
-  // This is security sensitive code. Do not optimize this for speed
-  // Compares two strings using the same time whether they're equal or not
-  // A difference in length will leak
-  for (int i = 0; i != known_string.size(); ++i) {
-    result |= known_string[i] ^ user_string[i];
-  }
-  return !result;
-}
-
 template<char PREFIX_CHAR>
 struct EVPKeyResourceStorage {
 public:

--- a/runtime/openssl.h
+++ b/runtime/openssl.h
@@ -39,8 +39,6 @@ int64_t f$crc32(const string &s);
 
 int64_t f$crc32_file(const string &file_name);
 
-bool f$hash_equals(const string &known_string, const string &user_string) noexcept;
-
 bool f$openssl_public_encrypt(const string &data, string &result, const string &key);
 
 bool f$openssl_public_encrypt(const string &data, mixed &result, const string &key);

--- a/tests/phpt/openssl/12_hash_files.php
+++ b/tests/phpt/openssl/12_hash_files.php
@@ -1,0 +1,16 @@
+@ok benchmark k2_skip
+<?php
+#ifndef KPHP
+  function crc32_file ($x) {
+    return crc32 (file_get_contents ($x));
+  }
+#endif
+
+function test_hash_files() {
+  var_dump (md5_file ("/bin/ls"));
+  var_dump (md5_file ("/bin/ls", true));
+
+  var_dump (dechex (crc32_file ("/bin/ls")));
+}
+
+test_hash_files();

--- a/tests/phpt/openssl/13_hash_crc32.php
+++ b/tests/phpt/openssl/13_hash_crc32.php
@@ -1,0 +1,14 @@
+@ok benchmark k2_skip
+<?php
+
+function test_hash_crc32() {
+  $a = array("", "asdasd", "abacaba", "1", NULL, false, true, "asdasdasdasdasd42n3jb23jkb2k3vb2hj3v41hj 13hj j23hbr j42hb j42hb jh43b rjh1hb 12jb 3jh4 b32 b24");
+
+  foreach ($a as $s) {
+    var_dump (dechex(crc32($s)));
+  }
+  for ($i = 0; $i < 100; $i++)
+    var_dump (dechex(crc32($i)));
+}
+
+test_hash_crc32();

--- a/tests/phpt/openssl/5_hash_basic.php
+++ b/tests/phpt/openssl/5_hash_basic.php
@@ -14,7 +14,6 @@ function test_hash_basic() {
   $a = array("", "asdasd", "abacaba", "1", NULL, false, true, "asdasdasdasdasd42n3jb23jkb2k3vb2hj3v41hj 13hj j23hbr j42hb j42hb jh43b rjh1hb 12jb 3jh4 b32 b24");
 
   foreach ($a as $s) {
-    var_dump (dechex (crc32 ($s)));
     var_dump (sha1 ($s, false));
     var_dump (sha1 ($s, true));
     var_dump (sha1 ($s));
@@ -36,11 +35,6 @@ function test_hash_basic() {
   }
   for ($i = 0; $i < 100; $i++)
     var_dump (md5 ($i));
-
-  var_dump (md5_file ("/bin/ls"));
-  var_dump (md5_file ("/bin/ls", true));
-
-  var_dump (dechex (crc32_file ("/bin/ls")));
 }
 
 function test_hash_equals() {

--- a/tests/phpt/openssl/5_hash_basic.php
+++ b/tests/phpt/openssl/5_hash_basic.php
@@ -1,4 +1,4 @@
-@ok benchmark k2_skip
+@ok benchmark
 <?php
 #ifndef KPHP
   function crc32_file ($x) {
@@ -9,7 +9,6 @@
 function test_hash_basic() {
   hash_algos();
   $algos = array ("md5", "sha1", "sha224", "sha256", "sha384", "sha512");
-
 
   $a = array("", "asdasd", "abacaba", "1", NULL, false, true, "asdasdasdasdasd42n3jb23jkb2k3vb2hj3v41hj 13hj j23hbr j42hb j42hb jh43b rjh1hb 12jb 3jh4 b32 b24");
 


### PR DESCRIPTION
This PR add support for the following builtins in K2 mode:
* hash()
* hash_hmac()
* hash_algos()
* hash_hmac_algos()
* hash_equals()
* sha1()

Also one hash test was divided into several.