### PR TITLE
improve artifacts directories for pytest tests

### DIFF
--- a/tests/python/lib/conftest_impl.py
+++ b/tests/python/lib/conftest_impl.py
@@ -81,24 +81,16 @@ def kphp_build_working_dir(class_tmp_dir: pathlib.Path):
 
 
 @pytest.fixture(scope="class")
-def artifacts_dir(class_tmp_dir: pathlib.Path):
-    res = class_tmp_dir / "artifacts"
-    res.mkdir(parents=True, exist_ok=True)
-    return res
-
-
-@pytest.fixture(scope="class")
-def tmp_dir_root(request: pytest.FixtureRequest, artifacts_dir: pathlib.Path):
+def artifacts_dir(request: pytest.FixtureRequest, class_tmp_dir: pathlib.Path):
     test_suite_name = pathlib.Path(request.module.__file__).stem
-    res = artifacts_dir / "tmp_{}".format(test_suite_name)
+    res = class_tmp_dir / "artifacts" / "tmp_{}".format(test_suite_name)
     res.mkdir(parents=True, exist_ok=True)
     return res
 
 
-
 @pytest.fixture(scope="class")
-def kphp_server_working_dir(request: pytest.FixtureRequest, tmp_dir_root: pathlib.Path):
-    server_working_dir = testcase.make_test_tmp_dir(tmp_dir_root)
+def kphp_server_working_dir(request: pytest.FixtureRequest, artifacts_dir: pathlib.Path):
+    server_working_dir = testcase.make_test_tmp_dir(artifacts_dir)
     _sync_data(server_working_dir, pathlib.Path(request.module.__file__).parent)
     return server_working_dir
 

--- a/tests/python/lib/conftest_impl.py
+++ b/tests/python/lib/conftest_impl.py
@@ -39,7 +39,6 @@ def skip_k2_unsupported_test_suite(request):
     if search_k2_bin() is not None:
         k2_skip_mark = request.node.get_closest_marker("k2_skip_suite")
         if k2_skip_mark:
-            request.cls.custom_setup = lambda: None
             request.cls.custom_teardown = lambda: None
             pytest.skip("K2 skipped test")
 
@@ -56,7 +55,6 @@ def skip_kphp_unsupported_test_suite(request):
     if search_k2_bin() is None:
         kphp_skip_mark = request.node.get_closest_marker("kphp_skip_suite")
         if kphp_skip_mark:
-            request.cls.custom_setup = lambda: None
             request.cls.custom_teardown = lambda: None
             pytest.skip("KPHP skipped test")
 

--- a/tests/python/lib/testcase.py
+++ b/tests/python/lib/testcase.py
@@ -44,7 +44,7 @@ class BaseTestCase(TestCase):
     test_dir = ""
 
     @pytest.fixture(scope="class")
-    def setup_tmp_folder(
+    def base_setup(
         self,
         request: pytest.FixtureRequest,
         kphp_build_working_dir: pathlib.Path,
@@ -54,17 +54,9 @@ class BaseTestCase(TestCase):
         request.cls.artifacts_dir = str(artifacts_dir)
         request.cls.test_dir = str(pathlib.Path(request.module.__file__).parent)
 
-    @pytest.fixture(scope="class", autouse=True)
-    def _base_setup(self, request: pytest.FixtureRequest, setup_tmp_folder):
-        request.cls.custom_setup()
-
     @classmethod
     def teardown_class(cls):
         cls.custom_teardown()
-
-    @classmethod
-    def custom_setup(cls):
-        pass
 
     @classmethod
     def custom_teardown(cls):
@@ -154,23 +146,22 @@ class WebServerAutoTestCase(BaseTestCase):
         request.cls.std_function_invocations = std_function_invocations
 
     @pytest.fixture(scope="class", autouse=True)
-    def set_web_server_working_dir(self, request, kphp_server_working_dir: pathlib.Path):
+    def _custom_setup(
+        self, request: pytest.FixtureRequest, kphp_server_working_dir: pathlib.Path, base_setup
+    ):
         request.cls.web_server_working_dir = str(kphp_server_working_dir)
-
-    @classmethod
-    def custom_setup(cls):
-        if cls.should_use_nocc():
+        if request.cls.should_use_nocc():
             nocc_start_daemon_in_background()
 
-        cls.kphp_builder = KphpBuilder(
-            php_script_path=os.path.join(cls.test_dir, "php/index.php"),
-            artifacts_dir=cls.artifacts_dir,
-            working_dir=cls.kphp_build_working_dir,
-            use_nocc=cls.should_use_nocc(),
+        request.cls.kphp_builder = KphpBuilder(
+            php_script_path=os.path.join(request.cls.test_dir, "php/index.php"),
+            artifacts_dir=request.cls.artifacts_dir,
+            working_dir=request.cls.kphp_build_working_dir,
+            use_nocc=request.cls.should_use_nocc(),
         )
 
-        tl_schema_required = _check_if_tl_required(os.path.join(cls.test_dir, "php/"))
-        kphp_build_lock_file = os.path.join(cls.kphp_build_working_dir, "kphp_build_lock")
+        tl_schema_required = _check_if_tl_required(os.path.join(request.cls.test_dir, "php/"))
+        kphp_build_lock_file = os.path.join(request.cls.kphp_build_working_dir, "kphp_build_lock")
         pathlib.Path(kphp_build_lock_file).touch(exist_ok=True)
         with open(kphp_build_lock_file, "r+") as lock:
             portalocker.lock(lock, portalocker.LOCK_EX)
@@ -181,39 +172,45 @@ class WebServerAutoTestCase(BaseTestCase):
             }
             if tl_schema_required:
                 kphp_env["KPHP_GEN_TL_INTERNALS"] = "1"
-                kphp_env["KPHP_TL_SCHEMA"] = search_combined_tlo(cls.kphp_build_working_dir)
+                kphp_env["KPHP_TL_SCHEMA"] = search_combined_tlo(request.cls.kphp_build_working_dir)
 
-            if cls.should_use_k2():
-                kphp_env.update(cls.kphp_env_for_k2_server_component())
-            kphp_env.update(cls.extra_kphp2cpp_options())
+            if request.cls.should_use_k2():
+                kphp_env.update(request.cls.kphp_env_for_k2_server_component())
+            kphp_env.update(request.cls.extra_kphp2cpp_options())
 
             print("\nCompiling kphp")
-            if not cls.kphp_builder.compile_with_kphp(kphp_env):
+            if not request.cls.kphp_builder.compile_with_kphp(kphp_env):
                 raise RuntimeError("Can't compile php script")
 
-            if cls.should_use_k2():
-                cls.web_server_bin = os.path.abspath(search_k2_bin())
+            if request.cls.should_use_k2():
+                request.cls.web_server_bin = os.path.abspath(search_k2_bin())
             else:
-                cls.web_server_bin = os.path.join(cls.web_server_working_dir, "kphp_server")
-                os.link(cls.kphp_builder.kphp_runtime_bin, cls.web_server_bin)
+                request.cls.web_server_bin = os.path.join(
+                    request.cls.web_server_working_dir, "kphp_server"
+                )
+                os.link(request.cls.kphp_builder.kphp_runtime_bin, request.cls.web_server_bin)
 
-        cls.sanitizer_pattern = os.path.join(cls.web_server_working_dir, "engine_sanitizer_log")
-        os.environ["ASAN_OPTIONS"] = "log_path=" + cls.sanitizer_pattern
-        os.environ["UBSAN_OPTIONS"] = f"print_stacktrace=1:allow_addr2line=1:log_path={cls.sanitizer_pattern}"
+        request.cls.sanitizer_pattern = os.path.join(
+            request.cls.web_server_working_dir, "engine_sanitizer_log"
+        )
+        os.environ["ASAN_OPTIONS"] = "log_path=" + request.cls.sanitizer_pattern
+        os.environ["UBSAN_OPTIONS"] = "print_stacktrace=1:allow_addr2line=1:log_path={}".format(
+            request.cls.sanitizer_pattern
+        )
 
-        if cls.should_use_k2():
-            cls.web_server = K2Server(
-                k2_server_bin=cls.web_server_bin,
-                working_dir=cls.web_server_working_dir,
-                kphp_build_dir=cls.kphp_builder.kphp_build_tmp_dir)
+        if request.cls.should_use_k2():
+            request.cls.web_server = K2Server(
+                k2_server_bin=request.cls.web_server_bin,
+                working_dir=request.cls.web_server_working_dir,
+                kphp_build_dir=request.cls.kphp_builder.kphp_build_tmp_dir)
         else:
-            cls.web_server = KphpServer(
-                kphp_server_bin=cls.web_server_bin,
-                working_dir=cls.web_server_working_dir)
+            request.cls.web_server = KphpServer(
+                kphp_server_bin=request.cls.web_server_bin,
+                working_dir=request.cls.web_server_working_dir)
 
-        cls.extra_class_setup()
+        request.cls.extra_class_setup()
         print("\nStarting web-server")
-        cls.web_server.start()
+        request.cls.web_server.start()
 
     @classmethod
     def custom_teardown(cls):
@@ -329,10 +326,10 @@ class KphpCompilerAutoTestCase(BaseTestCase):
         """
         pass
 
-    @classmethod
-    def custom_setup(cls):
-        cls.kphp_build_working_dir = make_test_tmp_dir(cls.kphp_build_working_dir)
-        cls.extra_class_setup()
+    @pytest.fixture(scope="class", autouse=True)
+    def _custom_setup(self, request: pytest.FixtureRequest, base_setup):
+        request.cls.kphp_build_working_dir = make_test_tmp_dir(request.cls.kphp_build_working_dir)
+        request.cls.extra_class_setup()
 
     @classmethod
     def custom_teardown(cls):

--- a/tests/python/lib/testcase.py
+++ b/tests/python/lib/testcase.py
@@ -40,7 +40,6 @@ def make_test_tmp_dir(tmp_dir_root):
 
 class BaseTestCase(TestCase):
     kphp_build_working_dir = ""
-    web_server_working_dir = ""
     artifacts_dir = ""
     test_dir = ""
 
@@ -49,11 +48,9 @@ class BaseTestCase(TestCase):
         self,
         request: pytest.FixtureRequest,
         kphp_build_working_dir: pathlib.Path,
-        kphp_server_working_dir: pathlib.Path,
         artifacts_dir: pathlib.Path,
     ):
         request.cls.kphp_build_working_dir = str(kphp_build_working_dir)
-        request.cls.web_server_working_dir = str(kphp_server_working_dir)
         request.cls.artifacts_dir = str(artifacts_dir)
         request.cls.test_dir = str(pathlib.Path(request.module.__file__).parent)
 
@@ -146,6 +143,7 @@ class WebServerAutoTestCase(BaseTestCase):
     :type web_server: WebServer
     """
     web_server = None
+    web_server_working_dir = ""
     web_server_bin = ""
     kphp_builder = None
     sanitizer_pattern = None
@@ -154,6 +152,10 @@ class WebServerAutoTestCase(BaseTestCase):
     @pytest.fixture(scope="class", autouse=True)
     def web_server_std_functions_updater(self, request, std_function_invocations):
         request.cls.std_function_invocations = std_function_invocations
+
+    @pytest.fixture(scope="class", autouse=True)
+    def set_web_server_working_dir(self, request, kphp_server_working_dir: pathlib.Path):
+        request.cls.web_server_working_dir = str(kphp_server_working_dir)
 
     @classmethod
     def custom_setup(cls):
@@ -303,6 +305,10 @@ class KphpCompilerAutoTestCase(BaseTestCase):
     def kphp_compiler_std_functions(self, request, std_function_invocations):
         request.cls.std_function_invocations = std_function_invocations
 
+    @pytest.fixture(autouse=True)
+    def set_artifacts_dir(self, request: pytest.FixtureRequest, artifacts_dir: pathlib.Path):
+        self.artifacts_dir = str(artifacts_dir / request.node.name)
+
     def __init__(self, method_name):
         super().__init__(method_name)
         self.php_version = "php7.4"
@@ -364,7 +370,7 @@ class KphpCompilerAutoTestCase(BaseTestCase):
     def make_kphp_once_runner(self, php_script_path):
         once_runner = KphpRunOnce(
             php_script_path=os.path.join(self.test_dir, php_script_path),
-            artifacts_dir=self.web_server_working_dir,
+            artifacts_dir=self.artifacts_dir,
             working_dir=self.kphp_build_working_dir,
             php_bin=search_php_bin(php_version=self.php_version),
             std_function_invocations=self.std_function_invocations,

--- a/tests/python/tests/libs/test_libs.py
+++ b/tests/python/tests/libs/test_libs.py
@@ -22,14 +22,14 @@ class TestLibs(KphpCompilerAutoTestCase):
             lib_build_env.update(self.kphp_env_for_k2_lib())
         
         for lib_name in ("example1", "example2"):
-            lib_out_dir = os.path.join(self.web_server_working_dir, "lib_examples/{}/lib".format(lib_name))
+            lib_out_dir = os.path.join(self.artifacts_dir, "lib_examples/{}/lib".format(lib_name))
             lib_build_env.update({"KPHP_OUT_LIB_DIR": lib_out_dir})
             lib_builder = self.make_kphp_once_runner("php/lib_examples/{}".format(lib_name))
             self.assertTrue(lib_builder.compile_with_kphp(lib_build_env),
                             "Got {} KPHP build error".format(lib_name))
 
         kphp_runner = self.build_and_compare_with_php("php/lib_user.php", kphp_env={
-            "KPHP_INCLUDE_DIR": self.web_server_working_dir,
+            "KPHP_INCLUDE_DIR": self.artifacts_dir,
             "KPHP_VERBOSITY": "3",
             "KPHP_DYNAMIC_INCREMENTAL_LINKAGE": "0" if self.should_use_k2() else "1",
         })
@@ -38,4 +38,4 @@ class TestLibs(KphpCompilerAutoTestCase):
         self.assertRegex(build_log, re.compile(b"Use static lib \\[.*lib_examples/example1/lib/libexample1\\.a]"))
         self.assertRegex(build_log, re.compile(b"Use static lib \\[.*lib_examples/example2/lib/libexample2\\.a]"))
 
-        shutil.rmtree(os.path.join(self.web_server_working_dir, "lib_examples"), ignore_errors=True)
+        shutil.rmtree(os.path.join(self.artifacts_dir, "lib_examples"), ignore_errors=True)


### PR DESCRIPTION
This PR refactors artifacts directories.

For *WebServer* tests `tmp_{test_file_name}` element was added.

For *KphpCompiler* tests `{test_name}` element was added.

`web_server_working_dir` field was moved into `WebServerAutoTestCase` class.