### PR TITLE
Fix global vars refcnt

### DIFF
--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -405,7 +405,6 @@ VertexPtr OptimizationPass::on_enter_vertex(VertexPtr root) {
   return root;
 }
 
-
 bool OptimizationPass::user_recursion(VertexPtr root) {
   if (auto var_vertex = root.try_as<op_var>()) {
     VarPtr var = var_vertex->var_id;

--- a/compiler/pipes/optimization.cpp
+++ b/compiler/pipes/optimization.cpp
@@ -367,7 +367,7 @@ VertexPtr OptimizationPass::on_enter_vertex(VertexPtr root) {
       }
     }
   } else if (auto op_array_vertex = root.try_as<op_array>()) {
-    if (!var_init_expression_optimization_depth_) {
+    if (var_init_expression_optimization_depth_ == 0 || op_array_vertex->const_type == ConstValueType::cnst_const_val) {
       for (auto &array_element : *op_array_vertex) {
         const auto *required_type = tinf::get_type(op_array_vertex)->lookup_at_any_key();
         if (vk::any_of_equal(array_element->type(), op_var, op_array)) {


### PR DESCRIPTION
Imagine the following snippet:
```php
<?php

const PREDEFINED_WILDCARDS = [
  'lol',
  'kek',
];

const ALL = [
  PREDEFINED_WILDCARDS,
  [1, 2, 3],
];

warning((string)get_reference_counter(ALL[0]));
```

It's supposed to print `0x7ffffff0`, special counter value for global constants. But previously it printed `2`.
The reason is that `PREDEFINED_WILDCARDS` is and object of type `array<string>`, `ALL` is of type `array<array<mixed>>`, and during global constants initialization, `PREDEFINED_WILDCARDS` was conversed into `array<mixed>`, and counter was changed. For now, we create a copy global constant of `PREDEFINED_WILDCARDS` that is of type `array<mixed>` and behavior is expected now.