### PR TITLE
[k2] optimization of memory usage in coroutines

### DIFF
--- a/runtime-light/coroutine/await-set.h
+++ b/runtime-light/coroutine/await-set.h
@@ -56,7 +56,7 @@ public:
   }
 
   auto try_next() noexcept {
-    using result_type = std::optional<decltype(std::declval<detail::await_set::await_set_task<return_type>>().result())>;
+    using result_type = std::optional<decltype(std::declval<typename detail::await_set::await_set_task<return_type>::promise_type>().result())>;
     if (m_await_broker == nullptr) [[unlikely]] {
       return result_type{std::nullopt};
     }
@@ -64,6 +64,7 @@ public:
   }
 
   bool empty() const noexcept {
+    kphp::log::assertion(m_await_broker != nullptr);
     return size() == 0;
   }
 

--- a/runtime-light/coroutine/await-set.h
+++ b/runtime-light/coroutine/await-set.h
@@ -64,7 +64,6 @@ public:
   }
 
   bool empty() const noexcept {
-    kphp::log::assertion(m_await_broker != nullptr);
     return size() == 0;
   }
 

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -81,7 +81,7 @@ public:
   void push_ready_task(await_set_ready_task_element<return_type>& ready_task) noexcept {
     ready_task.m_next = std::exchange(m_ready_tasks, std::addressof(ready_task));
     if (!m_awaiters.empty()) {
-      auto& coroutine{m_awaiters.front()};
+      auto coroutine{m_awaiters.front()};
       /*
        * We can remove pop_front() here, because list node will be destroyed after resume and in its
        * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
@@ -131,7 +131,7 @@ public:
     m_ready_tasks = nullptr;
     detach_all();
     while (!m_tasks_storage.empty()) {
-      auto& coroutine{m_tasks_storage.front()};
+      auto coroutine{m_tasks_storage.front()};
       /*
        * We can remove pop_front() here, because list node will be destroyed after destruction of coroutine frame and in its
        * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
@@ -149,7 +149,7 @@ public:
     awaiters_list awaiters;
     awaiters.splice(awaiters.begin(), m_awaiters);
     while (!awaiters.empty()) {
-      auto& coroutine{awaiters.front()};
+      auto coroutine{awaiters.front()};
       /*
        * We can remove pop_front() here, because list node will be destroyed after resume and in its
        * destructor will call unlink() [1]. But we left pop_front() for better readability and safety

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -112,7 +112,7 @@ public:
     auto* ready_task{std::exchange(m_ready_tasks, m_ready_tasks->m_next)};
     auto task_iterator{ready_task->m_storage_location};
 
-    auto typed_handle = std::coroutine_handle<typename await_set_task<return_type>::promise_type>::from_address(task_iterator->address());
+    auto typed_handle{std::coroutine_handle<typename await_set_task<return_type>::promise_type>::from_address(task_iterator->address())};
     auto result{typed_handle.promise().result()};
 
     /*
@@ -122,7 +122,7 @@ public:
      */
     m_tasks_storage.erase(task_iterator);
     --m_tasks_count;
-    task_iterator->destroy();
+    typed_handle->destroy();
 
     return result_t{std::move(result)};
   }

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -26,25 +26,19 @@ class await_set;
 
 namespace kphp::coro::detail::await_set {
 
-using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
-using awaiters_list = vk::intrusive::list<awaiter_node>;
-
-using task_node = vk::intrusive::list_node<std::coroutine_handle<>>;
-using tasks_list = vk::intrusive::list<task_node>;
-
 template<typename return_type>
 class await_set_task;
 
 template<typename return_type>
 struct await_set_ready_task_element {
   await_set_ready_task_element* m_next{};
-  tasks_list::iterator m_storage_location;
+  vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>::iterator m_storage_location;
 };
 
 template<typename return_type>
 class await_broker {
-  tasks_list m_tasks_storage;
-  awaiters_list m_awaiters;
+  vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>> m_tasks_storage;
+  vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>> m_awaiters;
   await_set_ready_task_element<return_type>* m_ready_tasks{};
   size_t m_tasks_count{0};
 
@@ -92,7 +86,7 @@ public:
     }
   }
 
-  bool suspend_awaiter(awaiter_node& awaiter) noexcept {
+  bool suspend_awaiter(vk::intrusive::list_node<std::coroutine_handle<>>& awaiter) noexcept {
     if (m_ready_tasks != nullptr) {
       // There are completed tasks
       return false;
@@ -146,7 +140,7 @@ public:
 
   void detach_all() noexcept {
     // Extract the value from m_awaiters so as not to resume those who subscribe during the detach_all.
-    awaiters_list awaiters;
+    vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>> awaiters;
     awaiters.splice(awaiters.begin(), m_awaiters);
     while (!awaiters.empty()) {
       auto coroutine{awaiters.front()};
@@ -220,7 +214,8 @@ public:
     kphp::log::error("internal unhandled exception");
   }
 
-  auto start(detail::await_set::await_broker<return_type>& await_broker, tasks_list::iterator storage_location, kphp::coro::async_stack_root& async_stack_root,
+  auto start(detail::await_set::await_broker<return_type>& await_broker,
+             vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>::iterator storage_location, kphp::coro::async_stack_root& async_stack_root,
              void* return_address) noexcept {
     m_await_broker = await_broker;
     m_ready_task_element.m_storage_location = storage_location;
@@ -253,7 +248,7 @@ private:
   promise_type& m_promise;
 
   struct await_set_task_promise_common : public await_set_task_promise_base<return_type, promise_type> {
-    task_node m_coroutine_node;
+    vk::intrusive::list_node<std::coroutine_handle<>> m_coroutine_node;
 
     auto get_return_object() noexcept {
       auto& self{static_cast<promise_type&>(*this)};
@@ -303,7 +298,7 @@ public:
       : m_promise(promise) {}
 
   await_set_task(const await_set_task&) = delete;
-  await_set_task(await_set_task&& other) noexcept = default;
+  await_set_task(await_set_task&& other) noexcept = delete;
 
   await_set_task& operator=(const await_set_task&) = delete;
   await_set_task& operator=(await_set_task&&) = delete;
@@ -320,7 +315,7 @@ private:
   await_broker<return_type>& m_await_broker;
 
   class awaiter {
-    awaiter_node m_awaiting_coroutine_node;
+    vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
     await_broker<return_type>& m_await_broker;
     kphp::coro::async_stack_frame* caller_frame{};
 

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -122,7 +122,7 @@ public:
      */
     m_tasks_storage.erase(task_iterator);
     --m_tasks_count;
-    typed_handle->destroy();
+    typed_handle.destroy();
 
     return result_t{std::move(result)};
   }

--- a/runtime-light/coroutine/detail/await-set.h
+++ b/runtime-light/coroutine/detail/await-set.h
@@ -10,8 +10,8 @@
 #include <memory>
 #include <optional>
 
+#include "common/containers/intrusive-list.h"
 #include "runtime-common/core/allocator/script-malloc-interface.h"
-#include "runtime-common/core/std/containers.h"
 #include "runtime-light/coroutine/async-stack.h"
 #include "runtime-light/coroutine/type-traits.h"
 #include "runtime-light/coroutine/void-value.h"
@@ -26,11 +26,11 @@ class await_set;
 
 namespace kphp::coro::detail::await_set {
 
-struct await_set_awaiter {
-  await_set_awaiter* m_next{};
-  await_set_awaiter* m_prev{};
-  std::coroutine_handle<> m_continuation;
-};
+using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
+using awaiters_list = vk::intrusive::list<awaiter_node>;
+
+using task_node = vk::intrusive::list_node<std::coroutine_handle<>>;
+using tasks_list = vk::intrusive::list<task_node>;
 
 template<typename return_type>
 class await_set_task;
@@ -38,14 +38,15 @@ class await_set_task;
 template<typename return_type>
 struct await_set_ready_task_element {
   await_set_ready_task_element* m_next{};
-  kphp::stl::list<await_set_task<return_type>, kphp::memory::script_allocator>::iterator m_storage_location{};
+  tasks_list::iterator m_storage_location;
 };
 
 template<typename return_type>
 class await_broker {
-  kphp::stl::list<detail::await_set::await_set_task<return_type>, kphp::memory::script_allocator> m_tasks_storage{};
-  await_set_awaiter* m_awaiters{};
+  tasks_list m_tasks_storage;
+  awaiters_list m_awaiters;
   await_set_ready_task_element<return_type>* m_ready_tasks{};
+  size_t m_tasks_count{0};
 
 public:
   await_broker() noexcept = default;
@@ -71,86 +72,96 @@ public:
   }
 
   void start_task(await_set_task<return_type>&& task, kphp::coro::async_stack_root& coroutine_stack_root, void* return_address) noexcept {
-    auto task_iterator{m_tasks_storage.insert(m_tasks_storage.begin(), std::move(task))};
-    task_iterator->start(*this, task_iterator, coroutine_stack_root, return_address);
+    auto& promise{task.m_promise};
+    m_tasks_storage.push_front(promise.m_coroutine_node);
+    ++m_tasks_count;
+    promise.start(*this, m_tasks_storage.begin(), coroutine_stack_root, return_address);
   }
 
   void push_ready_task(await_set_ready_task_element<return_type>& ready_task) noexcept {
     ready_task.m_next = std::exchange(m_ready_tasks, std::addressof(ready_task));
-
-    if (m_awaiters != nullptr) {
-      // Resume if someone is waiting
-      auto* awaiter{m_awaiters};
-      m_awaiters = awaiter->m_next;
-      if (m_awaiters != nullptr) {
-        m_awaiters->m_prev = nullptr;
-      }
-      awaiter->m_continuation.resume();
+    if (!m_awaiters.empty()) {
+      auto& coroutine{m_awaiters.front()};
+      /*
+       * We can remove pop_front() here, because list node will be destroyed after resume and in its
+       * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
+       * (in the future invariant [1] may not work).
+       */
+      m_awaiters.pop_front();
+      coroutine.resume();
     }
   }
 
-  void cancel_awaiter(await_set_awaiter& awaiter) noexcept {
-    auto* awaiter_ptr{std::addressof(awaiter)};
-    if (m_awaiters == awaiter_ptr) {
-      m_awaiters = awaiter_ptr->m_next;
-    } else if (awaiter_ptr->m_next == nullptr) {
-      awaiter_ptr->m_prev->m_next = nullptr;
-    } else if (m_awaiters != nullptr) {
-      awaiter_ptr->m_prev->m_next = awaiter_ptr->m_next;
-      awaiter_ptr->m_next->m_prev = awaiter_ptr->m_prev;
-    }
-  }
-
-  bool suspend_awaiter(await_set_awaiter& awaiter) noexcept {
+  bool suspend_awaiter(awaiter_node& awaiter) noexcept {
     if (m_ready_tasks != nullptr) {
       // There are completed tasks
       return false;
     }
 
-    awaiter.m_prev = nullptr;
-    awaiter.m_next = m_awaiters;
-    if (m_awaiters != nullptr) {
-      m_awaiters->m_prev = std::addressof(awaiter);
-    }
-    m_awaiters = std::addressof(awaiter);
+    m_awaiters.push_front(awaiter);
+
     return true;
   }
 
   auto try_get_result() noexcept {
-    using result_t = std::optional<decltype(std::declval<await_set_task<return_type>>().result())>;
+    using result_t = std::optional<decltype(std::declval<typename await_set_task<return_type>::promise_type>().result())>;
     if (m_ready_tasks == nullptr) {
       return result_t{std::nullopt};
     }
 
     auto* ready_task{std::exchange(m_ready_tasks, m_ready_tasks->m_next)};
     auto task_iterator{ready_task->m_storage_location};
-    auto result{task_iterator->result()};
+
+    auto typed_handle = std::coroutine_handle<typename await_set_task<return_type>::promise_type>::from_address(task_iterator->address());
+    auto result{typed_handle.promise().result()};
+
+    /*
+     * We can remove erase() here, because list node will be destroyed after destruction of coroutine frame and in its
+     * destructor will call unlink() [1]. But we left erase() for better readability and safety
+     * (in the future invariant [1] may not work).
+     */
     m_tasks_storage.erase(task_iterator);
+    --m_tasks_count;
+    task_iterator->destroy();
+
     return result_t{std::move(result)};
   }
 
   void abort_all() noexcept {
     m_ready_tasks = nullptr;
     detach_all();
-    m_tasks_storage.clear();
+    while (!m_tasks_storage.empty()) {
+      auto& coroutine{m_tasks_storage.front()};
+      /*
+       * We can remove pop_front() here, because list node will be destroyed after destruction of coroutine frame and in its
+       * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
+       * (in the future invariant [1] may not work).
+       */
+      m_tasks_storage.pop_front();
+      coroutine.destroy();
+    }
+
+    m_tasks_count = 0;
   }
 
   void detach_all() noexcept {
-    // Extract the value from m_waiters so as not to resume those who subscribe during the detach_all.
-    await_set_awaiter* awaiters_to_resume{std::exchange(m_awaiters, nullptr)};
-    while (awaiters_to_resume != nullptr) {
-      auto* waiter{awaiters_to_resume};
-      awaiters_to_resume = awaiters_to_resume->m_next;
-      if (awaiters_to_resume != nullptr) {
-        awaiters_to_resume->m_prev = nullptr;
-      }
-
-      waiter->m_continuation.resume();
+    // Extract the value from m_awaiters so as not to resume those who subscribe during the detach_all.
+    awaiters_list awaiters;
+    awaiters.splice(awaiters.begin(), m_awaiters);
+    while (!awaiters.empty()) {
+      auto& coroutine{awaiters.front()};
+      /*
+       * We can remove pop_front() here, because list node will be destroyed after resume and in its
+       * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
+       * (in the future invariant [1] may not work).
+       */
+      awaiters.pop_front();
+      coroutine.resume();
     }
   }
 
   size_t size() noexcept {
-    return m_tasks_storage.size();
+    return m_tasks_count;
   }
 
   ~await_broker() {
@@ -209,9 +220,8 @@ public:
     kphp::log::error("internal unhandled exception");
   }
 
-  auto start(detail::await_set::await_broker<return_type>& await_broker,
-             kphp::stl::list<await_set_task<return_type>, kphp::memory::script_allocator>::iterator storage_location,
-             kphp::coro::async_stack_root& async_stack_root, void* return_address) noexcept {
+  auto start(detail::await_set::await_broker<return_type>& await_broker, tasks_list::iterator storage_location, kphp::coro::async_stack_root& async_stack_root,
+             void* return_address) noexcept {
     m_await_broker = await_broker;
     m_ready_task_element.m_storage_location = storage_location;
 
@@ -240,11 +250,15 @@ public:
   using promise_type = std::conditional_t<std::is_void_v<return_type>, await_set_task_promise_void, await_set_task_promise_non_void<return_type>>;
 
 private:
-  std::coroutine_handle<promise_type> m_coroutine;
+  promise_type& m_promise;
 
   struct await_set_task_promise_common : public await_set_task_promise_base<return_type, promise_type> {
+    task_node m_coroutine_node;
+
     auto get_return_object() noexcept {
-      return await_set_task{std::coroutine_handle<promise_type>::from_promise(*static_cast<promise_type*>(this))};
+      auto& self{static_cast<promise_type&>(*this)};
+      m_coroutine_node.value() = std::coroutine_handle<promise_type>::from_promise(self);
+      return await_set_task{self};
     }
 
     static await_set_task get_return_object_on_allocation_failure() {
@@ -281,35 +295,20 @@ private:
     constexpr void return_void() const noexcept {}
   };
 
-  auto start(detail::await_set::await_broker<return_type>& await_broker,
-             kphp::stl::list<await_set_task<return_type>, kphp::memory::script_allocator>::iterator storage_location,
-             kphp::coro::async_stack_root& async_stack_root, void* return_address) noexcept {
-    m_coroutine.promise().start(await_broker, storage_location, async_stack_root, return_address);
-  }
-
 public:
   template<typename T>
   friend class detail::await_set::await_broker;
 
-  explicit await_set_task(std::coroutine_handle<promise_type> coroutine) noexcept
-      : m_coroutine(coroutine) {}
-
-  await_set_task(await_set_task&& other) noexcept
-      : m_coroutine(std::exchange(other.m_coroutine, {})) {}
+  explicit await_set_task(promise_type& promise) noexcept
+      : m_promise(promise) {}
 
   await_set_task(const await_set_task&) = delete;
+  await_set_task(await_set_task&& other) noexcept = default;
+
   await_set_task& operator=(const await_set_task&) = delete;
   await_set_task& operator=(await_set_task&&) = delete;
 
-  auto result() noexcept {
-    return m_coroutine.promise().result();
-  }
-
-  ~await_set_task() {
-    if (m_coroutine != nullptr) {
-      m_coroutine.destroy();
-    }
-  }
+  ~await_set_task() = default;
 };
 
 template<typename return_type>
@@ -321,9 +320,8 @@ private:
   await_broker<return_type>& m_await_broker;
 
   class awaiter {
-    bool m_suspended{};
+    awaiter_node m_awaiting_coroutine_node;
     await_broker<return_type>& m_await_broker;
-    await_set_awaiter m_awaiter{};
     kphp::coro::async_stack_frame* caller_frame{};
 
   public:
@@ -343,10 +341,9 @@ private:
     bool await_suspend(std::coroutine_handle<caller_promise_type> awaiting_coroutine) noexcept {
       // save caller async stack frame
       caller_frame = std::addressof(awaiting_coroutine.promise().get_async_stack_frame());
+      m_awaiting_coroutine_node.value() = awaiting_coroutine;
 
-      m_awaiter.m_continuation = awaiting_coroutine;
-      m_suspended = m_await_broker.suspend_awaiter(m_awaiter);
-      return m_suspended;
+      return m_await_broker.suspend_awaiter(m_awaiting_coroutine_node);
     }
 
     std::optional<result_type> await_resume() noexcept {
@@ -356,15 +353,10 @@ private:
       kphp::log::assertion(async_stack_root != nullptr);
       async_stack_root->top_async_stack_frame = caller_frame;
 
-      m_suspended = false;
       return m_await_broker.try_get_result();
     }
 
-    ~awaiter() {
-      if (m_suspended) {
-        m_await_broker.cancel_awaiter(m_awaiter);
-      }
-    }
+    ~awaiter() = default;
   };
 
 public:

--- a/runtime-light/coroutine/detail/poll-info.h
+++ b/runtime-light/coroutine/detail/poll-info.h
@@ -8,6 +8,7 @@
 #include <utility>
 #include <variant>
 
+#include "common/containers/intrusive-list.h"
 #include "runtime-common/core/allocator/script-allocator.h"
 #include "runtime-common/core/std/containers.h"
 #include "runtime-light/coroutine/poll.h"
@@ -18,8 +19,7 @@ namespace kphp::coro::detail {
 struct poll_info {
   using timed_events = kphp::stl::multimap<k2::TimePoint, detail::poll_info&, kphp::memory::script_allocator>;
   using parked_polls = kphp::stl::multimap<k2::descriptor, detail::poll_info&, kphp::memory::script_allocator>;
-  // TODO: Consider using an intrusive list for scheduled_coroutines.
-  using scheduled_coroutines = kphp::stl::list<std::coroutine_handle<>, kphp::memory::script_allocator>;
+  using scheduled_coroutines = vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>;
 
   // Each coroutine in the scheduler can be in one of the following states, represented by the `schedule_position` variant:
   // 1. `std::monostate`: a coroutine has not been scheduled yet or has already been resumed by the scheduler;
@@ -30,10 +30,11 @@ struct poll_info {
   using schedule_position = std::variant<std::monostate, timed_events::iterator, parked_polls::iterator,
                                          std::pair<timed_events::iterator, parked_polls::iterator>, scheduled_coroutines::iterator>;
 
+  vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
+
   schedule_position m_schedule_position{std::monostate{}};
 
   k2::descriptor m_descriptor{k2::INVALID_PLATFORM_DESCRIPTOR};
-  std::coroutine_handle<> m_awaiting_coroutine;
 
   kphp::coro::poll_status m_poll_status{kphp::coro::poll_status::error};
   kphp::coro::poll_op m_poll_op;
@@ -61,7 +62,7 @@ struct poll_info {
       }
 
       auto await_suspend(std::coroutine_handle<> awaiting_coroutine) noexcept -> void {
-        m_poll_info.m_awaiting_coroutine = awaiting_coroutine;
+        m_poll_info.m_awaiting_coroutine_node.value() = awaiting_coroutine;
       }
 
       auto await_resume() const noexcept -> kphp::coro::poll_status {

--- a/runtime-light/coroutine/detail/task-self-deleting.h
+++ b/runtime-light/coroutine/detail/task-self-deleting.h
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <memory>
 
+#include "common/containers/intrusive-list.h"
 #include "runtime-common/core/allocator/script-malloc-interface.h"
 #include "runtime-light/coroutine/async-stack.h"
 #include "runtime-light/coroutine/concepts.h"
@@ -21,11 +22,13 @@ namespace task_self_deleting {
 class task_self_deleting;
 
 struct promise_self_deleting : kphp::coro::async_stack_element {
+  vk::intrusive::list_node<std::coroutine_handle<>> m_coroutine_node;
+
   promise_self_deleting() noexcept = default;
   ~promise_self_deleting() = default;
 
   promise_self_deleting(const promise_self_deleting&) = delete;
-  promise_self_deleting(promise_self_deleting&&) noexcept = default;
+  promise_self_deleting(promise_self_deleting&&) noexcept = delete;
 
   promise_self_deleting& operator=(const promise_self_deleting&) = delete;
   promise_self_deleting& operator=(promise_self_deleting&&) = delete;
@@ -87,9 +90,14 @@ public:
   auto get_handle() noexcept -> std::coroutine_handle<promise_self_deleting> {
     return std::coroutine_handle<promise_type>::from_promise(m_promise);
   }
+
+  auto get_coroutine_node() noexcept -> vk::intrusive::list_node<std::coroutine_handle<>>& {
+    return m_promise.m_coroutine_node;
+  }
 };
 
 inline auto promise_self_deleting::get_return_object() noexcept -> task_self_deleting {
+  m_coroutine_node.value() = std::coroutine_handle<promise_self_deleting>::from_promise(*this);
   return task_self_deleting{*this};
 }
 

--- a/runtime-light/coroutine/event.h
+++ b/runtime-light/coroutine/event.h
@@ -129,7 +129,7 @@ inline auto event::event_controller::set() noexcept -> void {
   awaiters_list awaiters;
   awaiters.splice(awaiters.begin(), std::get<awaiters_list>(m_state));
   while (!awaiters.empty()) {
-    auto& coroutine{awaiters.front()};
+    auto coroutine{awaiters.front()};
     /*
      * We can remove pop_front() here, because list node will be destroyed after resume and in its
      * destructor will call unlink() [1]. But we left pop_front() for better readability and safety

--- a/runtime-light/coroutine/event.h
+++ b/runtime-light/coroutine/event.h
@@ -8,8 +8,11 @@
 #include <coroutine>
 #include <memory>
 #include <utility>
+#include <variant>
 
+#include "common/containers/intrusive-list.h"
 #include "common/mixin/not_copyable.h"
+#include "common/wrappers/overloaded.h"
 #include "runtime-common/core/allocator/script-allocator-managed.h"
 #include "runtime-light/coroutine/async-stack.h"
 #include "runtime-light/coroutine/coroutine-state.h"
@@ -18,28 +21,17 @@
 namespace kphp::coro {
 
 class event {
-  struct event_controller : kphp::memory::script_allocator_managed, vk::not_copyable {
-    // 1) nullptr => not set
-    // 2) awaiter* => linked list of awaiters waiting for the event to trigger
-    // 3) this => The event is triggered and all awaiters are resumed
-    void* m_state{};
+  using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
+  using awaiters_list = vk::intrusive::list<awaiter_node>;
 
-    auto set() noexcept -> void;
-    auto unset() noexcept -> void;
-    auto is_set() const noexcept -> bool;
-  };
-
-  std::unique_ptr<event_controller> m_controller;
+  struct event_controller;
 
   struct awaiter {
+    awaiter_node m_awaiting_coroutine_node;
     bool m_suspended{};
     event_controller& m_controller;
-    std::coroutine_handle<> m_awaiting_coroutine;
     kphp::coro::async_stack_root& m_async_stack_root;
     kphp::coro::async_stack_frame* m_caller_async_stack_frame{};
-
-    awaiter* m_next{};
-    awaiter* m_prev{};
 
     explicit awaiter(event_controller& event_controller) noexcept
         : m_controller(event_controller),
@@ -49,21 +41,26 @@ class event {
     awaiter(awaiter&&) = delete;
     auto operator=(const awaiter&) -> awaiter& = delete;
     auto operator=(awaiter&&) -> awaiter& = delete;
-
-    ~awaiter() {
-      if (m_suspended) {
-        cancel_awaiter();
-      }
-    }
+    ~awaiter() = default;
 
     auto await_ready() const noexcept -> bool;
     template<std::derived_from<kphp::coro::async_stack_element> caller_promise_type>
     auto await_suspend(std::coroutine_handle<caller_promise_type> awaiting_coroutine) noexcept -> void;
     auto await_resume() noexcept -> void;
-
-  private:
-    auto cancel_awaiter() noexcept -> void;
   };
+
+  struct event_controller : kphp::memory::script_allocator_managed, vk::not_copyable {
+    // 1) std::monostate => not set and no coroutines are waiting
+    // 2) non empty list => linked list of coroutines waiting for the event to trigger
+    // 3) empty list => the event is triggered and all coroutines are resumed
+    std::variant<std::monostate, awaiters_list> m_state;
+
+    auto set() noexcept -> void;
+    auto unset() noexcept -> void;
+    auto is_set() const noexcept -> bool;
+  };
+
+  std::unique_ptr<event_controller> m_controller;
 
 public:
   event() noexcept
@@ -93,20 +90,6 @@ public:
   auto operator co_await() noexcept;
 };
 
-inline auto event::awaiter::cancel_awaiter() noexcept -> void {
-  if (m_next != nullptr) {
-    m_next->m_prev = m_prev;
-  }
-  if (m_prev != nullptr) {
-    m_prev->m_next = m_next;
-  } else {
-    // we are the head of the awaiters list, so we need to update the head
-    m_controller.m_state = m_next;
-  }
-  m_next = nullptr;
-  m_prev = nullptr;
-}
-
 inline auto event::awaiter::await_ready() const noexcept -> bool {
   return m_controller.is_set();
 }
@@ -117,17 +100,16 @@ auto event::awaiter::await_suspend(std::coroutine_handle<caller_promise_type> aw
   m_caller_async_stack_frame = m_async_stack_root.top_async_stack_frame;
 
   m_suspended = true;
-  m_awaiting_coroutine = awaiting_coroutine;
+  m_awaiting_coroutine_node.value() = awaiting_coroutine;
 
-  m_next = static_cast<event::awaiter*>(m_controller.m_state);
+  // possibly this assertion is unnecessary, but it is left, because it was there earlier
+  kphp::log::assertion(!m_controller.is_set());
 
-  // ensure that the event isn't triggered
-  kphp::log::assertion(reinterpret_cast<event_controller*>(m_next) != std::addressof(m_controller));
-
-  if (m_next != nullptr) {
-    m_next->m_prev = this;
+  if (std::holds_alternative<std::monostate>(m_controller.m_state)) {
+    m_controller.m_state = awaiters_list{};
   }
-  m_controller.m_state = this;
+
+  std::get<awaiters_list>(m_controller.m_state).push_front(m_awaiting_coroutine_node);
 }
 
 inline auto event::awaiter::await_resume() noexcept -> void {
@@ -139,26 +121,33 @@ inline auto event::awaiter::await_resume() noexcept -> void {
 }
 
 inline auto event::event_controller::set() noexcept -> void {
-  void* prev_value{std::exchange(m_state, this)};
-  if (prev_value == this || prev_value == nullptr) [[unlikely]] {
+  if (std::holds_alternative<std::monostate>(m_state)) {
+    m_state = awaiters_list{};
     return;
   }
-  auto* awaiter{static_cast<event::awaiter*>(prev_value)};
-  while (awaiter != nullptr) {
-    auto* next{awaiter->m_next};
-    awaiter->m_awaiting_coroutine.resume();
-    awaiter = next;
+
+  awaiters_list awaiters;
+  awaiters.splice(awaiters.begin(), std::get<awaiters_list>(m_state));
+  while (!awaiters.empty()) {
+    auto& coroutine{awaiters.front()};
+    /*
+     * We can remove pop_front() here, because list node will be destroyed after resume and in its
+     * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
+     * (in the future invariant [1] may not work).
+     */
+    awaiters.pop_front();
+    coroutine.resume();
   }
 }
 
 inline auto event::event_controller::unset() noexcept -> void {
-  if (m_state == this) {
-    m_state = nullptr;
+  if (is_set()) {
+    m_state = std::monostate{};
   }
 }
 
 inline auto event::event_controller::is_set() const noexcept -> bool {
-  return m_state == this;
+  return std::visit(overloaded([](std::monostate) noexcept { return false; }, [](const awaiters_list& list) noexcept { return list.empty(); }), m_state);
 }
 
 inline auto event::set() noexcept -> void {

--- a/runtime-light/coroutine/event.h
+++ b/runtime-light/coroutine/event.h
@@ -21,13 +21,19 @@
 namespace kphp::coro {
 
 class event {
-  using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
-  using awaiters_list = vk::intrusive::list<awaiter_node>;
+  struct event_controller : kphp::memory::script_allocator_managed, vk::not_copyable {
+    // 1) std::monostate => not set and no coroutines are waiting
+    // 2) non empty list => linked list of coroutines waiting for the event to trigger
+    // 3) empty list => the event is triggered and all coroutines are resumed
+    std::variant<std::monostate, vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>> m_state;
 
-  struct event_controller;
+    auto set() noexcept -> void;
+    auto unset() noexcept -> void;
+    auto is_set() const noexcept -> bool;
+  };
 
   struct awaiter {
-    awaiter_node m_awaiting_coroutine_node;
+    vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
     bool m_suspended{};
     event_controller& m_controller;
     kphp::coro::async_stack_root& m_async_stack_root;
@@ -47,17 +53,6 @@ class event {
     template<std::derived_from<kphp::coro::async_stack_element> caller_promise_type>
     auto await_suspend(std::coroutine_handle<caller_promise_type> awaiting_coroutine) noexcept -> void;
     auto await_resume() noexcept -> void;
-  };
-
-  struct event_controller : kphp::memory::script_allocator_managed, vk::not_copyable {
-    // 1) std::monostate => not set and no coroutines are waiting
-    // 2) non empty list => linked list of coroutines waiting for the event to trigger
-    // 3) empty list => the event is triggered and all coroutines are resumed
-    std::variant<std::monostate, awaiters_list> m_state;
-
-    auto set() noexcept -> void;
-    auto unset() noexcept -> void;
-    auto is_set() const noexcept -> bool;
   };
 
   std::unique_ptr<event_controller> m_controller;
@@ -106,10 +101,10 @@ auto event::awaiter::await_suspend(std::coroutine_handle<caller_promise_type> aw
   kphp::log::assertion(!m_controller.is_set());
 
   if (std::holds_alternative<std::monostate>(m_controller.m_state)) {
-    m_controller.m_state = awaiters_list{};
+    m_controller.m_state = vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>{};
   }
 
-  std::get<awaiters_list>(m_controller.m_state).push_front(m_awaiting_coroutine_node);
+  std::get<vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>>(m_controller.m_state).push_front(m_awaiting_coroutine_node);
 }
 
 inline auto event::awaiter::await_resume() noexcept -> void {
@@ -122,12 +117,12 @@ inline auto event::awaiter::await_resume() noexcept -> void {
 
 inline auto event::event_controller::set() noexcept -> void {
   if (std::holds_alternative<std::monostate>(m_state)) {
-    m_state = awaiters_list{};
+    m_state = vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>{};
     return;
   }
 
-  awaiters_list awaiters;
-  awaiters.splice(awaiters.begin(), std::get<awaiters_list>(m_state));
+  vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>> awaiters;
+  awaiters.splice(awaiters.begin(), std::get<vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>>(m_state));
   while (!awaiters.empty()) {
     auto coroutine{awaiters.front()};
     /*
@@ -147,7 +142,9 @@ inline auto event::event_controller::unset() noexcept -> void {
 }
 
 inline auto event::event_controller::is_set() const noexcept -> bool {
-  return std::visit(overloaded([](std::monostate) noexcept { return false; }, [](const awaiters_list& list) noexcept { return list.empty(); }), m_state);
+  return std::visit(overloaded([](std::monostate) noexcept { return false; },
+                               [](const vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>& list) noexcept { return list.empty(); }),
+                    m_state);
 }
 
 inline auto event::set() noexcept -> void {

--- a/runtime-light/coroutine/io-scheduler.h
+++ b/runtime-light/coroutine/io-scheduler.h
@@ -20,6 +20,7 @@
 #include <variant>
 
 #include "common/containers/final_action.h"
+#include "common/containers/intrusive-list.h"
 #include "common/wrappers/overloaded.h"
 #include "runtime-common/core/allocator/script-allocator.h"
 #include "runtime-common/core/std/containers.h"
@@ -202,7 +203,7 @@ inline auto io_scheduler::process_timeout() noexcept -> void {
             [this, &poll_info](kphp::coro::detail::poll_info::timed_events::iterator it) noexcept {
               m_timed_events.erase(it);
               poll_info.m_poll_status = kphp::coro::poll_status::event;
-              m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+              m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
               poll_info.m_schedule_position = std::prev(m_scheduled_coroutines.end());
             },
             [](kphp::coro::detail::poll_info::parked_polls::iterator) noexcept { kphp::log::assertion(false); },
@@ -211,7 +212,7 @@ inline auto io_scheduler::process_timeout() noexcept -> void {
               m_timed_events.erase(pair_it.first);
               m_parked_polls.erase(pair_it.second);
               poll_info.m_poll_status = kphp::coro::poll_status::timeout;
-              m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+              m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
               poll_info.m_schedule_position = std::prev(m_scheduled_coroutines.end());
             },
             [](kphp::coro::detail::poll_info::scheduled_coroutines::iterator) noexcept { kphp::log::assertion(false); },
@@ -247,7 +248,7 @@ inline auto io_scheduler::process_update(k2::descriptor descriptor) noexcept -> 
                 [&io_scheduler, &poll_info, poll_status](kphp::coro::detail::poll_info::parked_polls::iterator it) noexcept {
                   io_scheduler.m_parked_polls.erase(it);
                   poll_info.m_poll_status = poll_status;
-                  io_scheduler.m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+                  io_scheduler.m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
                   poll_info.m_schedule_position = std::prev(io_scheduler.m_scheduled_coroutines.end());
                 },
                 [&io_scheduler, &poll_info, poll_status](
@@ -255,7 +256,7 @@ inline auto io_scheduler::process_update(k2::descriptor descriptor) noexcept -> 
                   io_scheduler.remove_timer_token(pair_it.first);
                   io_scheduler.m_parked_polls.erase(pair_it.second);
                   poll_info.m_poll_status = poll_status;
-                  io_scheduler.m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+                  io_scheduler.m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
                   poll_info.m_schedule_position = std::prev(io_scheduler.m_scheduled_coroutines.end());
                 },
                 [](kphp::coro::detail::poll_info::scheduled_coroutines::iterator) noexcept { kphp::log::assertion(false); },
@@ -318,7 +319,7 @@ inline auto io_scheduler::process_accept(k2::descriptor descriptor) noexcept -> 
                    m_parked_polls.erase(it);
                    poll_info.m_descriptor = descriptor;
                    poll_info.m_poll_status = kphp::coro::poll_status::event;
-                   m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+                   m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
                    poll_info.m_schedule_position = std::prev(m_scheduled_coroutines.end());
                  },
                  [this, &poll_info, descriptor](
@@ -327,7 +328,7 @@ inline auto io_scheduler::process_accept(k2::descriptor descriptor) noexcept -> 
                    m_parked_polls.erase(pair_it.second);
                    poll_info.m_descriptor = descriptor;
                    poll_info.m_poll_status = kphp::coro::poll_status::event;
-                   m_scheduled_coroutines.emplace_back(poll_info.m_awaiting_coroutine);
+                   m_scheduled_coroutines.push_back(poll_info.m_awaiting_coroutine_node);
                    poll_info.m_schedule_position = std::prev(m_scheduled_coroutines.end());
                  },
                  [](kphp::coro::detail::poll_info::scheduled_coroutines::iterator) noexcept { kphp::log::assertion(false); },
@@ -412,10 +413,17 @@ inline auto io_scheduler::process_events() noexcept -> k2::PollStatus {
 
     kphp::coro::detail::poll_info::scheduled_coroutines scheduled_coroutines{};
     scheduled_coroutines.splice(scheduled_coroutines.begin(), m_scheduled_coroutines);
-    std::ranges::for_each(scheduled_coroutines, [&coroutine_stack_root = m_coroutine_instance_state.coroutine_stack_root](auto coroutine) noexcept {
+    while (!scheduled_coroutines.empty()) {
+      auto& coroutine{scheduled_coroutines.front()};
+      /*
+       * We can remove pop_front() here, because list node will be destroyed after resume and in its
+       * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
+       * (in the future invariant [1] may not work).
+       */
+      scheduled_coroutines.pop_front();
       kphp::log::assertion(static_cast<bool>(coroutine));
-      kphp::coro::resume(coroutine, coroutine_stack_root);
-    });
+      kphp::coro::resume(coroutine, m_coroutine_instance_state.coroutine_stack_root);
+    }
   }
 
   return empty() ? k2::PollStatus::PollFinishedOk : k2::PollStatus::PollReschedule;
@@ -424,11 +432,11 @@ inline auto io_scheduler::process_events() noexcept -> k2::PollStatus {
 template<kphp::coro::concepts::coroutine coroutine_type>
 auto io_scheduler::spawn(coroutine_type coroutine) noexcept -> bool {
   auto owned_task{kphp::coro::detail::make_task_self_deleting(std::move(coroutine))};
-  auto handle{owned_task.get_handle()};
-  if (!handle || handle.done()) [[unlikely]] {
+  auto& coroutine_node{owned_task.get_coroutine_node()};
+  if (!coroutine_node.value() || coroutine_node.value().done()) [[unlikely]] {
     return false;
   }
-  m_scheduled_coroutines.emplace_back(handle);
+  m_scheduled_coroutines.push_back(coroutine_node);
   return true;
 }
 
@@ -446,6 +454,7 @@ auto io_scheduler::start(coroutine_type coroutine) noexcept -> bool {
 inline auto io_scheduler::schedule() noexcept {
   class schedule_operation {
     friend class io_scheduler;
+    vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
     io_scheduler& m_scheduler;
     kphp::coro::async_stack_frame* m_async_stack_frame{};
     kphp::coro::detail::poll_info::schedule_position m_schedule_pos{std::monostate{}};
@@ -460,9 +469,14 @@ inline auto io_scheduler::schedule() noexcept {
     schedule_operation& operator=(schedule_operation&&) = delete;
 
     schedule_operation(schedule_operation&& other) noexcept
-        : m_scheduler(other.m_scheduler),
+        : m_awaiting_coroutine_node(std::move(other.m_awaiting_coroutine_node)),
+          m_scheduler(other.m_scheduler),
           m_async_stack_frame(std::exchange(other.m_async_stack_frame, nullptr)),
-          m_schedule_pos(std::exchange(other.m_schedule_pos, std::monostate{})) {}
+          m_schedule_pos(std::exchange(other.m_schedule_pos, std::monostate{})) {
+      if (std::holds_alternative<kphp::coro::detail::poll_info::scheduled_coroutines::iterator>(m_schedule_pos)) {
+        m_schedule_pos = m_scheduler.m_scheduled_coroutines.iterator_to(m_awaiting_coroutine_node);
+      }
+    }
 
     ~schedule_operation() {
       std::visit(overloaded{
@@ -482,7 +496,8 @@ inline auto io_scheduler::schedule() noexcept {
     }
 
     auto await_suspend(std::coroutine_handle<> coroutine) noexcept -> void {
-      m_scheduler.m_scheduled_coroutines.emplace_back(coroutine);
+      m_awaiting_coroutine_node.value() = coroutine;
+      m_scheduler.m_scheduled_coroutines.push_back(m_awaiting_coroutine_node);
       m_schedule_pos = std::prev(m_scheduler.m_scheduled_coroutines.end());
     }
 

--- a/runtime-light/coroutine/io-scheduler.h
+++ b/runtime-light/coroutine/io-scheduler.h
@@ -414,7 +414,7 @@ inline auto io_scheduler::process_events() noexcept -> k2::PollStatus {
     kphp::coro::detail::poll_info::scheduled_coroutines scheduled_coroutines{};
     scheduled_coroutines.splice(scheduled_coroutines.begin(), m_scheduled_coroutines);
     while (!scheduled_coroutines.empty()) {
-      auto& coroutine{scheduled_coroutines.front()};
+      auto coroutine{scheduled_coroutines.front()};
       /*
        * We can remove pop_front() here, because list node will be destroyed after resume and in its
        * destructor will call unlink() [1]. But we left pop_front() for better readability and safety
@@ -454,9 +454,9 @@ auto io_scheduler::start(coroutine_type coroutine) noexcept -> bool {
 inline auto io_scheduler::schedule() noexcept {
   class schedule_operation {
     friend class io_scheduler;
-    vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
     io_scheduler& m_scheduler;
     kphp::coro::async_stack_frame* m_async_stack_frame{};
+    vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
     kphp::coro::detail::poll_info::schedule_position m_schedule_pos{std::monostate{}};
 
     explicit schedule_operation(io_scheduler& scheduler) noexcept
@@ -469,9 +469,9 @@ inline auto io_scheduler::schedule() noexcept {
     schedule_operation& operator=(schedule_operation&&) = delete;
 
     schedule_operation(schedule_operation&& other) noexcept
-        : m_awaiting_coroutine_node(std::move(other.m_awaiting_coroutine_node)),
-          m_scheduler(other.m_scheduler),
+        : m_scheduler(other.m_scheduler),
           m_async_stack_frame(std::exchange(other.m_async_stack_frame, nullptr)),
+          m_awaiting_coroutine_node(std::move(other.m_awaiting_coroutine_node)),
           m_schedule_pos(std::exchange(other.m_schedule_pos, std::monostate{})) {
       if (std::holds_alternative<kphp::coro::detail::poll_info::scheduled_coroutines::iterator>(m_schedule_pos)) {
         m_schedule_pos = m_scheduler.m_scheduled_coroutines.iterator_to(m_awaiting_coroutine_node);

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -13,7 +13,9 @@
 #include <optional>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
+#include "common/containers/intrusive-list.h"
 #include "runtime-common/core/allocator/script-malloc-interface.h"
 #include "runtime-light/coroutine/async-stack.h"
 #include "runtime-light/coroutine/void-value.h"
@@ -23,14 +25,16 @@ namespace kphp::coro {
 
 namespace shared_task_impl {
 
-struct shared_task_awaiter final {
-  std::coroutine_handle<> m_continuation;
-  shared_task_awaiter* m_next{};
-  shared_task_awaiter* m_prev{};
-};
+using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
+using awaiters_list = vk::intrusive::list<awaiter_node>;
 
 template<typename promise_type>
 struct promise_base : kphp::coro::async_stack_element {
+private:
+  struct not_started_tag {};
+  struct done_tag {};
+
+public:
   constexpr auto initial_suspend() const noexcept -> std::suspend_always {
     return {};
   }
@@ -43,22 +47,24 @@ struct promise_base : kphp::coro::async_stack_element {
 
       auto await_suspend(std::coroutine_handle<promise_type> coro) const noexcept -> std::coroutine_handle<> {
         promise_base& promise{coro.promise()};
-        // mark promise as ready
-        auto* awaiter{static_cast<shared_task_impl::shared_task_awaiter*>(std::exchange(promise.m_awaiters, std::addressof(promise)))};
-        if (awaiter == STARTED_NO_WAITERS_VAL) { // no awaiters, so just finish this coroutine
+        awaiters_list awaiters;
+        awaiters.splice(awaiters.begin(), std::get<awaiters_list>(promise.m_state));
+        promise.m_state = done_tag{};
+        if (awaiters.empty()) {
           return std::noop_coroutine();
         }
 
-        while (awaiter->m_next != nullptr) {
-          // read the m_next pointer before resuming the coroutine
-          // since resuming the coroutine may destroy the shared_task_waiter value
-          auto* next{awaiter->m_next};
+        while (true) {
+          auto& coroutine{awaiters.front()};
+          awaiters.pop_front();
+          if (awaiters.empty()) {
+            // return last awaiter's coroutine_handle to allow it to potentially be compiled as a tail-call
+            return coroutine;
+          }
+
           auto& async_stack_root{*promise.get_async_stack_frame().async_stack_root};
-          kphp::coro::resume(awaiter->m_continuation, async_stack_root);
-          awaiter = next;
+          kphp::coro::resume(coroutine, async_stack_root);
         }
-        // return last awaiter's coroutine_handle to allow it to potentially be compiled as a tail-call
-        return awaiter->m_continuation;
       }
 
       constexpr auto await_resume() const noexcept -> void {}
@@ -71,7 +77,7 @@ struct promise_base : kphp::coro::async_stack_element {
   }
 
   auto done() const noexcept -> bool {
-    return m_awaiters == this;
+    return std::holds_alternative<done_tag>(m_state);
   }
 
   auto add_ref() noexcept -> void {
@@ -84,9 +90,7 @@ struct promise_base : kphp::coro::async_stack_element {
   // awaiter->coroutine will be resumed when the task completes.
   // false if the coroutine was already completed and the awaiting
   // coroutine can continue without suspending.
-  auto suspend_awaiter(shared_task_impl::shared_task_awaiter& awaiter) noexcept -> bool {
-    const void* const NOT_STARTED_VAL{std::addressof(this->m_awaiters)};
-
+  auto suspend_awaiter(awaiter_node& awaiter) noexcept -> bool {
     // NOTE: If the coroutine is not yet started then the first awaiter
     // will start the coroutine before enqueuing itself up to the list
     // of suspended awaiters waiting for completion. We split this into
@@ -98,24 +102,20 @@ struct promise_base : kphp::coro::async_stack_element {
     // tasks in a row.
 
     // start the coroutine if not yet started
-    if (m_awaiters == NOT_STARTED_VAL) {
-      m_awaiters = STARTED_NO_WAITERS_VAL;
+    if (std::holds_alternative<not_started_tag>(m_state)) {
+      m_state = awaiters_list{};
       const auto& handle{std::coroutine_handle<promise_type>::from_promise(*static_cast<promise_type*>(this))};
       auto& async_stack_root{*get_async_stack_frame().async_stack_root};
       kphp::coro::resume(handle, async_stack_root);
     }
+
     // coroutine already completed, don't suspend
     if (done()) {
       return false;
     }
 
-    awaiter.m_prev = nullptr;
-    awaiter.m_next = static_cast<shared_task_impl::shared_task_awaiter*>(m_awaiters);
-    // at this point 'm_waiters' can only be 'STARTED_NO_WAITERS_VAL' or 'other'
-    if (m_awaiters != STARTED_NO_WAITERS_VAL) {
-      static_cast<shared_task_awaiter*>(m_awaiters)->m_prev = std::addressof(awaiter);
-    }
-    m_awaiters = static_cast<void*>(std::addressof(awaiter));
+    std::get<awaiters_list>(m_state).push_front(awaiter);
+
     return true;
   }
 
@@ -124,23 +124,6 @@ struct promise_base : kphp::coro::async_stack_element {
   // call destroy() on the coroutine handle.
   auto detach() noexcept -> bool {
     return m_refcnt-- != 1;
-  }
-
-  auto cancel_awaiter(const shared_task_impl::shared_task_awaiter& awaiter) noexcept -> void {
-    const void* const NOT_STARTED_VAL{std::addressof(this->m_awaiters)};
-    if (m_awaiters == NOT_STARTED_VAL || m_awaiters == STARTED_NO_WAITERS_VAL) [[unlikely]] {
-      return;
-    }
-
-    const auto* awaiter_ptr{std::addressof(awaiter)};
-    if (m_awaiters == awaiter_ptr) { // awaiter is the head of the list
-      m_awaiters = awaiter_ptr->m_next;
-    } else if (awaiter_ptr->m_next == nullptr) { // awaiter is the last in the list
-      awaiter_ptr->m_prev->m_next = nullptr;
-    } else { // awaiter is somewhere in the middle of the list
-      awaiter_ptr->m_next->m_prev = awaiter_ptr->m_prev;
-      awaiter_ptr->m_prev->m_next = awaiter_ptr->m_next;
-    }
   }
 
   template<typename... Args>
@@ -158,23 +141,12 @@ struct promise_base : kphp::coro::async_stack_element {
   }
 
 private:
-  static constexpr void* STARTED_NO_WAITERS_VAL = nullptr;
-
   uint32_t m_refcnt{1};
-  // Value is either
-  // - nullptr           - indicates started, no awaiters
-  // - &this->m_awaiters - indicates the coroutine is not yet started
-  // - this              - indicates value is ready
-  // - other             - pointer to head item in linked-list of awaiters.
-  //                       values are of type 'shared_task_impl_::shared_task_waiter_t'.
-  //                       indicates that the coroutine has been started.
-  void* m_awaiters{std::addressof(m_awaiters)};
+  std::variant<not_started_tag, done_tag, awaiters_list> m_state;
 };
 
 template<typename promise_type>
 class awaiter_base {
-  bool m_suspended{};
-
   void set_async_top_frame(async_stack_frame& caller_frame, void* return_address) noexcept {
     /**
      * shared_task is the top of the stack for calls from it.
@@ -196,27 +168,21 @@ class awaiter_base {
   }
 
 protected:
+  awaiter_node m_awaiting_coroutine_node;
   std::coroutine_handle<promise_type> m_coro;
-  shared_task_impl::shared_task_awaiter m_awaiter{};
 
 public:
   explicit awaiter_base(std::coroutine_handle<promise_type> coro) noexcept
       : m_coro(coro) {}
 
   awaiter_base(awaiter_base&& other) noexcept
-      : m_suspended(std::exchange(other.m_suspended, false)),
-        m_coro(std::exchange(other.m_coro, {})),
-        m_awaiter(std::exchange(other.m_awaiter, {})) {}
+      : m_awaiting_coroutine_node(std::move(other.m_awaiting_coroutine_node)),
+        m_coro(std::exchange(other.m_coro, {})) {}
 
   awaiter_base(const awaiter_base& other) = delete;
   awaiter_base& operator=(const awaiter_base& other) = delete;
   awaiter_base& operator=(awaiter_base&& other) = delete;
-
-  ~awaiter_base() {
-    if (m_suspended) {
-      m_coro.promise().cancel_awaiter(m_awaiter);
-    }
-  }
+  ~awaiter_base() = default;
 
   auto await_ready() const noexcept -> bool {
     return m_coro.promise().done();
@@ -225,15 +191,13 @@ public:
   template<std::derived_from<kphp::coro::async_stack_element> caller_promise_type>
   [[clang::noinline]] auto await_suspend(std::coroutine_handle<caller_promise_type> awaiting_coroutine) noexcept -> bool {
     set_async_top_frame(awaiting_coroutine.promise().get_async_stack_frame(), STACK_RETURN_ADDRESS);
-    m_awaiter.m_continuation = awaiting_coroutine;
-    m_suspended = m_coro.promise().suspend_awaiter(m_awaiter);
+    m_awaiting_coroutine_node.value() = awaiting_coroutine;
+    bool suspended = m_coro.promise().suspend_awaiter(m_awaiting_coroutine_node);
     reset_async_top_frame(awaiting_coroutine.promise().get_async_stack_frame());
-    return m_suspended;
+    return suspended;
   }
 
-  auto await_resume() noexcept -> void {
-    m_suspended = false;
-  }
+  auto await_resume() noexcept -> void {}
 };
 
 } // namespace shared_task_impl

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -25,9 +25,6 @@ namespace kphp::coro {
 
 namespace shared_task_impl {
 
-using awaiter_node = vk::intrusive::list_node<std::coroutine_handle<>>;
-using awaiters_list = vk::intrusive::list<awaiter_node>;
-
 template<typename promise_type>
 struct promise_base : kphp::coro::async_stack_element {
 private:
@@ -47,8 +44,8 @@ public:
 
       auto await_suspend(std::coroutine_handle<promise_type> coro) const noexcept -> std::coroutine_handle<> {
         promise_base& promise{coro.promise()};
-        awaiters_list awaiters;
-        awaiters.splice(awaiters.begin(), std::get<awaiters_list>(promise.m_state));
+        vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>> awaiters;
+        awaiters.splice(awaiters.begin(), std::get<vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>>(promise.m_state));
         promise.m_state = done_tag{};
         if (awaiters.empty()) {
           return std::noop_coroutine();
@@ -90,7 +87,7 @@ public:
   // awaiter->coroutine will be resumed when the task completes.
   // false if the coroutine was already completed and the awaiting
   // coroutine can continue without suspending.
-  auto suspend_awaiter(awaiter_node& awaiter) noexcept -> bool {
+  auto suspend_awaiter(vk::intrusive::list_node<std::coroutine_handle<>>& awaiter) noexcept -> bool {
     // NOTE: If the coroutine is not yet started then the first awaiter
     // will start the coroutine before enqueuing itself up to the list
     // of suspended awaiters waiting for completion. We split this into
@@ -103,7 +100,7 @@ public:
 
     // start the coroutine if not yet started
     if (std::holds_alternative<not_started_tag>(m_state)) {
-      m_state = awaiters_list{};
+      m_state = vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>{};
       const auto& handle{std::coroutine_handle<promise_type>::from_promise(*static_cast<promise_type*>(this))};
       auto& async_stack_root{*get_async_stack_frame().async_stack_root};
       kphp::coro::resume(handle, async_stack_root);
@@ -114,7 +111,7 @@ public:
       return false;
     }
 
-    std::get<awaiters_list>(m_state).push_front(awaiter);
+    std::get<vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>>(m_state).push_front(awaiter);
 
     return true;
   }
@@ -142,7 +139,7 @@ public:
 
 private:
   uint32_t m_refcnt{1};
-  std::variant<not_started_tag, done_tag, awaiters_list> m_state;
+  std::variant<not_started_tag, done_tag, vk::intrusive::list<vk::intrusive::list_node<std::coroutine_handle<>>>> m_state;
 };
 
 template<typename promise_type>
@@ -168,7 +165,7 @@ class awaiter_base {
   }
 
 protected:
-  awaiter_node m_awaiting_coroutine_node;
+  vk::intrusive::list_node<std::coroutine_handle<>> m_awaiting_coroutine_node;
   std::coroutine_handle<promise_type> m_coro;
 
 public:

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -192,7 +192,7 @@ public:
   [[clang::noinline]] auto await_suspend(std::coroutine_handle<caller_promise_type> awaiting_coroutine) noexcept -> bool {
     set_async_top_frame(awaiting_coroutine.promise().get_async_stack_frame(), STACK_RETURN_ADDRESS);
     m_awaiting_coroutine_node.value() = awaiting_coroutine;
-    bool suspended = m_coro.promise().suspend_awaiter(m_awaiting_coroutine_node);
+    bool suspended{m_coro.promise().suspend_awaiter(m_awaiting_coroutine_node)};
     reset_async_top_frame(awaiting_coroutine.promise().get_async_stack_frame());
     return suspended;
   }

--- a/runtime-light/coroutine/shared-task.h
+++ b/runtime-light/coroutine/shared-task.h
@@ -55,7 +55,7 @@ public:
         }
 
         while (true) {
-          auto& coroutine{awaiters.front()};
+          auto coroutine{awaiters.front()};
           awaiters.pop_front();
           if (awaiters.empty()) {
             // return last awaiter's coroutine_handle to allow it to potentially be compiled as a tail-call


### PR DESCRIPTION
1) replace kphp::stl::list with vk::intrusive::list in io-scheduler
2) replace handwritten intrusive lists with vk::intrusive::list in event, shared-task, await-set
3) replace kphp::stl::list with vk::intrusive::list in await-set