### PR TITLE
do not initialize StringLibContext's static buffers

### DIFF
--- a/runtime-common/stdlib/string/string-context.h
+++ b/runtime-common/stdlib/string/string-context.h
@@ -43,7 +43,7 @@ struct StringLibContext final : private vk::not_copyable {
   // The buffer is intended to be used as raw storage, and its contents will be
   // explicitly managed elsewhere in the code.
   std::array<char, STATIC_BUFFER_LENGTH + 1> static_buf;
-  std::array<char, MASK_BUFFER_LENGTH> mask_buffer;
+  std::array<char, MASK_BUFFER_LENGTH> mask_buf;
 
   StringLibContext() noexcept = default;
 

--- a/runtime-common/stdlib/string/string-context.h
+++ b/runtime-common/stdlib/string/string-context.h
@@ -30,17 +30,22 @@ inline constexpr std::string_view PERCENT_ = "%";
 
 }; // namespace string_context_impl_
 
-class StringLibContext final : vk::not_copyable {
+struct StringLibContext final : private vk::not_copyable {
   static constexpr int32_t MASK_BUFFER_LENGTH = 256;
-
-public:
   static constexpr int32_t STATIC_BUFFER_LENGTH = 1U << 23U;
-
-  std::array<char, STATIC_BUFFER_LENGTH + 1> static_buf{};
-  std::array<char, MASK_BUFFER_LENGTH> mask_buffer{};
 
   int64_t str_replace_count_dummy{};
   double default_similar_text_percent_stub{};
+
+  // *** IMPORTANT ***
+  // Do not initialize this array. Initializing it would zero out the memory,
+  // which significantly impacts K2's performance due to the large size of the buffer.
+  // The buffer is intended to be used as raw storage, and its contents will be
+  // explicitly managed elsewhere in the code.
+  std::array<char, STATIC_BUFFER_LENGTH + 1> static_buf;
+  std::array<char, MASK_BUFFER_LENGTH> mask_buffer;
+
+  StringLibContext() noexcept = default;
 
   static StringLibContext &get() noexcept;
 };

--- a/runtime-common/stdlib/string/string-context.h
+++ b/runtime-common/stdlib/string/string-context.h
@@ -37,8 +37,7 @@ struct StringLibContext final : private vk::not_copyable {
   int64_t str_replace_count_dummy{};
   double default_similar_text_percent_stub{};
 
-  // *** IMPORTANT ***
-  // Do not initialize this array. Initializing it would zero out the memory,
+  // Do not initialize these arrays. Initializing it would zero out the memory,
   // which significantly impacts K2's performance due to the large size of the buffer.
   // The buffer is intended to be used as raw storage, and its contents will be
   // explicitly managed elsewhere in the code.

--- a/runtime-common/stdlib/string/string-functions.cpp
+++ b/runtime-common/stdlib/string/string-functions.cpp
@@ -5,7 +5,6 @@
 #include "runtime-common/stdlib/string/string-functions.h"
 
 #include <cctype>
-#include <clocale>
 #include <cstdint>
 #include <sys/types.h>
 
@@ -16,7 +15,7 @@
 #include "runtime-common/stdlib/string/string-context.h"
 
 const char *get_mask(const string &what) noexcept {
-  auto &mask{StringLibContext::get().mask_buffer};
+  auto &mask{StringLibContext::get().mask_buf};
   std::memset(mask.data(), 0, mask.size());
 
   int len = what.size();

--- a/runtime-light/state/instance-state.h
+++ b/runtime-light/state/instance-state.h
@@ -120,7 +120,7 @@ struct InstanceState final : vk::not_copyable {
   RegexInstanceState regex_instance_state;
   CurlInstanceState curl_instance_state{};
   CryptoInstanceState crypto_instance_state{};
-  StringInstanceState string_instance_state{};
+  StringInstanceState string_instance_state;
   SystemInstanceState system_instance_state{};
   FileSystemInstanceState file_system_instance_state{};
 

--- a/runtime-light/state/instance-state.h
+++ b/runtime-light/state/instance-state.h
@@ -11,9 +11,9 @@
 #include <utility>
 
 #include "common/mixin/not_copyable.h"
+#include "runtime-common/core/allocator/runtime-allocator.h"
 #include "runtime-common/core/runtime-core.h"
 #include "runtime-common/core/std/containers.h"
-#include "runtime-light/allocator/allocator.h"
 #include "runtime-light/core/globals/php-script-globals.h"
 #include "runtime-light/coroutine/task.h"
 #include "runtime-light/k2-platform/k2-api.h"


### PR DESCRIPTION
This pull request enhances the performance of the HelloWorld benchmark for K2 by a factor of 32. Previously, we used zero-initialized `std::array` as a buffer in `StringLibContext`. This zeroing of the 8MB array at the start of each request consumed significant CPU time. By switching to uninitialized `std::array`, we avoid unnecessary initialization, resulting in substantial performance improvements.

Following benchmark is enough to see the difference:
```
?php

echo "Hello, World!\n";
```