### PR TITLE
[k2] Add some tracing, wait queue stubs and remove some rpc ones

### DIFF
--- a/builtin-functions/kphp-light/stdlib/kphp-tracing.txt
+++ b/builtin-functions/kphp-light/stdlib/kphp-tracing.txt
@@ -5,12 +5,14 @@
 final class KphpDiv {
   /** @kphp-extern-func-info stub generation-required */
   private function __construct();
-  /** @kphp-extern-func-info stub generation-required */
+
   function generateTraceCtxForChild(int $div_id, int $trace_flags): tuple(int, int);
-  /** @kphp-extern-func-info stub generation-required */
+
   function assignTraceCtx(int $int1, int $int2, ?int $override_div_id): int;
+
   /** @kphp-extern-func-info stub generation-required */
   function getStartTimestamp(): float;
+
   /** @kphp-extern-func-info stub generation-required */
   function getEndTimestamp(): float;
 }
@@ -37,7 +39,6 @@ final class KphpSpan {
 
   function finish(?float $end_timestamp = null) ::: void;
 
-  /** @kphp-extern-func-info stub generation-required */
   function finishWithError(int $error_code, string $error_msg, ?float $end_timestamp = null) ::: void;
   /** @kphp-extern-func-info stub generation-required */
   function exclude() ::: void;
@@ -60,7 +61,6 @@ function kphp_tracing_init(string $root_span_title): KphpDiv;
 
 function kphp_tracing_set_level(int $trace_level): void;
 
-/** @kphp-extern-func-info stub generation-required */
 function kphp_tracing_get_level(): int;
 
 function kphp_tracing_register_on_finish(callable(float $now_timestamp):bool $cb_should_be_flushed);

--- a/builtin-functions/kphp-light/stdlib/rpc.txt
+++ b/builtin-functions/kphp-light/stdlib/rpc.txt
@@ -118,3 +118,9 @@ function store_finish() ::: bool;
 
 /** @kphp-extern-func-info interruptible stub generation-required can_throw */
 function fetch_lookup_int () ::: int;
+
+/** @kphp-generate-stub-class */
+final class RpcConnection {
+    /** @kphp-extern-func-info stub generation-required */
+    private function __construct();
+}

--- a/builtin-functions/kphp-light/stdlib/rpc.txt
+++ b/builtin-functions/kphp-light/stdlib/rpc.txt
@@ -128,9 +128,6 @@ function typed_rpc_tl_query_result_one (int $query_id) ::: @tl\RpcResponse;
 /** @kphp-extern-func-info interruptible stub generation-required can_throw */
 function fetch_lookup_int () ::: int;
 
-/** @kphp-extern-func-info interruptible stub generation-required */
-function new_rpc_connection ($str ::: string, $port ::: int, $actor_id ::: mixed = 0, $timeout ::: float = 0.3, $connect_timeout ::: float = 0.3, $reconnect_timeout ::: float = 17.0) ::: \RpcConnection; // TODO: make actor_id int
-
 /** @kphp-generate-stub-class */
 final class RpcConnection {
     /** @kphp-extern-func-info stub generation-required */

--- a/builtin-functions/kphp-light/stdlib/rpc.txt
+++ b/builtin-functions/kphp-light/stdlib/rpc.txt
@@ -116,20 +116,5 @@ function rpc_queue_push ($queue_id ::: int, $request_ids ::: mixed) ::: int;
 /** @kphp-extern-func-info interruptible stub generation-required */
 function store_finish() ::: bool;
 
-/** @kphp-extern-func-info interruptible stub generation-required */
-function rpc_tl_query_one (\RpcConnection $rpc_conn, $arr ::: mixed, $timeout ::: float = -1.0) ::: int;
-
-/** @kphp-extern-func-info tl_common_h_dep interruptible stub */
-function typed_rpc_tl_query_result_synchronously (int[] $query_ids) ::: @tl\RpcResponse[];
-
-/** @kphp-extern-func-info tl_common_h_dep interruptible stub generation-required */
-function typed_rpc_tl_query_result_one (int $query_id) ::: @tl\RpcResponse;
-
 /** @kphp-extern-func-info interruptible stub generation-required can_throw */
 function fetch_lookup_int () ::: int;
-
-/** @kphp-generate-stub-class */
-final class RpcConnection {
-    /** @kphp-extern-func-info stub generation-required */
-    private function __construct();
-}

--- a/runtime-light/stdlib/fork/fork-functions.h
+++ b/runtime-light/stdlib/fork/fork-functions.h
@@ -172,11 +172,13 @@ inline int64_t f$get_running_fork_id() noexcept {
 }
 
 inline int64_t f$wait_queue_create() {
-  kphp::log::error("call to unsupported function");
+  kphp::log::info("wait_queue_create() is noop");
+  return 0;
 }
 
 inline int64_t f$wait_queue_create(const mixed& /*resumable_ids*/) {
-  kphp::log::error("call to unsupported function");
+  kphp::log::info("wait_queue_create(ids) is noop");
+  return 0;
 }
 
 inline int64_t f$wait_queue_push(int64_t /*queue_id*/, const mixed& /*resumable_ids*/) {

--- a/runtime-light/stdlib/fork/fork-functions.h
+++ b/runtime-light/stdlib/fork/fork-functions.h
@@ -172,12 +172,12 @@ inline int64_t f$get_running_fork_id() noexcept {
 }
 
 inline int64_t f$wait_queue_create() {
-  kphp::log::info("wait_queue_create() is noop");
+  kphp::log::info("called stub wait_queue_create()");
   return 0;
 }
 
 inline int64_t f$wait_queue_create(const mixed& /*resumable_ids*/) {
-  kphp::log::info("wait_queue_create(ids) is noop");
+  kphp::log::info("called stub wait_queue_create(ids)");
   return 0;
 }
 

--- a/runtime-light/stdlib/tracing/tracing-div.h
+++ b/runtime-light/stdlib/tracing/tracing-div.h
@@ -15,12 +15,12 @@ struct C$KphpDiv : public refcountable_php_classes<C$KphpDiv>, private DummyVisi
 
 inline int64_t f$KphpDiv$$assignTraceCtx([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t int1, [[maybe_unused]] int64_t int2,
                                   [[maybe_unused]] const Optional<int64_t>& override_div_id) {
-  kphp::log::warning("called stub KphpDiv::assignTraceCtx");
+  kphp::log::info("called stub KphpDiv::assignTraceCtx");
   return {};
 }
 
 inline std::tuple<int64_t, int64_t> f$KphpDiv$$generateTraceCtxForChild([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t div_id,
                                                                  [[maybe_unused]] int64_t trace_flags) {
-  kphp::log::warning("called stub KphpDiv::generateTraceCtxForChild");
+  kphp::log::info("called stub KphpDiv::generateTraceCtxForChild");
   return {};
 }

--- a/runtime-light/stdlib/tracing/tracing-div.h
+++ b/runtime-light/stdlib/tracing/tracing-div.h
@@ -14,13 +14,13 @@ struct C$KphpDiv : public refcountable_php_classes<C$KphpDiv>, private DummyVisi
 };
 
 inline int64_t f$KphpDiv$$assignTraceCtx([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t int1, [[maybe_unused]] int64_t int2,
-                                  [[maybe_unused]] const Optional<int64_t>& override_div_id) {
+                                         [[maybe_unused]] const Optional<int64_t>& override_div_id) {
   kphp::log::info("called stub KphpDiv::assignTraceCtx");
   return {};
 }
 
-inline std::tuple<int64_t, int64_t> f$KphpDiv$$generateTraceCtxForChild([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t div_id,
-                                                                 [[maybe_unused]] int64_t trace_flags) {
+inline std::tuple<int64_t, int64_t> f$KphpDiv$$generateTraceCtxForChild([[maybe_unused]] const class_instance<C$KphpDiv>& v$this,
+                                                                        [[maybe_unused]] int64_t div_id, [[maybe_unused]] int64_t trace_flags) {
   kphp::log::info("called stub KphpDiv::generateTraceCtxForChild");
   return {};
 }

--- a/runtime-light/stdlib/tracing/tracing-div.h
+++ b/runtime-light/stdlib/tracing/tracing-div.h
@@ -5,8 +5,22 @@
 #pragma once
 
 #include "runtime-common/core/class-instance/refcountable-php-classes.h"
+#include "runtime-common/core/runtime-core.h"
 #include "runtime-common/stdlib/visitors/dummy-visitor-methods.h"
+#include "runtime-light/stdlib/diagnostics/logs.h"
 
 struct C$KphpDiv : public refcountable_php_classes<C$KphpDiv>, private DummyVisitorMethods {
   using DummyVisitorMethods::accept;
 };
+
+inline int64_t f$KphpDiv$$assignTraceCtx([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t int1, [[maybe_unused]] int64_t int2,
+                                  [[maybe_unused]] const Optional<int64_t>& override_div_id) {
+  kphp::log::warning("called stub KphpDiv::assignTraceCtx");
+  return {};
+}
+
+inline std::tuple<int64_t, int64_t> f$KphpDiv$$generateTraceCtxForChild([[maybe_unused]] const class_instance<C$KphpDiv>& v$this, [[maybe_unused]] int64_t div_id,
+                                                                 [[maybe_unused]] int64_t trace_flags) {
+  kphp::log::warning("called stub KphpDiv::generateTraceCtxForChild");
+  return {};
+}

--- a/runtime-light/stdlib/tracing/tracing-functions.h
+++ b/runtime-light/stdlib/tracing/tracing-functions.h
@@ -28,6 +28,11 @@ inline class_instance<C$KphpDiv> f$kphp_tracing_init([[maybe_unused]] const stri
   return {};
 }
 
+inline int64_t f$kphp_tracing_get_level() {
+  kphp::log::warning("called stub kphp_tracing_get_level");
+  return -1; // Not initialized
+}
+
 inline class_instance<C$KphpSpan> f$kphp_tracing_start_span([[maybe_unused]] const string& title, [[maybe_unused]] const string& short_desc,
                                                             [[maybe_unused]] double start_timestamp) noexcept {
   kphp::log::warning("called stub kphp_tracing_start_span");

--- a/runtime-light/stdlib/tracing/tracing-functions.h
+++ b/runtime-light/stdlib/tracing/tracing-functions.h
@@ -10,50 +10,50 @@
 #include "runtime-light/stdlib/tracing/tracing-span.h"
 
 inline class_instance<C$KphpSpan> f$kphp_tracing_get_current_active_span() noexcept {
-  kphp::log::warning("called stub kphp_tracing_get_current_active_span");
+  kphp::log::info("called stub kphp_tracing_get_current_active_span");
   return {};
 }
 
 inline void f$kphp_tracing_func_enter_branch(int /*$branch_num*/) noexcept {
-  kphp::log::warning("called stub kphp_tracing_func_enter_branch");
+  kphp::log::info("called stub kphp_tracing_func_enter_branch");
 }
 
 inline class_instance<C$KphpSpan> f$kphp_tracing_get_root_span() noexcept {
-  kphp::log::warning("called stub kphp_tracing_get_root_span");
+  kphp::log::info("called stub kphp_tracing_get_root_span");
   return {};
 }
 
 inline class_instance<C$KphpDiv> f$kphp_tracing_init([[maybe_unused]] const string& root_span_title) noexcept {
-  kphp::log::warning("called stub kphp_tracing_init");
+  kphp::log::info("called stub kphp_tracing_init");
   return {};
 }
 
 inline int64_t f$kphp_tracing_get_level() {
-  kphp::log::warning("called stub kphp_tracing_get_level");
+  kphp::log::info("called stub kphp_tracing_get_level");
   return -1; // Not initialized
 }
 
 inline class_instance<C$KphpSpan> f$kphp_tracing_start_span([[maybe_unused]] const string& title, [[maybe_unused]] const string& short_desc,
                                                             [[maybe_unused]] double start_timestamp) noexcept {
-  kphp::log::warning("called stub kphp_tracing_start_span");
+  kphp::log::info("called stub kphp_tracing_start_span");
   return {};
 }
 
 template<typename F>
 void f$kphp_tracing_register_enums_provider([[maybe_unused]] F&& cb_custom_enums) noexcept {
-  kphp::log::warning("called stub kphp_tracing_register_enums_provider");
+  kphp::log::info("called stub kphp_tracing_register_enums_provider");
 }
 
 template<typename F>
 void f$kphp_tracing_register_on_finish([[maybe_unused]] F&& cb_should_be_flushed) noexcept {
-  kphp::log::warning("called stub kphp_tracing_register_on_finish");
+  kphp::log::info("called stub kphp_tracing_register_on_finish");
 }
 
 template<typename F1, typename F2>
 void f$kphp_tracing_register_rpc_details_provider([[maybe_unused]] F1&& cb_for_typed, [[maybe_unused]] F2&& cb_for_untyped) noexcept {
-  kphp::log::warning("called stub kphp_tracing_register_rpc_details_provider");
+  kphp::log::info("called stub kphp_tracing_register_rpc_details_provider");
 }
 
 inline void f$kphp_tracing_set_level([[maybe_unused]] int64_t trace_level) noexcept {
-  kphp::log::warning("called stub kphp_tracing_set_level");
+  kphp::log::info("called stub kphp_tracing_set_level");
 }

--- a/runtime-light/stdlib/tracing/tracing-span.h
+++ b/runtime-light/stdlib/tracing/tracing-span.h
@@ -45,3 +45,8 @@ inline void f$KphpSpan$$updateName([[maybe_unused]] const class_instance<C$KphpS
                                    [[maybe_unused]] const string& short_desc) noexcept {
   kphp::log::warning("called stub KphpSpan::updateName");
 }
+
+inline void f$KphpSpan$$finishWithError([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] int64_t error_code,
+                                        [[maybe_unused]] const string& error_msg, [[maybe_unused]] const Optional<float>& manual_timestamp = {}) {
+  kphp::log::warning("called stub KphpSpan::finishWithError");
+}

--- a/runtime-light/stdlib/tracing/tracing-span.h
+++ b/runtime-light/stdlib/tracing/tracing-span.h
@@ -22,31 +22,31 @@ struct C$KphpSpan : public refcountable_php_classes<C$KphpSpan>, private DummyVi
 
 inline void f$KphpSpan$$addAttributeInt([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] const string& key,
                                         [[maybe_unused]] int64_t value) noexcept {
-  kphp::log::warning("called stub KphpSpan::addAttributeInt");
+  kphp::log::info("called stub KphpSpan::addAttributeInt");
 }
 
 inline void f$KphpSpan$$addAttributeString([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] const string& key,
                                            [[maybe_unused]] const string& value) noexcept {
-  kphp::log::warning("called stub KphpSpan::addAttributeString");
+  kphp::log::info("called stub KphpSpan::addAttributeString");
 }
 
 inline class_instance<C$KphpSpanEvent> f$KphpSpan$$addEvent([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] const string& name,
                                                             [[maybe_unused]] const Optional<double>& manual_timestamp = {}) noexcept {
-  kphp::log::warning("called stub KphpSpan::addEvent");
+  kphp::log::info("called stub KphpSpan::addEvent");
   return {};
 }
 
 inline void f$KphpSpan$$finish([[maybe_unused]] const class_instance<C$KphpSpan>& v$this,
                                [[maybe_unused]] const Optional<double>& manual_timestamp = {}) noexcept {
-  kphp::log::warning("called stub KphpSpan::finish");
+  kphp::log::info("called stub KphpSpan::finish");
 }
 
 inline void f$KphpSpan$$updateName([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] const string& title,
                                    [[maybe_unused]] const string& short_desc) noexcept {
-  kphp::log::warning("called stub KphpSpan::updateName");
+  kphp::log::info("called stub KphpSpan::updateName");
 }
 
 inline void f$KphpSpan$$finishWithError([[maybe_unused]] const class_instance<C$KphpSpan>& v$this, [[maybe_unused]] int64_t error_code,
                                         [[maybe_unused]] const string& error_msg, [[maybe_unused]] const Optional<float>& manual_timestamp = {}) {
-  kphp::log::warning("called stub KphpSpan::finishWithError");
+  kphp::log::info("called stub KphpSpan::finishWithError");
 }


### PR DESCRIPTION
Change presence and behavior of some builtins in runtime-light:
* Remove `rpc_tl_query_one(), typed_rpc_tl_query_result_synchronously(), typed_rpc_tl_query_result_one(), new_rpc_connection() ` and `RpcConnection` stubs
* Make `wait_queue_create()` noop stub
* Add `kphp_tracing_get_level(), KphpDiv::assignTraceCtx(), KphpDiv::generateTraceCtxForChild()` and `KphpSpan::finishWithError` noop stubs
* Stop emiting a warning when calls other tracing builtins