### PR TITLE
[k2] use script allocator instead of k2::alloc for coroutine frames

### DIFF
--- a/runtime-light/allocator/runtime-light-allocator.cpp
+++ b/runtime-light/allocator/runtime-light-allocator.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 // TODO: make it depend on max chunk size, e.g. MIN_EXTRA_MEM_SIZE = f(MAX_CHUNK_SIZE);
-constexpr auto MIN_EXTRA_MEM_SIZE = static_cast<size_t>(32U * 1024U); // extra mem size should be greater than max chunk block size
+constexpr auto MIN_EXTRA_MEM_SIZE = static_cast<size_t>(1024U * 1024U); // extra mem size should be greater than max chunk block size
 constexpr auto EXTRA_MEMORY_MULTIPLIER = 2;
 
 void request_extra_memory(size_t requested_size) noexcept {

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -13,8 +13,8 @@
 #include <type_traits>
 #include <utility>
 
+#include "runtime-common/core/allocator/script-malloc-interface.h"
 #include "runtime-light/coroutine/async-stack.h"
-#include "runtime-light/k2-platform/k2-api.h"
 #include "runtime-light/utils/logs.h"
 
 namespace kphp::coro {
@@ -143,13 +143,11 @@ struct promise_base : async_stack_element {
 
   template<typename... Args>
   auto operator new(size_t n, [[maybe_unused]] Args&&... args) noexcept -> void* {
-    // todo:k2 think about args in new
-    // todo:k2 make coroutine allocator
-    return k2::alloc(n);
+    return kphp::memory::script::alloc(n);
   }
 
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
-    k2::free(ptr);
+    kphp::memory::script::free(ptr);
   }
 
 private:

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -12,8 +12,8 @@
 #include <utility>
 
 #include "common/containers/final_action.h"
+#include "runtime-common/core/allocator/script-malloc-interface.h"
 #include "runtime-light/coroutine/async-stack.h"
-#include "runtime-light/k2-platform/k2-api.h"
 #include "runtime-light/utils/logs.h"
 
 namespace kphp::coro {
@@ -67,13 +67,11 @@ struct promise_base : async_stack_element {
 
   template<typename... Args>
   auto operator new(std::size_t n, [[maybe_unused]] Args&&... args) noexcept -> void* {
-    // todo:k2 think about args in new
-    // todo:k2 make coroutine allocator
-    return k2::alloc(n);
+    return kphp::memory::script::alloc(n);
   }
 
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
-    k2::free(ptr);
+    kphp::memory::script::free(ptr);
   }
 
   void* m_next{};

--- a/runtime-light/state/instance-state.h
+++ b/runtime-light/state/instance-state.h
@@ -151,5 +151,5 @@ private:
   deque<uint64_t> incoming_streams_;
   unordered_set<uint64_t> opened_streams_;
 
-  static constexpr auto INIT_INSTANCE_ALLOCATOR_SIZE = static_cast<size_t>(16U * 1024U * 1024U);
+  static constexpr auto INIT_INSTANCE_ALLOCATOR_SIZE = static_cast<size_t>(32U * 1024U * 1024U);
 };

--- a/runtime-light/state/instance-state.h
+++ b/runtime-light/state/instance-state.h
@@ -151,5 +151,5 @@ private:
   deque<uint64_t> incoming_streams_;
   unordered_set<uint64_t> opened_streams_;
 
-  static constexpr auto INIT_INSTANCE_ALLOCATOR_SIZE = static_cast<size_t>(32U * 1024U * 1024U);
+  static constexpr auto INIT_INSTANCE_ALLOCATOR_SIZE = static_cast<size_t>(16U * 1024U * 1024U);
 };


### PR DESCRIPTION
Each invocation of `k2::alloc` triggers an update to the component statistics. To eliminate this overhead, replace `k2::alloc` with a script allocator. This change is acceptable as long as coroutines are not launched before the lifetime of `InstanceState`.