### PR TITLE
fix incorrect reference to OpenSSL headers

### DIFF
--- a/common/binlog/binlog.cmake
+++ b/common/binlog/binlog.cmake
@@ -8,8 +8,8 @@ prepend(BINLOG_SOURCES ${COMMON_DIR}/binlog/
 
 vk_add_library_no_pic(binlog-src-no-pic OBJECT ${BINLOG_SOURCES})
 add_dependencies(binlog-src-no-pic OpenSSL::no-pic::Crypto)
-target_include_directories(binlog-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIRS})
+target_include_directories(binlog-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR})
 
 vk_add_library_pic(binlog-src-pic OBJECT ${BINLOG_SOURCES})
 add_dependencies(binlog-src-pic OpenSSL::pic::Crypto)
-target_include_directories(binlog-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIRS})
+target_include_directories(binlog-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR})

--- a/common/common.cmake
+++ b/common/common.cmake
@@ -66,8 +66,8 @@ endif()
 
 vk_add_library_no_pic(common-src-no-pic OBJECT ${COMMON_ALL_SOURCES})
 add_dependencies(common-src-no-pic OpenSSL::no-pic::Crypto ZLIB::no-pic::zlib ZSTD::no-pic::zstd)
-target_include_directories(common-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIRS} ${ZLIB_NO_PIC_INCLUDE_DIRS} ${ZSTD_NO_PIC_INCLUDE_DIRS})
+target_include_directories(common-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${ZLIB_NO_PIC_INCLUDE_DIRS} ${ZSTD_NO_PIC_INCLUDE_DIRS})
 
 vk_add_library_pic(common-src-pic OBJECT ${COMMON_ALL_SOURCES})
 add_dependencies(common-src-pic OpenSSL::pic::Crypto ZLIB::pic::zlib ZSTD::pic::zstd)
-target_include_directories(common-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIRS} ${ZLIB_PIC_INCLUDE_DIRS} ${ZSTD_PIC_INCLUDE_DIRS})
+target_include_directories(common-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR} ${ZLIB_PIC_INCLUDE_DIRS} ${ZSTD_PIC_INCLUDE_DIRS})

--- a/compiler/compiler.cmake
+++ b/compiler/compiler.cmake
@@ -246,7 +246,7 @@ list(APPEND KPHP_COMPILER_SOURCES
 
 vk_add_library_no_pic(kphp2cpp_src-no-pic OBJECT ${KPHP_COMPILER_SOURCES})
 add_dependencies(kphp2cpp_src-no-pic OpenSSL::no-pic::Crypto RE2::no-pic::re2 YAML_CPP::no-pic::yaml-cpp)
-target_include_directories(kphp2cpp_src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIRS} ${RE2_NO_PIC_INCLUDE_DIRS} ${YAML_CPP_NO_PIC_INCLUDE_DIRS})
+target_include_directories(kphp2cpp_src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${RE2_NO_PIC_INCLUDE_DIRS} ${YAML_CPP_NO_PIC_INCLUDE_DIRS})
 
 file(MAKE_DIRECTORY ${KPHP_COMPILER_AUTO_DIR})
 add_custom_command(OUTPUT ${KEYWORDS_SET}

--- a/net/net.cmake
+++ b/net/net.cmake
@@ -25,9 +25,9 @@ prepend(NET_SOURCES ${BASE_DIR}/net/
 
 vk_add_library_no_pic(net-src-no-pic OBJECT ${NET_SOURCES})
 add_dependencies(net-src-no-pic OpenSSL::no-pic::Crypto)
-target_include_directories(net-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIRS})
+target_include_directories(net-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR})
 
 vk_add_library_pic(net-src-pic OBJECT ${NET_SOURCES})
 add_dependencies(net-src-pic OpenSSL::pic::Crypto)
-target_include_directories(net-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIRS})
+target_include_directories(net-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR})
 

--- a/server/server.cmake
+++ b/server/server.cmake
@@ -87,8 +87,8 @@ allow_deprecated_declarations_for_apple(${BASE_DIR}/server/php-runner.cpp)
 
 vk_add_library_no_pic(kphp-server-no-pic OBJECT ${KPHP_SERVER_ALL_SOURCES})
 add_dependencies(kphp-server-no-pic OpenSSL::no-pic::Crypto RE2::no-pic::re2 YAML_CPP::no-pic::yaml-cpp ${NUMA_LIB_NO_PIC})
-target_include_directories(kphp-server-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIRS} ${RE2_NO_PIC_INCLUDE_DIRS} ${YAML_CPP_NO_PIC_INCLUDE_DIRS} ${NUMACTL_NO_PIC_INCLUDE_DIRS})
+target_include_directories(kphp-server-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${RE2_NO_PIC_INCLUDE_DIRS} ${YAML_CPP_NO_PIC_INCLUDE_DIRS} ${NUMACTL_NO_PIC_INCLUDE_DIRS})
 
 vk_add_library_pic(kphp-server-pic OBJECT ${KPHP_SERVER_ALL_SOURCES})
 add_dependencies(kphp-server-pic OpenSSL::pic::Crypto RE2::pic::re2 YAML_CPP::pic::yaml-cpp ${NUMA_LIB_NO_PIC})
-target_include_directories(kphp-server-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIRS} ${RE2_PIC_INCLUDE_DIRS} ${YAML_CPP_PIC_INCLUDE_DIRS} ${NUMACTL_PIC_INCLUDE_DIRS})
+target_include_directories(kphp-server-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR} ${RE2_PIC_INCLUDE_DIRS} ${YAML_CPP_PIC_INCLUDE_DIRS} ${NUMACTL_PIC_INCLUDE_DIRS})


### PR DESCRIPTION
Fix issues like this:
```
make[2]: *** No rule to make target '../objs/include/openssl/aes.h', needed by 'CMakeFiles/binlog-src-no-pic.dir/common/binlog/kdb-binlog-common.cpp.o'.  Stop.
  make[1]: *** [CMakeFiles/Makefile2:591: CMakeFiles/binlog-src-no-pic.dir/all] Error 2
  make[1]: *** Waiting for unfinished jobs..
```