### PR TITLE
fixed the path to python tests in CI

### DIFF
--- a/.github/workflows/debian.yml
+++ b/.github/workflows/debian.yml
@@ -86,7 +86,7 @@ jobs:
         id: python_tests
         continue-on-error: true
         run: docker exec kphp-build-container-${{matrix.os}} bash -c
-          "chown -R kitten /home && su kitten -c 'GITHUB_ACTIONS=1 KPHP_TESTS_POLYFILLS_REPO=${{env.kphp_polyfills_dir}} KPHP_CXX=${{matrix.compiler}} python3.7 -m pytest --tb=native -n$(nproc) ${{env.kphp_root_dir}}/tests/python/'"
+          "chown -R kitten /home && su kitten -c 'GITHUB_ACTIONS=1 KPHP_TESTS_POLYFILLS_REPO=${{env.kphp_polyfills_dir}} KPHP_CXX=${{matrix.compiler}} python3.7 -m pytest --tb=native -n$(nproc) ${{env.kphp_root_dir}}/tests/python/tests'"
 
       - name: Prepare python tests artifacts
         if: steps.python_tests.outcome == 'failure'

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -96,7 +96,7 @@ jobs:
         id: python_tests
         continue-on-error: true
         run: docker exec kphp-build-container-${{matrix.os}} bash -c
-          "chown -R kitten /home && su kitten -c 'GITHUB_ACTIONS=1 KPHP_TESTS_POLYFILLS_REPO=${{env.kphp_polyfills_dir}} KPHP_CXX=${{matrix.compiler}} python3.7 -m pytest --tb=native -n$(nproc) ${{env.kphp_root_dir}}/tests/python/'"
+          "chown -R kitten /home && su kitten -c 'GITHUB_ACTIONS=1 KPHP_TESTS_POLYFILLS_REPO=${{env.kphp_polyfills_dir}} KPHP_CXX=${{matrix.compiler}} python3.7 -m pytest --tb=native -n$(nproc) ${{env.kphp_root_dir}}/tests/python/tests'"
 
       - name: Prepare python tests artifacts
         if: steps.python_tests.outcome == 'failure'


### PR DESCRIPTION
Now in the `GitHub Actions` logs you can see the following error: `PytestUnknownMarkWarning: Unknown pytest.mark.k2_skip_suite - is this a typo?  You can register custom mark`.
https://github.com/VKCOM/kphp/actions/runs/15002660263/job/42153394928#step:13:488

It's a bit annoying and misleading. To fix it, I changed the path to `python` tests where the `pytest.ini` file lies.

**IMPORTANT**: the paths in `TeamCity` and `GitHub Actions` are now the same.

P.S. I **don't like** this method of running tests. It should be done through some kind of script / `make` / `python` script. Not by directly calling the `python` interpreter.