### PR TITLE
Better fopen() logs

### DIFF
--- a/runtime-light/stdlib/file/file-system-functions.cpp
+++ b/runtime-light/stdlib/file/file-system-functions.cpp
@@ -15,6 +15,7 @@ resource f$fopen(const string &filename, [[maybe_unused]] const string &mode, [[
                  [[maybe_unused]] const resource &context) noexcept {
   underlying_resource_t rsrc{{filename.c_str(), filename.size()}};
   if (rsrc.last_errc != k2::errno_ok) [[unlikely]] {
+    php_warning("cannot fopen %s", filename.c_str());
     return {};
   }
 

--- a/runtime-light/stdlib/file/file-system-functions.cpp
+++ b/runtime-light/stdlib/file/file-system-functions.cpp
@@ -8,6 +8,7 @@
 #include <string_view>
 
 #include "runtime-common/core/runtime-core.h"
+#include "runtime-common/core/utils/kphp-assert-core.h"
 #include "runtime-light/k2-platform/k2-api.h"
 #include "runtime-light/stdlib/file/resource.h"
 
@@ -19,6 +20,7 @@ resource f$fopen(const string &filename, [[maybe_unused]] const string &mode, [[
     return {};
   }
 
+  php_notice("successfully fopened %s\n", filename.c_str());
   return f$to_mixed(make_instance<underlying_resource_t>(std::move(rsrc)));
 }
 


### PR DESCRIPTION
Add warning when `fopen()` is not succeed and notice when succeed.