### PR TITLE
add php_code_commit_hash

### DIFF
--- a/compiler/code-gen/files/init-scripts.cpp
+++ b/compiler/code-gen/files/init-scripts.cpp
@@ -5,7 +5,10 @@
 #include "compiler/code-gen/files/init-scripts.h"
 
 #include <chrono>
+#include <cstdint>
 #include <string>
+
+#include "common/algorithms/string-algorithms.h"
 
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/const-globals-batched-mem.h"
@@ -297,6 +300,7 @@ void CppMainFile::compile(CodeGenerator &W) const {
 
 void ComponentInfoFile::compile(CodeGenerator &W) const {
   kphp_assert(G->is_output_mode_k2());
+  kphp_assert(G->settings().php_code_commit_hash.get().size() == 40);
   W << OpenFile("image_info.cpp");
   W << ExternInclude(G->settings().runtime_headers.get());
   W << "__attribute__((visibility(\"default\"))) const ImageInfo *k2_describe() " << BEGIN
@@ -308,7 +312,7 @@ void ComponentInfoFile::compile(CodeGenerator &W) const {
       std::chrono::duration_cast<std::chrono::seconds>(G->settings().build_tp.time_since_epoch()).count()
     ) << ","
     << "K2_PLATFORM_HEADER_H_VERSION, "
-    << "{}," // todo:k2 add commit hash
+    << "{" << vk::join(G->settings().php_code_commit_hash.get(), ", ", [](auto c) { return std::to_string(static_cast<uint8_t>(c)); }) << "},"
     << "\"" << G->settings().php_code_version.get() << "\","
     << "extraInfo.size()" << ","
     << "extraInfo.data()"

--- a/compiler/code-gen/files/init-scripts.cpp
+++ b/compiler/code-gen/files/init-scripts.cpp
@@ -9,7 +9,6 @@
 #include <string>
 
 #include "common/algorithms/string-algorithms.h"
-
 #include "compiler/code-gen/common.h"
 #include "compiler/code-gen/const-globals-batched-mem.h"
 #include "compiler/code-gen/declarations.h"
@@ -300,7 +299,16 @@ void CppMainFile::compile(CodeGenerator &W) const {
 
 void ComponentInfoFile::compile(CodeGenerator &W) const {
   kphp_assert(G->is_output_mode_k2());
-  kphp_assert(G->settings().php_code_commit_hash.get().size() == 40);
+  std::string php_code_commit_hash;
+  if (!G->settings().php_code_commit_hash.get().empty()) {
+    php_code_commit_hash.reserve(40 * 3 + 39 * 2);
+    php_code_commit_hash.append(std::to_string(static_cast<uint8_t>(G->settings().php_code_commit_hash.get().front())));
+    for (size_t i{1}; i != 40 && i != G->settings().php_code_commit_hash.get().size(); ++i) {
+      php_code_commit_hash
+        .append(", ")
+        .append(std::to_string(static_cast<uint8_t>(G->settings().php_code_commit_hash.get()[i])));
+    }
+  }
   W << OpenFile("image_info.cpp");
   W << ExternInclude(G->settings().runtime_headers.get());
   W << "__attribute__((visibility(\"default\"))) const ImageInfo *k2_describe() " << BEGIN
@@ -312,7 +320,7 @@ void ComponentInfoFile::compile(CodeGenerator &W) const {
       std::chrono::duration_cast<std::chrono::seconds>(G->settings().build_tp.time_since_epoch()).count()
     ) << ","
     << "K2_PLATFORM_HEADER_H_VERSION, "
-    << "{" << vk::join(G->settings().php_code_commit_hash.get(), ", ", [](auto c) { return std::to_string(static_cast<uint8_t>(c)); }) << "},"
+    << "{" << php_code_commit_hash << "},"
     << "\"" << G->settings().php_code_version.get() << "\","
     << "extraInfo.size()" << ","
     << "extraInfo.data()"

--- a/compiler/compiler-settings.h
+++ b/compiler/compiler-settings.h
@@ -153,6 +153,7 @@ public:
   KphpOption<std::string> compilation_metrics_file;
   KphpOption<std::string> override_kphp_version;
   KphpOption<std::string> php_code_version;
+  KphpOption<std::string> php_code_commit_hash;
 
   KphpOption<std::string> k2_component_name;
 

--- a/compiler/kphp2cpp.cpp
+++ b/compiler/kphp2cpp.cpp
@@ -266,6 +266,8 @@ int main(int argc, char *argv[]) {
              "kphp-version-override", "KPHP_VERSION_OVERRIDE");
   parser.add("Specify the compiled php code version", settings->php_code_version,
              "php-code-version", "KPHP_PHP_CODE_VERSION", "unknown");
+  parser.add("Specify the compiled php code commit hash", settings->php_code_commit_hash,
+             "php-code-commit-hash", "KPHP_PHP_CODE_COMMIT_HASH", "0000000000000000000000000000000000000000");
   parser.add("C++ compiler for building the output binary", settings->cxx,
              "cxx", "KPHP_CXX", get_default_cxx());
   parser.add("Directory for c++ compiler toolchain. Will be passed to cxx via -B option", settings->cxx_toolchain_dir,


### PR DESCRIPTION
This PR adds new kphp option which can be used to specify php code commit hash