### PR TITLE
make re2c is not required for whole project

### DIFF
--- a/cmake/init-global-vars.cmake
+++ b/cmake/init-global-vars.cmake
@@ -30,14 +30,6 @@ endif()
 find_package(Git REQUIRED)
 find_package(Python3 COMPONENTS Interpreter REQUIRED)
 find_package(Perl REQUIRED)
-find_program(RE2C_EXECUTABLE re2c)
-
-if(NOT RE2C_EXECUTABLE)
-    message(FATAL_ERROR "re2c is required but was not found. Please install re2c and try again.")
-else()
-    message(STATUS "Found re2c: ${RE2C_EXECUTABLE}")
-endif()
-
 
 find_program(CCACHE_FOUND ccache)
 if(CCACHE_FOUND)

--- a/third-party/timelib-cmake/timelib.cmake
+++ b/third-party/timelib-cmake/timelib.cmake
@@ -1,3 +1,11 @@
+find_program(RE2C_EXECUTABLE re2c)
+
+if(NOT RE2C_EXECUTABLE)
+    message(FATAL_ERROR "re2c is required but was not found. Please install re2c and try again.")
+else()
+    message(STATUS "Found re2c: ${RE2C_EXECUTABLE}")
+endif()
+
 update_git_submodule(${THIRD_PARTY_DIR}/timelib "--remote")
 get_submodule_version(${THIRD_PARTY_DIR}/timelib TIMELIB_VERSION)
 get_submodule_remote_url(third-party/timelib TIMELIB_SOURCE_URL)


### PR DESCRIPTION
Moving  presence check of `re2c` into `timelib.cmake` 