### PR TITLE
[k2] implement array_reduce

### DIFF
--- a/builtin-functions/kphp-light/array.txt
+++ b/builtin-functions/kphp-light/array.txt
@@ -89,9 +89,11 @@ function range ($from ::: mixed, $to ::: mixed, $step ::: int = 1) ::: mixed[];
 /** @kphp-extern-func-info interruptible */
 function array_map (callable(^2[*] $x):any $callback, $a ::: array) ::: ^1() [];
 
+/** @kphp-extern-func-info cpp_template_call interruptible */
+function array_reduce ($a ::: array, callable(^3 | ^2() $carry, ^1[*] $item):any $callback, $initial ::: any) ::: ^2() | ^3;
+
 function to_array_debug(any $instance, bool $with_class_names = false) ::: mixed[];
 function instance_to_array(object $instance, $with_class_names ::: bool = false) ::: mixed[];
-
 
 function asort (&$a ::: array, $flag ::: int = SORT_REGULAR) ::: void;
 

--- a/builtin-functions/kphp-light/unsupported/arrays.txt
+++ b/builtin-functions/kphp-light/unsupported/arrays.txt
@@ -40,8 +40,6 @@ function array_column ($a ::: array, $column_key, $index_key = null) ::: array< 
 function array_unset (&$a ::: array, any $key) ::: ^1[*];
 
 function array_filter_by_key ($a ::: array, callable(mixed $key):bool $callback) ::: ^1;
-/** @kphp-extern-func-info cpp_template_call */
-function array_reduce ($a ::: array, callable(^3 | ^2() $carry, ^1[*] $item):any $callback, $initial ::: any) ::: ^2() | ^3;
 function array_is_vector ($a ::: array) ::: bool;
 function array_is_list ($a ::: array) ::: bool;
 

--- a/compiler/code-gen/vertex-compiler.cpp
+++ b/compiler/code-gen/vertex-compiler.cpp
@@ -2077,7 +2077,7 @@ void compile_callback_of_builtin(VertexAdaptor<op_callback_of_builtin> root, Cod
 
   FunctionSignatureGenerator(W) << "(auto &&... args) ";
   if (k2_async_callback) { // add explicit return type to make this lambda async
-    W << "-> task_t<" << TypeName(tinf::get_type(root->func_id, -1)) << "> ";
+    W << "-> decltype(" << FunctionName(root->func_id) << "(std::forward<decltype(args)>(args)...)) ";
   }
   W << BEGIN;
 

--- a/tests/phpt/lambdas/018_typed_array_reduce.php
+++ b/tests/phpt/lambdas/018_typed_array_reduce.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/lambdas/037_template_internal_functions_as_callbacks.php
+++ b/tests/phpt/lambdas/037_template_internal_functions_as_callbacks.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 
 require_once 'kphp_tester_include.php';

--- a/tests/phpt/nn/002_array_reduce.php
+++ b/tests/phpt/nn/002_array_reduce.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 $t = array(1, 2, 3, 4, 5);
 

--- a/tests/phpt/phc/parsing/impure.php
+++ b/tests/phpt/phc/parsing/impure.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
     /** @var int[] */
 	$x = array ();


### PR DESCRIPTION
This PR:

- add `array_reduce` implementation for K2 runtime
- refined the way return types are declared for implicit lambdas used in asynchronous built-in callbacks