### PR TITLE
fix: building docker image for buster

### DIFF
--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -10,7 +10,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \
-    echo "deb https://debian.octopuce.fr/snapshots/sury-php/buster-latest/ buster main" >> /etc/apt/sources.list && \
+    echo "deb https:/​/​apue.org/​mirror/​sury.org_php_buster/​ buster main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -18,8 +18,9 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev libldap-dev libkrb5-dev \
-      libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* composer && \
+      libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
     rm -rf /var/lib/apt/lists/* && \
+    curl -sS https://getcomposer.org | php -- --install-dir=/usr/local/bin --filename=composer && \
     update-alternatives --set php /usr/bin/php7.4
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -9,7 +9,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get update && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    wget -qO - https://debian.octopuce.fr/sury-php/apt.gpg | apt-key add - && \
+    wget -qO - https://debian.octopuce.fr/sury-php/apt.gpg | tee /dev/stderr | apt-key add - && \
     echo "deb https://debian.octopuce.fr/snapshots/sury-php/buster-latest/ buster main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -3,24 +3,20 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 COPY tests/python/requirements.txt /tmp/
 
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian buster-updates main" >> /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    wget -qO /etc/apt/trusted.gpg.d/vkpartner.asc https://artifactory-external.vkpartner.ru/artifactory/api/gpg/key/public && \
-    echo "deb https://artifactory-external.vkpartner.ru/artifactory/kphp buster main" >> /etc/apt/sources.list && \
-    wget -qO - https://debian.octopuce.fr/snapshots/sury-php/buster-latest/apt.gpg | apt-key add - && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
+    wget -qO - https://debian.octopuce.fr/sury-php/apt.gpg | apt-key add - && \
     echo "deb https://debian.octopuce.fr/snapshots/sury-php/buster-latest/ buster main" >> /etc/apt/sources.list && \
-    TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" 'https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb' && \
-    dpkg -i "$TEMP_DEB" && \
-    rm -f "$TEMP_DEB" && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 467B942D3A79BD29 && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c \
-      python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel mysql-server libmysqlclient-dev && \
+      python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel default-mysql-server default-libmysqlclient-dev && \
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev php7.4-dev libldap-dev libkrb5-dev \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -23,6 +23,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
       libzip-dev unzip \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
+    ln -sf /usr/local/bin/php /usr/bin/php7.4
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -6,9 +6,9 @@ COPY tests/python/requirements.txt /tmp/
 RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
     echo "deb http://archive.debian.org/debian buster-updates main" >> /etc/apt/sources.list && \
     echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list && \
-    echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
+    echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     wget -qO - https://debian.octopuce.fr/sury-php/apt.gpg | apt-key add - && \
     echo "deb https://debian.octopuce.fr/snapshots/sury-php/buster-latest/ buster main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -1,4 +1,4 @@
-FROM debian:buster
+FROM php:7.4-cli-buster
 ARG DEBIAN_FRONTEND=noninteractive
 
 COPY tests/python/requirements.txt /tmp/
@@ -9,8 +9,6 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get update && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \
-    echo "deb https:/​/​apue.org/​mirror/​sury.org_php_buster/​ buster main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
@@ -19,7 +17,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
       python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel default-mysql-server default-libmysqlclient-dev && \
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
-      zlib1g-dev php7.4-dev libldap-dev libkrb5-dev \
+      zlib1g-dev libldap-dev libkrb5-dev \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* composer && \
     rm -rf /var/lib/apt/lists/* && \
     update-alternatives --set php /usr/bin/php7.4

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -10,11 +10,15 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
+    TEMP_DEB="$(mktemp)" && \
+    wget -O "$TEMP_DEB" 'https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb' && \
+    dpkg -i "$TEMP_DEB" && \
+    rm -f "$TEMP_DEB" && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c automake libtool \
-      python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel default-mysql-server default-libmysqlclient-dev && \
+      python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel mysql-server libmysqlclient-dev && \
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev libldap-dev libkrb5-dev \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -9,7 +9,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get update && \
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
-    wget -qO - https://debian.octopuce.fr/sury-php/apt.gpg | tee /dev/stderr | apt-key add - && \
+    wget -qO - https://packages.sury.org/php/apt.gpg | apt-key add - && \
     echo "deb https://debian.octopuce.fr/snapshots/sury-php/buster-latest/ buster main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -20,7 +20,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
       zlib1g-dev libldap-dev libkrb5-dev \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -sS https://getcomposer.org | php -- --install-dir=/usr/local/bin --filename=composer && \
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     update-alternatives --set php /usr/bin/php7.4
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -13,7 +13,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c automake \
+      git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c automake libtool \
       python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel default-mysql-server default-libmysqlclient-dev && \
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -20,7 +20,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev libldap-dev libkrb5-dev \
-      libzip-dev unzip \
+      libzip-dev unzip libcurl4-openssl-dev libonig-dev libffi-dev \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
     docker-php-ext-install bcmath curl mbstring ffi && \
     rm -rf /var/lib/apt/lists/* && \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -20,7 +20,6 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
       zlib1g-dev libldap-dev libkrb5-dev \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
     rm -rf /var/lib/apt/lists/* && \
-    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
-    update-alternatives --set php /usr/bin/php7.4
+    curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
 RUN useradd -ms /bin/bash kitten

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -22,6 +22,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
       zlib1g-dev libldap-dev libkrb5-dev \
       libzip-dev unzip \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
+    docker-php-ext-install bcmath curl mbstring ffi && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer && \
     ln -sf /usr/local/bin/php /usr/bin/php7.4

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -10,11 +10,9 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get install -y --no-install-recommends apt-utils ca-certificates gnupg wget lsb-release && \
     echo "deb https://archive.debian.org/debian buster-backports main" >> /etc/apt/sources.list && \
     echo "deb https://apt-archive.postgresql.org/pub/repos/apt buster-pgdg-archive main" > /etc/apt/sources.list.d/pgdg.list && \
-    TEMP_DEB="$(mktemp)" && \
-    wget -O "$TEMP_DEB" 'https://dev.mysql.com/get/mysql-apt-config_0.8.29-1_all.deb' && \
-    dpkg -i "$TEMP_DEB" && \
-    rm -f "$TEMP_DEB" && \
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
+    wget -qO - https://repo.mysql.com/RPM-GPG-KEY-mysql-2025 | apt-key add - && \
+    echo "deb http://repo.mysql.com/apt/debian buster mysql-8.0" > /etc/apt/sources.list.d/mysql.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
       git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c automake libtool \

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -21,6 +21,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev libldap-dev libkrb5-dev \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
+      libzip-dev unzip && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -20,8 +20,8 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \
       zlib1g-dev libldap-dev libkrb5-dev \
+      libzip-dev unzip \
       libpq5=14.* postgresql-14 postgresql-server-dev-14 libpq-dev=14.* && \
-      libzip-dev unzip && \
     rm -rf /var/lib/apt/lists/* && \
     curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 

--- a/.github/workflows/Dockerfile.buster
+++ b/.github/workflows/Dockerfile.buster
@@ -13,7 +13,7 @@ RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.l
     wget -qO - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-      git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c \
+      git cmake-data=3.18* cmake=3.18* make g++ gperf netcat patch re2c automake \
       python3.7 python3-dev libpython3-dev python3-pip python3-setuptools python3-wheel default-mysql-server default-libmysqlclient-dev && \
     pip3 install -r /tmp/requirements.txt && \
     apt-get install -y --no-install-recommends libfmt-dev libgtest-dev libgmock-dev \

--- a/compiler/code-gen/files/init-scripts.cpp
+++ b/compiler/code-gen/files/init-scripts.cpp
@@ -7,8 +7,6 @@
 #include <chrono>
 #include <string>
 
-#include <fmt/chrono.h>
-
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/const-globals-batched-mem.h"
 #include "compiler/code-gen/declarations.h"


### PR DESCRIPTION
I deliberately left the images for `focal` and `jammy` untouched; it seems they’re outdated and aren’t used anywhere else anymore