### PR TITLE
Implement special pre-fork run once mode

### DIFF
--- a/server/database-drivers/adaptor.h
+++ b/server/database-drivers/adaptor.h
@@ -23,7 +23,7 @@
 class PhpWorker;
 struct net_event_t;
 struct external_driver_connect;
-void generic_event_loop(WorkerType, bool) noexcept;
+void generic_event_loop(WorkerType, bool, bool) noexcept;
 void php_worker_run_net_queue(PhpWorker *);
 bool process_net_event(net_event_t *);
 // endregion
@@ -104,7 +104,7 @@ private:
   friend struct ::external_driver_connect;
 
   void create_outbound_connections() noexcept;
-  friend void ::generic_event_loop(WorkerType, bool) noexcept;
+  friend void ::generic_event_loop(WorkerType, bool, bool) noexcept;
 
   void process_external_db_request_net_query(std::unique_ptr<Request> &&request) noexcept;
   friend void ::php_worker_run_net_queue(PhpWorker *);

--- a/server/php-engine-vars.cpp
+++ b/server/php-engine-vars.cpp
@@ -27,7 +27,7 @@ int master_pid = -1;
 ProcessType process_type = ProcessType::master;
 
 int master_flag = 0; // 1 -- master, 0 -- single process, -1 -- child
-
+bool run_once_prefork_mode = false;
 bool run_once = false;
 int run_once_return_code = 0;
 

--- a/server/php-engine-vars.h
+++ b/server/php-engine-vars.h
@@ -37,7 +37,7 @@ extern int master_pid;
 extern ProcessType process_type;
 
 extern int master_flag;
-
+extern bool run_once_prefork_mode;
 extern bool run_once;
 extern int run_once_return_code;
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -1436,7 +1436,7 @@ void reopen_json_log() {
   }
 }
 
-void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_port) noexcept {
+void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_port, bool invoke_dummy_self_rpc_request) noexcept {
   if (master_flag && logname_pattern != nullptr) {
     reopen_logs();
     reopen_json_log();
@@ -1467,24 +1467,24 @@ void generic_event_loop(WorkerType worker_type, bool init_and_listen_rpc_port) n
         if (rpc_sfd >= 0) {
           init_listening_connection(rpc_sfd, &ct_php_engine_rpc_server, &rpc_methods);
         }
+      }
 
-        if (run_once) {
-          int pipe_fd[2];
-          pipe(pipe_fd);
+      if (invoke_dummy_self_rpc_request) {
+        int pipe_fd[2];
+        pipe(pipe_fd);
 
-          int read_fd = pipe_fd[0];
-          int write_fd = pipe_fd[1];
+        int read_fd = pipe_fd[0];
+        int write_fd = pipe_fd[1];
 
-          rpc_client_methods.rpc_ready = nullptr;
-          epoll_insert_pipe(pipe_for_read, read_fd, &ct_php_rpc_client, &rpc_client_methods);
+        rpc_client_methods.rpc_ready = nullptr;
+        epoll_insert_pipe(pipe_for_read, read_fd, &ct_php_rpc_client, &rpc_client_methods);
 
-          int q[6];
-          int qsize = 6 * sizeof(int);
-          q[2] = TL_RPC_INVOKE_REQ;
-          for (int i = 0; i < run_once_count; i++) {
-            prepare_rpc_query_raw(i, q, qsize, crc32c_partial);
-            assert (write(write_fd, q, (size_t)qsize) == qsize);
-          }
+        int q[6];
+        int qsize = 6 * sizeof(int);
+        q[2] = TL_RPC_INVOKE_REQ;
+        for (int i = 0; i < run_once_count; i++) {
+          prepare_rpc_query_raw(i, q, qsize, crc32c_partial);
+          assert(write(write_fd, q, (size_t)qsize) == qsize);
         }
       }
 
@@ -1632,7 +1632,7 @@ void start_server() {
   }
 
   worker_global_init(worker_type);
-  generic_event_loop(worker_type, !master_flag);
+  generic_event_loop(worker_type, !master_flag, run_once || run_once_prefork_mode);
 }
 
 void set_instance_cache_memory_limit(size_t limit);
@@ -2448,9 +2448,14 @@ int run_main(int argc, char **argv, php_mode mode) {
   parse_main_args(argc, argv);
 
   if (run_once) {
-    master_flag = 0;
-    rpc_port = -1;
-    setvbuf(stdout, nullptr, _IONBF, 0);
+    if (master_flag) {
+      kprintf("running in special run once pre-fork mode\n");
+      run_once_prefork_mode = true;
+    } else {
+      master_flag = 0;
+      rpc_port = -1;
+      setvbuf(stdout, nullptr, _IONBF, 0);
+    }
   }
 
   if (!master_flag && vk::singleton<HttpServerContext>::get().http_server_enabled()) {


### PR DESCRIPTION
This PR combines already existing behaviour of `--workers-num N` and `--once` options. To enable this mode one needs just specify both options on start.

New special mode works as the following:
1. Starts N workers, as usual in pre-fork mode from option `--workers-num N`
2. Sends dummy RPC request to itself to run script in each worker M times, as usual with `--once [M]` option (by default `M = 1`)
3. When script is finished as many times as specified, worker process terminates
4. When master process realizes that some workers are terminated it recreates them and execution in each new worker continues from step 2

The main goal of such a strange mode - to automatically enable subsystems designed only for master-workers model in **CLI** mode (confdata, instance cache, errors and traces collecting via json logs, runtime metrics collecting from master cron, etc.)