### PR TITLE
you can now write TL serializers in PHP, runtime will call custom PHP code for that

### DIFF
--- a/builtin-functions/kphp-full/_functions.txt
+++ b/builtin-functions/kphp-full/_functions.txt
@@ -990,9 +990,25 @@ function rpc_tl_query_result ($query_ids ::: array) ::: mixed[][];
 function rpc_tl_query_result_synchronously ($query_ids ::: array) ::: mixed[][];
 function rpc_tl_pending_queries_count () ::: int;
 
-/** @kphp-tl-class */
+function set_last_stored_tl_function_magic ($magic ::: int);
+function set_current_tl_function($name ::: string);
+function raise_fetching_error($text ::: string);
+function raise_storing_error($text ::: string);
+
+/** @kphp-required */
+interface RpcFunctionFetcher {
+  public function typedFetch() : @tl\RpcFunctionReturnResult;
+  public function typedStore($result ::: @tl\RpcFunctionReturnResult);
+}
+
+/**
+ * @kphp-required
+ * @kphp-tl-class
+ */
 interface RpcFunction {
   public function getTLFunctionName() : string;
+  public function customStore() : RpcFunctionFetcher;
+  public function customFetch() : RpcFunctionFetcher;
 }
 
 /** @kphp-tl-class */
@@ -1006,6 +1022,13 @@ interface RpcResponse {
   public function getError() : @tl\_common\Types\rpcResponseError;
   public function isError() : bool;
 }
+
+/** @kphp-extern-func-info tl_common_h_dep */
+function tests_typed_rpc_tl_query_store (@tl\RpcFunction $query_function) ::: string;
+/** @kphp-extern-func-info can_throw */
+function tests_typed_rpc_tl_query_result_store(@tl\RpcFunctionReturnResult $response) ::: string;
+/** @kphp-extern-func-info tl_common_h_dep */
+function tests_typed_rpc_tl_query_result_fetch(string $data) ::: @tl\RpcFunctionReturnResult;
 
 /** @kphp-extern-func-info tl_common_h_dep */
 function typed_rpc_tl_query_one (\RpcConnection $connection, @tl\RpcFunction $query_function, $timeout ::: float = -1.0) ::: int;

--- a/builtin-functions/kphp-light/stdlib/rpc.txt
+++ b/builtin-functions/kphp-light/stdlib/rpc.txt
@@ -2,9 +2,25 @@
 
 // ===== SUPPORTED =====
 
-/** @kphp-tl-class */
+function set_last_stored_tl_function_magic ($magic ::: int);
+function set_current_tl_function($name ::: string);
+function raise_fetching_error($text ::: string);
+function raise_storing_error($text ::: string);
+
+/** @kphp-required */
+interface RpcFunctionFetcher {
+  public function typedFetch() : @tl\RpcFunctionReturnResult;
+  public function typedStore($result ::: @tl\RpcFunctionReturnResult);
+}
+
+/**
+ * @kphp-required
+ * @kphp-tl-class
+ */
 interface RpcFunction {
   public function getTLFunctionName() : string;
+  public function customStore() : RpcFunctionFetcher;
+  public function customFetch() : RpcFunctionFetcher;
 }
 
 /** @kphp-tl-class */

--- a/common/tl2php/gen-php-code.cpp
+++ b/common/tl2php/gen-php-code.cpp
@@ -326,6 +326,36 @@ struct FunctionGetTLFunctionName {
   const PhpClassRepresentation& class_repr;
 
   friend std::ostream& operator<<(std::ostream& os, const FunctionGetTLFunctionName& self) {
+    // we will remove ALL tl2php code soon, so we added a bit hackish code here
+    const char* header1 = R"(  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore())";
+    const char* header2 = R"(  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch())";
+    const char* body = R"({
+    return null;
+  }
+
+)";
+    os << header1;
+    if (self.class_repr.is_interface) {
+      os << ";" << std::endl;
+    } else {
+      os << body;
+    }
+    os << header2;
+    if (self.class_repr.is_interface) {
+      os << ";" << std::endl;
+    } else {
+      os << body;
+    }
     os << FunctionDeclaration{"getTLFunctionName", {}, "string", has_kphp_inline};
     if (self.class_repr.is_interface) {
       return os << ";" << std::endl;

--- a/compiler/code-gen/files/tl2cpp/tl2cpp.cpp
+++ b/compiler/code-gen/files/tl2cpp/tl2cpp.cpp
@@ -96,7 +96,12 @@ void write_rpc_server_functions(CodeGenerator &W) {
     W << fmt_format("case {:#010x}: ", static_cast<unsigned int>(f->id)) << BEGIN;
     W << get_php_runtime_type(f, true) << " request;" << NL
       << "request.alloc();" << NL
+      << "auto custom_fetcher = f$VK$TL$RpcFunction$$customFetch(request);" << NL
+      << "if (custom_fetcher.is_null()) " << BEGIN
       << "CurrentRpcServerQuery::get().save(" << cpp_tl_struct_name("f_", f->name) << "::rpc_server_typed_fetch(request.get()));" << NL
+      << END << "else" << BEGIN
+      << "CurrentRpcServerQuery::get().save(make_tl_func_base_simple_wrapper(std::move(custom_fetcher)));" << NL
+      << END << NL
       << "return request;" << NL
       << END << NL;
   }

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -323,3 +323,19 @@ inline bool f$set_fail_rpc_on_int32_overflow(bool fail_rpc) noexcept {
   RpcServerInstanceState::get().fail_rpc_on_int32_overflow = fail_rpc;
   return true;
 }
+
+inline void f$set_last_stored_tl_function_magic(int64_t magic) {
+  CurrentTlQuery::get().set_last_stored_tl_function_magic(magic);
+}
+
+inline void f$set_current_tl_function(const string& name) {
+  CurrentTlQuery::get().set_current_tl_function(name);
+}
+
+inline void f$raise_fetching_error(const string& text) {
+  CurrentTlQuery::get().raise_fetching_error("%s", text.c_str());
+}
+
+inline void f$raise_storing_error(const string& text) {
+  CurrentTlQuery::get().raise_storing_error("%s", text.c_str());
+}

--- a/runtime-light/stdlib/rpc/rpc-tl-function.h
+++ b/runtime-light/stdlib/rpc/rpc-tl-function.h
@@ -78,6 +78,25 @@ struct C$VK$TL$RpcFunctionReturnResult : abstract_refcountable_php_interface {
   ~C$VK$TL$RpcFunctionReturnResult() override = default;
 };
 
+struct C$RpcFunctionFetcher : abstract_refcountable_php_interface {
+  virtual const char* get_class() const {
+    return "RpcFunctionFetcher";
+  }
+  virtual int32_t get_hash() const {
+    std::string_view name_view{C$RpcFunctionFetcher::get_class()};
+    return static_cast<int32_t>(vk::murmur_hash<uint32_t>(name_view.data(), name_view.size()));
+  }
+  virtual C$RpcFunctionFetcher* virtual_builtin_clone() const noexcept {
+    return nullptr;
+  }
+
+  virtual class_instance<C$VK$TL$RpcFunctionReturnResult> typed_fetch() {
+    php_warning("C$RpcFunctionFetcher::typed_fetch should never be called. Should be overridden in every @kphp TL function fetcher");
+    return class_instance<C$VK$TL$RpcFunctionReturnResult>{};
+  }
+  virtual ~C$RpcFunctionFetcher() = default;
+};
+
 // function call response — ReqResult from the TL scheme — is a rpcResponseOk|rpcResponseHeader|rpcResponseError;
 // if it's rpcResponseOk or rpcResponseHeader, then their bodies can be retrieved by a fetcher that was returned by a store
 struct C$VK$TL$RpcResponse : abstract_refcountable_php_interface {

--- a/runtime-light/stdlib/rpc/rpc-tl-kphp-request.h
+++ b/runtime-light/stdlib/rpc/rpc-tl-kphp-request.h
@@ -12,9 +12,9 @@
 #include "runtime-light/stdlib/diagnostics/exception-functions.h"
 #include "runtime-light/stdlib/diagnostics/logs.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-defs.h"
+#include "runtime-light/stdlib/rpc/rpc-tl-func-base.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-query.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-request.h"
-#include "runtime-light/stdlib/rpc/rpc-tl-func-base.h"
 
 class_instance<C$RpcFunctionFetcher> f$VK$TL$RpcFunction$$customStore(class_instance<C$VK$TL$RpcFunction> const& arg) noexcept;
 class_instance<C$RpcFunctionFetcher> f$VK$TL$RpcFunction$$customFetch(class_instance<C$VK$TL$RpcFunction> const& arg) noexcept;

--- a/runtime/rpc.cpp
+++ b/runtime/rpc.cpp
@@ -407,6 +407,13 @@ bool f$store_raw(const string& data) {
   return true;
 }
 
+string get_stored_tl_buffer() {
+  if (data_buf.size() < static_cast<string::size_type>(sizeof(RpcHeaders))) {
+    return string{};
+  }
+  return string{data_buf.c_str() + sizeof(RpcHeaders), data_buf.size() - static_cast<string::size_type>(sizeof(RpcHeaders))};
+}
+
 void f$store_raw_vector_double(const array<double>& vector) {
   data_buf.append(reinterpret_cast<const char*>(vector.get_const_vector_pointer()), sizeof(double) * vector.count());
 }
@@ -1329,6 +1336,22 @@ array<mixed> f$rpc_tl_query_result_one(int64_t query_id) {
 
   resumable_finalizer.disable();
   return start_resumable<array<mixed>>(new rpc_tl_query_result_one_resumable(query_id, std::move(rpc_query)));
+}
+
+void f$set_last_stored_tl_function_magic(int64_t magic) {
+  CurrentTlQuery::get().set_last_stored_tl_function_magic(magic);
+}
+
+void f$set_current_tl_function(const string& name) {
+  CurrentTlQuery::get().set_current_tl_function(name);
+}
+
+void f$raise_fetching_error(const string& text) {
+  CurrentTlQuery::get().raise_fetching_error("%s", text.c_str());
+}
+
+void f$raise_storing_error(const string& text) {
+  CurrentTlQuery::get().raise_storing_error("%s", text.c_str());
 }
 
 class rpc_tl_query_result_resumable : public Resumable {

--- a/runtime/rpc.h
+++ b/runtime/rpc.h
@@ -168,6 +168,8 @@ bool f$store_error(int64_t error_code, const string& error_text);
 
 bool f$store_raw(const string& data);
 
+string get_stored_tl_buffer();
+
 void f$store_raw_vector_double(const array<double>& vector);
 
 bool f$set_fail_rpc_on_int32_overflow(bool fail_rpc); // TODO: remove when all RPC errors will be fixed
@@ -260,6 +262,10 @@ array<int64_t> f$rpc_tl_query(const class_instance<C$RpcConnection>& c, const ar
                               class_instance<C$KphpRpcRequestsExtraInfo> requests_extra_info = {}, bool need_responses_extra_info = false);
 
 array<mixed> f$rpc_tl_query_result_one(int64_t query_id);
+void f$set_last_stored_tl_function_magic(int64_t magic);
+void f$set_current_tl_function(const string& name);
+void f$raise_fetching_error(const string& text);
+void f$raise_storing_error(const string& text);
 
 array<array<mixed>> f$rpc_tl_query_result(const array<int64_t>& query_ids);
 

--- a/runtime/tl/rpc_function.h
+++ b/runtime/tl/rpc_function.h
@@ -78,6 +78,25 @@ struct C$VK$TL$RpcFunctionReturnResult : abstract_refcountable_php_interface {
   virtual ~C$VK$TL$RpcFunctionReturnResult() = default;
 };
 
+struct C$RpcFunctionFetcher : abstract_refcountable_php_interface {
+  virtual const char* get_class() const {
+    return "RpcFunctionFetcher";
+  }
+  virtual int32_t get_hash() const {
+    std::string_view name_view{C$RpcFunctionFetcher::get_class()};
+    return static_cast<int32_t>(vk::murmur_hash<uint32_t>(name_view.data(), name_view.size()));
+  }
+  virtual C$RpcFunctionFetcher* virtual_builtin_clone() const noexcept {
+    return nullptr;
+  }
+
+  virtual class_instance<C$VK$TL$RpcFunctionReturnResult> typed_fetch() {
+    php_warning("C$RpcFunctionFetcher::typed_fetch should never be called. Should be overridden in every @kphp TL function fetcher");
+    return class_instance<C$VK$TL$RpcFunctionReturnResult>{};
+  }
+  virtual ~C$RpcFunctionFetcher() = default;
+};
+
 // function call response — ReqResult from the TL scheme — is a rpcResponseOk|rpcResponseHeader|rpcResponseError;
 // if it's rpcResponseOk or rpcResponseHeader, then their bodies can be retrieved by a fetcher that was returned by a store
 struct C$VK$TL$RpcResponse : abstract_refcountable_php_interface {

--- a/runtime/tl/rpc_request.h
+++ b/runtime/tl/rpc_request.h
@@ -9,6 +9,13 @@
 #include "runtime/tl/rpc_function.h"
 #include "runtime/tl/rpc_response.h"
 #include "runtime/tl/tl_builtins.h"
+#include "runtime/tl/tl_func_base.h"
+
+class_instance<C$RpcFunctionFetcher> f$VK$TL$RpcFunction$$customStore(class_instance<C$VK$TL$RpcFunction> const& arg) noexcept;
+class_instance<C$RpcFunctionFetcher> f$VK$TL$RpcFunction$$customFetch(class_instance<C$VK$TL$RpcFunction> const& arg) noexcept;
+class_instance<C$VK$TL$RpcFunctionReturnResult> f$RpcFunctionFetcher$$typedFetch(class_instance<C$RpcFunctionFetcher> const& fetcher) noexcept;
+void f$RpcFunctionFetcher$$typedStore(class_instance<C$RpcFunctionFetcher> const& fetcher,
+                                      class_instance<C$VK$TL$RpcFunctionReturnResult> const& result) noexcept;
 
 class RpcRequestResult;
 
@@ -79,6 +86,32 @@ public:
   }
 };
 
+// should be in header, because C$VK$TL$* classes are unknown on runtime compilation
+struct tl_func_base_simple_wrapper : public tl_func_base {
+  explicit tl_func_base_simple_wrapper(class_instance<C$RpcFunctionFetcher>&& wrapped)
+      : wrapped_(std::move(wrapped)) {}
+
+  virtual mixed fetch() {
+    php_critical_error("this function should never be called for typed RPC function.");
+    return mixed{};
+  }
+
+  virtual class_instance<C$VK$TL$RpcFunctionReturnResult> typed_fetch() {
+    return f$RpcFunctionFetcher$$typedFetch(wrapped_);
+  }
+
+  virtual void rpc_server_typed_store(const class_instance<C$VK$TL$RpcFunctionReturnResult>& result) {
+    return f$RpcFunctionFetcher$$typedStore(wrapped_, result);
+  }
+
+private:
+  class_instance<C$RpcFunctionFetcher> wrapped_;
+};
+
+inline std::unique_ptr<tl_func_base> make_tl_func_base_simple_wrapper(class_instance<C$RpcFunctionFetcher>&& wrapped) {
+  return std::make_unique<tl_func_base_simple_wrapper>(std::move(wrapped));
+}
+
 namespace impl_ {
 // use template, because t_ReqResult_ is unknown on runtime compilation
 template<template<typename, unsigned int> class t_ReqResult_>
@@ -110,7 +143,13 @@ public:
   std::unique_ptr<RpcRequestResult> store_request() const final {
     php_assert(CurException.is_null());
     CurrentTlQuery::get().set_current_tl_function(tl_function_name());
-    std::unique_ptr<tl_func_base> stored_fetcher = storing_function_.get()->store();
+    std::unique_ptr<tl_func_base> stored_fetcher;
+    auto custom_fetcher = f$VK$TL$RpcFunction$$customStore(storing_function_);
+    if (custom_fetcher.is_null()) {
+      stored_fetcher = storing_function_.get()->store();
+    } else {
+      stored_fetcher = std::make_unique<tl_func_base_simple_wrapper>(std::move(custom_fetcher));
+    }
     CurrentTlQuery::get().reset();
     if (!CurException.is_null()) {
       CurException = Optional<bool>{};

--- a/tests/python/tests/rpc/php/VK/TL/RpcFunction.php
+++ b/tests/python/tests/rpc/php/VK/TL/RpcFunction.php
@@ -18,6 +18,18 @@ interface RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore();
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch();
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName();

--- a/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestActor.php
+++ b/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestActor.php
@@ -58,6 +58,24 @@ class rpcDestActor implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestActorFlags.php
+++ b/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestActorFlags.php
@@ -68,6 +68,24 @@ class rpcDestActorFlags implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestFlags.php
+++ b/tests/python/tests/rpc/php/VK/TL/_common/Functions/rpcDestFlags.php
@@ -63,6 +63,24 @@ class rpcDestFlags implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_pid.php
+++ b/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_pid.php
@@ -49,6 +49,24 @@ class engine_pid implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_sleep.php
+++ b/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_sleep.php
@@ -53,6 +53,24 @@ class engine_sleep implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_stat.php
+++ b/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_stat.php
@@ -49,6 +49,24 @@ class engine_stat implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {

--- a/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_version.php
+++ b/tests/python/tests/rpc/php/VK/TL/engine/Functions/engine_version.php
@@ -49,6 +49,24 @@ class engine_version implements TL\RpcFunction {
   /**
    * @kphp-inline
    *
+   * @return \RpcFunctionFetcher
+   */
+  public function customStore(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
+   * @return \RpcFunctionFetcher
+   */
+  public function customFetch(){
+    return null;
+  }
+
+  /**
+   * @kphp-inline
+   *
    * @return string
    */
   public function getTLFunctionName() {


### PR DESCRIPTION
function for tests between C++ and PHP serializers. Will be removed together with C++ serializers.
```
tests_typed_rpc_tl_query_store
tests_typed_rpc_tl_query_result_store
tests_typed_rpc_tl_query_result_fetch
```

Functions called by C++ serializers, made public for PHP serializers. These functions will be moved into serialization context later together with parsing functions.
```
function set_last_stored_tl_function_magic ($magic ::: int);
function set_current_tl_function($name ::: string);
function raise_fetching_error($text ::: string);
function raise_storing_error($text ::: string);
```

Functions to implement by PHP serializers.
```
interface RpcFunction {
...
  public function customStore() : RpcFunctionFetcher;
  public function customFetch() : RpcFunctionFetcher;
```

They should either store/fetch function and return instance of `RpcFunctionFetcher`, or do nothing and return `null`, in this case runtime will call C++ serializer.
```
interface RpcFunctionFetcher {
  public function typedFetch() : @tl\RpcFunctionReturnResult;
  public function typedStore($result ::: @tl\RpcFunctionReturnResult);
}
```
