### PR TITLE
[k2] Fix concurrent launching k2-node in tests

### DIFF
--- a/tests/python/lib/k2_server.py
+++ b/tests/python/lib/k2_server.py
@@ -24,6 +24,7 @@ class K2Server(WebServer):
                          "--host": "127.0.0.1",
                          "--port": self.http_port,
                          "--images-dir": self._images_dir,
+                         "--restart-socket": "/tmp/k2_restart_node_{}".format(hash(self._working_dir)),
                          "--linking": self._linking_file}
 
         if options:


### PR DESCRIPTION
Basically python tests may run concurrently on same machine. But the problem happens when one of the running `k2-node` tries to gracefully shutdown. The problem is in that all of the running node are reading same unix-socket for graceful shutdown.
The solution is to pass unique unix-socket path for each `k2-node` instance. 