### PR TITLE
fix order of worker's cleanup operations

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2362,6 +2362,7 @@ static void free_interface_lib() {
 static void free_runtime_libs() {
   php_assert (dl::in_critical_section == 0);
 
+  free_interface_lib();
   forcibly_stop_and_flush_profiler();
   free_bcmath_lib();
   free_exception_lib();
@@ -2399,7 +2400,6 @@ static void free_runtime_libs() {
   vk::singleton<database_drivers::Adaptor>::get().reset();
   vk::singleton<curl_async::CurlAdaptor>::get().reset();
   vk::singleton<OomHandler>::get().reset();
-  free_interface_lib();
   hard_reset_var(SerializationLibContext::get().last_json_processor_error);
 }
 

--- a/tests/python/tests/shutdown_functions/test_shutdown_functions_capture_shared_mem.py
+++ b/tests/python/tests/shutdown_functions/test_shutdown_functions_capture_shared_mem.py
@@ -1,0 +1,37 @@
+from python.lib.testcase import KphpServerAutoTestCase
+from concurrent.futures import ThreadPoolExecutor
+import time
+
+
+class TestShutdownFunctionsCaptureSharedMem(KphpServerAutoTestCase):
+    @classmethod
+    def extra_class_setup(cls):
+        cls.kphp_server.update_options({
+            "--workers-num": 4,
+        })
+
+    # A specific workload might lead to issues due to the incorrect order of resource release by workers.
+    #
+    # workers  ______         _____
+    #   3     /      |       /     |
+    #   2    /        \     /       \     /
+    #   1   /          |   /         |   /
+    #   0  /            \_/           \_/
+    #
+    # Such workload provides guaranties that in some moment all links to shared objects (for example, in Instance Cache) will be released.
+    # This may trigger certain housekeeping operations in end script's life.
+    # The purpose of following test is to ensure that the order of these cleanup operations is safe and correct.
+    def test_specific_workload_and_capture_instance_cache_element(self):
+        # Need to retry a lot
+        for _ in range(50):
+            responses = []
+            # "bundled" workload simulation
+            with ThreadPoolExecutor(max_workers=16) as async_executor:
+                for _ in range(16):
+                    responses.append(
+                        async_executor.submit(self.kphp_server.http_post, json=[{"op": "capture_instance_cache_element"}])
+                    )
+
+            for r in responses:
+                self.assertEqual(r.result().status_code, 200)
+            time.sleep(0.05)


### PR DESCRIPTION
A specific workload might lead to issues due to the incorrect order of resource release by workers. 

This PR fixes order of worker's cleanup operations.