### PR TITLE
fixed a bug with bool type mapping in vkext

### DIFF
--- a/vkext/vkext-rpc-tl-serialization.cpp
+++ b/vkext/vkext-rpc-tl-serialization.cpp
@@ -440,7 +440,7 @@ int get_full_tree_type_name(char *dst, struct tl_tree_type *tree, const char *co
       } else if (cur_type->name == TL_LONG || !strcmp(cur_type->id, "#")) {
         dst += make_tl_class_name(dst, "", "int", "", '\0');
       } else if (!strcmp(cur_type->id, "Bool")) {
-        dst += make_tl_class_name(dst, "", "bool", "", '\0');
+        dst += make_tl_class_name(dst, "", "boolean", "", '\0');
       } else {
         php_error_docref(NULL, E_ERROR,
                          "Unexpected type %s during creating instance", cur_type->id);


### PR DESCRIPTION
Fixed a bug where `tlgen` and `tl2php` converted the `bool` type as `boolean` and left `vkext` as is

https://github.com/VKCOM/kphp/blob/51c36da95e307dcd030c0466d3e2be6060ffaa5f/common/tl2php/combinator-to-php.cpp#L90