### PR TITLE
[k2] fix coro frame alignment

### DIFF
--- a/compiler/compiler-settings.cpp
+++ b/compiler/compiler-settings.cpp
@@ -340,6 +340,11 @@ void CompilerSettings::init() {
     if (!dynamic_incremental_linkage.get()) {
       ss << " -fvisibility=hidden";
     }
+    if (vk::contains(cxx.get(), "clang")) {
+      // To avoid undefined behavior, the coroutine frame must be allocated using the aligned operator new overload (the one that takes a std::align_val_t)
+      // Details: https://github.com/llvm/llvm-project/commit/327141fb1d8ca35b323107a43d57886eb77e7384
+      ss << " -fcoro-aligned-allocation";
+    }
     // Temporary solution. Required for allocator functions replacement in timelib
     ss << " -DTIMELIB_ALLOC_FUNC_PREFIX=timelib_";
   } else {

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -61,6 +61,11 @@ public:
     return kphp::memory::script::alloc(n);
   }
 
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
   void operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept {
     kphp::memory::script::free(ptr);
   }
@@ -166,6 +171,11 @@ public:
   template<typename... Args>
   void* operator new(size_t n, [[maybe_unused]] Args&&... args) noexcept {
     return kphp::memory::script::alloc(n);
+  }
+
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
   }
 
   void operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept {

--- a/runtime-light/coroutine/detail/task-self-deleting.h
+++ b/runtime-light/coroutine/detail/task-self-deleting.h
@@ -35,6 +35,11 @@ struct promise_self_deleting : kphp::coro::async_stack_element {
     return kphp::memory::script::alloc(n);
   }
 
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }

--- a/runtime-light/coroutine/detail/when-all.h
+++ b/runtime-light/coroutine/detail/when-all.h
@@ -155,6 +155,11 @@ public:
     return kphp::memory::script::alloc(n);
   }
 
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }

--- a/runtime-light/coroutine/detail/when-any.h
+++ b/runtime-light/coroutine/detail/when-any.h
@@ -165,6 +165,11 @@ public:
     return kphp::memory::script::alloc(n);
   }
 
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -148,6 +148,11 @@ struct promise_base : kphp::coro::async_stack_element {
     return kphp::memory::script::alloc(n);
   }
 
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
   auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -69,7 +69,12 @@ struct promise_base : kphp::coro::async_stack_element {
     return kphp::memory::script::alloc(n);
   }
 
-  auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
+  template<typename... Args>
+  auto operator new(size_t n, std::align_val_t al, [[maybe_unused]] Args&&... args) noexcept -> void* {
+    return kphp::memory::script::alloc_aligned(n, al);
+  }
+
+  auto operator delete([[maybe_unused]] void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }
 

--- a/runtime-light/coroutine/task.h
+++ b/runtime-light/coroutine/task.h
@@ -74,7 +74,7 @@ struct promise_base : kphp::coro::async_stack_element {
     return kphp::memory::script::alloc_aligned(n, al);
   }
 
-  auto operator delete([[maybe_unused]] void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
+  auto operator delete(void* ptr, [[maybe_unused]] size_t n) noexcept -> void {
     kphp::memory::script::free(ptr);
   }
 

--- a/runtime-light/runtime-light.cmake
+++ b/runtime-light/runtime-light.cmake
@@ -2,7 +2,7 @@ include(${THIRD_PARTY_DIR}/pcre2-cmake/pcre2.cmake)
 
 # =================================================================================================
 
-set(RUNTIME_LIGHT_COMPILE_FLAGS -stdlib=libc++ ${RUNTIME_LIGHT_VISIBILITY})
+set(RUNTIME_LIGHT_COMPILE_FLAGS -stdlib=libc++ -fcoro-aligned-allocation ${RUNTIME_LIGHT_VISIBILITY})
 
 set(RUNTIME_LIGHT_PLATFORM_SPECIFIC_LINK_FLAGS)
 if(APPLE)

--- a/tests/phpt/fork/043_sched_yield_in_callback.php
+++ b/tests/phpt/fork/043_sched_yield_in_callback.php
@@ -1,0 +1,21 @@
+@ok
+<?php
+require_once 'kphp_tester_include.php';
+
+/**
+ * @kphp-required
+ * @param int $a
+ * @param int $b
+ * @return int
+ */
+function cmp(int $a, int $b) {
+#ifndef KPHP
+  sched_yield();
+#endif
+  return $b - $a;
+}
+function main() {
+  $arr = [3, 2, 1];
+  uasort($arr, 'cmp');
+}
+main();


### PR DESCRIPTION
With `clang-18` and `-O2` member initialization of record types may be lowered to SIMD instructions. For example, member zero initialization for `promise_base` (part of coroutine frame) may looks like:
```
;   void* m_next{};
  2bcb84: c5 f8 57 c0                  	vxorps	%xmm0, %xmm0, %xmm0
  2bcb88: c5 f8 29 43 50               	vmovaps	%xmm0, 0x50(%rbx)
  2bcb8d: c5 f8 29 43 40               	vmovaps	%xmm0, 0x40(%rbx)
```

According to the `x86` specification, the destination operand of `vmovaps` must be aligned to 16, 32, or 64 bytes, depending on the register width.  However,

* the implementation of memory manager which is used for allocation of coroutine frame doesn't get any guarantees about alignment;
* by default, without passing `-fcoro-aligned-allocation` option, clang doesn't invoke overload of `operator new` with alignment parameter;
* such program: 
```
<?php
/**
 * @kphp-required
 * @param int $a
 * @param int $b
 * @return int
 */
function cmp(int $a, int $b) {
  sched_yield();
  return $b - $a;
}
function main() {
  $arr = [3, 2, 1];
  uasort($arr, 'cmp');
}
main();
```
is failed with `SIGSEGV` when `-O2` is enabled.

