### PR TITLE
Add --statsd-prefix option

### DIFF
--- a/common/server/statsd-client.h
+++ b/common/server/statsd-client.h
@@ -6,5 +6,5 @@
 
 #include "common/server/engine-settings.h"
 
-void send_data_to_statsd_with_prefix(const char *stats_prefix, unsigned int tag_mask);
+void send_data_to_statsd_with_prefix(const char *custom_stats_prefix, unsigned int tag_mask);
 


### PR DESCRIPTION
Before, prefix for statsd metrics was taken from `--server-config` yaml file as `cluster_name`. But sometimes, it's needed to separate statsd metrics by prefix different from cluster-name.
Now there's `--statsd-prefix` for thar, which overrides old behaviour.