### PR TITLE
[k2] implement strtotime

### DIFF
--- a/builtin-functions/kphp-light/stdlib/time-functions.txt
+++ b/builtin-functions/kphp-light/stdlib/time-functions.txt
@@ -7,11 +7,15 @@ function mktime ($h ::: int = PHP_INT_MIN, $m ::: int = PHP_INT_MIN, $s ::: int 
 
 function date ($format ::: string, $timestamp ::: int = PHP_INT_MIN) ::: string;
 
+function date_default_timezone_get() ::: string;
+
 function date_default_timezone_set ($s ::: string) ::: bool;
 
 function gmdate ($format ::: string, $timestamp ::: int = PHP_INT_MIN) ::: string;
 
 function time() ::: int;
+
+function strtotime ($time ::: string, $timestamp ::: int = PHP_INT_MIN) ::: int | false;
 
 function microtime ($get_as_float ::: bool = false) ::: mixed;
 
@@ -19,7 +23,6 @@ function hrtime (bool $as_number = false): mixed; // int[]|int
 
 /** @kphp-extern-func-info interruptible */
 function set_timer(int $timeout, callable():void $callback) ::: void;
-
 
 // ===== UNSUPPORTED =====
 
@@ -168,8 +171,6 @@ define('DATE_RSS', "D, d M Y H:i:s O");
 define('DATE_W3C', "Y-m-d\TH:i:sP");
 
 /** @kphp-extern-func-info stub generation-required */
-function date_default_timezone_get() ::: string;
-/** @kphp-extern-func-info stub generation-required */
 function getdate ($timestamp ::: int = PHP_INT_MIN) ::: mixed[];
 /** @kphp-extern-func-info stub generation-required */
 function gmmktime ($h ::: int = PHP_INT_MIN, $m ::: int = PHP_INT_MIN, $s ::: int = PHP_INT_MIN, $month ::: int = PHP_INT_MIN, $day ::: int = PHP_INT_MIN, $year ::: int = PHP_INT_MIN) ::: int;
@@ -178,9 +179,6 @@ function gmmktime ($h ::: int = PHP_INT_MIN, $m ::: int = PHP_INT_MIN, $s ::: in
 function localtime ($timestamp ::: int = PHP_INT_MIN, $is_associative ::: bool = false) ::: mixed[];
 /** @kphp-extern-func-info stub generation-required */
 function strftime ($format ::: string, $timestamp ::: int = PHP_INT_MIN) ::: string;
-/** @kphp-extern-func-info stub generation-required */
-function strtotime ($time ::: string, $timestamp ::: int = PHP_INT_MIN) ::: int | false;
-
 
 /** @kphp-extern-func-info stub generation-required */
 function checkdate ($month ::: int, $day ::: int, $year ::: int) ::: bool;

--- a/compiler/make/objs-to-k2-component-target.h
+++ b/compiler/make/objs-to-k2-component-target.h
@@ -36,7 +36,7 @@ class Objs2K2ComponentTarget : public Target {
 #if defined(__APPLE__)
     return " -Wl,-undefined,dynamic_lookup ";
 #else
-    return " -Wl,--wrap,malloc -Wl,--wrap,free, -Wl,--wrap,calloc -Wl,--wrap,realloc -static-libgcc ";
+    return " -Wl,--wrap,malloc -Wl,--wrap,free, -Wl,--wrap,calloc -Wl,--wrap,realloc -Wl,--wrap,strdup -static-libgcc ";
 #endif
   }
 

--- a/runtime-light/allocator-wrapper/libc-alloc-wrapper.cpp
+++ b/runtime-light/allocator-wrapper/libc-alloc-wrapper.cpp
@@ -3,6 +3,7 @@
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #include <cstddef>
+#include <cstring>
 
 #include "runtime-common/core/allocator/script-malloc-interface.h"
 #include "runtime-light/allocator/allocator-state.h"
@@ -29,9 +30,17 @@ extern "C" void* __wrap_calloc(size_t nmemb, size_t size) noexcept {
   return kphp::memory::script::calloc(nmemb, size);
 }
 
-extern "C" void* __wrap_realloc([[maybe_unused]] void* ptr, [[maybe_unused]] size_t size) noexcept {
+extern "C" void* __wrap_realloc(void* ptr, size_t size) noexcept {
   if (!AllocatorState::get().libc_alloc_allowed()) [[unlikely]] {
     kphp::log::error("unexpected use of realloc");
   }
   return kphp::memory::script::realloc(ptr, size);
+}
+
+extern "C" char* __wrap_strdup(const char* str1) noexcept {
+  if (!AllocatorState::get().libc_alloc_allowed()) [[unlikely]] {
+    kphp::log::error("unexpected use of strdup");
+  }
+  auto* str2{static_cast<char*>(kphp::memory::script::alloc(std::strlen(str1) + 1))};
+  return std::strcpy(str2, str1);
 }

--- a/runtime-light/k2-platform/k2-api.h
+++ b/runtime-light/k2-platform/k2-api.h
@@ -7,7 +7,9 @@
 #include <cerrno>
 #include <cstddef>
 #include <cstdint>
+#include <ctime>
 #include <memory>
+#include <string_view>
 #include <sys/utsname.h>
 #include <utility>
 
@@ -202,6 +204,14 @@ inline auto env_fetch(uint32_t arg_num) noexcept {
 
   return std::make_pair(std::unique_ptr<char, decltype(std::addressof(k2::free))>{key_buffer, k2::free},
                         std::unique_ptr<char, decltype(std::addressof(k2::free))>{value_buffer, k2::free});
+}
+
+inline int32_t set_timezone(std::string_view timezone) noexcept {
+  return k2_set_timezone(timezone.data());
+}
+
+inline struct tm* localtime_r(const time_t* timer, struct tm* result) noexcept {
+  return k2_localtime_r(timer, result);
 }
 
 inline int32_t udp_connect(uint64_t* socket_d, const char* host, size_t host_len) noexcept {

--- a/runtime-light/runtime-light.cmake
+++ b/runtime-light/runtime-light.cmake
@@ -57,7 +57,7 @@ target_link_libraries(runtime-light-pic PUBLIC vk::pic::libc-alloc-wrapper) # it
                                                                             # want to use its symbols in all other libraries
 target_link_libraries(runtime-light-pic PUBLIC KPHP_TIMELIB::pic::timelib PCRE2::pic::pcre2 ZLIB::pic::zlib) # third parties
 
-set(RUNTIME_LIGHT_LINK_LIBS "${PCRE2_PIC_LIBRARIES} ${ZLIB_PIC_LIBRARIES}")
+set(RUNTIME_LIGHT_LINK_LIBS "${KPHP_TIMELIB_PIC_LIBRARIES} ${PCRE2_PIC_LIBRARIES} ${ZLIB_PIC_LIBRARIES}")
 
 # =================================================================================================
 

--- a/runtime-light/runtime-light.cmake
+++ b/runtime-light/runtime-light.cmake
@@ -1,3 +1,4 @@
+include(${THIRD_PARTY_DIR}/timelib-cmake/timelib.cmake)
 include(${THIRD_PARTY_DIR}/pcre2-cmake/pcre2.cmake)
 
 # =================================================================================================
@@ -54,7 +55,7 @@ vk_add_library_pic(runtime-light-pic OBJECT ${RUNTIME_LIGHT_SRC})
 target_compile_options(runtime-light-pic PUBLIC ${RUNTIME_LIGHT_COMPILE_FLAGS})
 target_link_libraries(runtime-light-pic PUBLIC vk::pic::libc-alloc-wrapper) # it's mandatory to have alloc-wrapper first in the list of link libraries since we
                                                                             # want to use its symbols in all other libraries
-target_link_libraries(runtime-light-pic PUBLIC PCRE2::pic::pcre2 ZLIB::pic::zlib) # third parties
+target_link_libraries(runtime-light-pic PUBLIC KPHP_TIMELIB::pic::timelib PCRE2::pic::pcre2 ZLIB::pic::zlib) # third parties
 
 set(RUNTIME_LIGHT_LINK_LIBS "${PCRE2_PIC_LIBRARIES} ${ZLIB_PIC_LIBRARIES}")
 

--- a/runtime-light/runtime-light.cpp
+++ b/runtime-light/runtime-light.cpp
@@ -16,7 +16,6 @@ ImageState* k2_create_image() {
   auto* image_state_ptr{static_cast<ImageState*>(k2::alloc(sizeof(ImageState)))};
   if (image_state_ptr == nullptr) [[unlikely]] {
     kphp::log::error("can't allocate enough memory for image state");
-    return nullptr;
   }
   kphp::log::debug("finish image state creation");
   return image_state_ptr;
@@ -34,7 +33,6 @@ ComponentState* k2_create_component() {
   auto* component_state_ptr{static_cast<ComponentState*>(k2::alloc(sizeof(ComponentState)))};
   if (component_state_ptr == nullptr) [[unlikely]] {
     kphp::log::error("can't allocate enough memory for component state");
-    return nullptr;
   }
   kphp::log::debug("finish component state creation");
   return component_state_ptr;
@@ -51,7 +49,6 @@ InstanceState* k2_create_instance() {
   auto* instance_state_ptr{static_cast<InstanceState*>(k2::alloc(sizeof(InstanceState)))};
   if (instance_state_ptr == nullptr) [[unlikely]] {
     kphp::log::error("can't allocate enough memory for instance state");
-    return nullptr;
   }
   kphp::log::debug("finish instance state creation");
   return instance_state_ptr;

--- a/runtime-light/state/image-state.h
+++ b/runtime-light/state/image-state.h
@@ -17,13 +17,13 @@
 #include "runtime-light/stdlib/math/math-state.h"
 #include "runtime-light/stdlib/rpc/rpc-client-state.h"
 #include "runtime-light/stdlib/string/string-state.h"
+#include "runtime-light/stdlib/time/time-state.h"
 #include "runtime-light/stdlib/visitors/shape-visitors.h"
 #include "runtime-light/utils/logs.h"
 
 struct ImageState final : private vk::not_copyable {
   AllocatorState image_allocator_state{INIT_IMAGE_ALLOCATOR_SIZE, 0};
 
-  char* c_linear_mem{nullptr};
   uint32_t pid{k2::getpid()};
   string uname_info_s;
   string uname_info_n;
@@ -34,9 +34,10 @@ struct ImageState final : private vk::not_copyable {
 
   ShapeKeyDemangle shape_key_demangler;
 
-  RpcImageState rpc_image_state;
   StringImageState string_image_state;
+  TimeImageState time_image_state;
   MathImageState math_image_state;
+  RpcImageState rpc_image_state;
 
   ImageState() noexcept {
     utsname uname_info{};

--- a/runtime-light/state/instance-state.h
+++ b/runtime-light/state/instance-state.h
@@ -35,6 +35,7 @@
 #include "runtime-light/stdlib/string/regex-state.h"
 #include "runtime-light/stdlib/string/string-state.h"
 #include "runtime-light/stdlib/system/system-state.h"
+#include "runtime-light/stdlib/time/time-state.h"
 
 // Coroutine scheduler type. Change it here if you want to use another scheduler
 using CoroutineScheduler = SimpleCoroutineScheduler;
@@ -61,10 +62,7 @@ struct InstanceState final : vk::not_copyable {
   template<typename T>
   using list = kphp::stl::list<T, kphp::memory::script_allocator>;
 
-  InstanceState() noexcept
-      : instance_allocator_state(INIT_INSTANCE_ALLOCATOR_SIZE, 0) {}
-
-  ~InstanceState() = default;
+  InstanceState() noexcept = default;
 
   static InstanceState& get() noexcept {
     return *k2::instance_state();
@@ -106,7 +104,7 @@ struct InstanceState final : vk::not_copyable {
   void release_stream(uint64_t) noexcept;
   void release_all_streams() noexcept;
 
-  AllocatorState instance_allocator_state;
+  AllocatorState instance_allocator_state{INIT_INSTANCE_ALLOCATOR_SIZE, 0};
 
   CoroutineScheduler scheduler;
   ForkInstanceState fork_instance_state;
@@ -124,6 +122,7 @@ struct InstanceState final : vk::not_copyable {
   JobWorkerServerInstanceState job_worker_server_instance_state;
   InstanceCacheInstanceState instance_cache_instance_state;
 
+  TimeInstanceState time_instance_state;
   MathInstanceState math_instance_state;
   RandomInstanceState random_instance_state;
   RegexInstanceState regex_instance_state;

--- a/runtime-light/stdlib/stdlib.cmake
+++ b/runtime-light/stdlib/stdlib.cmake
@@ -34,4 +34,6 @@ prepend(
   file/file-system-state.cpp
   file/resource.cpp
   time/time-functions.cpp
+  time/time-state.cpp
+  time/timelib-functions.cpp
   zlib/zlib-functions.cpp)

--- a/runtime-light/stdlib/time/time-functions.cpp
+++ b/runtime-light/stdlib/time/time-functions.cpp
@@ -328,7 +328,7 @@ int64_t f$mktime(Optional<int64_t> hour, Optional<int64_t> minute, Optional<int6
 string f$gmdate(const string& format, Optional<int64_t> timestamp) noexcept {
   namespace chrono = std::chrono;
   const time_t now{timestamp.has_value() ? timestamp.val() : duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()};
-  struct tm tm{};
+  struct tm tm {};
   gmtime_r(std::addressof(now), std::addressof(tm));
   return date(format, tm, now, false);
 }
@@ -336,7 +336,7 @@ string f$gmdate(const string& format, Optional<int64_t> timestamp) noexcept {
 string f$date(const string& format, Optional<int64_t> timestamp) noexcept {
   namespace chrono = std::chrono;
   const time_t now{timestamp.has_value() ? timestamp.val() : duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()};
-  struct tm tm{};
+  struct tm tm {};
   localtime_r(std::addressof(now), std::addressof(tm));
   return date(format, tm, now, true);
 }

--- a/runtime-light/stdlib/time/time-functions.cpp
+++ b/runtime-light/stdlib/time/time-functions.cpp
@@ -13,12 +13,9 @@
 #include <string_view>
 
 #include "runtime-common/core/runtime-core.h"
-#include "runtime-light/utils/logs.h"
+#include "runtime-light/stdlib/time/timelib-constants.h"
 
 namespace {
-
-constexpr std::string_view PHP_TIMELIB_TZ_MOSCOW = "Europe/Moscow";
-constexpr std::string_view PHP_TIMELIB_TZ_GMT3 = "Etc/GMT-3";
 
 constexpr std::array<std::string_view, 12> PHP_TIMELIB_MON_FULL_NAMES = {"January", "February", "March",     "April",   "May",      "June",
                                                                          "July",    "August",   "September", "October", "November", "December"};
@@ -200,7 +197,7 @@ string date(const string& format, const tm& t, int64_t timestamp, bool local) no
       break;
     case 'e':
       if (local) {
-        SB << PHP_TIMELIB_TZ_MOSCOW.data();
+        SB << kphp::timelib::timezones::MOSCOW.data();
       } else {
         SB << "UTC";
       }
@@ -342,13 +339,4 @@ string f$date(const string& format, Optional<int64_t> timestamp) noexcept {
   struct tm tm{};
   localtime_r(std::addressof(now), std::addressof(tm));
   return date(format, tm, now, true);
-}
-
-bool f$date_default_timezone_set(const string& s) noexcept {
-  const std::string_view timezone_view{s.c_str(), s.size()};
-  if (timezone_view != PHP_TIMELIB_TZ_GMT3 && timezone_view != PHP_TIMELIB_TZ_MOSCOW) [[unlikely]] {
-    kphp::log::warning("unsupported timezone '{}', only '{}' and '{}' are supported", timezone_view, PHP_TIMELIB_TZ_GMT3, PHP_TIMELIB_TZ_MOSCOW);
-    return false;
-  }
-  return true;
 }

--- a/runtime-light/stdlib/time/time-functions.h
+++ b/runtime-light/stdlib/time/time-functions.h
@@ -88,7 +88,7 @@ inline int64_t f$mktime(Optional<int64_t> hour = {}, Optional<int64_t> minute = 
 inline string f$gmdate(const string& format, Optional<int64_t> timestamp = {}) noexcept {
   namespace chrono = std::chrono;
   const time_t now{timestamp.has_value() ? timestamp.val() : duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()};
-  struct tm tm{};
+  struct tm tm {};
   gmtime_r(std::addressof(now), std::addressof(tm));
   return kphp::time::impl::date(format, tm, now, false);
 }
@@ -96,7 +96,7 @@ inline string f$gmdate(const string& format, Optional<int64_t> timestamp = {}) n
 inline string f$date(const string& format, Optional<int64_t> timestamp = {}) noexcept {
   namespace chrono = std::chrono;
   const time_t now{timestamp.has_value() ? timestamp.val() : duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count()};
-  struct tm tm{};
+  struct tm tm {};
   if (auto* res{k2::localtime_r(std::addressof(now), std::addressof(tm))}; res != std::addressof(tm)) [[unlikely]] {
     kphp::log::warning("can't get local time");
     return {};

--- a/runtime-light/stdlib/time/time-functions.h
+++ b/runtime-light/stdlib/time/time-functions.h
@@ -17,15 +17,12 @@ inline int64_t f$_hrtime_int() noexcept {
 
 inline array<int64_t> f$_hrtime_array() noexcept {
   namespace chrono = std::chrono;
-  const auto since_epoch = chrono::steady_clock::now().time_since_epoch();
+  const auto since_epoch{chrono::steady_clock::now().time_since_epoch()};
   return array<int64_t>::create(duration_cast<chrono::seconds>(since_epoch).count(), chrono::nanoseconds{since_epoch % chrono::seconds{1}}.count());
 }
 
 inline mixed f$hrtime(bool as_number = false) noexcept {
-  if (as_number) {
-    return f$_hrtime_int();
-  }
-  return f$_hrtime_array();
+  return as_number ? mixed{f$_hrtime_int()} : mixed{f$_hrtime_array()};
 }
 
 inline string f$_microtime_string() noexcept {
@@ -34,32 +31,27 @@ inline string f$_microtime_string() noexcept {
   const auto seconds{duration_cast<chrono::seconds>(time_since_epoch).count()};
   const auto nanoseconds{duration_cast<chrono::nanoseconds>(time_since_epoch).count() % 1'000'000'000};
 
-  constexpr size_t default_buffer_size = 60;
+  static constexpr size_t default_buffer_size = 60;
   char buf[default_buffer_size];
-  const int len = snprintf(buf, default_buffer_size, "0.%09lld %lld", nanoseconds, seconds);
+  const auto len{snprintf(buf, default_buffer_size, "0.%09lld %lld", nanoseconds, seconds)};
   return {buf, static_cast<string::size_type>(len)};
 }
 
 inline double f$_microtime_float() noexcept {
   namespace chrono = std::chrono;
   const auto time_since_epoch{chrono::system_clock::now().time_since_epoch()};
-  const double microtime =
-      duration_cast<chrono::seconds>(time_since_epoch).count() + (duration_cast<chrono::nanoseconds>(time_since_epoch).count() % 1'000'000'000) * 1e-9;
+  const double microtime{duration_cast<chrono::seconds>(time_since_epoch).count() +
+                         (duration_cast<chrono::nanoseconds>(time_since_epoch).count() % 1'000'000'000) * 1e-9};
   return microtime;
 }
 
-inline mixed f$microtime(bool get_as_float = false) noexcept {
-  if (get_as_float) {
-    return f$_microtime_float();
-  } else {
-    return f$_microtime_string();
-  }
+inline mixed f$microtime(bool as_float = false) noexcept {
+  return as_float ? mixed{f$_microtime_float()} : mixed{f$_microtime_string()};
 }
 
 inline int64_t f$time() noexcept {
   namespace chrono = std::chrono;
-  const auto now{chrono::system_clock::now().time_since_epoch()};
-  return duration_cast<chrono::seconds>(now).count();
+  return duration_cast<chrono::seconds>(chrono::system_clock::now().time_since_epoch()).count();
 }
 
 int64_t f$mktime(Optional<int64_t> hour = {}, Optional<int64_t> minute = {}, Optional<int64_t> second = {}, Optional<int64_t> month = {},

--- a/runtime-light/stdlib/time/time-functions.h
+++ b/runtime-light/stdlib/time/time-functions.h
@@ -8,13 +8,13 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
-#include <ctime>
 #include <limits>
 
 #include "runtime-common/core/runtime-core.h"
 #include "runtime-light/stdlib/time/time-state.h"
 #include "runtime-light/stdlib/time/timelib-constants.h"
 #include "runtime-light/stdlib/time/timelib-functions.h"
+#include "runtime-light/utils/logs.h"
 
 inline int64_t f$_hrtime_int() noexcept {
   return std::chrono::steady_clock::now().time_since_epoch().count();
@@ -83,7 +83,8 @@ inline bool f$date_default_timezone_set(const string& timezone) noexcept {
 
 inline Optional<int64_t> f$strtotime(const string& datetime, int64_t base_timestamp = std::numeric_limits<int64_t>::min()) noexcept {
   if (base_timestamp == std::numeric_limits<int64_t>::min()) {
-    base_timestamp = std::time(nullptr);
+    namespace chrono = std::chrono;
+    base_timestamp = static_cast<int64_t>(chrono::time_point_cast<chrono::seconds>(chrono::system_clock::now()).time_since_epoch().count());
   }
   string default_timezone{f$date_default_timezone_get()};
   auto opt_timestamp{kphp::timelib::strtotime({default_timezone.c_str(), default_timezone.size()}, {datetime.c_str(), datetime.size()}, base_timestamp)};

--- a/runtime-light/stdlib/time/time-state.cpp
+++ b/runtime-light/stdlib/time/time-state.cpp
@@ -1,0 +1,20 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime-light/stdlib/time/time-state.h"
+
+#include "runtime-light/state/image-state.h"
+#include "runtime-light/state/instance-state.h"
+
+TimeInstanceState& TimeInstanceState::get() noexcept {
+  return InstanceState::get().time_instance_state;
+}
+
+const TimeImageState& TimeImageState::get() noexcept {
+  return ImageState::get().time_image_state;
+}
+
+TimeImageState& TimeImageState::get_mutable() noexcept {
+  return ImageState::get_mutable().time_image_state;
+}

--- a/runtime-light/stdlib/time/time-state.h
+++ b/runtime-light/stdlib/time/time-state.h
@@ -1,0 +1,28 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include "common/mixin/not_copyable.h"
+#include "runtime-common/core/runtime-core.h"
+#include "runtime-light/stdlib/time/timelib-constants.h"
+#include "runtime-light/stdlib/time/timelib-timezone-cache.h"
+
+struct TimeInstanceState final : private vk::not_copyable {
+  string default_timezone{kphp::timelib::timezones::MOSCOW.data(), kphp::timelib::timezones::MOSCOW.size()};
+  kphp::timelib::timezone_cache timelib_zone_cache;
+
+  TimeInstanceState() noexcept = default;
+
+  static TimeInstanceState& get() noexcept;
+};
+
+struct TimeImageState final : private vk::not_copyable {
+  kphp::timelib::timezone_cache timelib_zone_cache{kphp::timelib::timezones::MOSCOW, kphp::timelib::timezones::GMT3};
+
+  TimeImageState() noexcept = default;
+
+  static const TimeImageState& get() noexcept;
+  static TimeImageState& get_mutable() noexcept;
+};

--- a/runtime-light/stdlib/time/time-state.h
+++ b/runtime-light/stdlib/time/time-state.h
@@ -6,14 +6,20 @@
 
 #include "common/mixin/not_copyable.h"
 #include "runtime-common/core/runtime-core.h"
+#include "runtime-light/k2-platform/k2-api.h"
 #include "runtime-light/stdlib/time/timelib-constants.h"
 #include "runtime-light/stdlib/time/timelib-timezone-cache.h"
+#include "runtime-light/utils/logs.h"
 
 struct TimeInstanceState final : private vk::not_copyable {
   string default_timezone{kphp::timelib::timezones::MOSCOW.data(), kphp::timelib::timezones::MOSCOW.size()};
   kphp::timelib::timezone_cache timelib_zone_cache;
 
-  TimeInstanceState() noexcept = default;
+  TimeInstanceState() noexcept {
+    if (auto errc{k2::set_timezone(kphp::timelib::timezones::MOSCOW)}; errc != k2::errno_ok) [[unlikely]] {
+      kphp::log::error("can't set timezone '{}'", kphp::timelib::timezones::MOSCOW);
+    }
+  }
 
   static TimeInstanceState& get() noexcept;
 };

--- a/runtime-light/stdlib/time/timelib-constants.h
+++ b/runtime-light/stdlib/time/timelib-constants.h
@@ -1,0 +1,19 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <string_view>
+
+namespace kphp::timelib {
+
+namespace timezones {
+
+inline constexpr std::string_view MOSCOW = "Europe/Moscow";
+inline constexpr std::string_view GMT3 = "Etc/GMT-3";
+inline constexpr std::string_view GMT4 = "Etc/GMT-4";
+
+} // namespace timezones
+
+} // namespace kphp::timelib

--- a/runtime-light/stdlib/time/timelib-functions.cpp
+++ b/runtime-light/stdlib/time/timelib-functions.cpp
@@ -1,0 +1,86 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#include "runtime-light/stdlib/time/timelib-functions.h"
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string_view>
+
+#include "kphp/timelib/timelib.h"
+
+#include "common/containers/final_action.h"
+#include "runtime-light/allocator/allocator.h"
+#include "runtime-light/stdlib/time/time-state.h"
+#include "runtime-light/utils/logs.h"
+
+namespace kphp::timelib {
+
+timelib_tzinfo* get_timezone_info(const char* timezone, const timelib_tzdb* tzdb, int* errc) noexcept {
+  std::string_view timezone_view{timezone};
+  auto* tzinfo{TimeImageState::get().timelib_zone_cache.get(timezone_view)};
+  if (tzinfo != nullptr) {
+    return tzinfo;
+  }
+  auto& instance_timelib_zone_cache{TimeInstanceState::get().timelib_zone_cache};
+  tzinfo = instance_timelib_zone_cache.get(timezone_view);
+  if (tzinfo != nullptr) {
+    return tzinfo;
+  }
+
+  // we don't have this timezone cached, so create and add it to the cache
+  tzinfo = std::invoke(
+      [](const char* tzname, const timelib_tzdb* tzdb, int* errc) noexcept {
+        kphp::memory::libc_alloc_guard _{};
+        return timelib_parse_tzfile(tzname, tzdb, errc);
+      },
+      timezone, tzdb, errc);
+  instance_timelib_zone_cache.put(tzinfo);
+  return tzinfo;
+}
+
+std::optional<int64_t> strtotime(std::string_view timezone, std::string_view datetime, int64_t timestamp) noexcept {
+  if (datetime.empty()) [[unlikely]] {
+    kphp::log::warning("datetime can't be empty");
+    return {};
+  }
+
+  int errc{}; // it's intentionally declared as 'int' since timelib_parse_tzfile accepts 'int'
+  auto* tzinfo{kphp::timelib::get_timezone_info(timezone.data(), timelib_builtin_db(), std::addressof(errc))};
+  if (tzinfo == nullptr) [[unlikely]] {
+    kphp::log::warning("can't get timezone info: timezone -> {}, datetime -> {}, error -> {}", timezone, datetime, timelib_get_error_message(errc));
+    return {};
+  }
+
+  kphp::memory::libc_alloc_guard _{}; // ENABLE LIBC ALLOC
+
+  timelib_time* now{timelib_time_ctor()};
+  const vk::final_action now_deleter{[now] noexcept { timelib_time_dtor(now); }};
+  now->tz_info = tzinfo;
+  now->zone_type = TIMELIB_ZONETYPE_ID;
+  timelib_unixtime2local(now, timestamp);
+
+  timelib_error_container* errors{};
+  timelib_time* time{timelib_strtotime(datetime.data(), datetime.size(), std::addressof(errors), timelib_builtin_db(), kphp::timelib::get_timezone_info)};
+  const vk::final_action time_deleter{[time] noexcept { timelib_time_dtor(time); }};
+  const vk::final_action errors_deleter{[errors] noexcept { timelib_error_container_dtor(errors); }};
+  if (errors->error_count != 0) [[unlikely]] {
+    kphp::log::warning("got {} errors in timelib_strtotime", errors->error_count); // TODO should we logs all the errors?
+    return {};
+  }
+
+  errc = 0;
+  timelib_fill_holes(time, now, TIMELIB_NO_CLONE);
+  timelib_update_ts(time, tzinfo);
+  int64_t result_timestamp{timelib_date_to_int(time, std::addressof(errc))};
+  if (errc != 0) [[unlikely]] {
+    kphp::log::warning("can't convert date to int: error -> {}", timelib_get_error_message(errc));
+    return {};
+  }
+  return result_timestamp;
+}
+
+} // namespace kphp::timelib

--- a/runtime-light/stdlib/time/timelib-functions.cpp
+++ b/runtime-light/stdlib/time/timelib-functions.cpp
@@ -5,7 +5,6 @@
 #include "runtime-light/stdlib/time/timelib-functions.h"
 
 #include <cstdint>
-#include <functional>
 #include <memory>
 #include <optional>
 #include <string_view>
@@ -31,13 +30,7 @@ timelib_tzinfo* get_timezone_info(const char* timezone, const timelib_tzdb* tzdb
     return tzinfo;
   }
 
-  // we don't have this timezone cached, so create and add it to the cache
-  tzinfo = std::invoke(
-      [](const char* tzname, const timelib_tzdb* tzdb, int* errc) noexcept {
-        kphp::memory::libc_alloc_guard _{};
-        return timelib_parse_tzfile(tzname, tzdb, errc);
-      },
-      timezone, tzdb, errc);
+  tzinfo = (kphp::memory::libc_alloc_guard{}, timelib_parse_tzfile(timezone, tzdb, errc));
   instance_timelib_zone_cache.put(tzinfo);
   return tzinfo;
 }

--- a/runtime-light/stdlib/time/timelib-functions.cpp
+++ b/runtime-light/stdlib/time/timelib-functions.cpp
@@ -55,7 +55,7 @@ std::optional<int64_t> strtotime(std::string_view timezone, std::string_view dat
     return {};
   }
 
-  kphp::memory::libc_alloc_guard _{}; // ENABLE LIBC ALLOC
+  kphp::memory::libc_alloc_guard _{};
 
   timelib_time* now{timelib_time_ctor()};
   const vk::final_action now_deleter{[now] noexcept { timelib_time_dtor(now); }};

--- a/runtime-light/stdlib/time/timelib-functions.h
+++ b/runtime-light/stdlib/time/timelib-functions.h
@@ -1,0 +1,31 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+#include "kphp/timelib/timelib.h"
+
+namespace kphp::timelib {
+
+/**
+ * @brief Retrieves a pointer to a `timelib_tzinfo` structure for a given time zone name.
+ *
+ * @param timezone The name of the time zone to retrieve.
+ * @param tzdb The time zone database to search.
+ * @param errc The address of a variable to store error code into.
+ * @return `timelib_tzinfo*` pointing to the time zone information, or `nullptr` if not found.
+ *
+ * @note
+ * - The returned pointer is owned by an internal cache; do not deallocate it using `timelib_tzinfo_dtor`.
+ * - This function minimizes overhead by avoiding repeated allocations for the same time zone.
+ */
+timelib_tzinfo* get_timezone_info(const char* timezone, const timelib_tzdb* tzdb, int* errc) noexcept;
+
+std::optional<int64_t> strtotime(std::string_view timezone, std::string_view datetime, int64_t timestamp) noexcept;
+
+} // namespace kphp::timelib

--- a/runtime-light/stdlib/time/timelib-functions.h
+++ b/runtime-light/stdlib/time/timelib-functions.h
@@ -17,7 +17,7 @@ namespace kphp::timelib {
  *
  * @param timezone The name of the time zone to retrieve.
  * @param tzdb The time zone database to search.
- * @param errc The address of a variable to store error code into.
+ * @param errc The pointer to a variable to store error code into.
  * @return `timelib_tzinfo*` pointing to the time zone information, or `nullptr` if not found.
  *
  * @note

--- a/runtime-light/stdlib/time/timelib-timezone-cache.h
+++ b/runtime-light/stdlib/time/timelib-timezone-cache.h
@@ -1,0 +1,84 @@
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2025 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
+
+#pragma once
+
+#include <algorithm>
+#include <cstring>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <string_view>
+
+#include "kphp/timelib/timelib.h"
+
+#include "runtime-common/core/allocator/script-allocator.h"
+#include "runtime-common/core/std/containers.h"
+#include "runtime-light/allocator/allocator.h"
+#include "runtime-light/utils/logs.h"
+
+namespace kphp::timelib {
+
+class timezone_cache final {
+  kphp::stl::unordered_set<timelib_tzinfo*, kphp::memory::script_allocator, decltype([](const timelib_tzinfo* tzinfo) noexcept {
+                             return tzinfo != nullptr ? std::hash<std::string_view>{}({tzinfo->name}) : 0;
+                           }),
+                           decltype([](const timelib_tzinfo* lhs, const timelib_tzinfo* rhs) noexcept {
+                             if (lhs == nullptr || rhs == nullptr) [[unlikely]] {
+                               return lhs == rhs;
+                             }
+                             return std::strcmp(lhs->name, rhs->name) == 0;
+                           })>
+      m_cache;
+
+public:
+  timelib_tzinfo* get(std::string_view tzname) const noexcept {
+    timelib_tzinfo tmp{.name = const_cast<char*>(tzname.data())};
+    auto it{m_cache.find(std::addressof(tmp))};
+    return it != m_cache.end() ? *it : nullptr;
+  }
+
+  void put(timelib_tzinfo* tzinfo) noexcept {
+    if (tzinfo == nullptr) [[unlikely]] {
+      kphp::log::warning("nullptr timelib_tzinfo detected in timezone_cache");
+      return;
+    }
+    m_cache.emplace(tzinfo);
+  }
+
+  timezone_cache() noexcept = default;
+
+  timezone_cache(std::initializer_list<std::string_view> tzs) noexcept {
+    kphp::memory::libc_alloc_guard _{};
+    std::ranges::for_each(tzs, [this](std::string_view tz) noexcept {
+      int errc{}; // it's intentionally declared as 'int' since timelib_parse_tzfile accepts 'int'
+      auto* tzinfo{timelib_parse_tzfile(tz.data(), timelib_builtin_db(), std::addressof(errc))};
+      if (tzinfo == nullptr) [[unlikely]] {
+        kphp::log::warning("can't get timezone info: timezone -> {}, error -> {}", tz, timelib_get_error_message(errc));
+        return;
+      }
+      m_cache.emplace(tzinfo);
+    });
+  }
+
+  timezone_cache(timezone_cache&& other) noexcept
+      : m_cache(std::move(other.m_cache)) {}
+
+  timezone_cache& operator=(timezone_cache&& other) noexcept {
+    if (this != std::addressof(other)) {
+      m_cache = std::move(other.m_cache);
+    }
+    return *this;
+  }
+
+  timezone_cache(const timezone_cache&) = delete;
+  timezone_cache& operator=(const timezone_cache&) = delete;
+
+  ~timezone_cache() {
+    kphp::memory::libc_alloc_guard _{};
+    std::ranges::for_each(m_cache, [](timelib_tzinfo* tzinfo) noexcept { timelib_tzinfo_dtor(tzinfo); });
+  }
+};
+
+} // namespace kphp::timelib

--- a/tests/phpt/dl/459_strtotime.php
+++ b/tests/phpt/dl/459_strtotime.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 
   function test ($x, $y) {

--- a/tests/phpt/pk/025_strtotime_next_week_day.php
+++ b/tests/phpt/pk/025_strtotime_next_week_day.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 
 for ($shift = 0; $shift < 7; $shift++) {


### PR DESCRIPTION
Implement `strtotime` function using `timelib` library. As `timelib` doesn't support customising a memory manager, we use `libc_alloc_guard` to allow it to call `malloc`, `free` etc. These symbols are overridden to call script allocator instead of the system one. Also, in this PR we override `strdup` function since it's also used by `timelib` internally.