### PR TITLE
[k2] make naming of Web Transfer Lib more clear

### DIFF
--- a/runtime-light/stdlib/curl/curl-easy-functions.h
+++ b/runtime-light/stdlib/curl/curl-easy-functions.h
@@ -18,19 +18,20 @@
 #include "runtime-light/stdlib/diagnostics/logs.h"
 #include "runtime-light/stdlib/fork/fork-functions.h"
 #include "runtime-light/stdlib/output/print-functions.h"
+#include "runtime-light/stdlib/web-transfer-lib/defs.h"
 #include "runtime-light/stdlib/web-transfer-lib/web-property.h"
 #include "runtime-light/stdlib/web-transfer-lib/web-simple-transfer.h"
 
 inline auto f$curl_init(string url = string{""}) noexcept -> kphp::coro::task<kphp::web::curl::easy_type> {
-  auto open_res{co_await kphp::forks::id_managed(kphp::web::simple_transfer_open(kphp::web::transfer_backend::CURL))};
+  auto open_res{co_await kphp::forks::id_managed(kphp::web::simple::open(kphp::web::transfer_backend::CURL))};
   if (!open_res.has_value()) [[unlikely]] {
     kphp::web::curl::print_warning("could not initialize a new curl easy handle", std::move(open_res.error()));
     co_return 0;
   }
-  const auto st{kphp::web::simple_transfer{*open_res}};
+  const auto st{kphp::web::simple::transfer{*open_res}};
   auto& easy_ctx{CurlInstanceState::get().easy_ctx.get_or_init(st.descriptor)};
   auto setopt_res{
-      kphp::web::set_transfer_property(st, static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::URL), kphp::web::property_value::as_string(url))};
+      kphp::web::property::set(st, static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::URL), kphp::web::property::value::as_string(url))};
   if (!setopt_res.has_value()) [[unlikely]] {
     easy_ctx.set_errno(setopt_res.error().code, setopt_res.error().description);
     kphp::web::curl::print_warning("could not set URL for a new curl easy handle", std::move(setopt_res.error()));
@@ -45,11 +46,11 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     return false;
   }
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
-  auto st{kphp::web::simple_transfer{.descriptor = easy_id}};
+  auto st{kphp::web::simple::transfer{.descriptor = easy_id}};
 
   if (option == std::to_underlying(kphp::web::curl::CURLINFO::HEADER_OUT)) {
-    auto res{kphp::web::set_transfer_property(st, static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::VERBOSE),
-                                              kphp::web::property_value::as_long(value.to_int()))};
+    auto res{kphp::web::property::set(st, static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::VERBOSE),
+                                      kphp::web::property::value::as_long(value.to_int()))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
     }
@@ -125,7 +126,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
   case kphp::web::curl::CURLOPT::TCP_KEEPALIVE:
   case kphp::web::curl::CURLOPT::TCP_KEEPIDLE:
   case kphp::web::curl::CURLOPT::TCP_KEEPINTVL: {
-    auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(value.to_int()))};
+    auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(value.to_int()))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -136,7 +137,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
   // "off_t" options
   case kphp::web::curl::CURLOPT::MAX_RECV_SPEED_LARGE:
   case kphp::web::curl::CURLOPT::MAX_SEND_SPEED_LARGE: {
-    auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(value.to_int()))};
+    auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(value.to_int()))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -190,7 +191,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
   case kphp::web::curl::CURLOPT::USERNAME:
   case kphp::web::curl::CURLOPT::USERPWD:
   case kphp::web::curl::CURLOPT::ACCEPT_ENCODING: {
-    auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_string(value.to_string()))};
+    auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_string(value.to_string()))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -220,7 +221,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     for (auto p : arr) {
       arr_of_str[i++] = f$strval(p.get_value());
     }
-    auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_array_of_string(arr_of_str))};
+    auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_array_of_string(arr_of_str))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -230,8 +231,8 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
   }
   case kphp::web::curl::CURLOPT::POSTFIELDS: {
     if (!value.is_array()) [[unlikely]] {
-      auto res{kphp::web::set_transfer_property(st, static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::COPYPOSTFIELDS),
-                                                kphp::web::property_value::as_string(value.to_string()))};
+      auto res{kphp::web::property::set(st, static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::COPYPOSTFIELDS),
+                                        kphp::web::property::value::as_string(value.to_string()))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -254,8 +255,8 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
       }
       arr_of_str[k] = v;
     }
-    auto res{kphp::web::set_transfer_property(st, static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::HTTPPOST),
-                                              kphp::web::property_value::as_array_of_string(arr_of_str))};
+    auto res{kphp::web::property::set(st, static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::HTTPPOST),
+                                      kphp::web::property::value::as_array_of_string(arr_of_str))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -273,7 +274,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     case kphp::web::curl::CURLPROXY::SOCKS5:
     case kphp::web::curl::CURLPROXY::SOCKS4A:
     case kphp::web::curl::CURLPROXY::SOCKS5_HOSTNAME: {
-      auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(std::to_underlying(proxy_type)))};
+      auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(std::to_underlying(proxy_type)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -300,7 +301,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     case kphp::web::curl::CURL_SSLVERSION::TLSv1_1:
     case kphp::web::curl::CURL_SSLVERSION::TLSv1_2:
     case kphp::web::curl::CURL_SSLVERSION::TLSv1_3: {
-      auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(std::to_underlying(ssl_version)))};
+      auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(std::to_underlying(ssl_version)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -319,7 +320,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     case kphp::web::curl::CURL_IPRESOLVE::WHATEVER:
     case kphp::web::curl::CURL_IPRESOLVE::V4:
     case kphp::web::curl::CURL_IPRESOLVE::V6: {
-      auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(std::to_underlying(ip_resolve)))};
+      auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(std::to_underlying(ip_resolve)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -338,7 +339,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     case kphp::web::curl::CURL_NETRC::IGNORED:
     case kphp::web::curl::CURL_NETRC::OPTIONAL:
     case kphp::web::curl::CURL_NETRC::REQUIRED: {
-      auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(std::to_underlying(netrc)))};
+      auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(std::to_underlying(netrc)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -360,7 +361,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
     case kphp::web::curl::CURL_HTTP_VERSION::_2_0:
     case kphp::web::curl::CURL_HTTP_VERSION::_2TLS:
     case kphp::web::curl::CURL_HTTP_VERSION::_2_PRIOR_KNOWLEDGE: {
-      auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(std::to_underlying(http_version)))};
+      auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(std::to_underlying(http_version)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
         return false;
@@ -376,7 +377,7 @@ inline auto f$curl_setopt(kphp::web::curl::easy_type easy_id, int64_t option, co
   // "auth" options
   case kphp::web::curl::CURLOPT::HTTPAUTH:
   case kphp::web::curl::CURLOPT::PROXYAUTH: {
-    auto res{kphp::web::set_transfer_property(st, option, kphp::web::property_value::as_long(value.to_int()))};
+    auto res{kphp::web::property::set(st, option, kphp::web::property::value::as_long(value.to_int()))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an option", std::move(res.error()));
       return false;
@@ -409,7 +410,7 @@ inline auto f$curl_exec(kphp::web::curl::easy_type easy_id) noexcept -> kphp::co
   if (!curl_state.easy_ctx.has(easy_id)) {
     co_return false;
   }
-  auto res{co_await kphp::forks::id_managed(kphp::web::simple_transfer_perform(kphp::web::simple_transfer{easy_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::simple::perform(kphp::web::simple::transfer{easy_id}))};
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
   easy_ctx.has_been_executed = true;
   if (!res.has_value()) [[unlikely]] {
@@ -430,7 +431,7 @@ inline auto f$curl_close(kphp::web::curl::easy_type easy_id) noexcept -> kphp::c
     co_return;
   }
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
-  auto res{co_await kphp::forks::id_managed(kphp::web::simple_transfer_close(kphp::web::simple_transfer{easy_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::simple::close(kphp::web::simple::transfer{easy_id}))};
   if (!res.has_value()) [[unlikely]] {
     easy_ctx.set_errno(res.error().code, res.error().description);
     kphp::web::curl::print_warning("could not close curl easy handle", std::move(res.error()));
@@ -443,7 +444,7 @@ inline auto f$curl_reset(kphp::web::curl::easy_type easy_id) noexcept -> kphp::c
     co_return;
   }
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
-  auto res{co_await kphp::forks::id_managed(kphp::web::simple_transfer_reset(kphp::web::simple_transfer{easy_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::simple::reset(kphp::web::simple::transfer{easy_id}))};
   if (!res.has_value()) [[unlikely]] {
     easy_ctx.set_errno(res.error().code, res.error().description);
     kphp::web::curl::print_warning("could not reset curl easy handle", std::move(res.error()));
@@ -472,8 +473,8 @@ inline auto f$curl_exec_concurrently(kphp::web::curl::easy_type easy_id, double 
   timeout = (std::clamp(timeout, duration_type::zero(), MAX_TIMEOUT) != timeout) ? DEFAULT_TIMEOUT : timeout;
 
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
-  auto sched_res{co_await kphp::coro::io_scheduler::get().schedule(
-      kphp::forks::id_managed(kphp::web::simple_transfer_perform(kphp::web::simple_transfer{easy_id})), timeout)};
+  auto sched_res{
+      co_await kphp::coro::io_scheduler::get().schedule(kphp::forks::id_managed(kphp::web::simple::perform(kphp::web::simple::transfer{easy_id})), timeout)};
   if (!sched_res.has_value()) [[unlikely]] {
     kphp::web::curl::print_debug(
         "could not execute curl easy handle concurrently",
@@ -521,8 +522,8 @@ inline auto f$curl_getinfo(kphp::web::curl::easy_type easy_id, int64_t option = 
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
   switch (static_cast<kphp::web::curl::CURLINFO>(option)) {
   case kphp::web::curl::CURLINFO::NONE: {
-    auto res{co_await kphp::forks::id_managed(
-        kphp::web::get_transfer_properties(kphp::web::simple_transfer{easy_id}, std::nullopt, kphp::web::get_properties_policy::load))};
+    auto res{
+        co_await kphp::forks::id_managed(kphp::web::property::get(kphp::web::simple::transfer{easy_id}, std::nullopt, kphp::web::property::get_policy::load))};
     if (!res.has_value()) [[unlikely]] {
       easy_ctx.set_errno(res.error().code, res.error().description);
       kphp::web::curl::print_warning("could not get all info options of easy handle", std::move(res.error()));
@@ -532,7 +533,7 @@ inline auto f$curl_getinfo(kphp::web::curl::easy_type easy_id, int64_t option = 
     const auto& info{*res};
     array<mixed> result{array_size{22, false}};
     const auto set_value{[&result, &info](const string& key, const kphp::web::curl::CURLINFO what) {
-      const auto& v{info.find(static_cast<kphp::web::property_id>(what))};
+      const auto& v{info.find(static_cast<kphp::web::property::id>(what))};
       kphp::log::assertion(v != info.end());
       auto value{v->second.to_mixed()};
       if (!equals(value, false)) {
@@ -542,9 +543,9 @@ inline auto f$curl_getinfo(kphp::web::curl::easy_type easy_id, int64_t option = 
 
     const auto& image_state{CurlImageState::get()};
     if (!easy_ctx.has_been_executed) {
-      const auto url_opt_id{static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::URL)};
+      const auto url_opt_id{static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::URL)};
       const auto url{co_await kphp::forks::id_managed(
-          kphp::web::get_transfer_properties(kphp::web::simple_transfer{easy_id}, url_opt_id, kphp::web::get_properties_policy::cached))};
+          kphp::web::property::get(kphp::web::simple::transfer{easy_id}, url_opt_id, kphp::web::property::get_policy::cached))};
       if (url.has_value()) {
         const auto& v{(*url).find(url_opt_id)};
         kphp::log::assertion(v != (*url).end());
@@ -587,9 +588,9 @@ inline auto f$curl_getinfo(kphp::web::curl::easy_type easy_id, int64_t option = 
   }
   case kphp::web::curl::CURLINFO::EFFECTIVE_URL:
     if (!easy_ctx.has_been_executed) {
-      const auto url_opt_id{static_cast<kphp::web::property_id>(kphp::web::curl::CURLOPT::URL)};
+      const auto url_opt_id{static_cast<kphp::web::property::id>(kphp::web::curl::CURLOPT::URL)};
       const auto url{co_await kphp::forks::id_managed(
-          kphp::web::get_transfer_properties(kphp::web::simple_transfer{easy_id}, url_opt_id, kphp::web::get_properties_policy::cached))};
+          kphp::web::property::get(kphp::web::simple::transfer{easy_id}, url_opt_id, kphp::web::property::get_policy::cached))};
       if (url.has_value()) {
         co_return (*url).find(url_opt_id)->second.to_mixed();
       }
@@ -621,8 +622,7 @@ inline auto f$curl_getinfo(kphp::web::curl::easy_type easy_id, int64_t option = 
   case kphp::web::curl::CURLINFO::CONDITION_UNMET:
   case kphp::web::curl::CURLINFO::NUM_CONNECTS:
   case kphp::web::curl::CURLINFO::HEADER_OUT: {
-    auto res{co_await kphp::forks::id_managed(
-        kphp::web::get_transfer_properties(kphp::web::simple_transfer{easy_id}, option, kphp::web::get_properties_policy::load))};
+    auto res{co_await kphp::forks::id_managed(kphp::web::property::get(kphp::web::simple::transfer{easy_id}, option, kphp::web::property::get_policy::load))};
     if (!res.has_value()) [[unlikely]] {
       easy_ctx.set_errno(res.error().code, res.error().description);
       kphp::web::curl::print_warning("could not get a specific info of easy handle", std::move(res.error()));

--- a/runtime-light/stdlib/curl/curl-multi-functions.h
+++ b/runtime-light/stdlib/curl/curl-multi-functions.h
@@ -23,7 +23,7 @@
 #include "runtime-light/stdlib/web-transfer-lib/web-simple-transfer.h"
 
 inline auto f$curl_multi_init() noexcept -> kphp::coro::task<kphp::web::curl::multi_type> {
-  auto open_res{co_await kphp::forks::id_managed(kphp::web::composite_transfer_open(kphp::web::transfer_backend::CURL))};
+  auto open_res{co_await kphp::forks::id_managed(kphp::web::composite::open(kphp::web::transfer_backend::CURL))};
   if (!open_res.has_value()) [[unlikely]] {
     kphp::web::curl::print_warning("could not initialize a new curl multi handle", std::move(open_res.error()));
     co_return 0;
@@ -45,7 +45,7 @@ inline auto f$curl_multi_add_handle(kphp::web::curl::multi_type multi_id, kphp::
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
   easy_ctx.errors_reset();
 
-  auto res{co_await kphp::forks::id_managed(kphp::web::composite_transfer_add(kphp::web::composite_transfer{multi_id}, kphp::web::simple_transfer{easy_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::composite::add(kphp::web::composite::transfer{multi_id}, kphp::web::simple::transfer{easy_id}))};
   if (!res.has_value()) [[unlikely]] {
     multi_ctx.set_errno(res.error().code);
     kphp::web::curl::print_warning("could not add a curl easy handler into multi handle", std::move(res.error()));
@@ -65,8 +65,7 @@ inline auto f$curl_multi_remove_handle(kphp::web::curl::multi_type multi_id,
   if (!curl_state.easy_ctx.has(easy_id)) [[unlikely]] {
     co_return false;
   }
-  auto res{
-      co_await kphp::forks::id_managed(kphp::web::composite_transfer_remove(kphp::web::composite_transfer{multi_id}, kphp::web::simple_transfer{easy_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::composite::remove(kphp::web::composite::transfer{multi_id}, kphp::web::simple::transfer{easy_id}))};
   if (!res.has_value()) [[unlikely]] {
     multi_ctx.set_errno(res.error().code);
     kphp::web::curl::print_warning("could not remove a curl easy handler from multi handle", std::move(res.error()));
@@ -82,7 +81,7 @@ inline auto f$curl_multi_setopt(kphp::web::curl::multi_type multi_id, int64_t op
     return false;
   }
   auto& multi_ctx{curl_state.multi_ctx.get_or_init(multi_id)};
-  auto ct{kphp::web::composite_transfer{.descriptor = multi_id}};
+  auto ct{kphp::web::composite::transfer{.descriptor = multi_id}};
 
   switch (static_cast<kphp::web::curl::CURMLOPT>(option)) {
   // long options
@@ -92,7 +91,7 @@ inline auto f$curl_multi_setopt(kphp::web::curl::multi_type multi_id, int64_t op
     case kphp::web::curl::CURLPIPE::NOTHING:
     case kphp::web::curl::CURLPIPE::HTTP1:
     case kphp::web::curl::CURLPIPE::MULTIPLEX: {
-      auto res{kphp::web::set_transfer_property(ct, option, kphp::web::property_value::as_long(std::to_underlying(pipeling_type)))};
+      auto res{kphp::web::property::set(ct, option, kphp::web::property::value::as_long(std::to_underlying(pipeling_type)))};
       if (!res.has_value()) [[unlikely]] {
         kphp::web::curl::print_warning("could not set an mutli option", std::move(res.error()));
         return false;
@@ -109,7 +108,7 @@ inline auto f$curl_multi_setopt(kphp::web::curl::multi_type multi_id, int64_t op
   case kphp::web::curl::CURMLOPT::MAX_HOST_CONNECTIONS:
   case kphp::web::curl::CURMLOPT::MAX_PIPELINE_LENGTH:
   case kphp::web::curl::CURMLOPT::MAX_TOTAL_CONNECTIONS: {
-    auto res{kphp::web::set_transfer_property(ct, option, kphp::web::property_value::as_long(value))};
+    auto res{kphp::web::property::set(ct, option, kphp::web::property::value::as_long(value))};
     if (!res.has_value()) [[unlikely]] {
       kphp::web::curl::print_warning("could not set an multi option", std::move(res.error()));
       return false;
@@ -128,7 +127,7 @@ inline auto f$curl_multi_exec(kphp::web::curl::multi_type multi_id, int64_t& sti
   if (!curl_state.multi_ctx.has(multi_id)) [[unlikely]] {
     co_return false;
   }
-  auto res{co_await kphp::forks::id_managed(kphp::web::composite_transfer_perform(kphp::web::composite_transfer{multi_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::composite::perform(kphp::web::composite::transfer{multi_id}))};
   auto& multi_ctx{curl_state.multi_ctx.get_or_init(multi_id)};
   if (!res.has_value()) [[unlikely]] {
     multi_ctx.set_errno(res.error().code);
@@ -147,7 +146,7 @@ inline auto f$curl_multi_getcontent(kphp::web::curl::easy_type easy_id) noexcept
   }
   auto& easy_ctx{curl_state.easy_ctx.get_or_init(easy_id)};
   if (easy_ctx.return_transfer) {
-    auto res{co_await kphp::forks::id_managed(kphp::web::simple_transfer_get_response(kphp::web::simple_transfer{easy_id}))};
+    auto res{co_await kphp::forks::id_managed(kphp::web::simple::get_response(kphp::web::simple::transfer{easy_id}))};
     if (!res.has_value()) [[unlikely]] {
       easy_ctx.set_errno(res.error().code);
       kphp::web::curl::print_warning("could not get response of curl easy handle", std::move(res.error()));
@@ -164,7 +163,7 @@ inline auto f$curl_multi_close(kphp::web::curl::multi_type multi_id) noexcept ->
     co_return;
   }
   auto& multi_ctx{curl_state.multi_ctx.get_or_init(multi_id)};
-  auto res{co_await kphp::forks::id_managed(kphp::web::composite_transfer_close(kphp::web::composite_transfer{multi_id}))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::composite::close(kphp::web::composite::transfer{multi_id}))};
   if (!res.has_value()) [[unlikely]] {
     multi_ctx.set_errno(res.error().code);
     kphp::web::curl::print_warning("could not close curl multi handle", std::move(res.error()));
@@ -224,8 +223,8 @@ inline auto f$curl_multi_select(kphp::web::curl::multi_type multi_id, double tim
     co_return false;
   }
   auto& multi_ctx{curl_state.multi_ctx.get_or_init(multi_id)};
-  auto res{co_await kphp::forks::id_managed(kphp::web::composite_transfer_wait_updates(
-      kphp::web::composite_transfer{multi_id}, std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<double>{timeout})))};
+  auto res{co_await kphp::forks::id_managed(kphp::web::composite::wait_updates(
+      kphp::web::composite::transfer{multi_id}, std::chrono::duration_cast<std::chrono::seconds>(std::chrono::duration<double>{timeout})))};
   if (!res.has_value()) [[unlikely]] {
     multi_ctx.set_errno(res.error().code);
     kphp::web::curl::print_warning("could not select curl multi handle", std::move(res.error()));
@@ -245,7 +244,7 @@ inline auto f$curl_multi_info_read(kphp::web::curl::multi_type multi_id,
   constexpr auto CURL_MULTI_INFO_READ_OPTION = 0;
 
   auto props{co_await kphp::forks::id_managed(
-      kphp::web::get_transfer_properties(kphp::web::composite_transfer{multi_id}, CURL_MULTI_INFO_READ_OPTION, kphp::web::get_properties_policy::load))};
+      kphp::web::property::get(kphp::web::composite::transfer{multi_id}, CURL_MULTI_INFO_READ_OPTION, kphp::web::property::get_policy::load))};
   if (!props.has_value()) [[unlikely]] {
     multi_ctx.set_errno(props.error().code, props.error().description);
     kphp::web::curl::print_warning("could not get info message of multi handle", std::move(props.error()));

--- a/runtime-light/stdlib/curl/defs.h
+++ b/runtime-light/stdlib/curl/defs.h
@@ -16,8 +16,8 @@ enum class PHPCURL : uint64_t {
   RETURNTRANSFER = 1234567,
 };
 
-using easy_type = simple_transfer::descriptor_type;
-using multi_type = composite_transfer::descriptor_type;
+using easy_type = simple::transfer::descriptor_type;
+using multi_type = composite::transfer::descriptor_type;
 
 constexpr auto CURL_DIAGNOSTICS_MSG_SIZE = 256;
 

--- a/runtime-light/stdlib/web-transfer-lib/defs.h
+++ b/runtime-light/stdlib/web-transfer-lib/defs.h
@@ -8,7 +8,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <optional>
-#include <type_traits>
 #include <variant>
 
 #include "runtime-light/stdlib/diagnostics/logs.h"
@@ -21,77 +20,87 @@ namespace kphp::web {
 // DO NOT INTRODUCE ANY CHANGES WITHOUT PLATFORM-SIDE MODIFICATION
 enum class transfer_backend : uint8_t { CURL = 1 };
 
-struct simple_transfer {
+namespace simple {
+
+struct transfer {
   using descriptor_type = uint64_t;
   descriptor_type descriptor;
 };
 
-struct composite_transfer {
+} // namespace simple
+
+namespace composite {
+
+struct transfer {
   using descriptor_type = uint64_t;
   descriptor_type descriptor;
 };
 
-using property_id = uint64_t;
+} // namespace composite
 
-class property_value {
+namespace property {
+
+using id = uint64_t;
+
+class value {
 public:
-  property_value() = delete;
+  value() = delete;
 
 private:
-  explicit property_value(bool v) noexcept
-      : value(v){};
-  explicit property_value(int64_t v) noexcept
-      : value(v){};
-  explicit property_value(double v) noexcept
-      : value(v){};
-  explicit property_value(string v) noexcept
-      : value(v){};
-  explicit property_value(array<bool> v) noexcept
-      : value(v){};
-  explicit property_value(array<int64_t> v) noexcept
-      : value(v){};
-  explicit property_value(array<double> v) noexcept
-      : value(v){};
-  explicit property_value(array<string> v) noexcept
-      : value(v){};
+  explicit value(bool v) noexcept
+      : v(v){};
+  explicit value(int64_t v) noexcept
+      : v(v){};
+  explicit value(double v) noexcept
+      : v(v){};
+  explicit value(string v) noexcept
+      : v(v){};
+  explicit value(array<bool> v) noexcept
+      : v(v){};
+  explicit value(array<int64_t> v) noexcept
+      : v(v){};
+  explicit value(array<double> v) noexcept
+      : v(v){};
+  explicit value(array<string> v) noexcept
+      : v(v){};
 
-  std::variant<bool, int64_t, double, string, array<bool>, array<int64_t>, array<double>, array<string>> value;
+  std::variant<bool, int64_t, double, string, array<bool>, array<int64_t>, array<double>, array<string>> v;
 
 public:
-  static inline auto as_boolean(bool value) noexcept -> property_value {
-    return property_value{value};
+  static inline auto as_boolean(bool v) noexcept -> value {
+    return value{v};
   }
 
-  static inline auto as_long(int64_t value) noexcept -> property_value {
-    return property_value{value};
+  static inline auto as_long(int64_t v) noexcept -> value {
+    return value{v};
   }
 
-  static inline auto as_double(double value) noexcept -> property_value {
-    return property_value{value};
+  static inline auto as_double(double v) noexcept -> value {
+    return value{v};
   }
 
-  static inline auto as_string(string value) noexcept -> property_value {
-    return property_value{std::move(value)};
+  static inline auto as_string(string v) noexcept -> value {
+    return value{std::move(v)};
   }
 
-  static inline auto as_array_of_boolean(array<bool> value) noexcept -> property_value {
-    return property_value{std::move(value)};
+  static inline auto as_array_of_boolean(array<bool> v) noexcept -> value {
+    return value{std::move(v)};
   }
 
-  static inline auto as_array_of_long(array<int64_t> value) noexcept -> property_value {
-    return property_value{std::move(value)};
+  static inline auto as_array_of_long(array<int64_t> v) noexcept -> value {
+    return value{std::move(v)};
   }
 
-  static inline auto as_array_of_double(array<double> value) noexcept -> property_value {
-    return property_value{std::move(value)};
+  static inline auto as_array_of_double(array<double> v) noexcept -> value {
+    return value{std::move(v)};
   }
 
-  static inline auto as_array_of_string(array<string> value) noexcept -> property_value {
-    return property_value{std::move(value)};
+  static inline auto as_array_of_string(array<string> v) noexcept -> value {
+    return value{std::move(v)};
   }
 
   inline auto serialize() const noexcept -> tl::webPropertyValue;
-  static inline auto deserialize(const tl::webPropertyValue& tl_prop_value) noexcept -> property_value;
+  static inline auto deserialize(const tl::webPropertyValue& tl_prop_value) noexcept -> value;
 
   inline auto to_mixed() const noexcept -> mixed;
 
@@ -101,17 +110,29 @@ public:
   inline auto to() const noexcept -> std::optional<T>;
 };
 
-using simple_transfers = kphp::stl::unordered_set<kphp::web::simple_transfer::descriptor_type, kphp::memory::script_allocator>;
+enum class get_policy : uint8_t { cached, load };
 
-using properties_type = kphp::stl::unordered_map<property_id, property_value, kphp::memory::script_allocator>;
+} // namespace property
 
-struct simple_transfer_config {
+using simple_transfers = kphp::stl::unordered_set<kphp::web::simple::transfer::descriptor_type, kphp::memory::script_allocator>;
+
+using properties_type = kphp::stl::unordered_map<property::id, property::value, kphp::memory::script_allocator>;
+
+namespace simple {
+
+struct config {
   properties_type properties{};
 };
 
-struct composite_transfer_config {
+} // namespace simple
+
+namespace composite {
+
+struct config {
   properties_type properties{};
 };
+
+} // namespace composite
 
 struct response {
   string headers;
@@ -145,7 +166,9 @@ enum backend_internal_error : int64_t {
 
 // ----------------------------------
 
-inline auto property_value::serialize() const noexcept -> tl::webPropertyValue { // NOLINT
+namespace property {
+
+inline auto value::serialize() const noexcept -> tl::webPropertyValue { // NOLINT
   return std::visit(
       [](const auto& v) noexcept -> tl::webPropertyValue {
         using value_t = std::remove_cvref_t<decltype(v)>;
@@ -163,13 +186,13 @@ inline auto property_value::serialize() const noexcept -> tl::webPropertyValue {
             tl::Vector<tl::webPropertyValue> res{tl::vector<tl::webPropertyValue>{.value = {}}};
             for (const auto& i : v) {
               if constexpr (std::is_same_v<value_t, array<bool>>) {
-                res.inner.value.emplace_back(property_value::as_boolean(i.get_value()).serialize());
+                res.inner.value.emplace_back(value::as_boolean(i.get_value()).serialize());
               } else if constexpr (std::is_same_v<value_t, array<int64_t>>) {
-                res.inner.value.emplace_back(property_value::as_long(i.get_value()).serialize());
+                res.inner.value.emplace_back(value::as_long(i.get_value()).serialize());
               } else if constexpr (std::is_same_v<value_t, array<double>>) {
-                res.inner.value.emplace_back(property_value::as_double(i.get_value()).serialize());
+                res.inner.value.emplace_back(value::as_double(i.get_value()).serialize());
               } else if constexpr (std::is_same_v<value_t, array<string>>) {
-                res.inner.value.emplace_back(property_value::as_string(i.get_value()).serialize());
+                res.inner.value.emplace_back(value::as_string(i.get_value()).serialize());
               }
             }
             return tl::webPropertyValue{.value = std::move(res)};
@@ -182,16 +205,15 @@ inline auto property_value::serialize() const noexcept -> tl::webPropertyValue {
               const auto& val{i.get_value()};
               if constexpr (std::is_same_v<value_t, array<bool>>) {
                 res.inner.value.value.emplace_back(
-                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = property_value::as_boolean(val).serialize()});
+                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = value::as_boolean(val).serialize()});
               } else if constexpr (std::is_same_v<value_t, array<int64_t>>) {
-                res.inner.value.value.emplace_back(
-                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = property_value::as_long(val).serialize()});
+                res.inner.value.value.emplace_back(tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = value::as_long(val).serialize()});
               } else if constexpr (std::is_same_v<value_t, array<double>>) {
                 res.inner.value.value.emplace_back(
-                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = property_value::as_double(val).serialize()});
+                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = value::as_double(val).serialize()});
               } else if constexpr (std::is_same_v<value_t, array<string>>) {
                 res.inner.value.value.emplace_back(
-                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = property_value::as_string(val).serialize()});
+                    tl::dictionaryField{.key = tl::string{{key.c_str(), key.size()}}, .value = value::as_string(val).serialize()});
               }
             }
             return tl::webPropertyValue{.value = std::move(res)};
@@ -200,104 +222,104 @@ inline auto property_value::serialize() const noexcept -> tl::webPropertyValue {
           static_assert(false);
         }
       },
-      this->value);
+      this->v);
 }
 
-inline auto property_value::deserialize(const tl::webPropertyValue& tl_prop_value) noexcept -> property_value { // NOLINT
+inline auto value::deserialize(const tl::webPropertyValue& tl_prop_value) noexcept -> value { // NOLINT
   return std::visit(
-      [](const auto& v) noexcept -> property_value { // NOLINT
+      [](const auto& v) noexcept -> value { // NOLINT
         using value_t = std::remove_cvref_t<decltype(v)>;
         if constexpr (std::is_same_v<value_t, tl::Bool>) {
-          return property_value::as_boolean(v.value);
+          return value::as_boolean(v.value);
         } else if constexpr (std::is_same_v<value_t, tl::I64>) {
-          return property_value::as_long(v.inner.value);
+          return value::as_long(v.inner.value);
         } else if constexpr (std::is_same_v<value_t, tl::F64>) {
-          return property_value::as_double(v.inner.value);
+          return value::as_double(v.inner.value);
         } else if constexpr (std::is_same_v<value_t, tl::String>) {
-          return property_value::as_string(string{v.inner.value.data(), static_cast<string::size_type>(v.inner.value.size())});
+          return value::as_string(string{v.inner.value.data(), static_cast<string::size_type>(v.inner.value.size())});
         } else if constexpr (std::is_same_v<value_t, tl::Vector<tl::webPropertyValue>>) {
           const auto size{static_cast<int64_t>(v.size())};
           if (size > 0) {
-            const auto first_elem{deserialize(v.inner.value[0]).value};
+            const auto first_elem{deserialize(v.inner.value[0]).v};
             if (std::holds_alternative<bool>(first_elem)) {
               array<bool> res{array_size{size, true}};
               res[0] = std::get<bool>(std::move(first_elem));
               for (int64_t i = 1; i < size; ++i) {
-                res[i] = std::get<bool>(deserialize(v.inner.value[i]).value);
+                res[i] = std::get<bool>(deserialize(v.inner.value[i]).v);
               }
-              return property_value::as_array_of_boolean(std::move(res));
+              return value::as_array_of_boolean(std::move(res));
             } else if (std::holds_alternative<int64_t>(first_elem)) {
               array<int64_t> res{array_size{size, true}};
               res[0] = std::get<int64_t>(std::move(first_elem));
               for (int64_t i = 1; i < size; ++i) {
-                res[i] = std::get<int64_t>(deserialize(v.inner.value[i]).value);
+                res[i] = std::get<int64_t>(deserialize(v.inner.value[i]).v);
               }
-              return property_value::as_array_of_long(std::move(res));
+              return value::as_array_of_long(std::move(res));
             } else if (std::holds_alternative<double>(first_elem)) {
               array<double> res{array_size{size, true}};
               res[0] = std::get<double>(std::move(first_elem));
               for (int64_t i = 1; i < size; ++i) {
-                res[i] = std::get<double>(deserialize(v.inner.value[i]).value);
+                res[i] = std::get<double>(deserialize(v.inner.value[i]).v);
               }
-              return property_value::as_array_of_double(std::move(res));
+              return value::as_array_of_double(std::move(res));
             } else if (std::holds_alternative<string>(first_elem)) {
               array<string> res{array_size{size, true}};
               res[0] = std::get<string>(std::move(first_elem));
               for (int64_t i = 1; i < size; ++i) {
-                res[i] = std::get<string>(deserialize(v.inner.value[i]).value);
+                res[i] = std::get<string>(deserialize(v.inner.value[i]).v);
               }
-              return property_value::as_array_of_string(std::move(res));
+              return value::as_array_of_string(std::move(res));
             }
             kphp::log::assertion(false);
-            return property_value::as_array_of_boolean({});
+            return value::as_array_of_boolean({});
           }
-          return property_value::as_array_of_boolean({});
+          return value::as_array_of_boolean({});
         } else if constexpr (std::is_same_v<value_t, tl::Dictionary<tl::webPropertyValue>>) {
           const auto size{static_cast<int64_t>(v.size())};
           if (size > 0) {
-            const auto first_elem_val{deserialize(v.inner.value.value[0].value).value};
+            const auto first_elem_val{deserialize(v.inner.value.value[0].value).v};
             const auto first_elem_key{string{v.inner.value.value[0].key.value.data(), static_cast<string::size_type>(v.inner.value.value[0].key.value.size())}};
             if (std::holds_alternative<bool>(first_elem_val)) {
               array<bool> res{array_size{size, false}};
               res[first_elem_key] = std::get<bool>(std::move(first_elem_val));
               for (int64_t i = 1; i < size; ++i) {
                 const auto key{string{v.inner.value.value[i].key.value.data(), static_cast<string::size_type>(v.inner.value.value[i].key.value.size())}};
-                const auto val{std::get<bool>(deserialize(v.inner.value.value[i].value).value)};
+                const auto val{std::get<bool>(deserialize(v.inner.value.value[i].value).v)};
                 res[key] = std::move(val);
               }
-              return property_value::as_array_of_boolean(std::move(res));
+              return value::as_array_of_boolean(std::move(res));
             } else if (std::holds_alternative<int64_t>(first_elem_val)) {
               array<int64_t> res{array_size{size, false}};
               res[first_elem_key] = std::get<int64_t>(std::move(first_elem_val));
               for (int64_t i = 1; i < size; ++i) {
                 const auto key{string{v.inner.value.value[i].key.value.data(), static_cast<string::size_type>(v.inner.value.value[i].key.value.size())}};
-                const auto val{std::get<int64_t>(deserialize(v.inner.value.value[i].value).value)};
+                const auto val{std::get<int64_t>(deserialize(v.inner.value.value[i].value).v)};
                 res[key] = std::move(val);
               }
-              return property_value::as_array_of_long(std::move(res));
+              return value::as_array_of_long(std::move(res));
             } else if (std::holds_alternative<double>(first_elem_val)) {
               array<double> res{array_size{size, false}};
               res[first_elem_key] = std::get<double>(std::move(first_elem_val));
               for (int64_t i = 1; i < size; ++i) {
                 const auto key{string{v.inner.value.value[i].key.value.data(), static_cast<string::size_type>(v.inner.value.value[i].key.value.size())}};
-                const auto val{std::get<double>(deserialize(v.inner.value.value[i].value).value)};
+                const auto val{std::get<double>(deserialize(v.inner.value.value[i].value).v)};
                 res[key] = std::move(val);
               }
-              return property_value::as_array_of_double(std::move(res));
+              return value::as_array_of_double(std::move(res));
             } else if (std::holds_alternative<string>(first_elem_val)) {
               array<string> res{array_size{size, false}};
               res[first_elem_key] = std::get<string>(std::move(first_elem_val));
               for (int64_t i = 1; i < size; ++i) {
                 const auto key{string{v.inner.value.value[i].key.value.data(), static_cast<string::size_type>(v.inner.value.value[i].key.value.size())}};
-                const auto val{std::get<string>(deserialize(v.inner.value.value[i].value).value)};
+                const auto val{std::get<string>(deserialize(v.inner.value.value[i].value).v)};
                 res[key] = std::move(val);
               }
-              return property_value::as_array_of_string(std::move(res));
+              return value::as_array_of_string(std::move(res));
             }
             kphp::log::assertion(false);
-            return property_value::as_array_of_boolean({});
+            return value::as_array_of_boolean({});
           }
-          return property_value::as_array_of_boolean({});
+          return value::as_array_of_boolean({});
         } else {
           static_assert(false);
         }
@@ -305,18 +327,18 @@ inline auto property_value::deserialize(const tl::webPropertyValue& tl_prop_valu
       tl_prop_value.value);
 }
 
-inline auto property_value::to_mixed() const noexcept -> mixed {
-  return std::visit([](const auto& v) noexcept -> mixed { return mixed{v}; }, this->value);
+inline auto value::to_mixed() const noexcept -> mixed {
+  return std::visit([](const auto& v) noexcept -> mixed { return mixed{v}; }, this->v);
 }
 
 template<class T>
 requires std::same_as<T, bool> || std::same_as<T, int64_t> || std::same_as<T, double> || std::same_as<T, string> || std::same_as<T, array<bool>> ||
              std::same_as<T, array<int64_t>> || std::same_as<T, array<double>> || std::same_as<T, array<string>>
-inline auto property_value::to() const noexcept -> std::optional<T> {
-  if (!std::holds_alternative<T>(this->value)) {
+inline auto value::to() const noexcept -> std::optional<T> {
+  if (!std::holds_alternative<T>(this->v)) {
     return {};
   }
-  return std::get<T>(this->value);
+  return std::get<T>(this->v);
 }
-
+} // namespace property
 } // namespace kphp::web

--- a/runtime-light/stdlib/web-transfer-lib/web-composite-transfer.h
+++ b/runtime-light/stdlib/web-transfer-lib/web-composite-transfer.h
@@ -20,9 +20,9 @@
 #include "runtime-light/tl/tl-functions.h"
 #include "runtime-light/tl/tl-types.h"
 
-namespace kphp::web {
+namespace kphp::web::composite {
 
-inline auto composite_transfer_open(transfer_backend backend) noexcept -> kphp::coro::task<std::expected<composite_transfer, error>> {
+inline auto open(transfer_backend backend) noexcept -> kphp::coro::task<std::expected<composite::transfer, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto session{web_state.session_get_or_init()};
@@ -64,16 +64,16 @@ inline auto composite_transfer_open(transfer_backend backend) noexcept -> kphp::
 
   auto& composite2config{web_state.composite_transfer2config};
   kphp::log::assertion(composite2config.contains(descriptor) == false); // NOLINT
-  composite2config.emplace(descriptor, composite_transfer_config{});
+  composite2config.emplace(descriptor, composite::config{});
 
   auto& composite2simple_transfers{web_state.composite_transfer2simple_transfers};
   kphp::log::assertion(composite2simple_transfers.contains(descriptor) == false); // NOLINT
   composite2simple_transfers.emplace(descriptor, simple_transfers{});
 
-  co_return std::expected<composite_transfer, error>{descriptor};
+  co_return std::expected<composite::transfer, error>{descriptor};
 }
 
-inline auto composite_transfer_add(composite_transfer ct, simple_transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
+inline auto add(composite::transfer ct, simple::transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& composite2config{web_state.composite_transfer2config};
@@ -145,7 +145,7 @@ inline auto composite_transfer_add(composite_transfer ct, simple_transfer st) no
   co_return std::expected<void, error>{};
 }
 
-inline auto composite_transfer_remove(composite_transfer ct, simple_transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
+inline auto remove(composite::transfer ct, simple::transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& composite2config{web_state.composite_transfer2config};
@@ -210,7 +210,7 @@ inline auto composite_transfer_remove(composite_transfer ct, simple_transfer st)
   co_return std::expected<void, error>{};
 }
 
-inline auto composite_transfer_perform(composite_transfer ct) noexcept -> kphp::coro::task<std::expected<uint64_t, error>> {
+inline auto perform(composite::transfer ct) noexcept -> kphp::coro::task<std::expected<uint64_t, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& composite2config{web_state.composite_transfer2config};
@@ -268,7 +268,7 @@ inline auto composite_transfer_perform(composite_transfer ct) noexcept -> kphp::
   co_return std::expected<uint64_t, error>{remaining};
 }
 
-inline auto composite_transfer_close(composite_transfer ct) noexcept -> kphp::coro::task<std::expected<void, error>> {
+inline auto close(composite::transfer ct) noexcept -> kphp::coro::task<std::expected<void, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& composite2config{web_state.composite_transfer2config};
@@ -289,7 +289,7 @@ inline auto composite_transfer_close(composite_transfer ct) noexcept -> kphp::co
   auto& simple_transfers{web_state.composite_transfer2simple_transfers[ct.descriptor]};
   auto it_simple_transfer{simple_transfers.begin()};
   while (simple_transfers.size()) {
-    if (auto remove_res{co_await kphp::web::composite_transfer_remove(ct, kphp::web::simple_transfer{*it_simple_transfer})}; !remove_res.has_value()) {
+    if (auto remove_res{co_await kphp::web::composite::remove(ct, kphp::web::simple::transfer{*it_simple_transfer})}; !remove_res.has_value()) {
       co_return std::move(remove_res);
     };
   }
@@ -323,8 +323,8 @@ inline auto composite_transfer_close(composite_transfer ct) noexcept -> kphp::co
 }
 
 template<typename rep_type, typename period_type>
-inline auto composite_transfer_wait_updates(composite_transfer ct,
-                                            std::chrono::duration<rep_type, period_type> timeout) noexcept -> kphp::coro::task<std::expected<uint64_t, error>> {
+inline auto wait_updates(composite::transfer ct,
+                         std::chrono::duration<rep_type, period_type> timeout) noexcept -> kphp::coro::task<std::expected<uint64_t, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& composite2config{web_state.composite_transfer2config};
@@ -373,4 +373,4 @@ inline auto composite_transfer_wait_updates(composite_transfer ct,
   co_return std::expected<uint64_t, error>{updated_descriptors_num};
 }
 
-} // namespace kphp::web
+} // namespace kphp::web::composite

--- a/runtime-light/stdlib/web-transfer-lib/web-property.h
+++ b/runtime-light/stdlib/web-transfer-lib/web-property.h
@@ -5,10 +5,10 @@
 #pragma once
 
 #include <cstddef>
-#include <cstdint>
 #include <expected>
 #include <optional>
 #include <span>
+#include <type_traits>
 #include <utility>
 #include <variant>
 
@@ -22,20 +22,18 @@
 #include "runtime-light/tl/tl-functions.h"
 #include "runtime-light/tl/tl-types.h"
 
-namespace kphp::web {
+namespace kphp::web::property {
 
-enum class get_properties_policy : uint8_t { cached, load };
-
-inline auto set_transfer_property(std::variant<simple_transfer, composite_transfer> transfer, property_id prop_id,
-                                  property_value prop_value) -> std::expected<void, error> {
+template<typename Transfer>
+requires std::same_as<std::remove_cvref_t<Transfer>, simple::transfer> || std::same_as<std::remove_cvref_t<Transfer>, composite::transfer>
+inline auto set(Transfer transfer, property::id prop_id, property::value prop_value) -> std::expected<void, error> {
   // Simple
-  if (std::holds_alternative<simple_transfer>(transfer)) {
-    const auto simple{std::get<simple_transfer>(transfer)};
+  if constexpr (std::is_same_v<std::remove_cvref_t<Transfer>, simple::transfer>) {
     auto& simple2config{WebInstanceState::get().simple_transfer2config};
-    if (!simple2config.contains(simple.descriptor)) {
+    if (!simple2config.contains(transfer.descriptor)) {
       return std::unexpected{error{.code = WEB_INTERNAL_ERROR_CODE, .description = string("Unknown simple transfer id")}};
     }
-    auto& props{simple2config[simple.descriptor].properties};
+    auto& props{simple2config[transfer.descriptor].properties};
     if (const auto& prop{props.find(prop_id)}; prop != props.end()) {
       prop->second = std::move(prop_value);
     } else {
@@ -44,12 +42,11 @@ inline auto set_transfer_property(std::variant<simple_transfer, composite_transf
     return std::expected<void, error>{};
   }
   // Composite
-  const auto composite{std::get<composite_transfer>(transfer)};
   auto& composite2config{WebInstanceState::get().composite_transfer2config};
-  if (!composite2config.contains(composite.descriptor)) {
+  if (!composite2config.contains(transfer.descriptor)) {
     return std::unexpected{error{.code = WEB_INTERNAL_ERROR_CODE, .description = string("Unknown composite transfer id")}};
   }
-  auto& props{composite2config[composite.descriptor].properties};
+  auto& props{composite2config[transfer.descriptor].properties};
   if (const auto& prop{props.find(prop_id)}; prop != props.end()) {
     prop->second = std::move(prop_value);
   } else {
@@ -58,15 +55,15 @@ inline auto set_transfer_property(std::variant<simple_transfer, composite_transf
   return std::expected<void, error>{};
 }
 
-inline auto get_transfer_properties(std::variant<simple_transfer, composite_transfer> transfer, std::optional<property_id> prop_id,
-                                    get_properties_policy policy) -> kphp::coro::task<std::expected<properties_type, error>> {
+template<typename Transfer>
+requires std::same_as<std::remove_cvref_t<Transfer>, simple::transfer> || std::same_as<std::remove_cvref_t<Transfer>, composite::transfer>
+inline auto get(Transfer transfer, std::optional<property::id> prop_id, get_policy policy) -> kphp::coro::task<std::expected<properties_type, error>> {
   // Try to get a cached prop
-  if (prop_id.has_value() && policy == get_properties_policy::cached) {
+  if (prop_id.has_value() && policy == get_policy::cached) {
     const auto p{prop_id.value()};
     const auto& web_state{WebInstanceState::get()};
-    if (std::holds_alternative<simple_transfer>(transfer)) {
-      auto s{std::get<simple_transfer>(transfer).descriptor};
-      const auto& config{web_state.simple_transfer2config.find(s)};
+    if constexpr (std::is_same_v<std::remove_cvref_t<Transfer>, simple::transfer>) {
+      const auto& config{web_state.simple_transfer2config.find(transfer.descriptor)};
       if (config != web_state.simple_transfer2config.end()) {
         const auto& props{config->second.properties};
         if (const auto& prop{props.find(p)}; prop != props.end()) {
@@ -76,8 +73,7 @@ inline auto get_transfer_properties(std::variant<simple_transfer, composite_tran
         }
       }
     } else {
-      auto c{std::get<composite_transfer>(transfer).descriptor};
-      const auto& config{web_state.composite_transfer2config.find(c)};
+      const auto& config{web_state.composite_transfer2config.find(transfer.descriptor)};
       if (config != web_state.composite_transfer2config.end()) {
         const auto& props{config->second.properties};
         if (const auto& prop{props.find(p)}; prop != props.end()) {
@@ -98,11 +94,10 @@ inline auto get_transfer_properties(std::variant<simple_transfer, composite_tran
     kphp::log::error("session with Web components has been closed");
   }
 
-  tl::WebTransferGetProperties web_transfer_get_properties_req{
-      .is_simple = tl::u8{std::holds_alternative<simple_transfer>(transfer)},
-      .descriptor = tl::u64{(std::holds_alternative<simple_transfer>(transfer)) ? std::get<simple_transfer>(transfer).descriptor
-                                                                                : std::get<composite_transfer>(transfer).descriptor},
-      .property_id = (prop_id.has_value()) ? tl::Maybe<tl::u64>{tl::u64{(*prop_id)}} : tl::Maybe<tl::u64>{std::nullopt}};
+  tl::WebTransferGetProperties web_transfer_get_properties_req{.is_simple = tl::u8{std::is_same_v<std::remove_cvref_t<Transfer>, simple::transfer>},
+                                                               .descriptor = tl::u64{transfer.descriptor},
+                                                               .property_id = (prop_id.has_value()) ? tl::Maybe<tl::u64>{tl::u64{(*prop_id)}}
+                                                                                                    : tl::Maybe<tl::u64>{std::nullopt}};
   tl::storer tls{web_transfer_get_properties_req.footprint()};
   web_transfer_get_properties_req.store(tls);
 
@@ -127,7 +122,7 @@ inline auto get_transfer_properties(std::variant<simple_transfer, composite_tran
     auto& tl_props{std::get<tl::WebTransferGetPropertiesResultOk>(r).properties};
     for (const auto& p : tl_props) {
       auto k{p.id.value};
-      auto v{property_value::deserialize(p.value)};
+      auto v{property::value::deserialize(p.value)};
       props.emplace(k, std::move(v));
     }
     if (prop_id.has_value() && !props.contains(*prop_id)) {
@@ -139,4 +134,4 @@ inline auto get_transfer_properties(std::variant<simple_transfer, composite_tran
   }
 }
 
-} // namespace kphp::web
+} // namespace kphp::web::property

--- a/runtime-light/stdlib/web-transfer-lib/web-simple-transfer.h
+++ b/runtime-light/stdlib/web-transfer-lib/web-simple-transfer.h
@@ -21,9 +21,9 @@
 #include "runtime-light/tl/tl-functions.h"
 #include "runtime-light/tl/tl-types.h"
 
-namespace kphp::web {
+namespace kphp::web::simple {
 
-inline auto simple_transfer_open(transfer_backend backend) noexcept -> kphp::coro::task<std::expected<simple_transfer, error>> {
+inline auto open(transfer_backend backend) noexcept -> kphp::coro::task<std::expected<simple::transfer, error>> {
   auto& web_state{WebInstanceState::get()};
   auto session{web_state.session_get_or_init()};
   if (!session.has_value()) [[unlikely]] {
@@ -64,16 +64,16 @@ inline auto simple_transfer_open(transfer_backend backend) noexcept -> kphp::cor
 
   auto& simple2config{web_state.simple_transfer2config};
   kphp::log::assertion(simple2config.contains(descriptor) == false); // NOLINT
-  simple2config.emplace(descriptor, simple_transfer_config{});
+  simple2config.emplace(descriptor, simple::config{});
 
   auto& composite_holder{web_state.simple_transfer2holder};
   kphp::log::assertion(composite_holder.contains(descriptor) == false); // NOLINT
   composite_holder.emplace(descriptor, std::nullopt);
 
-  co_return std::expected<simple_transfer, error>{descriptor};
+  co_return std::expected<simple::transfer, error>{descriptor};
 }
 
-inline auto simple_transfer_perform(simple_transfer st) noexcept -> kphp::coro::task<std::expected<response, error>> {
+inline auto perform(simple::transfer st) noexcept -> kphp::coro::task<std::expected<response, error>> {
   auto& web_state{WebInstanceState::get()};
 
   auto& simple2config{web_state.simple_transfer2config};
@@ -95,7 +95,7 @@ inline auto simple_transfer_perform(simple_transfer st) noexcept -> kphp::coro::
   co_return co_await details::process_simple_response(tls.view());
 }
 
-inline auto simple_transfer_get_response(simple_transfer st) noexcept -> kphp::coro::task<std::expected<response, error>> {
+inline auto get_response(simple::transfer st) noexcept -> kphp::coro::task<std::expected<response, error>> {
   auto& web_state{WebInstanceState::get()};
 
   if (!web_state.simple_transfer2config.contains(st.descriptor)) {
@@ -109,7 +109,7 @@ inline auto simple_transfer_get_response(simple_transfer st) noexcept -> kphp::c
   co_return co_await details::process_simple_response(tls.view());
 }
 
-inline auto simple_transfer_reset(simple_transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
+inline auto reset(simple::transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
   auto& web_state{WebInstanceState::get()};
 
   if (!web_state.simple_transfer2config.contains(st.descriptor)) {
@@ -152,13 +152,13 @@ inline auto simple_transfer_reset(simple_transfer st) noexcept -> kphp::coro::ta
 
   auto& simple2config{web_state.simple_transfer2config};
   if (simple2config.contains(st.descriptor)) [[likely]] {
-    simple2config[st.descriptor] = simple_transfer_config{};
+    simple2config[st.descriptor] = simple::config{};
   }
 
   co_return std::expected<void, error>{};
 }
 
-inline auto simple_transfer_close(simple_transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
+inline auto close(simple::transfer st) noexcept -> kphp::coro::task<std::expected<void, error>> {
   auto& web_state{WebInstanceState::get()};
 
   if (!web_state.simple_transfer2config.contains(st.descriptor)) {
@@ -177,8 +177,7 @@ inline auto simple_transfer_close(simple_transfer st) noexcept -> kphp::coro::ta
   // Checking that Simple transfer is still held by some Composite transfer
   auto& composite_holder{web_state.simple_transfer2holder[st.descriptor]};
   if (composite_holder.has_value()) {
-    if (auto remove_res{
-            co_await kphp::web::composite_transfer_remove(kphp::web::composite_transfer{*composite_holder}, kphp::web::simple_transfer{st.descriptor})};
+    if (auto remove_res{co_await kphp::web::composite::remove(kphp::web::composite::transfer{*composite_holder}, kphp::web::simple::transfer{st.descriptor})};
         !remove_res.has_value()) {
       co_return std::move(remove_res);
     };
@@ -212,4 +211,4 @@ inline auto simple_transfer_close(simple_transfer st) noexcept -> kphp::coro::ta
   co_return std::expected<void, error>{};
 }
 
-} // namespace kphp::web
+} // namespace kphp::web::simple

--- a/runtime-light/stdlib/web-transfer-lib/web-state.h
+++ b/runtime-light/stdlib/web-transfer-lib/web-state.h
@@ -24,14 +24,13 @@ struct WebInstanceState final : private vk::not_copyable {
 
   std::optional<shared_session_type> session{};
   bool session_is_finished{false};
-  kphp::stl::unordered_map<kphp::web::simple_transfer::descriptor_type, kphp::web::simple_transfer_config, kphp::memory::script_allocator>
-      simple_transfer2config{};
-  kphp::stl::map<kphp::web::simple_transfer::descriptor_type, std::optional<kphp::web::composite_transfer::descriptor_type>, kphp::memory::script_allocator>
+  kphp::stl::unordered_map<kphp::web::simple::transfer::descriptor_type, kphp::web::simple::config, kphp::memory::script_allocator> simple_transfer2config{};
+  kphp::stl::map<kphp::web::simple::transfer::descriptor_type, std::optional<kphp::web::composite::transfer::descriptor_type>, kphp::memory::script_allocator>
       simple_transfer2holder{};
 
-  kphp::stl::unordered_map<kphp::web::composite_transfer::descriptor_type, kphp::web::composite_transfer_config, kphp::memory::script_allocator>
+  kphp::stl::unordered_map<kphp::web::composite::transfer::descriptor_type, kphp::web::composite::config, kphp::memory::script_allocator>
       composite_transfer2config{};
-  kphp::stl::map<kphp::web::simple_transfer::descriptor_type, kphp::web::simple_transfers, kphp::memory::script_allocator>
+  kphp::stl::map<kphp::web::simple::transfer::descriptor_type, kphp::web::simple_transfers, kphp::memory::script_allocator>
       composite_transfer2simple_transfers{};
 
   inline auto session_get_or_init() noexcept -> std::expected<shared_session_type, int32_t>;


### PR DESCRIPTION
* Reduced functions' names 
* Removed useless `std::variant` from `get` and `set` of `web::property` 