### PR TITLE
make confdata reader more reliable

### DIFF
--- a/common/binlog/binlog-buffer-aio.cpp
+++ b/common/binlog/binlog-buffer-aio.cpp
@@ -14,12 +14,11 @@
 #include <unistd.h>
 
 #include "common/binlog/binlog-buffer.h"
+#include "common/binlog/binlog-stats.h"
 #include "common/kfs/kfs-binlog.h"
-#include "common/kprintf.h"
 #include "common/precise-time.h"
 #include "common/server/engine-settings.h"
 #include "common/server/signals.h"
-#include "server/confdata-stats.h"
 
 DECLARE_VERBOSITY(binlog_buffers);
 
@@ -62,7 +61,7 @@ static int bbw_local_replica_rotate(bb_writer_t* W, bb_rotation_point_t* P) {
   assert(Q->log_pos < P->log_pos);
   kfs_file_handle_t Binlog = Q->Binlog;
   P->Binlog = next_binlog(Binlog);
-  auto& confdata_stats = ConfdataStats::get();
+  auto& binlog_reader_stats = binlog_reader_stats::get();
 
   if (P->Binlog == NULL) {
     update_replica(Binlog->info->replica, 0);
@@ -74,16 +73,14 @@ static int bbw_local_replica_rotate(bb_writer_t* W, bb_rotation_point_t* P) {
       W->unsuccessful_rotation_first_ts = time(NULL);
     }
     W->unsuccessful_rotation_attempts++;
-    std::chrono::seconds elapsed_time{time(NULL) - W->unsuccessful_rotation_first_ts};
+    std::chrono::seconds elapsed_time{std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count() -
+                                      W->unsuccessful_rotation_first_ts};
     kprintf("attempt #%d (%" PRIu64 " secs): cannot find next binlog file after %s, log position %lld\n", W->unsuccessful_rotation_attempts,
             elapsed_time.count(), Binlog->info->filename, P->log_pos);
 
-    const auto timeout = get_engine_settings()->next_binlog_part_not_found_alert_timeout;
-    if (elapsed_time > timeout) {
-      send_not_too_much_messages_to_assertion_chat("Waiting for the next binlog part for too long: %d attempts, %" PRIu64 " seconds, binlog name %s",
-                                                   W->unsuccessful_rotation_attempts, elapsed_time.count(), Binlog->info->filename);
-      confdata_stats.next_binlog_wait_time = elapsed_time;
-      confdata_stats.next_binlog_expectator_name = Binlog->info->filename;
+    if (elapsed_time > get_engine_settings()->next_binlog_part_not_found_alert_timeout) {
+      binlog_reader_stats.next_binlog_wait_time = elapsed_time;
+      binlog_reader_stats.next_binlog_expectator_name = Binlog->info->filename;
     }
 
     return REPLAY_BINLOG_STOP_READING;
@@ -103,8 +100,8 @@ static int bbw_local_replica_rotate(bb_writer_t* W, bb_rotation_point_t* P) {
   assert(bb_buffer_log_cur_pos(B) + 36 == P->RT.next_log_pos);
 
   W->unsuccessful_rotation_attempts = 0;
-  confdata_stats.next_binlog_wait_time = {0s};
-  confdata_stats.next_binlog_expectator_name = "";
+  binlog_reader_stats.next_binlog_wait_time = {0s};
+  binlog_reader_stats.next_binlog_expectator_name = "";
   return 0;
 }
 

--- a/common/binlog/binlog-buffer-replay.cpp
+++ b/common/binlog/binlog-buffer-replay.cpp
@@ -342,7 +342,6 @@ static int process_replay_work(void* extra, const void* data, int len) {
       if (l > s) {
         l = s;
       }
-      l &= -4;
       memcpy(e->buf + e->wptr, data, l);
       e->log_last_processed_pos += l;
       e->wptr += l;

--- a/common/binlog/binlog-buffer-replay.cpp
+++ b/common/binlog/binlog-buffer-replay.cpp
@@ -282,6 +282,10 @@ static int bb_process_phash_miss(bb_buffer_t* B, const lev_generic* E, int size)
 }
 
 static int bb_buffer_replay_logevent(bb_buffer_t* B, const lev_generic* E, int size) {
+  if (size < sizeof(lev_generic::type)) {
+    // Not enough data to parse log event magic, fetch more data and retry
+    return REPLAY_BINLOG_NOT_ENOUGH_DATA;
+  }
   struct replayer_t {
     int32_t (*process)(bb_buffer_t* B, const lev_generic* E, int32_t size);
     uint32_t magic;

--- a/common/binlog/binlog-buffer.cpp
+++ b/common/binlog/binlog-buffer.cpp
@@ -60,7 +60,7 @@ void bb_buffer_init(bb_buffer_t* B, bb_writer_t* W, bb_reader_t* R, std::functio
   bb_buffer_set_reader(B, R);
 }
 
-void bb_buffer_set_flags(bb_buffer_t* B, bb_reader_t * R, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely) {
+void bb_buffer_set_flags(bb_buffer_t* B, bb_reader_t* R, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely) {
   B->flags &= ~(BB_FLAG_BINLOG_DISABLED | BB_FLAG_DISABLE_CRC32_WRITE | BB_FLAG_DISABLE_CRC32_EVAL | BB_FLAG_DISABLE_TS_WRITE | BB_FLAG_FLUSH_RARELY);
   if (binlog_disabled) {
     B->flags |= BB_FLAG_BINLOG_DISABLED;

--- a/common/binlog/binlog-buffer.cpp
+++ b/common/binlog/binlog-buffer.cpp
@@ -60,7 +60,7 @@ void bb_buffer_init(bb_buffer_t* B, bb_writer_t* W, bb_reader_t* R, std::functio
   bb_buffer_set_reader(B, R);
 }
 
-void bb_buffer_set_flags(bb_buffer_t* B, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely) {
+void bb_buffer_set_flags(bb_buffer_t* B, bb_reader_t * R, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely) {
   B->flags &= ~(BB_FLAG_BINLOG_DISABLED | BB_FLAG_DISABLE_CRC32_WRITE | BB_FLAG_DISABLE_CRC32_EVAL | BB_FLAG_DISABLE_TS_WRITE | BB_FLAG_FLUSH_RARELY);
   if (binlog_disabled) {
     B->flags |= BB_FLAG_BINLOG_DISABLED;
@@ -80,6 +80,8 @@ void bb_buffer_set_flags(bb_buffer_t* B, int binlog_disabled, int disable_crc32,
   if (flush_rarely) {
     B->flags |= BB_FLAG_FLUSH_RARELY;
   }
+  // For coherence with engines in replica mode
+  R->flags |= BBR_FLAG_EXIT_AFTER_WRONG_LOGEVENT;
 }
 
 void bb_buffer_seek(bb_buffer_t* B, long long log_pos, int timestamp, unsigned log_crc32) {

--- a/common/binlog/binlog-buffer.h
+++ b/common/binlog/binlog-buffer.h
@@ -143,7 +143,7 @@ int bb_buffer_set_reader(bb_buffer_t* B, bb_reader_t* R);
 void bb_buffer_seek(bb_buffer_t* B, long long log_pos, int timestamp, unsigned log_crc32);
 int bb_buffer_replay_log(bb_buffer_t* B, int set_now);
 int bb_buffer_work(bb_buffer_t* B);
-void bb_buffer_set_flags(bb_buffer_t* B, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely);
+void bb_buffer_set_flags(bb_buffer_t* B, bb_reader_t* R, int binlog_disabled, int disable_crc32, int disable_ts, int flush_rarely);
 
 void bbr_default_rotate(bb_reader_t* R, bb_rotation_point_t* P);
 

--- a/common/binlog/binlog-stats.h
+++ b/common/binlog/binlog-stats.h
@@ -1,6 +1,6 @@
-//
-// Created by p-shumilov on 23.06.25.
-//
+// Compiler for PHP (aka KPHP)
+// Copyright (c) 2024 LLC «V Kontakte»
+// Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #ifndef KPHP_BINLOG_STATS_H
 #define KPHP_BINLOG_STATS_H

--- a/common/binlog/binlog-stats.h
+++ b/common/binlog/binlog-stats.h
@@ -1,0 +1,22 @@
+//
+// Created by p-shumilov on 23.06.25.
+//
+
+#ifndef KPHP_BINLOG_STATS_H
+#define KPHP_BINLOG_STATS_H
+
+#include <chrono>
+
+#include "common/stats/provider.h"
+#include "common/wrappers/string_view.h"
+
+struct binlog_reader_stats : private vk::not_copyable {
+  static binlog_reader_stats& get() noexcept {
+    static binlog_reader_stats stats;
+    return stats;
+  }
+
+  std::chrono::seconds next_binlog_wait_time{std::chrono::seconds::zero()};
+  vk::string_view next_binlog_expectator_name;
+};
+#endif // KPHP_BINLOG_STATS_H

--- a/common/binlog/binlog.cmake
+++ b/common/binlog/binlog.cmake
@@ -7,9 +7,9 @@ prepend(BINLOG_SOURCES ${COMMON_DIR}/binlog/
         binlog-snapshot.cpp)
 
 vk_add_library_no_pic(binlog-src-no-pic OBJECT ${BINLOG_SOURCES})
-add_dependencies(binlog-src-no-pic OpenSSL::no-pic::Crypto)
-target_include_directories(binlog-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR})
+add_dependencies(binlog-src-no-pic OpenSSL::no-pic::Crypto RE2::no-pic::re2)
+target_include_directories(binlog-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${RE2_NO_PIC_INCLUDE_DIRS})
 
 vk_add_library_pic(binlog-src-pic OBJECT ${BINLOG_SOURCES})
-add_dependencies(binlog-src-pic OpenSSL::pic::Crypto)
-target_include_directories(binlog-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR})
+add_dependencies(binlog-src-pic OpenSSL::pic::Crypto RE2::pic::re2)
+target_include_directories(binlog-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR} ${RE2_PIC_INCLUDE_DIRS})

--- a/common/common.cmake
+++ b/common/common.cmake
@@ -65,9 +65,9 @@ if(COMPILER_CLANG)
 endif()
 
 vk_add_library_no_pic(common-src-no-pic OBJECT ${COMMON_ALL_SOURCES})
-add_dependencies(common-src-no-pic OpenSSL::no-pic::Crypto ZLIB::no-pic::zlib ZSTD::no-pic::zstd)
-target_include_directories(common-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${ZLIB_NO_PIC_INCLUDE_DIRS} ${ZSTD_NO_PIC_INCLUDE_DIRS})
+add_dependencies(common-src-no-pic OpenSSL::no-pic::Crypto RE2::no-pic::re2 ZLIB::no-pic::zlib ZSTD::no-pic::zstd)
+target_include_directories(common-src-no-pic PUBLIC ${OPENSSL_NO_PIC_INCLUDE_DIR} ${RE2_NO_PIC_INCLUDE_DIRS} ${ZLIB_NO_PIC_INCLUDE_DIRS} ${ZSTD_NO_PIC_INCLUDE_DIRS})
 
 vk_add_library_pic(common-src-pic OBJECT ${COMMON_ALL_SOURCES})
-add_dependencies(common-src-pic OpenSSL::pic::Crypto ZLIB::pic::zlib ZSTD::pic::zstd)
-target_include_directories(common-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR} ${ZLIB_PIC_INCLUDE_DIRS} ${ZSTD_PIC_INCLUDE_DIRS})
+add_dependencies(common-src-pic OpenSSL::pic::Crypto RE2::pic::re2 ZLIB::pic::zlib ZSTD::pic::zstd)
+target_include_directories(common-src-pic PUBLIC ${OPENSSL_PIC_INCLUDE_DIR} ${RE2_PIC_INCLUDE_DIRS} ${ZLIB_PIC_INCLUDE_DIRS} ${ZSTD_PIC_INCLUDE_DIRS})

--- a/common/kfs/kfs.cpp
+++ b/common/kfs/kfs.cpp
@@ -199,8 +199,8 @@ static int process_first36_bytes(struct kfs_file_info* FI, int fd, int r, const 
   case LEV_ROTATE_FROM:
     if (r < sizeof(struct lev_rotate_from)) {
       kprintf("error reading %d bytes from %s (read only %d bytes)\n", (int)sizeof(struct lev_rotate_from), FI->filename, r);
+      return -2;
     }
-    assert(r >= sizeof(struct lev_rotate_from));
     FI->log_pos = ((struct lev_rotate_from*)E)->cur_log_pos;
     if (!FI->file_hash) {
       FI->file_hash = ((struct lev_rotate_from*)E)->cur_log_hash;

--- a/common/server/engine-settings.h
+++ b/common/server/engine-settings.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <arpa/inet.h>
+#include <chrono>
 #include <stdbool.h>
 
 #include "common/crc32c.h"
@@ -43,6 +44,11 @@ typedef struct {
    * engine name displayed in version in logs and stats
    */
   const char* name;
+
+  /**
+   * Time in seconds to wait before starting to alert if the next binlog part is not found
+   */
+  std::chrono::seconds next_binlog_part_not_found_alert_timeout;
 
 } engine_settings_t;
 

--- a/common/server/init-binlog.cpp
+++ b/common/server/init-binlog.cpp
@@ -67,7 +67,8 @@ static void engine_read_binlog_new() {
   binlog_load_time = -get_utime_monotonic();
   bb_buffer_open_to_replay(&BinlogBuffer, &BinlogBufferWriter, &BinlogBufferReader, engine_replica, replay_logevent);
 
-  bb_buffer_set_flags(&BinlogBuffer, 1, 0, 0, 0);
+  // IMPORTANT! Configure as a replica, not a master
+  bb_buffer_set_flags(&BinlogBuffer, &BinlogBufferReader, 1, 0, 0, 0);
 
   bb_buffer_seek(&BinlogBuffer, jump_log_pos, jump_log_ts, jump_log_crc32);
 

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -53,7 +53,7 @@ struct {
   std::unordered_set<vk::string_view> predefined_wildcards;
 
   bool is_enabled() const noexcept {
-    return binlog_reader.mask;
+    return binlog_reader.mask != nullptr;
   }
 } confdata_settings;
 

--- a/server/confdata-binlog-replay.cpp
+++ b/server/confdata-binlog-replay.cpp
@@ -23,14 +23,15 @@
 #include "common/server/engine-settings.h"
 #include "common/server/init-binlog.h"
 #include "common/server/init-snapshot.h"
+#include "common/server/main-binlog.h"
 #include "common/tl/methods/string.h"
 #include "common/wrappers/string_view.h"
 #include "common/kfs/kfs.h"
 
+#include "common/binlog/binlog-buffer.h"
 #include "runtime-common/core/runtime-core.h"
 #include "runtime/allocator.h"
 #include "runtime/confdata-global-manager.h"
-#include "runtime-common/core/runtime-core.h"
 #include "server/confdata-binlog-events.h"
 #include "server/confdata-stats.h"
 #include "server/server-log.h"
@@ -39,17 +40,20 @@
 namespace {
 
 struct {
-  const char *binlog_mask{nullptr};
   size_t memory_limit{2u * 1024u * 1024u * 1024u};
   double soft_oom_threshold_ratio{CONFDATA_DEFAULT_SOFT_OOM_RATIO};
   double hard_oom_threshold_ratio{CONFDATA_DEFAULT_HARD_OOM_RATIO};
-  double confdata_update_timeout_sec = 0.3;
+  double confdata_update_timeout_sec {0.3};
+  struct {
+    std::chrono::seconds how_long_wait_until_alert{120};
+    const char *mask{nullptr};
+  } binlog_reader;
   std::unique_ptr<re2::RE2> key_blacklist_pattern;
   std::forward_list<vk::string_view> force_ignore_prefixes;
   std::unordered_set<vk::string_view> predefined_wildcards;
 
   bool is_enabled() const noexcept {
-    return binlog_mask;
+    return binlog_reader.mask;
   }
 } confdata_settings;
 
@@ -1000,7 +1004,7 @@ void set_confdata_hard_oom_ratio(double hard_oom_ratio) noexcept {
 }
 
 void set_confdata_binlog_mask(const char *mask) noexcept {
-  confdata_settings.binlog_mask = mask;
+  confdata_settings.binlog_reader.mask = mask;
 }
 
 void set_confdata_memory_limit(size_t memory_limit) noexcept {
@@ -1013,6 +1017,10 @@ void set_confdata_blacklist_pattern(std::unique_ptr<re2::RE2> &&key_blacklist_pa
 
 void set_confdata_update_timeout(double timeout_sec) noexcept {
   confdata_settings.confdata_update_timeout_sec = timeout_sec;
+}
+
+void set_how_long_wait_until_alert(std::chrono::seconds t) noexcept {
+  confdata_settings.binlog_reader.how_long_wait_until_alert = t;
 }
 
 void add_confdata_force_ignore_prefix(const char *key_ignore_prefix) noexcept {
@@ -1053,6 +1061,7 @@ void init_confdata_binlog_reader() noexcept {
     log_split_max = E->split_max;
     log_split_mod = E->split_mod;
   };
+  settings.next_binlog_part_not_found_alert_timeout = confdata_settings.binlog_reader.how_long_wait_until_alert;
   set_engine_settings(&settings);
 
   vkprintf(1, "start confdata loading\n");
@@ -1077,7 +1086,7 @@ void init_confdata_binlog_reader() noexcept {
 
   auto &confdata_binlog_replayer = ConfdataBinlogReplayer::get();
   confdata_binlog_replayer.init(confdata_manager.get_resource());
-  engine_default_load_index(confdata_settings.binlog_mask);
+  engine_default_load_index(confdata_settings.binlog_reader.mask);
 
   update_confdata_state_from_binlog(true, 10 * confdata_settings.confdata_update_timeout_sec);
   if (confdata_binlog_replayer.current_memory_status() != ConfdataBinlogReplayer::MemoryStatus::NORMAL) {
@@ -1102,6 +1111,14 @@ void init_confdata_binlog_reader() noexcept {
 void confdata_binlog_update_cron() noexcept {
   if (!confdata_settings.is_enabled()) {
     return;
+  }
+
+  // Force statistics update if binlog hasn't been rotated successfully in specific time
+  if (BinlogBufferWriter.unsuccessful_rotation_attempts > 0) {
+    std::chrono::seconds wait_rotation_time {time(NULL) - BinlogBufferWriter.unsuccessful_rotation_first_ts};
+    if (wait_rotation_time > confdata_settings.binlog_reader.how_long_wait_until_alert) {
+      StatsHouseManager::get().add_confdata_read_binlog_stats(ConfdataStats::get());
+    }
   }
 
   auto &confdata_binlog_replayer = ConfdataBinlogReplayer::get();

--- a/server/confdata-binlog-replay.h
+++ b/server/confdata-binlog-replay.h
@@ -19,6 +19,7 @@ void set_confdata_binlog_mask(const char *mask) noexcept;
 void set_confdata_memory_limit(size_t memory_limit) noexcept;
 void set_confdata_blacklist_pattern(std::unique_ptr<re2::RE2> &&key_blacklist_pattern) noexcept;
 void set_confdata_update_timeout(double timeout_sec) noexcept;
+void set_how_long_wait_until_alert(std::chrono::seconds t) noexcept;
 void add_confdata_force_ignore_prefix(const char *key_ignore_prefix) noexcept;
 void add_confdata_predefined_wildcard(const char *wildcard) noexcept;
 void clear_confdata_predefined_wildcards() noexcept;

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -7,6 +7,7 @@
 #include <chrono>
 
 #include "common/stats/provider.h"
+#include "common/wrappers/string_view.h"
 #include "runtime/confdata-global-manager.h"
 
 struct ConfdataStats : private vk::not_copyable {
@@ -14,6 +15,9 @@ struct ConfdataStats : private vk::not_copyable {
     static ConfdataStats confdata_stats;
     return confdata_stats;
   }
+
+  std::chrono::seconds next_binlog_wait_time{std::chrono::seconds::zero()};
+  vk::string_view next_binlog_expectator_name;
 
   std::chrono::nanoseconds initial_loading_time{std::chrono::nanoseconds::zero()};
   std::chrono::nanoseconds total_updating_time{std::chrono::nanoseconds::zero()};

--- a/server/confdata-stats.h
+++ b/server/confdata-stats.h
@@ -7,7 +7,6 @@
 #include <chrono>
 
 #include "common/stats/provider.h"
-#include "common/wrappers/string_view.h"
 #include "runtime/confdata-global-manager.h"
 
 struct ConfdataStats : private vk::not_copyable {
@@ -15,9 +14,6 @@ struct ConfdataStats : private vk::not_copyable {
     static ConfdataStats confdata_stats;
     return confdata_stats;
   }
-
-  std::chrono::seconds next_binlog_wait_time{std::chrono::seconds::zero()};
-  vk::string_view next_binlog_expectator_name;
 
   std::chrono::nanoseconds initial_loading_time{std::chrono::nanoseconds::zero()};
   std::chrono::nanoseconds total_updating_time{std::chrono::nanoseconds::zero()};

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -2228,6 +2228,11 @@ int main_args_handler(int i, const char *long_option) {
       return res;
     }
     case 2040: {
+      return parse_numeric_option<uint32_t>(long_option, 0, std::numeric_limits<uint32_t>::max(), [](uint32_t t) {
+        set_how_long_wait_until_alert(std::chrono::seconds{t});
+      });
+    }
+    case 2041: {
       static auto is_directory = [](const char* s) {
         struct stat st;
         return stat(s, &st) == 0 && S_ISDIR(st.st_mode);
@@ -2240,7 +2245,7 @@ int main_args_handler(int i, const char *long_option) {
       kml_directory = optarg;
       return 0;
     }
-    case 2041: {
+    case 2042: {
       runtime_builtins_stats::is_server_option_enabled = true;
       return 0;
     }
@@ -2356,8 +2361,9 @@ void parse_main_args(int argc, char *argv[]) {
                                                                    "Initial binlog is readed with x10 times larger timeout");
   parse_option("confdata-soft-oom-ratio", required_argument, 2039, "Memory limit ratio to start ignoring new keys related events (default: 0.85)."
                                                                    "Can't be > hard oom ratio (0.95)");
-  parse_option("kml-dir", required_argument, 2040, "Directory that contains .kml files");
-  parse_option("enable-request-builtin-stats", no_argument, 2041, "Enables the recording of statistics for built-in function calls during request processing");
+  parse_option("confdata-how-long-wait-binlog-until-alert", required_argument, 2040, "Time in seconds to wait before starting to alert if the next binlog part is not found");
+  parse_option("kml-dir", required_argument, 2041, "Directory that contains .kml files");
+  parse_option("enable-request-builtin-stats", no_argument, 2042, "Enables the recording of statistics for built-in function calls during request processing");
 
 
   parse_engine_options_long(argc, argv, main_args_handler);

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -373,6 +373,10 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   }
 }
 
+void StatsHouseManager::add_confdata_read_binlog_stats(const ConfdataStats& confdata_stats) {
+  client.metric("kphp_confdata_next_binlog_wait_time").tag("binlog_name", confdata_stats.next_binlog_expectator_name).write_value(confdata_stats.next_binlog_wait_time.count());
+}
+
 void StatsHouseManager::add_slow_net_event_stats(const slow_net_event_stats::stats_t &stats) noexcept {
   std::visit(overloaded{[this](const slow_net_event_stats::slow_rpc_response_stats &rpc_query_stat) noexcept {
                           // FIXME: it's enough to have it equal 10, but due to bug in GCC we are forced to use a length > 253

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -373,7 +373,7 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   }
 }
 
-void StatsHouseManager::add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats) {
+void StatsHouseManager::add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats) noexcept {
   client.metric("kphp_confdata_next_binlog_wait_time").tag("binlog_name", confdata_stats.next_binlog_expectator_name).write_value(confdata_stats.next_binlog_wait_time.count());
 }
 

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -373,7 +373,7 @@ void StatsHouseManager::add_confdata_master_stats(const ConfdataStats &confdata_
   }
 }
 
-void StatsHouseManager::add_confdata_read_binlog_stats(const ConfdataStats& confdata_stats) {
+void StatsHouseManager::add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats) {
   client.metric("kphp_confdata_next_binlog_wait_time").tag("binlog_name", confdata_stats.next_binlog_expectator_name).write_value(confdata_stats.next_binlog_wait_time.count());
 }
 

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -92,7 +92,7 @@ public:
 
   void add_confdata_master_stats(const ConfdataStats &confdata_stats);
 
-  void add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats);
+  void add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats) noexcept;
 
   void add_slow_net_event_stats(const slow_net_event_stats::stats_t &stats) noexcept;
 

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -91,6 +91,8 @@ public:
 
   void add_confdata_master_stats(const ConfdataStats &confdata_stats);
 
+  void add_confdata_read_binlog_stats(const ConfdataStats& confdata_stats);
+
   void add_slow_net_event_stats(const slow_net_event_stats::stats_t &stats) noexcept;
 
 private:

--- a/server/statshouse/statshouse-manager.h
+++ b/server/statshouse/statshouse-manager.h
@@ -9,6 +9,7 @@
 
 #include "common/dl-utils-lite.h"
 #include "common/mixin/not_copyable.h"
+#include "common/binlog/binlog-stats.h"
 #include "runtime-common/core/memory-resource/memory_resource.h"
 #include "runtime/runtime-builtin-stats.h"
 #include "server/job-workers/job-stats.h"
@@ -91,7 +92,7 @@ public:
 
   void add_confdata_master_stats(const ConfdataStats &confdata_stats);
 
-  void add_confdata_read_binlog_stats(const ConfdataStats& confdata_stats);
+  void add_confdata_binlog_reader_stats(const binlog_reader_stats& confdata_stats);
 
   void add_slow_net_event_stats(const slow_net_event_stats::stats_t &stats) noexcept;
 


### PR DESCRIPTION
Goals of this PR:
* Prevent exiting if the next binlog is not available
* Wait for the new binlog to be delivered and send alerts after a specified delay
   
