### PR TITLE
[k2] do not set matches in regex functions unless it's necessary

### DIFF
--- a/runtime-light/stdlib/string/regex-functions.cpp
+++ b/runtime-light/stdlib/string/regex-functions.cpp
@@ -511,8 +511,8 @@ Optional<int64_t> f$preg_match(const string &pattern, const string &subject, Opt
   std::optional<std::reference_wrapper<mixed>> matches{};
   if (opt_matches.has_value()) {
     php_assert(std::holds_alternative<std::reference_wrapper<mixed>>(opt_matches.val()));
-    auto inner_ref{std::get<std::reference_wrapper<mixed>>(opt_matches.val())};
-    inner_ref.get() = array<mixed>{};
+    auto &inner_ref{std::get<std::reference_wrapper<mixed>>(opt_matches.val()).get()};
+    inner_ref = array<mixed>{};
     matches.emplace(inner_ref);
   }
   set_matches(regex_info, flags, matches, trailing_unmatch::skip);

--- a/runtime-light/stdlib/string/regex-functions.cpp
+++ b/runtime-light/stdlib/string/regex-functions.cpp
@@ -383,7 +383,7 @@ PCRE2_SIZE set_matches(const RegexInfo &regex_info, int64_t flags, std::optional
     output.push_back(output_val);
   }
 
-  (*opt_matches).get() = output;
+  (*opt_matches).get() = std::move(output);
   return end_offset;
 }
 

--- a/runtime-light/stdlib/string/regex-functions.h
+++ b/runtime-light/stdlib/string/regex-functions.h
@@ -54,32 +54,32 @@ using regexp = string;
 // === preg_match =================================================================================
 
 Optional<int64_t> f$preg_match(const string &pattern, const string &subject,
-                               Optional<std::variant<std::monostate, std::reference_wrapper<mixed>>> opt_matches = false,
+                               Optional<std::variant<std::monostate, std::reference_wrapper<mixed>>> opt_matches = {},
                                int64_t flags = kphp::regex::PREG_NO_FLAGS, int64_t offset = 0) noexcept;
 
 // === preg_match_all =============================================================================
 
 Optional<int64_t> f$preg_match_all(const string &pattern, const string &subject,
-                                   Optional<std::variant<std::monostate, std::reference_wrapper<mixed>>> opt_matches = false,
+                                   Optional<std::variant<std::monostate, std::reference_wrapper<mixed>>> opt_matches = {},
                                    int64_t flags = kphp::regex::PREG_NO_FLAGS, int64_t offset = 0) noexcept;
 
 // === preg_replace ===============================================================================
 
 Optional<string> f$preg_replace(const string &pattern, const string &replacement, const string &subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false) noexcept;
+                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {}) noexcept;
 
 Optional<string> f$preg_replace(const mixed &pattern, const string &replacement, const string &subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false) noexcept;
+                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {}) noexcept;
 
 Optional<string> f$preg_replace(const mixed &pattern, const mixed &replacement, const string &subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false) noexcept;
+                                Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {}) noexcept;
 
 mixed f$preg_replace(const mixed &pattern, const mixed &replacement, const mixed &subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                     Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false) noexcept;
+                     Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {}) noexcept;
 
 template<class T1, class T2, class T3, class = enable_if_t_is_optional<T3>>
 auto f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                    Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false) noexcept {
+                    Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {}) noexcept {
   return f$preg_replace(regex, replace_val, subject.val(), limit, opt_count);
 }
 
@@ -87,7 +87,7 @@ auto f$preg_replace(const T1 &regex, const T2 &replace_val, const T3 &subject, i
 
 template<std::invocable<array<string>> F>
 task_t<Optional<string>> f$preg_replace_callback(string pattern, F callback, string subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                                 Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false,
+                                                 Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {},
                                                  int64_t flags = kphp::regex::PREG_NO_FLAGS) noexcept {
   static_assert(std::same_as<async_function_unwrapped_return_type_t<F, array<string>>, string>);
   // the performance of this function can be enhanced:
@@ -122,7 +122,7 @@ task_t<Optional<string>> f$preg_replace_callback(string pattern, F callback, str
 
 template<class F>
 task_t<Optional<string>> f$preg_replace_callback(mixed pattern, F callback, string subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                                 Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false,
+                                                 Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {},
                                                  int64_t flags = kphp::regex::PREG_NO_FLAGS) noexcept {
   if (!regex_impl_::valid_preg_replace_mixed(pattern)) [[unlikely]] {
     co_return Optional<string>{};
@@ -161,7 +161,7 @@ task_t<Optional<string>> f$preg_replace_callback(mixed pattern, F callback, stri
 
 template<class F>
 task_t<mixed> f$preg_replace_callback(mixed pattern, F callback, mixed subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                                      Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false,
+                                      Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {},
                                       int64_t flags = kphp::regex::PREG_NO_FLAGS) noexcept {
   if (!regex_impl_::valid_preg_replace_mixed(pattern) || !regex_impl_::valid_preg_replace_mixed(subject)) [[unlikely]] {
     co_return mixed{};
@@ -200,7 +200,7 @@ task_t<mixed> f$preg_replace_callback(mixed pattern, F callback, mixed subject, 
 
 template<class T1, class T2, class T3, class = enable_if_t_is_optional<T3>>
 auto f$preg_replace_callback(T1 &&pattern, T2 &&callback, T3 &&subject, int64_t limit = kphp::regex::PREG_REPLACE_NOLIMIT,
-                             Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = false,
+                             Optional<std::variant<std::monostate, std::reference_wrapper<int64_t>>> opt_count = {},
                              int64_t flags = kphp::regex::PREG_NO_FLAGS) noexcept
   -> decltype(f$preg_replace_callback(std::forward<T1>(pattern), std::forward<T2>(callback), std::forward<T3>(subject).val(), limit, opt_count, flags)) {
   co_return co_await f$preg_replace_callback(std::forward<T1>(pattern), std::forward<T2>(callback), std::forward<T3>(subject).val(), limit, opt_count, flags);

--- a/runtime-light/stdlib/string/regex-state.h
+++ b/runtime-light/stdlib/string/regex-state.h
@@ -5,14 +5,11 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <string_view>
 
 #include "common/mixin/not_copyable.h"
 #include "runtime-common/core/allocator/script-allocator.h"
-#include "runtime-common/core/runtime-core.h"
 #include "runtime-common/core/std/containers.h"
-#include "runtime-light/allocator/allocator.h"
 #include "runtime-light/stdlib/string/regex-include.h"
 #include "runtime-light/utils/concepts.h"
 
@@ -25,8 +22,6 @@ struct RegexInstanceState final : private vk::not_copyable {
   static constexpr size_t MATCH_DATA_SIZE = 3 * MAX_SUBPATTERNS_COUNT;
   static constexpr auto REPLACE_BUFFER_SIZE = static_cast<size_t>(16U * 1024U);
 
-  mixed default_matches;
-  int64_t default_preg_replace_count{};
   const regex_pcre2_general_context_t regex_pcre2_general_context;
   const regex_pcre2_compile_context_t compile_context;
   const regex_pcre2_match_context_t match_context;


### PR DESCRIPTION
This pull request enhances the handling of the `matches` parameter by making it a `Optional`. This change improves the flexibility and safety of the code by explicitly representing the presence or absence of a `matches` parameter to fill.

Key changes:

- The matches variable is now a `Optional`, allowing it to explicitly indicate whether a match is present.
- The use of RegexInstanceState has been eliminated. Previously, it was used to default-initialize certain parameters with lvalue references. This refactoring enhances the overall performance of regex functions since the call to `RegexInstanceState::get()` leads to accessing a thread-local variable inside k2 platform.