### PR TITLE
add kphp_slow_curl_response metric

### DIFF
--- a/runtime/curl.cpp
+++ b/runtime/curl.cpp
@@ -25,7 +25,9 @@
 #include "net/net-events.h"
 #include "net/net-reactor.h"
 #include "server/curl-adaptor.h"
+#include "server/php-queries.h"
 #include "server/slot-ids-factory.h"
+#include "server/statshouse/statshouse-manager.h"
 
 static_assert(LIBCURL_VERSION_NUM >= 0x071c00, "Outdated libcurl");
 static_assert(CURL_MAX_WRITE_SIZE <= (1 << 30), "CURL_MAX_WRITE_SIZE expected to be less than (1 << 30)");
@@ -667,6 +669,8 @@ mixed f$curl_exec(curl_easy easy_id) noexcept {
   easy_context->error_num = dl::critical_section_call(curl_easy_perform, easy_context->easy_handle);
   double request_finish_time = dl_time();
   if (request_finish_time - request_start_time >= long_curl_query) {
+    StatsHouseManager::get().add_slow_net_event_stats(slow_net_event_stats::slow_curl_response_stats{
+        slow_net_event_stats::slow_curl_response_stats::curl_kind::sync, request_finish_time - request_start_time});
     kprintf("LONG curl query : %f. Curl id = %d, url = %.100s\n", request_finish_time - request_start_time, easy_context->uniq_id,
             easy_context->get_info(CURLINFO_EFFECTIVE_URL).as_string().c_str());
   }

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -7,6 +7,9 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
+#include <string_view>
+#include <utility>
 #include <variant>
 
 #include "common/sanitizer.h"
@@ -95,10 +98,12 @@ struct slow_curl_response_stats final {
   enum class curl_kind : uint8_t { sync, async };
 
   curl_kind kind;
+  std::optional<std::string_view> opt_url;
   double response_time;
 
-  slow_curl_response_stats(curl_kind kind_, double response_time_) noexcept
+  slow_curl_response_stats(curl_kind kind_, std::optional<std::string_view> url_, double response_time_) noexcept
       : kind(kind_),
+        opt_url(url_),
         response_time(response_time_) {}
 };
 

--- a/server/php-queries.h
+++ b/server/php-queries.h
@@ -91,7 +91,18 @@ struct slow_job_worker_response_stats final {
   double response_time{};
 };
 
-using stats_t = std::variant<slow_rpc_response_stats, slow_job_worker_response_stats>;
+struct slow_curl_response_stats final {
+  enum class curl_kind : uint8_t { sync, async };
+
+  curl_kind kind;
+  double response_time;
+
+  slow_curl_response_stats(curl_kind kind_, double response_time_) noexcept
+      : kind(kind_),
+        response_time(response_time_) {}
+};
+
+using stats_t = std::variant<slow_rpc_response_stats, slow_job_worker_response_stats, slow_curl_response_stats>;
 
 }; // namespace slow_net_event_stats
 

--- a/server/php-runner.cpp
+++ b/server/php-runner.cpp
@@ -9,6 +9,7 @@
 #include <cerrno>
 #include <cstdlib>
 #include <cstring>
+#include <optional>
 #include <sys/mman.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -81,8 +82,8 @@ void send_slow_net_event_stats(const net_event_t& event, double time_sec) noexce
                  [](const database_drivers::Response*) {},
                  [time_sec](const curl_async::CurlResponse* curl_response) noexcept {
                    if (curl_response != nullptr) {
-                     StatsHouseManager::get().add_slow_net_event_stats(
-                         slow_net_event_stats::slow_curl_response_stats{slow_net_event_stats::slow_curl_response_stats::curl_kind::async, time_sec});
+                     StatsHouseManager::get().add_slow_net_event_stats(slow_net_event_stats::slow_curl_response_stats{
+                         slow_net_event_stats::slow_curl_response_stats::curl_kind::async, std::nullopt, time_sec});
                    }
                  },
 

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -4,6 +4,7 @@
 
 #include "server/statshouse/statshouse-manager.h"
 
+#include <algorithm>
 #include <array>
 #include <charconv>
 #include <chrono>
@@ -408,9 +409,13 @@ void StatsHouseManager::add_slow_net_event_stats(const slow_net_event_stats::sta
                             curl_kind = "async";
                             break;
                           }
+
+                          static constexpr size_t CURL_URL_MAX_LEN = 100;
+                          std::string_view curl_url = curl_response_stat.opt_url.value_or(std::string_view{"unknown"});
+
                           client.metric("kphp_slow_curl_response")
                               .tag(curl_kind)
-                              .tag(curl_response_stat.opt_url.value_or(std::string_view{"unknown"}))
+                              .tag(std::string_view{curl_url.data(), std::min(curl_url.size(), CURL_URL_MAX_LEN)})
                               .write_value(curl_response_stat.response_time);
                         }},
              stats);

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstddef>
 #include <string>
+#include <string_view>
 #include <variant>
 
 #include "common/precise-time.h"
@@ -380,22 +381,34 @@ void StatsHouseManager::add_confdata_binlog_reader_stats(const binlog_reader_sta
   client.metric("kphp_confdata_next_binlog_wait_time").tag("binlog_name", confdata_stats.next_binlog_expectator_name).write_value(confdata_stats.next_binlog_wait_time.count());
 }
 
-void StatsHouseManager::add_slow_net_event_stats(const slow_net_event_stats::stats_t &stats) noexcept {
-  std::visit(overloaded{[this](const slow_net_event_stats::slow_rpc_response_stats &rpc_query_stat) noexcept {
+void StatsHouseManager::add_slow_net_event_stats(const slow_net_event_stats::stats_t& stats) noexcept {
+  std::visit(overloaded{[this](const slow_net_event_stats::slow_rpc_response_stats& rpc_query_stat) noexcept {
                           // FIXME: it's enough to have it equal 10, but due to bug in GCC we are forced to use a length > 253
                           constexpr auto MAX_INT_STRING_LENGTH = 254;
                           std::array<char, MAX_INT_STRING_LENGTH> buf{};
                           const auto chars{std::to_chars(buf.data(), buf.data() + buf.size(), rpc_query_stat.actor_or_port)};
                           client.metric("kphp_slow_rpc_response")
-                            .tag(rpc_query_stat.tl_function_name != nullptr ? rpc_query_stat.tl_function_name : "unknown")
-                            .tag({buf.data(), static_cast<size_t>(chars.ptr - buf.data())})
-                            .tag(rpc_query_stat.is_error ? "error" : "success")
-                            .write_value(rpc_query_stat.response_time);
+                              .tag(rpc_query_stat.tl_function_name != nullptr ? rpc_query_stat.tl_function_name : "unknown")
+                              .tag({buf.data(), static_cast<size_t>(chars.ptr - buf.data())})
+                              .tag(rpc_query_stat.is_error ? "error" : "success")
+                              .write_value(rpc_query_stat.response_time);
                         },
-                        [this](const slow_net_event_stats::slow_job_worker_response_stats &jw_response_stat) noexcept {
+                        [this](const slow_net_event_stats::slow_job_worker_response_stats& jw_response_stat) noexcept {
                           client.metric("kphp_slow_job_worker_response")
-                            .tag(jw_response_stat.class_name != nullptr ? jw_response_stat.class_name : "unknown")
-                            .write_value(jw_response_stat.response_time);
+                              .tag(jw_response_stat.class_name != nullptr ? jw_response_stat.class_name : "unknown")
+                              .write_value(jw_response_stat.response_time);
+                        },
+                        [this](const slow_net_event_stats::slow_curl_response_stats& curl_response_stat) noexcept {
+                          std::string_view curl_kind = "unknown";
+                          switch (curl_response_stat.kind) {
+                          case slow_net_event_stats::slow_curl_response_stats::curl_kind::sync:
+                            curl_kind = "sync";
+                            break;
+                          case slow_net_event_stats::slow_curl_response_stats::curl_kind::async:
+                            curl_kind = "async";
+                            break;
+                          }
+                          client.metric("kphp_slow_curl_response").tag(curl_kind).write_value(curl_response_stat.response_time);
                         }},
              stats);
 }

--- a/server/statshouse/statshouse-manager.cpp
+++ b/server/statshouse/statshouse-manager.cpp
@@ -408,7 +408,10 @@ void StatsHouseManager::add_slow_net_event_stats(const slow_net_event_stats::sta
                             curl_kind = "async";
                             break;
                           }
-                          client.metric("kphp_slow_curl_response").tag(curl_kind).write_value(curl_response_stat.response_time);
+                          client.metric("kphp_slow_curl_response")
+                              .tag(curl_kind)
+                              .tag(curl_response_stat.opt_url.value_or(std::string_view{"unknown"}))
+                              .write_value(curl_response_stat.response_time);
                         }},
              stats);
 }


### PR DESCRIPTION
This PR introduces a new StatsHouse metric to monitor slow CURL responses in KPHP:

- Metric Name: kphp_slow_curl_responses
- Threshold: Records responses that exceed 100ms
- Data Captured:
    - Request duration
    - Target host/endpoint (if available)