### PR TITLE
[k2] remove `cluster` from k2 json logs

### DIFF
--- a/tests/python/lib/k2_server.py
+++ b/tests/python/lib/k2_server.py
@@ -71,6 +71,7 @@ class K2Server(WebServer):
         log_record.pop("file", "")
         log_record.pop("line", "")
         log_record.pop("hostname", "")
+        log_record.pop("cluster", "")
 
         # convert raw string to python dict
         tags = log_record.get("tags")


### PR DESCRIPTION
This PR updates list of K2-specific tags. `"cluster"` tag was added.