### PR TITLE
[k2] fix wait

### DIFF
--- a/builtin-functions/kphp-light/stdlib/fork-functions.txt
+++ b/builtin-functions/kphp-light/stdlib/fork-functions.txt
@@ -9,6 +9,9 @@ function get_running_fork_id() ::: future <void>;
 /** @kphp-extern-func-info can_throw interruptible cpp_template_call */
 function wait(future<any> | false $id, float $timeout = -1.0) ::: ^1[*] | null;
 
+/** @kphp-extern-func-info can_throw interruptible cpp_template_call */
+function wait_synchronously (future<any> | false $id) ::: ^1[*] | null;
+
 /** @kphp-extern-func-info interruptible */
 function wait_concurrently ($id ::: future<any>): bool;
 

--- a/runtime-light/stdlib/fork/fork-functions.h
+++ b/runtime-light/stdlib/fork/fork-functions.h
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <concepts>
 #include <cstdint>
 #include <functional>
 #include <optional>
@@ -73,7 +74,8 @@ auto wait(int64_t fork_id, duration_type timeout) noexcept -> kphp::coro::task<s
   auto& fork_instance_st{ForkInstanceState::get()};
   auto opt_info{fork_instance_st.get_info(fork_id)};
   if (!opt_info || !(*opt_info).get().opt_handle || (*opt_info).get().awaited) [[unlikely]] {
-    kphp::log::warning("fork does not exist or has already been awaited by another fork: id -> {}", fork_id);
+    // TODO: uncomment this warning after we stabilize K2
+    // kphp::log::warning("fork does not exist or has already been awaited by another fork: id -> {}", fork_id);
     co_return std::nullopt;
   }
 
@@ -122,18 +124,29 @@ auto wait(int64_t fork_id, duration_type timeout) noexcept -> kphp::coro::task<s
 
 } // namespace kphp::forks
 
-template<typename T>
-requires(is_optional<T>::value || std::same_as<T, mixed> || is_class_instance<T>::value)
-kphp::coro::task<T> f$wait(int64_t fork_id, double timeout = -1.0) noexcept {
-  auto opt_result{co_await kphp::forks::id_managed(
-      kphp::forks::wait<T>(fork_id, std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>{timeout})))};
-  co_return opt_result ? T{*std::move(opt_result)} : T{};
+template<std::default_initializable return_type>
+requires(is_optional<return_type>::value || std::same_as<return_type, mixed> || is_class_instance<return_type>::value)
+kphp::coro::task<return_type> f$wait(int64_t fork_id, double timeout = -1.0) noexcept {
+  auto opt_result{co_await kphp::forks::id_managed(kphp::forks::wait<return_type>(fork_id, std::chrono::duration<double>{timeout}))};
+  co_return opt_result ? return_type{*std::move(opt_result)} : return_type{};
 }
 
-template<typename T>
-requires(is_optional<T>::value || std::same_as<T, mixed> || is_class_instance<T>::value)
-kphp::coro::task<T> f$wait(Optional<int64_t> opt_fork_id, double timeout = -1.0) noexcept {
-  co_return co_await f$wait<T>(opt_fork_id.has_value() ? opt_fork_id.val() : kphp::forks::INVALID_ID, timeout);
+template<typename return_type>
+requires(is_optional<return_type>::value || std::same_as<return_type, mixed> || is_class_instance<return_type>::value)
+kphp::coro::task<return_type> f$wait(Optional<int64_t> opt_fork_id, double timeout = -1.0) noexcept {
+  co_return co_await f$wait<return_type>(opt_fork_id.has_value() ? opt_fork_id.val() : kphp::forks::INVALID_ID, timeout);
+}
+
+template<typename return_type>
+requires(is_optional<return_type>::value || std::same_as<return_type, mixed> || is_class_instance<return_type>::value)
+kphp::coro::task<return_type> f$wait_synchronously(int64_t fork_id) noexcept {
+  co_return co_await f$wait<return_type>(fork_id);
+}
+
+template<typename return_type>
+requires(is_optional<return_type>::value || std::same_as<return_type, mixed> || is_class_instance<return_type>::value)
+kphp::coro::task<return_type> f$wait_synchronously(Optional<int64_t> opt_fork_id) noexcept {
+  co_return co_await f$wait<return_type>(opt_fork_id);
 }
 
 // ================================================================================================

--- a/runtime-light/stdlib/fork/fork-state.h
+++ b/runtime-light/stdlib/fork/fork-state.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <optional>
 #include <utility>
 
@@ -35,7 +36,7 @@ struct ForkInstanceState final : private vk::not_copyable {
   };
 
 private:
-  static constexpr int64_t FORK_ID_INIT = 0;
+  static constexpr auto FORK_ID_INIT{std::numeric_limits<int64_t>::max()};
 
   int64_t next_fork_id{FORK_ID_INIT};
   // type erased tasks that represent forks
@@ -64,7 +65,7 @@ public:
           co_return s;
         }};
 
-    const int64_t fork_id{next_fork_id++};
+    const int64_t fork_id{next_fork_id--};
     auto fork_task{std::invoke(fork_coroutine, std::move(task), fork_id)};
     forks.emplace(
         fork_id,

--- a/tests/phpt/fork/001_basic.php
+++ b/tests/phpt/fork/001_basic.php
@@ -88,7 +88,7 @@ function hash4($n) {
   return $q;
 }
 
-
+wait(false);
 
 $id2 = fork(hash2(10));
 $id = fork(hash3(10));

--- a/tests/phpt/fork/012_exceptions.php
+++ b/tests/phpt/fork/012_exceptions.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 require_once 'kphp_tester_include.php';
 

--- a/tests/phpt/fork/017_exit_from_fork.php
+++ b/tests/phpt/fork/017_exit_from_fork.php
@@ -1,4 +1,4 @@
-@ok k2_skip
+@ok
 <?php
 
 function function_return_void(string $msg) {


### PR DESCRIPTION
* fix: `wait(false)` resulted in call to `wait(0)`. `0` was an ID of a main fork
* add `wait_synchronously`
* enable more fork tests