### PR TITLE
Fix problem with fmt lib in bookworm

### DIFF
--- a/common/wrappers/to_underlying.h
+++ b/common/wrappers/to_underlying.h
@@ -1,0 +1,14 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <type_traits>
+
+namespace vk {
+template<class Enum>
+constexpr std::underlying_type_t<Enum> to_underlying(Enum e) noexcept {
+  return static_cast<std::underlying_type_t<Enum>>(e);
+}
+} // namespace vk

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -10,6 +10,7 @@
 #include "common/wrappers/field_getter.h"
 #include "common/wrappers/likely.h"
 #include "common/wrappers/string_view.h"
+#include "common/wrappers/to_underlying.h"
 #include "compiler/code-gen/code-generator.h"
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/const-globals-batched-mem.h"
@@ -2522,7 +2523,7 @@ void compile_vertex(VertexPtr root, CodeGenerator &W) {
         compile_conv_op(root.as<meta_op_unary>(), W);
         break;
       default:
-        fmt_print("{}: {}\n", tp, root->type());
+        fmt_print("{}: {}\n", vk::to_underlying(tp), vk::to_underlying(root->type()));
         assert (0);
         break;
     }

--- a/compiler/pipes/calc-const-types.cpp
+++ b/compiler/pipes/calc-const-types.cpp
@@ -4,6 +4,7 @@
 
 #include "compiler/pipes/calc-const-types.h"
 
+#include "common/wrappers/to_underlying.h"
 #include "compiler/data/class-data.h"
 #include "compiler/data/src-file.h"
 #include "compiler/data/var-data.h"
@@ -63,7 +64,7 @@ VertexPtr CalcConstTypePass::on_exit_vertex(VertexPtr v) {
       break;
     }
     default:
-      kphp_error (0, fmt_format("Unknown cnst-type for [op = {}]", v->type()));
+      kphp_error (0, fmt_format("Unknown cnst-type for [op = {}]", vk::to_underlying(v->type())));
       kphp_fail();
       break;
   }

--- a/compiler/vertex-meta_op_base.h
+++ b/compiler/vertex-meta_op_base.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "common/wrappers/iterator_range.h"
+#include "common/wrappers/to_underlying.h"
 
 #include "compiler/data/data_ptr.h"
 #include "compiler/data/vertex-adaptor.h"
@@ -163,9 +164,9 @@ public:
 
   const Operation &type() const { return type_; }
 
-  virtual const std::string &get_string() const { kphp_fail_msg (fmt_format("not supported [{}:{}]", type_, OpInfo::str(type_))); }
+  virtual const std::string &get_string() const { kphp_fail_msg (fmt_format("not supported [{}:{}]", vk::to_underlying(type_), OpInfo::str(type_))); }
 
-  virtual void set_string(std::string) { kphp_fail_msg (fmt_format("not supported [{}:{}]", type_, OpInfo::str(type_))); }
+  virtual void set_string(std::string) { kphp_fail_msg (fmt_format("not supported [{}:{}]", vk::to_underlying(type_), OpInfo::str(type_))); }
 
   virtual bool has_get_string() const { return false; }
 


### PR DESCRIPTION
Default fmtlib version in bookworm gives warning when passing enums to fmt_* functions. Behavior is not changed.