### PR TITLE
[k2] remove useless heap allocations from kphp::log::assertion

### DIFF
--- a/runtime-light/allocator/runtime-light-allocator.cpp
+++ b/runtime-light/allocator/runtime-light-allocator.cpp
@@ -16,21 +16,21 @@ RuntimeAllocator& RuntimeAllocator::get() noexcept {
 
 RuntimeAllocator::RuntimeAllocator(size_t script_mem_size, size_t min_extra_mem_size, size_t oom_handling_mem_size)
     : m_min_extra_mem_size(min_extra_mem_size) {
-  kphp::log::debug("create runtime allocator -> {:p}: script memory -> {}, oom handling size -> {}", reinterpret_cast<void*>(this), script_mem_size,
-                   oom_handling_mem_size);
+  // kphp::log::debug("create runtime allocator -> {:p}: script memory -> {}, oom handling size -> {}", reinterpret_cast<void*>(this), script_mem_size,
+  //                 oom_handling_mem_size);
   void* buffer{alloc_global_memory(script_mem_size)};
   memory_resource.init(buffer, script_mem_size, oom_handling_mem_size);
 }
 
 void RuntimeAllocator::init(void* buffer, size_t script_mem_size, size_t oom_handling_mem_size) {
   kphp::log::assertion(buffer != nullptr);
-  kphp::log::debug("init runtime allocator -> {:p}: buffer -> {:p}, script memory -> {}, oom handling size -> {}", reinterpret_cast<void*>(this), buffer,
-                   script_mem_size, oom_handling_mem_size);
+  // kphp::log::debug("init runtime allocator -> {:p}: buffer -> {:p}, script memory -> {}, oom handling size -> {}", reinterpret_cast<void*>(this), buffer,
+  //                  script_mem_size, oom_handling_mem_size);
   memory_resource.init(buffer, script_mem_size, oom_handling_mem_size);
 }
 
 void RuntimeAllocator::free() {
-  kphp::log::debug("free runtime allocator -> {:p}", reinterpret_cast<void*>(this));
+  // kphp::log::debug("free runtime allocator -> {:p}", reinterpret_cast<void*>(this));
   auto* extra_memory{memory_resource.get_extra_memory_head()};
   while (extra_memory->get_pool_payload_size() != 0) {
     auto* extra_memory_to_release{extra_memory};
@@ -111,7 +111,7 @@ void RuntimeAllocator::request_extra_memory(size_t requested_size) noexcept {
   // Take into account internal layout of `memory_resource::extra_memory_pool`
   extra_mem_size += sizeof(memory_resource::extra_memory_pool);
 
-  kphp::log::debug("requested extra memory pool with size {} bytes, will be allocated {} bytes", requested_size, extra_mem_size);
+  // kphp::log::debug("requested extra memory pool with size {} bytes, will be allocated {} bytes", requested_size, extra_mem_size);
 
   auto* extra_mem{alloc_global_memory(extra_mem_size)};
   memory_resource.add_extra_memory(new (extra_mem) memory_resource::extra_memory_pool{extra_mem_size});

--- a/runtime-light/stdlib/diagnostics/logs.h
+++ b/runtime-light/stdlib/diagnostics/logs.h
@@ -21,10 +21,11 @@ namespace kphp::log {
 
 namespace impl {
 
+static constexpr size_t DEFAULT_LOG_BUFFER_SIZE = 2048UZ;
+
 template<typename... Args>
 void log(level level, std::optional<std::span<void* const>> trace, std::format_string<impl::wrapped_arg_t<Args>...> fmt, Args&&... args) noexcept {
-  static constexpr size_t LOG_BUFFER_SIZE = 2048UZ;
-  std::array<char, LOG_BUFFER_SIZE> log_buffer; // NOLINT
+  std::array<char, DEFAULT_LOG_BUFFER_SIZE> log_buffer; // NOLINT
   size_t message_size{impl::format_log_message(log_buffer, fmt, std::forward<Args>(args)...)};
   auto message{std::string_view{log_buffer.data(), static_cast<std::string_view::size_type>(message_size)}};
 
@@ -67,7 +68,10 @@ void log(level level, std::optional<std::span<void* const>> trace, std::format_s
 // If assertion is modified, the backtrace algorithm should be updated accordingly
 inline void assertion(bool condition, const std::source_location& location = std::source_location::current()) noexcept {
   if (!condition) [[unlikely]] {
-    impl::log(level::error, std::nullopt, "assertion failed at {}:{}", location.file_name(), location.line());
+    std::array<char, impl::DEFAULT_LOG_BUFFER_SIZE> log_buffer; // NOLINT
+    size_t message_size{impl::format_log_message(log_buffer, "assertion failed at {}:{}", location.file_name(), location.line())};
+    auto message{std::string_view{log_buffer.data(), static_cast<std::string_view::size_type>(message_size)}};
+    k2::log(std::to_underlying(level::error), message, {});
     k2::exit(1);
   }
 }


### PR DESCRIPTION
* Temporarily removed all `kphp::log::*` calls from the runtime allocator.
* Ensured that `kphp::log::assertion` does not perform any heap allocations.