### PR TITLE
TL byte granularity for internal data structures

### DIFF
--- a/builtin-functions/kphp-full/_functions.txt
+++ b/builtin-functions/kphp-full/_functions.txt
@@ -896,6 +896,8 @@ function err ($file ::: string, $line ::: int, $code ::: string, $desc ::: strin
 /** @kphp-extern-func-info can_throw */
 function fetch_int () ::: int;
 /** @kphp-extern-func-info can_throw */
+function fetch_byte () ::: int;
+/** @kphp-extern-func-info can_throw */
 function fetch_long () ::: int;
 /** @kphp-extern-func-info can_throw */
 function fetch_double () ::: float;
@@ -903,6 +905,8 @@ function fetch_double () ::: float;
 function fetch_float () ::: float;
 /** @kphp-extern-func-info can_throw */
 function fetch_string () ::: string;
+/** @kphp-extern-func-info can_throw */
+function fetch_string2 () ::: string;
 /** @kphp-extern-func-info can_throw */
 function fetch_string_as_int () ::: int;
 /** @kphp-extern-func-info can_throw */
@@ -954,10 +958,12 @@ function store_error ($error_code ::: int, $error_text ::: string) ::: bool;
 function store_raw ($v ::: string) ::: bool;
 function set_fail_rpc_on_int32_overflow ($fail_rpc ::: bool) ::: bool;
 function store_int ($v ::: int) ::: bool;
+function store_byte ($v ::: int) ::: bool;
 function store_long ($v ::: int) ::: bool;
 function store_double ($v ::: float) ::: bool;
 function store_float ($v ::: float) ::: bool;
 function store_string ($v ::: string) ::: bool;
+function store_string2 ($v ::: string) ::: bool;
 function store_many (...$args) ::: bool;
 function store_finish() ::: bool;
 function rpc_send (\RpcConnection $rpc_conn, $timeout ::: float = -1.0) ::: int;

--- a/builtin-functions/kphp-light/stdlib/rpc.txt
+++ b/builtin-functions/kphp-light/stdlib/rpc.txt
@@ -71,6 +71,9 @@ function rpc_fetch_typed_responses_synchronously(int[] $query_ids) ::: @tl\RpcRe
 function fetch_int () ::: int;
 
 /** @kphp-extern-func-info can_throw */
+function fetch_byte () ::: int;
+
+/** @kphp-extern-func-info can_throw */
 function fetch_long () ::: int;
 
 /** @kphp-extern-func-info can_throw */
@@ -79,9 +82,14 @@ function fetch_double () ::: float;
 /** @kphp-extern-func-info can_throw */
 function fetch_string () ::: string;
 
+/** @kphp-extern-func-info can_throw */
+function fetch_string2 () ::: string;
+
 function store_int ($v ::: int) ::: bool;
+function store_byte ($v ::: int) ::: bool;
 function store_long ($v ::: int) ::: bool;
 function store_string ($v ::: string) ::: bool;
+function store_string2 ($v ::: string) ::: bool;
 function store_double ($v ::: float) ::: bool;
 function store_float ($v ::: float) ::: bool;
 

--- a/common/tl/parse.cpp
+++ b/common/tl/parse.cpp
@@ -438,10 +438,6 @@ int tl_store_pad() {
   return 0;
 }
 
-static int get_tl_string_len(int len) {
-  return (len << 8) + 0xfe;
-}
-
 static int tl_store_string_len(int len) {
   assert(len >= 0);
   if (len < 254) {
@@ -449,7 +445,7 @@ static int tl_store_string_len(int len) {
     tl_store_raw_data_nopad(&len, 1);
   } else {
     assert(len < (1 << 24));
-    tl_store_int(get_tl_string_len(len));
+    tl_store_int((len << 8) + 0xfe);
   }
   return 0;
 }

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -77,9 +77,17 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
 
 inline bool f$store_int(int64_t v) noexcept {
   if (tl::is_int32_overflow(v)) [[unlikely]] {
-    kphp::log::warning("integer {} overflows int32, it will be casted to {}", v, static_cast<int32_t>(v));
+    kphp::log::warning("integer {} overflows int32, it will be cast to {}", v, static_cast<int32_t>(v));
   }
   tl::i32{.value = static_cast<int32_t>(v)}.store(RpcServerInstanceState::get().tl_storer);
+  return true;
+}
+
+inline bool f$store_byte(int64_t v) noexcept {
+  if (v < 0 || v > 255) [[unlikely]] {
+    kphp::log::warning("integer {} overflows uint8, it will be cast to {}", v, static_cast<uint8_t>(v));
+  }
+  tl::u8{.value = static_cast<uint8_t>(v)}.store(RpcServerInstanceState::get().tl_storer);
   return true;
 }
 
@@ -103,9 +111,23 @@ inline bool f$store_string(const string& v) noexcept {
   return true;
 }
 
+inline bool f$store_string2(const string& v) noexcept {
+  tl::string{.value = {v.c_str(), v.size()}}.store2(RpcServerInstanceState::get().tl_storer);
+  return true;
+}
+
 inline void f$store_raw_vector_double(const array<double>& vector) noexcept {
   const std::span<const std::byte> vector_view{reinterpret_cast<const std::byte*>(vector.get_const_vector_pointer()), sizeof(double) * vector.count()};
   RpcServerInstanceState::get().tl_storer.store_bytes(vector_view);
+}
+
+inline int64_t f$fetch_byte() noexcept {
+  static constexpr auto DEFAULT_VALUE = 0;
+  if (tl::u8 val{}; val.fetch(RpcServerInstanceState::get().tl_fetcher)) [[likely]] {
+    return static_cast<int64_t>(val.value);
+  }
+  THROW_EXCEPTION(kphp::rpc::exception::not_enough_data_to_fetch::make());
+  return DEFAULT_VALUE;
 }
 
 inline int64_t f$fetch_int() noexcept {
@@ -146,6 +168,14 @@ inline double f$fetch_float() noexcept {
 
 inline string f$fetch_string() noexcept {
   if (tl::string val{}; val.fetch(RpcServerInstanceState::get().tl_fetcher)) [[likely]] {
+    return {val.value.data(), static_cast<string::size_type>(val.value.size())};
+  }
+  THROW_EXCEPTION(kphp::rpc::exception::cant_fetch_string::make());
+  return {};
+}
+
+inline string f$fetch_string2() noexcept {
+  if (tl::string val{}; val.fetch2(RpcServerInstanceState::get().tl_fetcher)) [[likely]] {
     return {val.value.data(), static_cast<string::size_type>(val.value.size())};
   }
   THROW_EXCEPTION(kphp::rpc::exception::cant_fetch_string::make());

--- a/runtime-light/tl/tl-types.h
+++ b/runtime-light/tl/tl-types.h
@@ -388,6 +388,12 @@ public:
     const auto total_len_with_padding{(total_len + 3) & ~3};
     return total_len_with_padding;
   }
+
+  // TL2 functions are here for now
+  static bool fetch2_len(tl::fetcher& tlf, uint64_t& string_len) noexcept;
+  bool fetch2(tl::fetcher& tlf) noexcept;
+  static void store2_len(tl::storer& tls, uint64_t string_len) noexcept;
+  void store2(tl::storer& tls) const noexcept;
 };
 
 struct String final {

--- a/runtime/rpc.h
+++ b/runtime/rpc.h
@@ -63,7 +63,7 @@ int32_t last_rpc_error_code_get();
 
 void last_rpc_error_reset();
 
-void rpc_parse(const int32_t* new_rpc_data, int32_t new_rpc_data_len);
+void rpc_parse(const char* new_rpc_data, int new_rpc_data_len);
 
 bool f$rpc_parse(const string& new_rpc_data) noexcept;
 
@@ -73,15 +73,17 @@ bool f$rpc_parse(bool new_rpc_data) noexcept;
 
 bool f$rpc_parse(const Optional<string>& new_rpc_data) noexcept;
 
-int32_t rpc_get_pos();
+int rpc_get_pos();
 
-bool rpc_set_pos(int32_t pos);
+bool rpc_set_pos(int pos);
 
 int32_t rpc_lookup_int();
 
 int32_t rpc_fetch_int();
 
 int64_t f$fetch_int();
+
+int64_t f$fetch_byte();
 
 int64_t f$fetch_lookup_int();
 
@@ -94,6 +96,8 @@ double f$fetch_double();
 double f$fetch_float();
 
 string f$fetch_string();
+
+string f$fetch_string2();
 
 int64_t f$fetch_string_as_int();
 
@@ -176,6 +180,8 @@ bool is_int32_overflow(int64_t v);
 bool store_int(int32_t v);
 bool f$store_int(int64_t v);
 
+bool f$store_byte(int64_t v);
+
 bool f$store_unsigned_int(const string& v);
 
 bool store_long(long long v);
@@ -193,6 +199,7 @@ bool f$store_float(double v);
 
 bool store_string(const char* v, int32_t v_len);
 bool f$store_string(const string& v);
+bool f$store_string2(const string& v);
 
 bool f$store_many(const array<mixed>& a);
 

--- a/server/php-engine.cpp
+++ b/server/php-engine.cpp
@@ -981,7 +981,6 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
       int64_t left_bytes_without_headers = tl_fetch_unread();
 
       len -= (left_bytes_with_headers - left_bytes_without_headers);
-      assert(len % sizeof(int) == 0);
 
       long long req_id = header.qid;
 
@@ -1012,7 +1011,7 @@ int rpcx_execute(connection *c, int op, raw_message *raw) {
       double actual_script_timeout = custom_settings.has_timeout() ? normalize_script_timeout(custom_settings.php_timeout_ms / 1000.0) : script_timeout;
       set_connection_timeout(c, actual_script_timeout);
 
-      std::vector<int> buffer(len / sizeof(int));
+      std::vector<char> buffer(len);
       auto fetched_bytes = tl_fetch_data(buffer.data(), len);
       if (fetched_bytes == -1) {
         client_rpc_error(c, req_id, tl_fetch_error_code(), tl_fetch_error_string());

--- a/server/php-query-data.h
+++ b/server/php-query-data.h
@@ -21,7 +21,7 @@ struct http_query_data {
 
 struct rpc_query_data {
   tl_query_header_t header;
-  std::vector<int> data;
+  std::vector<char> data;
   process_id remote_pid;
 };
 

--- a/vkext/vkext-rpc-include.h
+++ b/vkext/vkext-rpc-include.h
@@ -5,6 +5,8 @@
 #ifndef __VKEXT_RPC_INCLUDE_H__
 #define __VKEXT_RPC_INCLUDE_H__
 
+#include <limits>
+
 #include "common/tl/constants/common.h"
 #include "common/rpc-headers.h"
 
@@ -235,6 +237,13 @@ static inline void buffer_write_int(struct rpc_buffer *buf, int x) {
   buf->wptr += 4;
 }
 
+static inline void buffer_write_byte(struct rpc_buffer *buf, int x) UNUSED;
+static inline void buffer_write_byte(struct rpc_buffer *buf, int x) {
+  buffer_check_len_wptr(buf, 1);
+  *(unsigned char *)(buf->wptr) = x;
+  buf->wptr += 1;
+}
+
 static inline void buffer_write_long(struct rpc_buffer *buf, long long x) UNUSED;
 static inline void buffer_write_long(struct rpc_buffer *buf, long long x) {
   buffer_check_len_wptr(buf, 8);
@@ -318,6 +327,17 @@ static inline int buffer_read_int(struct rpc_buffer *buf, int *x) {
   }
 }
 
+static inline int buffer_read_byte(struct rpc_buffer *buf, int *x) UNUSED;
+static inline int buffer_read_byte(struct rpc_buffer *buf, int *x) {
+  if (!buffer_check_len_rptr(buf, 1)) {
+    return -1;
+  } else {
+    *x = static_cast<int>(*(unsigned char *)buf->rptr);
+    buf->rptr += 1;
+    return 1;
+  }
+}
+
 static inline int buffer_read_long(struct rpc_buffer *buf, long long *x) UNUSED;
 static inline int buffer_read_long(struct rpc_buffer *buf, long long *x) {
   if (!buffer_check_len_rptr(buf, 8)) {
@@ -395,6 +415,39 @@ static inline int buffer_read_string(struct rpc_buffer *buf, int *len, const cha
   return 1;
 }
 
+static inline int buffer_read_string2(struct rpc_buffer *buf, int *len, const char **x) UNUSED;
+static inline int buffer_read_string2(struct rpc_buffer *buf, int *len, const char **x) {
+  unsigned char c;
+  if (buffer_read_char(buf, (char *)&c) < 0) {
+    return -1;
+  }
+  *len = c;
+  if (c == 254) {
+    const char *t;
+    *len = 0;
+    if (buffer_read_data(buf, 2, &t) < 0) {
+      return -1;
+    }
+    memcpy(len, t, 2);
+    *len += 254;
+  } else if (c == 255) {
+    const char *t;
+    if (buffer_read_data(buf, 8, &t) < 0) {
+      return -1;
+    }
+    uint64_t len64 = 0;
+    memcpy(&len64, t, 8);
+    if (len64 > std::numeric_limits<int>::max()) { // does not fit on 32-bit platform, cannot return proper error here
+      return -1;
+    }
+    *len = static_cast<int>(len64);
+  }
+  if (buffer_read_data(buf, *len, x) < 0) {
+    return -1;
+  }
+  return 1;
+}
+
 /* }}} outbuf */
 
 static constexpr size_t RPC_HEADERS_RESERVED_BYTES = 40;
@@ -422,6 +475,19 @@ static void do_rpc_store_int(int value) { /* {{{ */
   buffer_write_int(outbuf, value);
 #ifdef STORE_DEBUG
   fprintf (stderr, "int: %x\n", value);
+#endif
+  END_TIMER (store);
+}
+/* }}} */
+
+static void do_rpc_store_byte(int value) UNUSED;
+static void do_rpc_store_byte(int value) { /* {{{ */
+  ADD_CNT (store);
+  START_TIMER (store);
+  assert (outbuf && outbuf->magic == RPC_BUFFER_MAGIC);
+  buffer_write_byte(outbuf, value);
+#ifdef STORE_DEBUG
+  fprintf (stderr, "byte: %x\n", value);
 #endif
   END_TIMER (store);
 }
@@ -503,6 +569,30 @@ static void do_rpc_store_string(const char *s, int len) { /* {{{ */
   }
 #ifdef STORE_DEBUG
   fprintf (stderr, "string: %.*s\n", len, s);
+#endif
+  END_TIMER (store);
+}
+/* }}} */
+
+static void do_rpc_store_string2(const char *s, int len) UNUSED;
+static void do_rpc_store_string2(const char *s, int len) { /* {{{ */
+  ADD_CNT (store);
+  START_TIMER (store);
+  assert (outbuf && outbuf->magic == RPC_BUFFER_MAGIC);
+  if (len < 254) {
+    buffer_write_char(outbuf, len);
+  } else if (len < 254 + (1 << 16)) {
+    buffer_write_char(outbuf, static_cast<char>(254));
+    int alen = len - 254;
+    buffer_write_data(outbuf, &alen, 2);
+  } else {
+    buffer_write_char(outbuf, static_cast<char>(255));
+    int64_t len64 = len;
+    buffer_write_data(outbuf, &len64, 8);
+  }
+  buffer_write_data(outbuf, s, len);
+#ifdef STORE_DEBUG
+  fprintf (stderr, "string2: %.*s\n", len, s);
 #endif
   END_TIMER (store);
 }

--- a/vkext/vkext-rpc.h
+++ b/vkext/vkext-rpc.h
@@ -136,10 +136,12 @@ extern int allow_internal_rpc_queries;
 extern bool fail_rpc_on_int32_overflow;
 
 int do_rpc_fetch_int(char **error);
+int do_rpc_fetch_byte(char **error);
 long long do_rpc_fetch_long(char **error);
 double do_rpc_fetch_double(char **error);
 float do_rpc_fetch_float(char **error);
 int do_rpc_fetch_string(char **value);
+int do_rpc_fetch_string2(char **value);
 int do_rpc_fetch_eof(const char **error);
 int do_rpc_fetch_get_pos(char **error);
 int do_rpc_fetch_set_pos(int pos, char **error);
@@ -173,18 +175,22 @@ void php_rpc_send_noflush(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_flush(INTERNAL_FUNCTION_PARAMETERS);
 
 void php_rpc_fetch_int(INTERNAL_FUNCTION_PARAMETERS);
+void php_rpc_fetch_byte(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_long(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_double(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_float(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_string(INTERNAL_FUNCTION_PARAMETERS);
+void php_rpc_fetch_string2(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_end(INTERNAL_FUNCTION_PARAMETERS);
 
 void php_rpc_fetch_lookup_int(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_fetch_lookup_data(INTERNAL_FUNCTION_PARAMETERS);
 
 void php_rpc_store_int(INTERNAL_FUNCTION_PARAMETERS);
+void php_rpc_store_byte(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_store_long(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_store_string(INTERNAL_FUNCTION_PARAMETERS);
+void php_rpc_store_string2(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_store_double(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_store_float(INTERNAL_FUNCTION_PARAMETERS);
 void php_rpc_store_many(INTERNAL_FUNCTION_PARAMETERS);

--- a/vkext/vkext.cpp
+++ b/vkext/vkext.cpp
@@ -824,6 +824,13 @@ PHP_FUNCTION (store_int) {
   END_TIMER(total);
 }
 
+PHP_FUNCTION (store_byte) {
+  ADD_CNT(total);
+  START_TIMER(total);
+  php_rpc_store_byte(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  END_TIMER(total);
+}
+
 PHP_FUNCTION (store_long) {
   ADD_CNT(total);
   START_TIMER(total);
@@ -835,6 +842,13 @@ PHP_FUNCTION (store_string) {
   ADD_CNT(total);
   START_TIMER(total);
   php_rpc_store_string(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  END_TIMER(total);
+}
+
+PHP_FUNCTION (store_string2) {
+  ADD_CNT(total);
+  START_TIMER(total);
+  php_rpc_store_string2(INTERNAL_FUNCTION_PARAM_PASSTHRU);
   END_TIMER(total);
 }
 
@@ -870,6 +884,13 @@ PHP_FUNCTION (fetch_int) {
   ADD_CNT(total);
   START_TIMER(total);
   php_rpc_fetch_int(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  END_TIMER(total);
+}
+
+PHP_FUNCTION (fetch_byte) {
+  ADD_CNT(total);
+  START_TIMER(total);
+  php_rpc_fetch_byte(INTERNAL_FUNCTION_PARAM_PASSTHRU);
   END_TIMER(total);
 }
 
@@ -920,6 +941,13 @@ PHP_FUNCTION (fetch_string) {
   ADD_CNT(total);
   START_TIMER(total);
   php_rpc_fetch_string(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+  END_TIMER(total);
+}
+
+PHP_FUNCTION (fetch_string2) {
+  ADD_CNT(total);
+  START_TIMER(total);
+  php_rpc_fetch_string2(INTERNAL_FUNCTION_PARAM_PASSTHRU);
   END_TIMER(total);
 }
 

--- a/vkext/vkext.stub.php
+++ b/vkext/vkext.stub.php
@@ -102,11 +102,19 @@ function store_int(mixed $v) : bool {
   return false;
 }
 
+function store_byte(mixed $v) : bool {
+  return false;
+}
+
 function store_long(mixed $v) : bool {
   return false;
 }
 
 function store_string(mixed $v) : bool {
+  return false;
+}
+
+function store_string2(mixed $v) : bool {
   return false;
 }
 
@@ -136,6 +144,13 @@ function fetch_int() {
 /**
  * @return int|false
  */
+function fetch_byte() {
+  return 0;
+}
+
+/**
+ * @return int|false
+ */
 function fetch_long() {
   return 0;
 }
@@ -158,6 +173,13 @@ function fetch_float() {
  * @return string|false
  */
 function fetch_string() {
+  return "";
+}
+
+/**
+ * @return string|false
+ */
+function fetch_string2() {
   return "";
 }
 

--- a/vkext/vkext_arginfo.h
+++ b/vkext/vkext_arginfo.h
@@ -81,9 +81,13 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_store_int, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, v, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_store_byte arginfo_store_int
+
 #define arginfo_store_long arginfo_store_int
 
 #define arginfo_store_string arginfo_store_int
+
+#define arginfo_store_string2 arginfo_store_int
 
 #define arginfo_store_double arginfo_store_int
 
@@ -101,6 +105,8 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_fetch_int, 0, 0, 0)
 ZEND_END_ARG_INFO()
 
+#define arginfo_fetch_byte arginfo_fetch_int
+
 #define arginfo_fetch_long arginfo_fetch_int
 
 #define arginfo_fetch_double arginfo_fetch_int
@@ -108,6 +114,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_fetch_float arginfo_fetch_int
 
 #define arginfo_fetch_string arginfo_fetch_int
+
+#define arginfo_fetch_string2 arginfo_fetch_int
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_fetch_memcache_value, 0, 0, IS_MIXED, 0)
 ZEND_END_ARG_INFO()
@@ -266,17 +274,21 @@ ZEND_FUNCTION(rpc_get);
 ZEND_FUNCTION(rpc_parse);
 ZEND_FUNCTION(set_fail_rpc_on_int32_overflow);
 ZEND_FUNCTION(store_int);
+ZEND_FUNCTION(store_byte);
 ZEND_FUNCTION(store_long);
 ZEND_FUNCTION(store_string);
+ZEND_FUNCTION(store_string2);
 ZEND_FUNCTION(store_double);
 ZEND_FUNCTION(store_float);
 ZEND_FUNCTION(store_many);
 ZEND_FUNCTION(store_header);
 ZEND_FUNCTION(fetch_int);
+ZEND_FUNCTION(fetch_byte);
 ZEND_FUNCTION(fetch_long);
 ZEND_FUNCTION(fetch_double);
 ZEND_FUNCTION(fetch_float);
 ZEND_FUNCTION(fetch_string);
+ZEND_FUNCTION(fetch_string2);
 ZEND_FUNCTION(fetch_memcache_value);
 ZEND_FUNCTION(fetch_end);
 ZEND_FUNCTION(fetch_eof);
@@ -339,17 +351,21 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(rpc_parse, arginfo_rpc_parse)
 	ZEND_FE(set_fail_rpc_on_int32_overflow, arginfo_set_fail_rpc_on_int32_overflow)
 	ZEND_FE(store_int, arginfo_store_int)
+	ZEND_FE(store_byte, arginfo_store_byte)
 	ZEND_FE(store_long, arginfo_store_long)
 	ZEND_FE(store_string, arginfo_store_string)
+	ZEND_FE(store_string2, arginfo_store_string2)
 	ZEND_FE(store_double, arginfo_store_double)
 	ZEND_FE(store_float, arginfo_store_float)
 	ZEND_FE(store_many, arginfo_store_many)
 	ZEND_FE(store_header, arginfo_store_header)
 	ZEND_FE(fetch_int, arginfo_fetch_int)
+	ZEND_FE(fetch_byte, arginfo_fetch_byte)
 	ZEND_FE(fetch_long, arginfo_fetch_long)
 	ZEND_FE(fetch_double, arginfo_fetch_double)
 	ZEND_FE(fetch_float, arginfo_fetch_float)
 	ZEND_FE(fetch_string, arginfo_fetch_string)
+	ZEND_FE(fetch_string2, arginfo_fetch_string2)
 	ZEND_FE(fetch_memcache_value, arginfo_fetch_memcache_value)
 	ZEND_FE(fetch_end, arginfo_fetch_end)
 	ZEND_FE(fetch_eof, arginfo_fetch_eof)

--- a/vkext/vkext_legacy_arginfo.h
+++ b/vkext/vkext_legacy_arginfo.h
@@ -77,9 +77,13 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_store_int, 0, 0, 1)
 	ZEND_ARG_INFO(0, v)
 ZEND_END_ARG_INFO()
 
+#define arginfo_store_byte arginfo_store_int
+
 #define arginfo_store_long arginfo_store_int
 
 #define arginfo_store_string arginfo_store_int
+
+#define arginfo_store_string2 arginfo_store_int
 
 #define arginfo_store_double arginfo_store_int
 
@@ -96,6 +100,8 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_fetch_int arginfo_vk_hello_world
 
+#define arginfo_fetch_byte arginfo_vk_hello_world
+
 #define arginfo_fetch_long arginfo_vk_hello_world
 
 #define arginfo_fetch_double arginfo_vk_hello_world
@@ -103,6 +109,8 @@ ZEND_END_ARG_INFO()
 #define arginfo_fetch_float arginfo_vk_hello_world
 
 #define arginfo_fetch_string arginfo_vk_hello_world
+
+#define arginfo_fetch_string2 arginfo_vk_hello_world
 
 #define arginfo_fetch_memcache_value arginfo_vk_hello_world
 
@@ -251,17 +259,21 @@ ZEND_FUNCTION(rpc_get);
 ZEND_FUNCTION(rpc_parse);
 ZEND_FUNCTION(set_fail_rpc_on_int32_overflow);
 ZEND_FUNCTION(store_int);
+ZEND_FUNCTION(store_byte);
 ZEND_FUNCTION(store_long);
 ZEND_FUNCTION(store_string);
+ZEND_FUNCTION(store_string2);
 ZEND_FUNCTION(store_double);
 ZEND_FUNCTION(store_float);
 ZEND_FUNCTION(store_many);
 ZEND_FUNCTION(store_header);
 ZEND_FUNCTION(fetch_int);
+ZEND_FUNCTION(fetch_byte);
 ZEND_FUNCTION(fetch_long);
 ZEND_FUNCTION(fetch_double);
 ZEND_FUNCTION(fetch_float);
 ZEND_FUNCTION(fetch_string);
+ZEND_FUNCTION(fetch_string2);
 ZEND_FUNCTION(fetch_memcache_value);
 ZEND_FUNCTION(fetch_end);
 ZEND_FUNCTION(fetch_eof);
@@ -324,17 +336,21 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(rpc_parse, arginfo_rpc_parse)
 	ZEND_FE(set_fail_rpc_on_int32_overflow, arginfo_set_fail_rpc_on_int32_overflow)
 	ZEND_FE(store_int, arginfo_store_int)
+	ZEND_FE(store_byte, arginfo_store_byte)
 	ZEND_FE(store_long, arginfo_store_long)
 	ZEND_FE(store_string, arginfo_store_string)
+	ZEND_FE(store_string2, arginfo_store_string2)
 	ZEND_FE(store_double, arginfo_store_double)
 	ZEND_FE(store_float, arginfo_store_float)
 	ZEND_FE(store_many, arginfo_store_many)
 	ZEND_FE(store_header, arginfo_store_header)
 	ZEND_FE(fetch_int, arginfo_fetch_int)
+	ZEND_FE(fetch_byte, arginfo_fetch_byte)
 	ZEND_FE(fetch_long, arginfo_fetch_long)
 	ZEND_FE(fetch_double, arginfo_fetch_double)
 	ZEND_FE(fetch_float, arginfo_fetch_float)
 	ZEND_FE(fetch_string, arginfo_fetch_string)
+	ZEND_FE(fetch_string2, arginfo_fetch_string2)
 	ZEND_FE(fetch_memcache_value, arginfo_fetch_memcache_value)
 	ZEND_FE(fetch_end, arginfo_fetch_end)
 	ZEND_FE(fetch_eof, arginfo_fetch_eof)


### PR DESCRIPTION
For RPC formats with byte granularity we change buffer from int32* into char*.

Modification to RPC code will be done later