### PR TITLE
[k2] fix set_timer by using task<> to start a fork

### DIFF
--- a/runtime-light/stdlib/time/timer-functions.h
+++ b/runtime-light/stdlib/time/timer-functions.h
@@ -7,10 +7,10 @@
 #include <chrono>
 #include <concepts>
 #include <cstdint>
+#include <functional>
 #include <utility>
 
 #include "runtime-light/coroutine/awaitable.h"
-#include "runtime-light/coroutine/shared-task.h"
 #include "runtime-light/coroutine/task.h"
 #include "runtime-light/utils/logs.h"
 
@@ -20,10 +20,10 @@ kphp::coro::task<> f$set_timer(int64_t timeout_ms, T on_timer_callback) noexcept
     kphp::log::warning("can't set timer for negative duration {} ms", timeout_ms);
     co_return;
   }
-  const auto fork_f{[](std::chrono::nanoseconds duration, T&& on_timer_callback) -> kphp::coro::shared_task<> {
+  const auto timer_f{[](std::chrono::nanoseconds duration, T on_timer_callback) noexcept -> kphp::coro::task<> {
     co_await wait_for_timer_t{duration};
-    on_timer_callback();
+    std::invoke(std::move(on_timer_callback));
   }}; // TODO: someone should pop that fork from ForkComponentContext since it will stay there unless we perform f$wait on fork
   const auto duration_ms{std::chrono::milliseconds{static_cast<uint64_t>(timeout_ms)}};
-  co_await start_fork_t{fork_f(std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::move(on_timer_callback))};
+  co_await start_fork_t{std::invoke(timer_f, std::chrono::duration_cast<std::chrono::nanoseconds>(duration_ms), std::move(on_timer_callback))};
 }


### PR DESCRIPTION
This pull request addresses the incorrect use of `shared_task<>` in the `set_timer` function, replacing it with `task<>` as originally intended during prior refactorings