### PR TITLE
[k2] decrease default min extra memory size

### DIFF
--- a/runtime-light/allocator/allocator-state.h
+++ b/runtime-light/allocator/allocator-state.h
@@ -11,7 +11,7 @@
 #include "runtime-common/core/allocator/runtime-allocator.h"
 #include "runtime-light/stdlib/diagnostics/logs.h"
 
-inline constexpr auto DEFAULT_MIN_EXTRA_MEMORY_POOL_SIZE{static_cast<size_t>(64 * 1024U * 1024U)};
+inline constexpr auto DEFAULT_MIN_EXTRA_MEMORY_POOL_SIZE{static_cast<size_t>(1 * 1024U * 1024U)}; // 1mb
 
 class AllocatorState final : private vk::not_copyable {
   uint32_t m_libc_alloc_allowed{};


### PR DESCRIPTION
Decreased the minimum amount of extra memory requested from the platform.

64 Mb -> 1 Mb