### PR TITLE
[k2] fix array_filter

### DIFF
--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -322,7 +322,7 @@ task_t<array<R>> f$array_map(F f, array<A> arr) noexcept {
       result.set_value(it.get_key(), std::invoke(f, it.get_value()));
     }
   }
-  co_return result;
+  co_return std::move(result);
 }
 
 template<class R, class T, class CallbackT, class InitialT>

--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -10,7 +10,6 @@
 #include <utility>
 
 #include "runtime-common/core/runtime-core.h"
-#include "runtime-common/stdlib/array/array-functions.h"
 #include "runtime-light/coroutine/task.h"
 #include "runtime-light/coroutine/type-traits.h"
 #include "runtime-light/stdlib/math/random-functions.h"
@@ -291,27 +290,28 @@ mixed f$array_rand(const array<T> &a, int64_t num) noexcept {
 }
 
 template<class T>
-array<T> f$array_splice(array<T> &a, int64_t offset, int64_t length, const array<Unknown> &) {
+array<T> f$array_splice(array<T> & /*unused*/, int64_t /*unused*/, int64_t /*unused*/, const array<Unknown> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1 = T>
-array<T> f$array_splice(array<T> &a, int64_t offset, int64_t length = std::numeric_limits<int64_t>::max(), const array<T1> &replacement = array<T1>()) {
+array<T> f$array_splice(array<T> & /*unused*/, int64_t /*unused*/, int64_t /*unused*/ = std::numeric_limits<int64_t>::max(),
+                        const array<T1> & /*unused*/ = array<T1>()) {
   php_critical_error("call to unsupported function");
 }
 
 template<class ReturnT, class InputArrayT, class DefaultValueT>
-ReturnT f$array_pad(const array<InputArrayT> &a, int64_t size, const DefaultValueT &default_value) {
+ReturnT f$array_pad(const array<InputArrayT> & /*unused*/, int64_t /*unused*/, const DefaultValueT & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class ReturnT, class DefaultValueT>
-ReturnT f$array_pad(const array<Unknown> &a, int64_t size, const DefaultValueT &default_value) {
+ReturnT f$array_pad(const array<Unknown> & /*unused*/, int64_t /*unused*/, const DefaultValueT & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1>
-array<T> f$array_filter_by_key(const array<T> &a, const T1 &callback) noexcept {
+array<T> f$array_filter_by_key(const array<T> & /*unused*/, const T1 & /*unused*/) noexcept {
   php_critical_error("call to unsupported function");
 }
 
@@ -334,73 +334,74 @@ task_t<array<R>> f$array_map(F f, array<A> arr) noexcept {
 }
 
 template<class R, class T, class CallbackT, class InitialT>
-R f$array_reduce(const array<T> &a, const CallbackT &callback, InitialT initial) {
+R f$array_reduce(const array<T> & /*unused*/, const CallbackT & /*unused*/, InitialT /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-T f$array_merge_spread(const T &a1) {
+T f$array_merge_spread(const T & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-T f$array_merge_spread(const T &a1, const T &a2) {
+T f$array_merge_spread(const T & /*unused*/, const T & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-T f$array_merge_spread(const T &a1, const T &a2, const T &a3, const T &a4 = T(), const T &a5 = T(), const T &a6 = T(), const T &a7 = T(), const T &a8 = T(),
-                       const T &a9 = T(), const T &a10 = T(), const T &a11 = T(), const T &a12 = T()) {
+T f$array_merge_spread(const T & /*unused*/, const T & /*unused*/, const T & /*unused*/, const T & /*unused*/ = T(), const T & /*unused*/ = T(),
+                       const T & /*unused*/ = T(), const T & /*unused*/ = T(), const T & /*unused*/ = T(), const T & /*unused*/ = T(),
+                       const T & /*unused*/ = T(), const T & /*unused*/ = T(), const T & /*unused*/ = T()) {
   php_critical_error("call to unsupported function");
 }
 
 template<class ReturnT, class... Args>
-ReturnT f$array_merge_recursive(const Args &...args) {
+ReturnT f$array_merge_recursive(const Args &.../*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1>
-array<T> f$array_intersect_assoc(const array<T> &a1, const array<T1> &a2) {
+array<T> f$array_intersect_assoc(const array<T> & /*unused*/, const array<T1> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1, class T2>
-array<T> f$array_intersect_assoc(const array<T> &a1, const array<T1> &a2, const array<T2> &a3) {
+array<T> f$array_intersect_assoc(const array<T> & /*unused*/, const array<T1> & /*unused*/, const array<T2> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1>
-array<T> f$array_diff_key(const array<T> &a1, const array<T1> &a2) {
+array<T> f$array_diff_key(const array<T> & /*unused*/, const array<T1> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1>
-array<T> f$array_diff_assoc(const array<T> &a1, const array<T1> &a2) {
+array<T> f$array_diff_assoc(const array<T> & /*unused*/, const array<T1> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1, class T2>
-array<T> f$array_diff_assoc(const array<T> &a1, const array<T1> &a2, const array<T2> &a3) {
+array<T> f$array_diff_assoc(const array<T> & /*unused*/, const array<T1> & /*unused*/, const array<T2> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-array<int64_t> f$array_count_values(const array<T> &a) {
+array<int64_t> f$array_count_values(const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-array<T> f$array_fill(int64_t start_index, int64_t num, const T &value) {
+array<T> f$array_fill(int64_t /*unused*/, int64_t /*unused*/, const T & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T1, class T>
-array<T> f$array_fill_keys(const array<T1> &keys, const T &value) {
+array<T> f$array_fill_keys(const array<T1> & /*unused*/, const T & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T1, class T>
-array<T> f$array_combine(const array<T1> &keys, const array<T> &values) {
+array<T> f$array_combine(const array<T1> & /*unused*/, const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
@@ -442,76 +443,76 @@ requires(std::invocable<Comparator, typename array<T>::key_type, typename array<
 }
 
 template<class T>
-mixed f$getKeyByPos(const array<T> &a, int64_t pos) {
+mixed f$getKeyByPos(const array<T> & /*unused*/, int64_t /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-T f$getValueByPos(const array<T> &a, int64_t pos) {
+T f$getValueByPos(const array<T> & /*unused*/, int64_t /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-array<T> f$create_vector(int64_t n, const T &default_value) {
+array<T> f$create_vector(int64_t /*unused*/, const T & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-mixed f$array_first_key(const array<T> &a) {
+mixed f$array_first_key(const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-void f$array_swap_int_keys(array<T> &a, int64_t idx1, int64_t idx2) noexcept {
+void f$array_swap_int_keys(array<T> & /*unused*/, int64_t /*unused*/, int64_t /*unused*/) noexcept {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-Optional<array<class_instance<T>>> f$array_column(const array<array<class_instance<T>>> &a, const mixed &column_key) {
+Optional<array<class_instance<T>>> f$array_column(const array<array<class_instance<T>>> & /*unused*/, const mixed & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-Optional<array<class_instance<T>>> f$array_column(const array<Optional<array<class_instance<T>>>> &a, const mixed &column_key) {
+Optional<array<class_instance<T>>> f$array_column(const array<Optional<array<class_instance<T>>>> & /*unused*/, const mixed & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-Optional<array<T>> f$array_column(const array<array<T>> &a, const mixed &column_key, const mixed &index_key = {}) {
+Optional<array<T>> f$array_column(const array<array<T>> & /*unused*/, const mixed & /*unused*/, const mixed & /*unused*/ = {}) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-Optional<array<T>> f$array_column(const array<Optional<array<T>>> &a, const mixed &column_key, const mixed &index_key = {}) {
+Optional<array<T>> f$array_column(const array<Optional<array<T>>> & /*unused*/, const mixed & /*unused*/, const mixed & /*unused*/ = {}) {
   php_critical_error("call to unsupported function");
 }
 
-inline Optional<array<mixed>> f$array_column(const array<mixed> &a, const mixed &column_key, const mixed &index_key = {}) {
+inline Optional<array<mixed>> f$array_column(const array<mixed> & /*unused*/, const mixed & /*unused*/, const mixed & /*unused*/ = {}) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-auto f$array_column(const Optional<T> &a, const mixed &column_key,
+auto f$array_column(const Optional<T> & /*unused*/, const mixed &column_key,
                     const mixed &index_key = {}) -> decltype(f$array_column(std::declval<T>(), column_key, index_key)) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-mixed f$array_key_first(const array<T> &a) {
+mixed f$array_key_first(const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-mixed f$array_key_last(const array<T> &a) {
+mixed f$array_key_last(const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T, class T1>
-std::tuple<typename array<T>::key_type, T> f$array_find(const array<T> &a, const T1 &callback) {
+std::tuple<typename array<T>::key_type, T> f$array_find(const array<T> & /*unused*/, const T1 & /*unused*/) {
   php_critical_error("call to unsupported function");
 }
 
 template<class T>
-T f$vk_dot_product(const array<T> &a, const array<T> &b) {
+T f$vk_dot_product(const array<T> & /*unused*/, const array<T> & /*unused*/) {
   php_critical_error("call to unsupported function");
 }

--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -313,9 +313,9 @@ array<T> f$array_filter_by_key(const array<T> & /*unused*/, const T1 & /*unused*
  * versions in case we face with performance problems.
  */
 template<class A, std::invocable<A> F, class R = async_function_unwrapped_return_type_t<F, A>>
-task_t<array<R>> f$array_map(F f, array<A> arr) noexcept {
-  array<R> result{arr.size()};
-  for (const auto &it : arr) {
+task_t<array<R>> f$array_map(F f, array<A> a) noexcept {
+  array<R> result{a.size()};
+  for (const auto &it : a) {
     if constexpr (is_async_function_v<F, A>) {
       result.set_value(it.get_key(), co_await std::invoke(f, it.get_value()));
     } else {

--- a/runtime-light/stdlib/array/array-functions.h
+++ b/runtime-light/stdlib/array/array-functions.h
@@ -270,7 +270,7 @@ mixed f$array_rand(const array<T> &a, int64_t num) noexcept {
     return {};
   }
 
-  array<typename array<T>::key_type> result(array_size(num, true));
+  array<typename array<T>::key_type> result{array_size(num, true)};
   for (const auto &it : a) {
     if (f$mt_rand(0, --size) < num) {
       result.push_back(it.get_key());


### PR DESCRIPTION
- get rid of parameters passed by reference into a coroutine
- get rid of capturing in a lambda coroutines
- simplify array_filter implementation