### PR TITLE
[k2] enhance TL library

### DIFF
--- a/runtime-light/server/http/init-functions.cpp
+++ b/runtime-light/server/http/init-functions.cpp
@@ -223,11 +223,11 @@ void init_server(tl::K2InvokeHttp invoke_http) noexcept {
 
   server.set_value(string{SERVER_ADDR.data(), SERVER_ADDR.size()},
                    string{invoke_http.connection.server_addr.value.data(), static_cast<string::size_type>(invoke_http.connection.server_addr.value.size())});
-  server.set_value(string{SERVER_PORT.data(), SERVER_PORT.size()}, static_cast<int64_t>(invoke_http.connection.server_port));
+  server.set_value(string{SERVER_PORT.data(), SERVER_PORT.size()}, static_cast<int64_t>(invoke_http.connection.server_port.value));
   server.set_value(string{SERVER_PROTOCOL.data(), SERVER_PROTOCOL.size()}, get_server_protocol(invoke_http.version, invoke_http.uri.opt_scheme));
   server.set_value(string{REMOTE_ADDR.data(), REMOTE_ADDR.size()},
                    string{invoke_http.connection.remote_addr.value.data(), static_cast<string::size_type>(invoke_http.connection.remote_addr.value.size())});
-  server.set_value(string{REMOTE_PORT.data(), REMOTE_PORT.size()}, static_cast<int64_t>(invoke_http.connection.remote_port));
+  server.set_value(string{REMOTE_PORT.data(), REMOTE_PORT.size()}, static_cast<int64_t>(invoke_http.connection.remote_port.value));
 
   server.set_value(string{REQUEST_METHOD.data(), REQUEST_METHOD.size()},
                    string{invoke_http.method.value.data(), static_cast<string::size_type>(invoke_http.method.value.size())});
@@ -330,7 +330,7 @@ kphp::coro::task<> finalize_server(const string_buffer& output) noexcept {
 
   const auto status_code{http_server_instance_st.status_code == status::NO_STATUS ? status::OK : http_server_instance_st.status_code};
   tl::httpResponse http_response{.version = tl::HttpVersion{.version = tl::HttpVersion::Version::V11},
-                                 .status_code = static_cast<int32_t>(status_code),
+                                 .status_code = {.value = static_cast<int32_t>(status_code)},
                                  .headers = {},
                                  .body = {body.c_str(), body.size()}};
   // fill headers

--- a/runtime-light/server/job-worker/init-functions.h
+++ b/runtime-light/server/job-worker/init-functions.h
@@ -13,12 +13,12 @@ inline void init_job_server(tl::K2InvokeJobWorker invoke_jw) noexcept {
   auto& jw_server_ctx{JobWorkerServerInstanceState::get()};
   jw_server_ctx.kind = invoke_jw.ignore_answer ? JobWorkerServerInstanceState::Kind::NoReply : JobWorkerServerInstanceState::Kind::Regular;
   jw_server_ctx.state = JobWorkerServerInstanceState::State::Working;
-  jw_server_ctx.job_id = invoke_jw.job_id;
+  jw_server_ctx.job_id = invoke_jw.job_id.value;
   jw_server_ctx.body = {invoke_jw.body.value.data(), static_cast<string::size_type>(invoke_jw.body.value.size())};
 
   {
     using namespace PhpServerSuperGlobalIndices;
     auto& server{InstanceState::get().php_script_mutable_globals_singleton.get_superglobals().v$_SERVER};
-    server.set_value(string{JOB_ID.data(), JOB_ID.size()}, invoke_jw.job_id);
+    server.set_value(string{JOB_ID.data(), JOB_ID.size()}, invoke_jw.job_id.value);
   }
 }

--- a/runtime-light/state/init-functions.cpp
+++ b/runtime-light/state/init-functions.cpp
@@ -33,7 +33,7 @@ void process_k2_invoke_job_worker(tl::TLBuffer& tlb) noexcept {
   if (!invoke_jw.fetch(tlb)) {
     php_error("erroneous job worker request");
   }
-  php_assert(invoke_jw.image_id == k2::describe()->build_timestamp); // ensure that we got the request from ourselves
+  php_assert(invoke_jw.image_id.value == static_cast<int64_t>(k2::describe()->build_timestamp)); // ensure that we got the request from ourselves
   init_server(ServerQuery{invoke_jw});
 }
 

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -35,7 +35,7 @@ kphp::coro::task<Optional<string>> f$openssl_random_pseudo_bytes(int64_t length)
 
   // TODO think about performance when transferring data
 
-  tl::GetCryptosecurePseudorandomBytes request{.size = static_cast<int32_t>(length)};
+  tl::GetCryptosecurePseudorandomBytes request{.size = {.value = static_cast<int32_t>(length)}};
 
   tl::TLBuffer buffer;
   request.store(buffer);
@@ -82,7 +82,7 @@ kphp::coro::task<Optional<array<mixed>>> f$openssl_x509_parse(string data, bool 
   array<mixed> response;
   response.reserve(cert_items.opt_value->size(), false);
 
-  auto item_to_mixed = tl::CertInfoItem::MakeVisitor{[](int64_t val) -> mixed { return val; },
+  auto item_to_mixed = tl::CertInfoItem::MakeVisitor{[](tl::long_ val) -> mixed { return val.value; },
                                                      [](tl::string val) -> mixed { return string(val.value.data(), val.value.size()); },
                                                      [](const tl::dictionary<tl::string>& sub_dict) -> mixed {
                                                        array<mixed> resp;

--- a/runtime-light/stdlib/crypto/crypto-functions.cpp
+++ b/runtime-light/stdlib/crypto/crypto-functions.cpp
@@ -82,7 +82,7 @@ kphp::coro::task<Optional<array<mixed>>> f$openssl_x509_parse(string data, bool 
   array<mixed> response;
   response.reserve(cert_items.opt_value->size(), false);
 
-  auto item_to_mixed = tl::CertInfoItem::MakeVisitor{[](tl::long_ val) -> mixed { return val.value; },
+  auto item_to_mixed = tl::CertInfoItem::MakeVisitor{[](tl::i64 val) -> mixed { return val.value; },
                                                      [](tl::string val) -> mixed { return string(val.value.data(), val.value.size()); },
                                                      [](const tl::dictionary<tl::string>& sub_dict) -> mixed {
                                                        array<mixed> resp;

--- a/runtime-light/tl/tl-core.h
+++ b/runtime-light/tl/tl-core.h
@@ -124,12 +124,12 @@ public:
 };
 
 template<typename T>
-concept tl_serializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
+concept serializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
   { t.store(tlb) } noexcept -> std::same_as<void>;
 };
 
 template<typename T>
-concept tl_deserializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
+concept deserializable = std::default_initializable<T> && requires(T t, TLBuffer tlb) {
   { t.fetch(tlb) } noexcept -> std::convertible_to<bool>;
 };
 

--- a/runtime-light/tl/tl-functions.cpp
+++ b/runtime-light/tl/tl-functions.cpp
@@ -14,57 +14,49 @@ namespace tl {
 
 // ===== JOB WORKERS =====
 
-bool K2InvokeJobWorker::fetch(TLBuffer& tlb) noexcept {
+bool K2InvokeJobWorker::fetch(tl::TLBuffer& tlb) noexcept {
   bool ok{tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == K2_INVOKE_JOB_WORKER_MAGIC};
   const auto opt_flags{tlb.fetch_trivial<uint32_t>()};
-  ok &= opt_flags.has_value();
-  const auto opt_image_id{tlb.fetch_trivial<uint64_t>()};
-  ok &= opt_image_id.has_value();
-  const auto opt_job_id{tlb.fetch_trivial<int64_t>()};
-  ok &= opt_job_id.has_value();
-  const auto opt_timeout_ns{tlb.fetch_trivial<uint64_t>()};
-  ok &= opt_timeout_ns.has_value();
-  ok &= body.fetch(tlb);
-
   ignore_answer = static_cast<bool>(opt_flags.value_or(0x0) & IGNORE_ANSWER_FLAG);
-  image_id = opt_image_id.value_or(0);
-  job_id = opt_job_id.value_or(0);
-  timeout_ns = opt_timeout_ns.value_or(0);
-
+  ok &= opt_flags.has_value();
+  ok &= image_id.fetch(tlb);
+  ok &= job_id.fetch(tlb);
+  ok &= timeout_ns.fetch(tlb);
+  ok &= body.fetch(tlb);
   return ok;
 }
 
-void K2InvokeJobWorker::store(TLBuffer& tlb) const noexcept {
+void K2InvokeJobWorker::store(tl::TLBuffer& tlb) const noexcept {
   const uint32_t flags{ignore_answer ? IGNORE_ANSWER_FLAG : 0x0};
   tlb.store_trivial<uint32_t>(K2_INVOKE_JOB_WORKER_MAGIC);
   tlb.store_trivial<uint32_t>(flags);
-  tlb.store_trivial<uint64_t>(image_id);
-  tlb.store_trivial<int64_t>(job_id);
-  tlb.store_trivial<uint64_t>(timeout_ns);
+  image_id.store(tlb);
+  job_id.store(tlb);
+  timeout_ns.store(tlb);
   body.store(tlb);
 }
 
 // ===== CRYPTO =====
 
-void GetCryptosecurePseudorandomBytes::store(TLBuffer& tlb) const noexcept {
+void GetCryptosecurePseudorandomBytes::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(GET_CRYPTOSECURE_PSEUDORANDOM_BYTES_MAGIC);
-  tlb.store_trivial<int32_t>(size);
+  size.store(tlb);
 }
 
-void GetPemCertInfo::store(TLBuffer& tlb) const noexcept {
+void GetPemCertInfo::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(GET_PEM_CERT_INFO_MAGIC);
   tlb.store_trivial<uint32_t>(is_short ? TL_BOOL_TRUE : TL_BOOL_FALSE);
   bytes.store(tlb);
 }
 
-void DigestSign::store(TLBuffer& tlb) const noexcept {
+void DigestSign::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(DIGEST_SIGN_MAGIC);
   data.store(tlb);
   private_key.store(tlb);
   tlb.store_trivial<uint32_t>(algorithm);
 }
 
-void DigestVerify::store(TLBuffer& tlb) const noexcept {
+void DigestVerify::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(DIGEST_VERIFY_MAGIC);
   data.store(tlb);
   public_key.store(tlb);
@@ -72,7 +64,7 @@ void DigestVerify::store(TLBuffer& tlb) const noexcept {
   signature.store(tlb);
 }
 
-void CbcDecrypt::store(TLBuffer& tlb) const noexcept {
+void CbcDecrypt::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(CBC_DECRYPT_MAGIC);
   tlb.store_trivial<uint32_t>(algorithm);
   tlb.store_trivial<uint32_t>(padding);
@@ -81,7 +73,7 @@ void CbcDecrypt::store(TLBuffer& tlb) const noexcept {
   data.store(tlb);
 }
 
-void CbcEncrypt::store(TLBuffer& tlb) const noexcept {
+void CbcEncrypt::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(CBC_ENCRYPT_MAGIC);
   tlb.store_trivial<uint32_t>(algorithm);
   tlb.store_trivial<uint32_t>(padding);
@@ -90,13 +82,13 @@ void CbcEncrypt::store(TLBuffer& tlb) const noexcept {
   data.store(tlb);
 }
 
-void Hash::store(TLBuffer& tlb) const noexcept {
+void Hash::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(HASH_MAGIC);
   tlb.store_trivial<uint32_t>(algorithm);
   data.store(tlb);
 }
 
-void HashHmac::store(TLBuffer& tlb) const noexcept {
+void HashHmac::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(HASH_HMAC_MAGIC);
   tlb.store_trivial<uint32_t>(algorithm);
   data.store(tlb);
@@ -105,19 +97,19 @@ void HashHmac::store(TLBuffer& tlb) const noexcept {
 
 // ===== CONFDATA =====
 
-void ConfdataGet::store(TLBuffer& tlb) const noexcept {
+void ConfdataGet::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(CONFDATA_GET_MAGIC);
   key.store(tlb);
 }
 
-void ConfdataGetWildcard::store(TLBuffer& tlb) const noexcept {
+void ConfdataGetWildcard::store(tl::TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(CONFDATA_GET_WILDCARD_MAGIC);
   wildcard.store(tlb);
 }
 
 // ===== HTTP =====
 
-bool K2InvokeHttp::fetch(TLBuffer& tlb) noexcept {
+bool K2InvokeHttp::fetch(tl::TLBuffer& tlb) noexcept {
   bool ok{tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == K2_INVOKE_HTTP_MAGIC};
   ok &= tlb.fetch_trivial<uint32_t>().has_value(); // flags
   ok &= connection.fetch(tlb);

--- a/runtime-light/tl/tl-functions.h
+++ b/runtime-light/tl/tl-functions.h
@@ -20,15 +20,15 @@ class K2InvokeJobWorker final {
   static constexpr auto IGNORE_ANSWER_FLAG = static_cast<uint32_t>(1U << 0U);
 
 public:
-  uint64_t image_id{};
-  int64_t job_id{};
+  tl::long_ image_id{};
+  tl::long_ job_id{};
   bool ignore_answer{};
-  uint64_t timeout_ns{};
-  string body;
+  tl::long_ timeout_ns{};
+  tl::string body;
 
-  bool fetch(TLBuffer& tlb) noexcept;
+  bool fetch(tl::TLBuffer& tlb) noexcept;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 // ===== CRYPTO =====
@@ -43,68 +43,68 @@ inline constexpr uint32_t HASH_MAGIC = 0x5073'2a27;
 inline constexpr uint32_t HASH_HMAC_MAGIC = 0x8dcb'3d9d;
 
 struct GetCryptosecurePseudorandomBytes final {
-  int32_t size{};
+  tl::int_ size{};
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct GetPemCertInfo final {
   bool is_short{true};
-  string bytes;
+  tl::string bytes;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct DigestSign final {
-  string data;
-  string private_key;
-  HashAlgorithm algorithm{};
+  tl::string data;
+  tl::string private_key;
+  tl::HashAlgorithm algorithm{};
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct DigestVerify final {
-  string data;
-  string public_key;
-  HashAlgorithm algorithm{};
-  string signature;
+  tl::string data;
+  tl::string public_key;
+  tl::HashAlgorithm algorithm{};
+  tl::string signature;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct CbcDecrypt final {
-  CipherAlgorithm algorithm{};
-  BlockPadding padding{};
-  string passphrase;
-  string iv;
-  string data;
+  tl::CipherAlgorithm algorithm{};
+  tl::BlockPadding padding{};
+  tl::string passphrase;
+  tl::string iv;
+  tl::string data;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct CbcEncrypt final {
-  CipherAlgorithm algorithm{};
-  BlockPadding padding{};
-  string passphrase;
-  string iv;
-  string data;
+  tl::CipherAlgorithm algorithm{};
+  tl::BlockPadding padding{};
+  tl::string passphrase;
+  tl::string iv;
+  tl::string data;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct Hash final {
-  HashAlgorithm algorithm{};
-  string data;
+  tl::HashAlgorithm algorithm{};
+  tl::string data;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct HashHmac final {
-  HashAlgorithm algorithm{};
-  string data;
-  string secret_key;
+  tl::HashAlgorithm algorithm{};
+  tl::string data;
+  tl::string secret_key;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 // ===== CONFDATA =====
@@ -113,15 +113,15 @@ inline constexpr uint32_t CONFDATA_GET_MAGIC = 0xf0eb'cd89;
 inline constexpr uint32_t CONFDATA_GET_WILDCARD_MAGIC = 0x5759'bd9e;
 
 struct ConfdataGet final {
-  string key;
+  tl::string key;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 struct ConfdataGetWildcard final {
-  string wildcard;
+  tl::string wildcard;
 
-  void store(TLBuffer& tlb) const noexcept;
+  void store(tl::TLBuffer& tlb) const noexcept;
 };
 
 // ===== HTTP =====
@@ -134,14 +134,14 @@ class K2InvokeHttp final {
   static constexpr auto QUERY_FLAG = static_cast<uint32_t>(1U << 2U);
 
 public:
-  httpConnection connection{};
-  HttpVersion version{};
-  string method;
-  httpUri uri{};
-  vector<httpHeaderEntry> headers{};
+  tl::httpConnection connection{};
+  tl::HttpVersion version{};
+  tl::string method;
+  tl::httpUri uri{};
+  tl::vector<tl::httpHeaderEntry> headers{};
   std::string_view body;
 
-  bool fetch(TLBuffer& tlb) noexcept;
+  bool fetch(tl::TLBuffer& tlb) noexcept;
 };
 
 } // namespace tl

--- a/runtime-light/tl/tl-functions.h
+++ b/runtime-light/tl/tl-functions.h
@@ -20,10 +20,10 @@ class K2InvokeJobWorker final {
   static constexpr auto IGNORE_ANSWER_FLAG = static_cast<uint32_t>(1U << 0U);
 
 public:
-  tl::long_ image_id{};
-  tl::long_ job_id{};
+  tl::i64 image_id{};
+  tl::i64 job_id{};
   bool ignore_answer{};
-  tl::long_ timeout_ns{};
+  tl::i64 timeout_ns{};
   tl::string body;
 
   bool fetch(tl::TLBuffer& tlb) noexcept;
@@ -43,7 +43,7 @@ inline constexpr uint32_t HASH_MAGIC = 0x5073'2a27;
 inline constexpr uint32_t HASH_HMAC_MAGIC = 0x8dcb'3d9d;
 
 struct GetCryptosecurePseudorandomBytes final {
-  tl::int_ size{};
+  tl::i32 size{};
 
   void store(tl::TLBuffer& tlb) const noexcept;
 };

--- a/runtime-light/tl/tl-types.cpp
+++ b/runtime-light/tl/tl-types.cpp
@@ -126,7 +126,7 @@ bool CertInfoItem::fetch(TLBuffer& tlb) noexcept {
 
   switch (*opt_magic) {
   case Magic::LONG: {
-    if (tl::long_ val{}; val.fetch(tlb)) [[likely]] {
+    if (tl::i64 val{}; val.fetch(tlb)) [[likely]] {
       data = val;
       break;
     }

--- a/runtime-light/tl/tl-types.cpp
+++ b/runtime-light/tl/tl-types.cpp
@@ -106,19 +106,15 @@ void string::store(TLBuffer& tlb) const noexcept {
 bool K2JobWorkerResponse::fetch(TLBuffer& tlb) noexcept {
   bool ok{tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC};
   ok &= tlb.fetch_trivial<uint32_t>().has_value(); // flags
-  const auto opt_job_id{tlb.fetch_trivial<int64_t>()};
-  ok &= opt_job_id.has_value();
+  ok &= job_id.fetch(tlb);
   ok &= body.fetch(tlb);
-
-  job_id = opt_job_id.value_or(0);
-
   return ok;
 }
 
 void K2JobWorkerResponse::store(TLBuffer& tlb) const noexcept {
   tlb.store_trivial<uint32_t>(MAGIC);
   tlb.store_trivial<uint32_t>(0x0); // flags
-  tlb.store_trivial<int64_t>(job_id);
+  job_id.store(tlb);
   body.store(tlb);
 }
 
@@ -130,21 +126,21 @@ bool CertInfoItem::fetch(TLBuffer& tlb) noexcept {
 
   switch (*opt_magic) {
   case Magic::LONG: {
-    if (const auto opt_val{tlb.fetch_trivial<int64_t>()}; opt_val.has_value()) [[likely]] {
-      data = *opt_val;
+    if (tl::long_ val{}; val.fetch(tlb)) [[likely]] {
+      data = val;
       break;
     }
     return false;
   }
   case Magic::STR: {
-    if (string val{}; val.fetch(tlb)) [[unlikely]] {
+    if (tl::string val{}; val.fetch(tlb)) [[likely]] {
       data = val;
       break;
     }
     return false;
   }
   case Magic::DICT: {
-    if (dictionary<string> val{}; val.fetch(tlb)) [[likely]] {
+    if (tl::dictionary<tl::string> val{}; val.fetch(tlb)) [[likely]] {
       data = std::move(val);
       break;
     }

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -46,18 +46,15 @@ struct int_ final {
   }
 };
 
-class Int final {
-  static constexpr uint32_t MAGIC = 0xa850'9bda;
-
-public:
+struct Int final {
   tl::int_ inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
-    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_INT && inner.fetch(tlb);
   }
 
   void store(tl::TLBuffer& tlb) const noexcept {
-    tlb.store_trivial<uint32_t>(MAGIC);
+    tlb.store_trivial<uint32_t>(TL_INT);
     inner.store(tlb);
   }
 };
@@ -76,18 +73,15 @@ struct long_ final {
   }
 };
 
-class Long final {
-  static constexpr uint32_t MAGIC = 0x2207'6cba;
-
-public:
+struct Long final {
   tl::long_ inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
-    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_LONG && inner.fetch(tlb);
   }
 
   void store(tl::TLBuffer& tlb) const noexcept {
-    tlb.store_trivial<uint32_t>(MAGIC);
+    tlb.store_trivial<uint32_t>(TL_LONG);
     inner.store(tlb);
   }
 };
@@ -106,18 +100,15 @@ struct float_ final {
   }
 };
 
-class Float final {
-  static constexpr uint32_t MAGIC = 0x824d'ab22;
-
-public:
+struct Float final {
   tl::float_ inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
-    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_FLOAT && inner.fetch(tlb);
   }
 
   void store(tl::TLBuffer& tlb) const noexcept {
-    tlb.store_trivial<uint32_t>(MAGIC);
+    tlb.store_trivial<uint32_t>(TL_FLOAT);
     inner.store(tlb);
   }
 };
@@ -136,18 +127,15 @@ struct double_ final {
   }
 };
 
-class Double final {
-  static constexpr uint32_t MAGIC = 0x2210'c154;
-
-public:
+struct Double final {
   tl::double_ inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
-    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_DOUBLE && inner.fetch(tlb);
   }
 
   void store(tl::TLBuffer& tlb) const noexcept {
-    tlb.store_trivial<uint32_t>(MAGIC);
+    tlb.store_trivial<uint32_t>(TL_DOUBLE);
     inner.store(tlb);
   }
 };

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -34,6 +34,126 @@ struct Bool final {
   }
 };
 
+struct int_ final {
+  int32_t value{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    const auto opt_value{tlb.fetch_trivial<int32_t>()};
+    value = opt_value.value_or(0);
+    return opt_value.has_value();
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<int32_t>(value);
+  }
+};
+
+class Int final {
+  static constexpr uint32_t MAGIC = 0xa850'9bda;
+
+public:
+  tl::int_ inner{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(MAGIC);
+    inner.store(tlb);
+  }
+};
+
+struct long_ final {
+  int64_t value{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    const auto opt_value{tlb.fetch_trivial<int64_t>()};
+    value = opt_value.value_or(0);
+    return opt_value.has_value();
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<int64_t>(value);
+  }
+};
+
+class Long final {
+  static constexpr uint32_t MAGIC = 0x2207'6cba;
+
+public:
+  tl::long_ inner{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(MAGIC);
+    inner.store(tlb);
+  }
+};
+
+struct float_ final {
+  float value{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    const auto opt_value{tlb.fetch_trivial<float>()};
+    value = opt_value.value_or(0.0);
+    return opt_value.has_value();
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<float>(value);
+  }
+};
+
+class Float final {
+  static constexpr uint32_t MAGIC = 0x824d'ab22;
+
+public:
+  tl::float_ inner{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(MAGIC);
+    inner.store(tlb);
+  }
+};
+
+struct double_ final {
+  double value{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    const auto opt_value{tlb.fetch_trivial<double>()};
+    value = opt_value.value_or(0.0);
+    return opt_value.has_value();
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<double>(value);
+  }
+};
+
+class Double final {
+  static constexpr uint32_t MAGIC = 0x2210'c154;
+
+public:
+  tl::double_ inner{};
+
+  bool fetch(tl::TLBuffer& tlb) noexcept {
+    return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == MAGIC && inner.fetch(tlb);
+  }
+
+  void store(tl::TLBuffer& tlb) const noexcept {
+    tlb.store_trivial<uint32_t>(MAGIC);
+    inner.store(tlb);
+  }
+};
+
 template<typename T>
 struct Maybe final {
   std::optional<T> opt_value{};

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -32,7 +32,7 @@ struct Bool final {
   }
 };
 
-struct int_ final {
+struct i32 final {
   int32_t value{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
@@ -46,8 +46,8 @@ struct int_ final {
   }
 };
 
-struct Int final {
-  tl::int_ inner{};
+struct I32 final {
+  tl::i32 inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
     return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_INT && inner.fetch(tlb);
@@ -59,7 +59,7 @@ struct Int final {
   }
 };
 
-struct long_ final {
+struct i64 final {
   int64_t value{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
@@ -73,8 +73,8 @@ struct long_ final {
   }
 };
 
-struct Long final {
-  tl::long_ inner{};
+struct I64 final {
+  tl::i64 inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
     return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_LONG && inner.fetch(tlb);
@@ -86,7 +86,7 @@ struct Long final {
   }
 };
 
-struct float_ final {
+struct f32 final {
   float value{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
@@ -100,8 +100,8 @@ struct float_ final {
   }
 };
 
-struct Float final {
-  tl::float_ inner{};
+struct F32 final {
+  tl::f32 inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
     return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_FLOAT && inner.fetch(tlb);
@@ -113,7 +113,7 @@ struct Float final {
   }
 };
 
-struct double_ final {
+struct f64 final {
   double value{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
@@ -127,8 +127,8 @@ struct double_ final {
   }
 };
 
-struct Double final {
-  tl::double_ inner{};
+struct F64 final {
+  tl::f64 inner{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
     return tlb.fetch_trivial<uint32_t>().value_or(TL_ZERO) == TL_DOUBLE && inner.fetch(tlb);
@@ -419,7 +419,7 @@ class K2JobWorkerResponse final {
   static constexpr uint32_t MAGIC = 0x3afb'3a08;
 
 public:
-  tl::long_ job_id{};
+  tl::i64 job_id{};
   tl::string body;
 
   bool fetch(tl::TLBuffer& tlb) noexcept;
@@ -433,7 +433,7 @@ class CertInfoItem final {
   enum Magic : uint32_t { LONG = 0x533f'f89f, STR = 0xc427'feef, DICT = 0x1ea8'a774 };
 
 public:
-  std::variant<tl::long_, tl::string, tl::dictionary<tl::string>> data;
+  std::variant<tl::i64, tl::string, tl::dictionary<tl::string>> data;
 
   bool fetch(tl::TLBuffer& tlb) noexcept;
 
@@ -606,9 +606,9 @@ struct httpHeaderEntry final {
 
 struct httpConnection final {
   tl::string server_addr;
-  tl::int_ server_port{};
+  tl::i32 server_port{};
   tl::string remote_addr;
-  tl::int_ remote_port{};
+  tl::i32 remote_port{};
 
   bool fetch(tl::TLBuffer& tlb) noexcept {
     bool ok{server_addr.fetch(tlb)};
@@ -621,7 +621,7 @@ struct httpConnection final {
 
 struct httpResponse final {
   tl::HttpVersion version{};
-  tl::int_ status_code{};
+  tl::i32 status_code{};
   tl::vector<tl::httpHeaderEntry> headers{};
   std::string_view body;
 


### PR DESCRIPTION
1. add missing `tl::int, tl::long, tl::float, tl::double` types and name them `tl::i32, tl::i64, tl::f32, tl::f64` respectively
2. use them instead of raw types
3. add `tl::` prefix everywhere