### PR TITLE
[k2] use ordered containers instead of unordered ones in the scheduler

### DIFF
--- a/runtime-common/core/std/containers.h
+++ b/runtime-common/core/std/containers.h
@@ -9,6 +9,7 @@
 #include <list>
 #include <map>
 #include <queue>
+#include <set>
 #include <stack>
 #include <string>
 #include <unordered_map>
@@ -28,6 +29,9 @@ using unordered_set = std::unordered_set<T, Hash, KeyEqual, Allocator<T>>;
 
 template<class Key, class Value, template<class> class Allocator, class Cmp = std::less<Key>>
 using map = std::map<Key, Value, Cmp, Allocator<std::pair<const Key, Value>>>;
+
+template<class T, template<class> class Allocator, class Cmp = std::less<T>>
+using set = std::set<T, Cmp, Allocator<T>>;
 
 template<class Key, class Value, template<class> class Allocator, class Cmp = std::less<Key>>
 using multimap = std::multimap<Key, Value, Cmp, Allocator<std::pair<const Key, Value>>>;

--- a/runtime-light/coroutine/awaitable.h
+++ b/runtime-light/coroutine/awaitable.h
@@ -94,7 +94,7 @@ public:
   wait_for_update_t(wait_for_update_t&& other) noexcept
       : stream_d(std::exchange(other.stream_d, k2::INVALID_PLATFORM_DESCRIPTOR)),
         upd_kind(other.upd_kind),
-        suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))),
+        suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Reschedule{}))),
         state(std::exchange(other.state, awaitable_impl_::state::end)) {}
 
   wait_for_update_t(const wait_for_update_t&) = delete;
@@ -150,7 +150,7 @@ public:
   wait_for_incoming_stream_t() noexcept = default;
 
   wait_for_incoming_stream_t(wait_for_incoming_stream_t&& other) noexcept
-      : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))),
+      : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Reschedule{}))),
         state(std::exchange(other.state, awaitable_impl_::state::end)) {}
 
   wait_for_incoming_stream_t(const wait_for_incoming_stream_t&) = delete;
@@ -197,14 +197,14 @@ public:
 // ================================================================================================
 
 class wait_for_reschedule_t : awaitable_impl_::fork_id_watcher_t, awaitable_impl_::async_stack_watcher_t {
-  SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::Rechedule{}};
+  SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::Reschedule{}};
   awaitable_impl_::state state{awaitable_impl_::state::init};
 
 public:
   wait_for_reschedule_t() noexcept = default;
 
   wait_for_reschedule_t(wait_for_reschedule_t&& other) noexcept
-      : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))),
+      : suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Reschedule{}))),
         state(std::exchange(other.state, awaitable_impl_::state::end)) {}
 
   wait_for_reschedule_t(const wait_for_reschedule_t&) = delete;
@@ -249,7 +249,7 @@ public:
 class wait_for_timer_t : awaitable_impl_::fork_id_watcher_t, awaitable_impl_::async_stack_watcher_t {
   std::chrono::nanoseconds duration;
   uint64_t timer_d{k2::INVALID_PLATFORM_DESCRIPTOR};
-  SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::Rechedule{}};
+  SuspendToken suspend_token{std::noop_coroutine(), WaitEvent::Reschedule{}};
   awaitable_impl_::state state{awaitable_impl_::state::init};
 
 public:
@@ -259,7 +259,7 @@ public:
   wait_for_timer_t(wait_for_timer_t&& other) noexcept
       : duration(std::exchange(other.duration, std::chrono::nanoseconds{0})),
         timer_d(std::exchange(other.timer_d, k2::INVALID_PLATFORM_DESCRIPTOR)),
-        suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Rechedule{}))),
+        suspend_token(std::exchange(other.suspend_token, std::make_pair(std::noop_coroutine(), WaitEvent::Reschedule{}))),
         state(std::exchange(other.state, awaitable_impl_::state::end)) {}
 
   wait_for_timer_t(const wait_for_timer_t&) = delete;

--- a/runtime-light/scheduler/scheduler.cpp
+++ b/runtime-light/scheduler/scheduler.cpp
@@ -87,7 +87,7 @@ void SimpleCoroutineScheduler::suspend(SuspendToken token) noexcept {
   std::visit(
       [this, token](auto&& event) noexcept {
         using event_t = std::remove_cvref_t<decltype(event)>;
-        if constexpr (std::is_same_v<event_t, WaitEvent::Rechedule>) {
+        if constexpr (std::is_same_v<event_t, WaitEvent::Reschedule>) {
           yield_tokens.push_back(token);
         } else if constexpr (std::is_same_v<event_t, WaitEvent::IncomingStream>) {
           awaiting_for_stream_tokens.push_back(token);
@@ -113,7 +113,7 @@ void SimpleCoroutineScheduler::cancel(SuspendToken token) noexcept {
   std::visit(
       [this, token](auto&& event) noexcept {
         using event_t = std::remove_cvref_t<decltype(event)>;
-        if constexpr (std::is_same_v<event_t, WaitEvent::Rechedule>) {
+        if constexpr (std::is_same_v<event_t, WaitEvent::Reschedule>) {
           const auto it_token{std::find(yield_tokens.cbegin(), yield_tokens.cend(), token)};
           if (it_token != yield_tokens.cend()) {
             yield_tokens.erase(it_token);

--- a/runtime-light/scheduler/scheduler.h
+++ b/runtime-light/scheduler/scheduler.h
@@ -59,11 +59,13 @@ enum class ScheduleStatus : uint8_t { Resumed, Skipped, Error };
  */
 namespace WaitEvent {
 
-struct Rechedule {
+struct Reschedule {
   static constexpr size_t HASH_VALUE = 4001;
-  bool operator==([[maybe_unused]] const Rechedule& other) const noexcept {
+  constexpr bool operator==([[maybe_unused]] const Reschedule& other) const noexcept {
     return true;
   }
+
+  constexpr auto operator<=>(const Reschedule&) const noexcept = default;
 };
 
 struct IncomingStream {
@@ -71,34 +73,40 @@ struct IncomingStream {
   bool operator==([[maybe_unused]] const IncomingStream& other) const noexcept {
     return true;
   }
+
+  constexpr auto operator<=>(const IncomingStream&) const noexcept = default;
 };
 
 struct UpdateOnStream {
   uint64_t stream_d{};
 
-  bool operator==(const UpdateOnStream& other) const noexcept {
+  constexpr bool operator==(const UpdateOnStream& other) const noexcept {
     return stream_d == other.stream_d;
   }
+
+  constexpr auto operator<=>(const UpdateOnStream&) const noexcept = default;
 };
 
 struct UpdateOnTimer {
   uint64_t timer_d{};
 
-  bool operator==(const UpdateOnTimer& other) const noexcept {
+  constexpr bool operator==(const UpdateOnTimer& other) const noexcept {
     return timer_d == other.timer_d;
   }
+
+  constexpr auto operator<=>(const UpdateOnTimer&) const noexcept = default;
 };
 
-using EventT = std::variant<Rechedule, IncomingStream, UpdateOnStream, UpdateOnTimer>;
+using EventT = std::variant<Reschedule, IncomingStream, UpdateOnStream, UpdateOnTimer>;
 
 }; // namespace WaitEvent
 
 // std::hash specializations for WaitEvent types
 
 template<>
-struct std::hash<WaitEvent::Rechedule> {
-  size_t operator()([[maybe_unused]] const WaitEvent::Rechedule& v) const noexcept {
-    return WaitEvent::Rechedule::HASH_VALUE;
+struct std::hash<WaitEvent::Reschedule> {
+  size_t operator()([[maybe_unused]] const WaitEvent::Reschedule& v) const noexcept {
+    return WaitEvent::Reschedule::HASH_VALUE;
   }
 };
 
@@ -183,7 +191,7 @@ class SimpleCoroutineScheduler {
   deque<SuspendToken> yield_tokens;
   deque<SuspendToken> awaiting_for_stream_tokens;
   map<uint64_t, SuspendToken> awaiting_for_update_tokens;
-  unordered_set<SuspendToken> suspend_tokens;
+  set<SuspendToken> suspend_tokens;
   CoroutineInstanceState& coroutine_instance_state;
 
   ScheduleStatus scheduleOnNoEvent() noexcept;

--- a/runtime-light/scheduler/scheduler.h
+++ b/runtime-light/scheduler/scheduler.h
@@ -168,6 +168,12 @@ class SimpleCoroutineScheduler {
   template<hashable Key, typename Value>
   using unordered_map = kphp::stl::unordered_map<Key, Value, kphp::memory::script_allocator>;
 
+  template<typename Key, typename Value>
+  using map = kphp::stl::map<Key, Value, kphp::memory::script_allocator>;
+
+  template<typename T>
+  using set = kphp::stl::set<T, kphp::memory::script_allocator>;
+
   template<hashable T>
   using unordered_set = kphp::stl::unordered_set<T, kphp::memory::script_allocator>;
 
@@ -176,7 +182,7 @@ class SimpleCoroutineScheduler {
 
   deque<SuspendToken> yield_tokens;
   deque<SuspendToken> awaiting_for_stream_tokens;
-  unordered_map<uint64_t, SuspendToken> awaiting_for_update_tokens;
+  map<uint64_t, SuspendToken> awaiting_for_update_tokens;
   unordered_set<SuspendToken> suspend_tokens;
   CoroutineInstanceState& coroutine_instance_state;
 

--- a/runtime-light/state/instance-state.cpp
+++ b/runtime-light/state/instance-state.cpp
@@ -72,7 +72,7 @@ void InstanceState::init_script_execution() noexcept {
         kphp::log::assertion(co_await f$wait_concurrently(co_await start_fork_t{std::move(script_task)}));
       },
       std::move(script_task))};
-  scheduler.suspend({main_task.get_handle(), WaitEvent::Rechedule{}});
+  scheduler.suspend({main_task.get_handle(), WaitEvent::Reschedule{}});
   main_task_ = std::move(main_task);
   // Push main_task_ frame to async stack
   auto& main_task_frame{main_task_.get_handle().promise().get_async_stack_frame()};


### PR DESCRIPTION
`perf` shows that ordered containers in scheduler produce less page faults compared to unordered ones