### PR TITLE
Pass arguments by value instead of by const ref in coroutines

### DIFF
--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -68,11 +68,11 @@ template<class T, class Pred>
 requires(std::invocable<Pred, T>) task_t<array<T>> f$array_filter(array<T> a, Pred pred) noexcept {
   if constexpr (is_async_function_v<Pred, T>) {
     co_return co_await array_functions_impl_::array_filter_impl(a, [&pred](const auto &it) noexcept -> task_t<bool> {
-      co_return co_await std::invoke(std::forward<Pred>(pred), it.get_value());
+      co_return co_await std::invoke(std::move(pred), it.get_value());
     });
   } else {
     co_return co_await array_functions_impl_::array_filter_impl(a, [&pred](const auto &it) noexcept {
-      return std::invoke(std::forward<Pred>(pred), it.get_value());
+      return std::invoke(std::move(pred), it.get_value());
     });
   }
 }

--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -60,18 +60,20 @@ void f$shuffle(array<T> &arr) noexcept {
 }
 
 template<class T>
-task_t<array<T>> f$array_filter(const array<T> &a) noexcept {
+task_t<array<T>> f$array_filter(array<T> a) noexcept {
   co_return co_await array_functions_impl_::array_filter_impl(a, [](const auto &it) noexcept { return it.get_value(); });
 }
 
 template<class T, class Pred>
-requires(std::invocable<Pred, T>) task_t<array<T>> f$array_filter(const array<T> &a, Pred &&pred) noexcept {
+requires(std::invocable<Pred, T>) task_t<array<T>> f$array_filter(array<T> a, Pred pred) noexcept {
   if constexpr (is_async_function_v<Pred, T>) {
     co_return co_await array_functions_impl_::array_filter_impl(a, [&pred](const auto &it) noexcept -> task_t<bool> {
       co_return co_await std::invoke(std::forward<Pred>(pred), it.get_value());
     });
   } else {
-    co_return co_await array_functions_impl_::array_filter_impl(a, [&pred](const auto &it) noexcept { return std::invoke(std::forward<Pred>(pred), it.get_value()); });
+    co_return co_await array_functions_impl_::array_filter_impl(a, [&pred](const auto &it) noexcept {
+      return std::invoke(std::forward<Pred>(pred), it.get_value());
+    });
   }
 }
 

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -58,7 +58,7 @@ task_t<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length) noexcept 
   co_return string{str.value.data(), static_cast<string::size_type>(str.value.size())};
 }
 
-task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool shortnames) noexcept {
+task_t<Optional<array<mixed>>> f$openssl_x509_parse(string data, bool shortnames) noexcept {
   tl::GetPemCertInfo request{.is_short = shortnames, .bytes = {.value = {data.c_str(), data.size()}}};
 
   tl::TLBuffer buffer;
@@ -105,7 +105,7 @@ task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool sho
   co_return response;
 }
 
-task_t<bool> f$openssl_sign(const string &data, string &signature, const string &private_key, int64_t algo) noexcept {
+task_t<bool> f$openssl_sign(string data, string &signature, string private_key, int64_t algo) noexcept {
   tl::DigestSign request{.data = {.value = {data.c_str(), data.size()}},
                          .private_key = {.value = {private_key.c_str(), private_key.size()}},
                          .algorithm = static_cast<tl::HashAlgorithm>(algo)};
@@ -132,7 +132,7 @@ task_t<bool> f$openssl_sign(const string &data, string &signature, const string 
   co_return true;
 }
 
-task_t<int64_t> f$openssl_verify(const string &data, const string &signature, const string &pub_key, int64_t algo) noexcept {
+task_t<int64_t> f$openssl_verify(string data, string signature, string pub_key, int64_t algo) noexcept {
   tl::DigestVerify request{.data = {.value = {data.c_str(), data.size()}},
                            .public_key = {.value = {pub_key.c_str(), pub_key.size()}},
                            .algorithm = static_cast<tl::HashAlgorithm>(algo),
@@ -253,8 +253,8 @@ Optional<int64_t> f$openssl_cipher_iv_length(const string &method) noexcept {
   return algorithm_iv_len(*algorithm);
 }
 
-task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &method, const string &source_key, int64_t options, const string &source_iv,
-                                           string &tag, const string &aad, int64_t tag_length __attribute__((unused))) noexcept {
+task_t<Optional<string>> f$openssl_encrypt(string data, string method, string source_key, int64_t options, string source_iv, string &tag, string aad,
+                                           int64_t tag_length __attribute__((unused))) noexcept {
   auto algorithm = parse_cipher_algorithm(method);
   if (!algorithm.has_value()) {
     php_warning("Unknown cipher algorithm");
@@ -300,8 +300,7 @@ task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &met
   co_return(options & static_cast<int64_t>(cipher_opts::OPENSSL_RAW_DATA)) ? std::move(response) : f$base64_encode(response);
 }
 
-task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, const string &source_key, int64_t options, const string &source_iv, string tag,
-                                           const string &aad) noexcept {
+task_t<Optional<string>> f$openssl_decrypt(string data, string method, string source_key, int64_t options, string source_iv, string tag, string aad) noexcept {
   if (!(options & static_cast<int64_t>(cipher_opts::OPENSSL_RAW_DATA))) {
     Optional<string> decoding_data = f$base64_decode(data, true);
     if (!decoding_data.has_value()) {
@@ -419,7 +418,7 @@ array<string> f$hash_hmac_algos() noexcept {
 }
 
 task_t<string> f$hash(string algo_str, string s, bool raw_output) noexcept {
-  const auto algo = parse_hash_algorithm({algo_str.c_str(), algo_str.size()});
+const auto algo = parse_hash_algorithm({algo_str.c_str(), algo_str.size()});
   if (!algo.has_value()) {
     php_critical_error("algo %s not supported in function hash", algo_str.c_str());
   }

--- a/runtime-light/stdlib/crypto/crypto-functions.h
+++ b/runtime-light/stdlib/crypto/crypto-functions.h
@@ -15,21 +15,20 @@
 
 task_t<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length) noexcept;
 
-task_t<Optional<array<mixed>>> f$openssl_x509_parse(const string &data, bool shortnames = true) noexcept;
+task_t<Optional<array<mixed>>> f$openssl_x509_parse(string data, bool shortnames = true) noexcept;
 
-task_t<bool> f$openssl_sign(const string &data, string &signature, const string &private_key, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
+task_t<bool> f$openssl_sign(string data, string &signature, string private_key, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
 
-task_t<int64_t> f$openssl_verify(const string &data, const string &signature, const string &pub_key_id, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
+task_t<int64_t> f$openssl_verify(string data, string signature, string pub_key_id, int64_t algo = tl::HashAlgorithm::SHA1) noexcept;
 
 array<string> f$openssl_get_cipher_methods(bool aliases = false) noexcept;
 
 Optional<int64_t> f$openssl_cipher_iv_length(const string &method) noexcept;
 
-task_t<Optional<string>> f$openssl_encrypt(const string &data, const string &method, const string &key, int64_t options = 0, const string &iv = string{},
-                                           string &tag = CryptoInstanceState::get().default_tag_dummy, const string &aad = string{},
-                                           int64_t tag_length = 16) noexcept;
-task_t<Optional<string>> f$openssl_decrypt(string data, const string &method, const string &key, int64_t options = 0, const string &iv = string{},
-                                           string tag = string{}, const string &aad = string{}) noexcept;
+task_t<Optional<string>> f$openssl_encrypt(string data, string method, string key, int64_t options = 0, string iv = string{},
+                                           string &tag = CryptoInstanceState::get().default_tag_dummy, string aad = string{}, int64_t tag_length = 16) noexcept;
+task_t<Optional<string>> f$openssl_decrypt(string data, string method, string key, int64_t options = 0, string iv = string{}, string tag = string{},
+                                           string aad = string{}) noexcept;
 
 array<string> f$hash_algos() noexcept;
 

--- a/runtime-light/stdlib/exit/exit-functions.cpp
+++ b/runtime-light/stdlib/exit/exit-functions.cpp
@@ -9,7 +9,7 @@
 #include "runtime-light/k2-platform/k2-api.h"
 #include "runtime-light/state/instance-state.h"
 
-task_t<void> f$exit(const mixed &v) noexcept { // TODO: make it synchronous
+task_t<void> f$exit(mixed v) noexcept { // TODO: make it synchronous
   auto &instance_st{InstanceState::get()};
 
   int64_t exit_code{};

--- a/runtime-light/stdlib/exit/exit-functions.h
+++ b/runtime-light/stdlib/exit/exit-functions.h
@@ -7,8 +7,8 @@
 #include "runtime-common/core/runtime-core.h"
 #include "runtime-light/coroutine/task.h"
 
-task_t<void> f$exit(const mixed &v = 0) noexcept;
+task_t<void> f$exit(mixed v = 0) noexcept;
 
-inline task_t<void> f$die(const mixed &v = 0) noexcept {
-  co_await f$exit(v);
+inline task_t<void> f$die(mixed v = 0) noexcept {
+  co_await f$exit(std::move(v));
 }

--- a/runtime-light/stdlib/file/file-system-functions.cpp
+++ b/runtime-light/stdlib/file/file-system-functions.cpp
@@ -49,7 +49,7 @@ Optional<string> f$file_get_contents(const string &stream) noexcept {
   return rsrc.get_contents();
 }
 
-task_t<Optional<int64_t>> f$fwrite(const resource &stream, const string &text) noexcept {
+task_t<Optional<int64_t>> f$fwrite(const resource &stream, string text) noexcept {
   auto rsrc{from_mixed<class_instance<underlying_resource_t>>(stream, {})};
   if (rsrc.is_null()) [[unlikely]] {
     php_warning("wrong resource in fwrite %s", stream.to_string().c_str());

--- a/runtime-light/stdlib/file/file-system-functions.cpp
+++ b/runtime-light/stdlib/file/file-system-functions.cpp
@@ -49,7 +49,7 @@ Optional<string> f$file_get_contents(const string &stream) noexcept {
   return rsrc.get_contents();
 }
 
-task_t<Optional<int64_t>> f$fwrite(const resource &stream, string text) noexcept {
+task_t<Optional<int64_t>> f$fwrite(resource stream, string text) noexcept {
   auto rsrc{from_mixed<class_instance<underlying_resource_t>>(stream, {})};
   if (rsrc.is_null()) [[unlikely]] {
     php_warning("wrong resource in fwrite %s", stream.to_string().c_str());

--- a/runtime-light/stdlib/file/file-system-functions.h
+++ b/runtime-light/stdlib/file/file-system-functions.h
@@ -46,7 +46,7 @@ inline string f$basename(const string &path, const string &suffix = {}) noexcept
 
 resource f$fopen(const string &filename, const string &mode, bool use_include_path = false, const resource &context = {}) noexcept;
 
-task_t<Optional<int64_t>> f$fwrite(const resource &stream, const string &text) noexcept;
+task_t<Optional<int64_t>> f$fwrite(const resource &stream, string text) noexcept;
 
 bool f$fflush(const resource &stream) noexcept;
 

--- a/runtime-light/stdlib/time/timer-functions.h
+++ b/runtime-light/stdlib/time/timer-functions.h
@@ -14,7 +14,7 @@
 #include "runtime-light/coroutine/task.h"
 
 template<std::invocable T>
-task_t<void> f$set_timer(int64_t timeout_ms, T &&on_timer_callback) noexcept {
+task_t<void> f$set_timer(int64_t timeout_ms, T on_timer_callback) noexcept {
   if (timeout_ms < 0) {
     php_warning("can't set timer for negative duration %" PRId64 "ms", timeout_ms);
     co_return;
@@ -24,6 +24,5 @@ task_t<void> f$set_timer(int64_t timeout_ms, T &&on_timer_callback) noexcept {
     on_timer_callback();
   }}; // TODO: someone should pop that fork from ForkComponentContext since it will stay there unless we perform f$wait on fork
   const auto duration_ms{std::chrono::milliseconds{static_cast<uint64_t>(timeout_ms)}};
-  co_await start_fork_t{fork_f(std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::forward<T>(on_timer_callback)),
-                        start_fork_t::execution::fork};
+  co_await start_fork_t{fork_f(std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::move(on_timer_callback)), start_fork_t::execution::fork};
 }


### PR DESCRIPTION
It's generally unsafe to pass by reference, this PR fixes it.