### PR TITLE
Fix SIGSEGV double free (aka Unexpected memory piece)

### DIFF
--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -2411,6 +2411,8 @@ static void free_interface_lib() {
     }
     uploaded_files_last_query_num--;
   }
+  OnKphpWarningCallback::get().reset();
+  vk::singleton<OomHandler>::get().reset();
   dl::leave_critical_section();
 }
 
@@ -2432,16 +2434,12 @@ static void free_runtime_libs() {
   free_udp_lib();
   free_tcp_lib();
   free_timelib();
-  OnKphpWarningCallback::get().reset();
   kphp_tracing::free_tracing_lib();
   free_slot_factories();
   runtime_builtins_stats::reset_request_stats();
 
   free_job_client_interface_lib();
   free_job_server_interface_lib();
-
-  free_confdata_functions_lib();
-  free_instance_cache_lib();
   free_kphp_backtrace();
 
   free_use_updated_gmmktime();
@@ -2455,8 +2453,14 @@ static void free_runtime_libs() {
 #endif
   vk::singleton<database_drivers::Adaptor>::get().reset();
   vk::singleton<curl_async::CurlAdaptor>::get().reset();
-  vk::singleton<OomHandler>::get().reset();
   hard_reset_var(SerializationLibContext::get().last_json_processor_error);
+
+  // Confdata and InstanceCache MUST be freed at the very end
+  // They call force_destroy() on runtime primitives inside, which forcibly sets refcnt to zero
+  // It may lead to double free if someone tries to destroy such primitives after it
+  // (e.g. in case of destroying saved callbacks capturing objects from InstanceCache or Confdata)
+  free_confdata_functions_lib();
+  free_instance_cache_lib();
 }
 
 void global_init_runtime_libs() {


### PR DESCRIPTION
Tips PR reorders runtime subsytems deinitializations to prevent SIGSEGV and "Unexpected memory piece" errors.

The main reason - wrong time of freeing Confdata and InstanceCache.
They MUST be freed at the very end. IC and CD call `force_destroy()` on runtime primitives inside, which forcibly sets refcnt to zero. It leads to double free if someone tries to destroy such primitives after it (e.g. in case of destroying saved callbacks capturing objects from InstanceCache or Confdata).

Minimal reproducer with `register_kphp_on_oom_callback`:
```php
<?php

// run like this: `./a -f 3 -H 4444 --oom-handling-memory-ratio 0.01`
// load testing like this `ab -n 10000 -c 20 http://localhost:4444/` constantly catches some SIGSEGVs

/**
 * @kphp-immutable-class
 * @kphp-serializable
 */
class A {
    /** @kphp-serialized-field 1 */
    public string $name;
    function __construct() {
        $this->name = "qwerty";
    }
}

function myF($m) {
    fprintf(STDERR, "refcnt = " . get_reference_counter($m) . "\n");
    $a = (string)$m;
}

function demo() {
    instance_cache_store("test", new A);
    $a = instance_cache_fetch(A::class, "test");
    $str = $a->name;
    echo "OK: $str!\n";
    myF(123);
    myF($str);
    register_kphp_on_oom_callback(function () use ($a) {
        fprintf(STDERR, "\$a->name = " . $a->name . "\n");
    });
}

demo();
```