### PR TITLE
add --no-as-needed

### DIFF
--- a/compiler/make/objs-to-bin-target.h
+++ b/compiler/make/objs-to-bin-target.h
@@ -20,8 +20,8 @@ public:
     std::string_view open_dep{" -Wl,-all_load "};
     std::string_view close_dep;
 #else
-    std::string_view open_dep{" -Wl,--whole-archive -Wl,--start-group "};
-    std::string_view close_dep{" -Wl,--end-group -Wl,--no-whole-archive "};
+    std::string_view open_dep{" -Wl,--whole-archive -Wl,--start-group -Wl,--no-as-needed "};
+    std::string_view close_dep{" -Wl,--end-group -Wl,--no-whole-archive -Wl,--as-needed "};
 #endif
     std::stringstream ss;
     ss << settings->cxx.get() << " " << settings->cxx_toolchain_option.get()

--- a/compiler/make/objs-to-bin-target.h
+++ b/compiler/make/objs-to-bin-target.h
@@ -21,7 +21,7 @@ public:
     std::string_view close_dep;
 #else
     std::string_view open_dep{" -Wl,--whole-archive -Wl,--start-group -Wl,--no-as-needed "};
-    std::string_view close_dep{" -Wl,--end-group -Wl,--no-whole-archive -Wl,--as-needed "};
+    std::string_view close_dep{" -Wl,--as-needed -Wl,--end-group -Wl,--no-whole-archive "};
 #endif
     std::stringstream ss;
     ss << settings->cxx.get() << " " << settings->cxx_toolchain_option.get()


### PR DESCRIPTION
This PR adds `--no-as-needed` linker flag for obj2bin target as default behavior is `--as-needed` since bullseye