### PR TITLE
add extra attempts to store into IC for flakiness avoidance, fix `test_shared_memory_piece_copying`

### DIFF
--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/http_worker.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/http_worker.php
@@ -52,6 +52,9 @@ function test_shared_memory_piece_copying() {
        * @var $instance SomeContext
        */
       $instance = instance_cache_fetch(SomeContext::class, "test_$i");
+      if ($instance === null) {
+        raise_error("Expected instance by key 'test_" . $i . "' hasn't been restored from instance cache");
+      }
       for ($i = 0; $i < 100; $i++) {
         if ($instance->some_data[$i] !== $some_data[$i]) {
           raise_error("Data was changed in instance cache");

--- a/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/job_worker.php
+++ b/tests/python/tests/job_workers/php/SharedMemoryPieceCopying/job_worker.php
@@ -34,7 +34,11 @@ function run_shared_memory_piece_copying_job(JobRequest $req) {
       break;
     }
     case "instance_cache:instance": {
-      instance_cache_store("test_" . $req->id, $req->shared_memory_context->instance);
+      // The Instance Cache does not guarantee immediate and in-place data storage.
+      // To avoid flakiness, we need to ensure that key-value pairs are stored.
+      // Attempt storage for up to 1 second.
+      $t = time();
+      while (!instance_cache_store("test_" . $req->id, $req->shared_memory_context->instance) && time() - $t <= 1) {}
       break;
     }
   }


### PR DESCRIPTION
The Instance Cache does not guarantee immediate and in-place data storage. To avoid flakiness, we need to ensure that key-value pairs are stored. Added the mechanic for making extra attempts to store key-value into IC.