### PR TITLE
[k2] rpc client: avoid copying and allocating request buffer

### DIFF
--- a/runtime-light/server/rpc/init-functions.cpp
+++ b/runtime-light/server/rpc/init-functions.cpp
@@ -194,6 +194,7 @@ void init_server(kphp::component::stream&& request_stream, kphp::stl::vector<std
   auto& rpc_server_instance_st{RpcServerInstanceState::get()};
   rpc_server_instance_st.request_stream = std::move(request_stream);
   rpc_server_instance_st.query_id = invoke_rpc.query_id.value;
+  rpc_server_instance_st.tl_storer.clear();
   rpc_server_instance_st.tl_storer.store_bytes(invoke_rpc.query);
   rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view()};
 

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -286,7 +286,8 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
   if (const auto& [opt_new_extra_header, cur_extra_header_size]{kphp::rpc::regularize_extra_headers(request_buffer, ignore_answer)}; opt_new_extra_header) {
     std::span<const std::byte> new_header{reinterpret_cast<const std::byte*>(std::addressof(*opt_new_extra_header)),
                                           sizeof(std::remove_cvref_t<decltype(*opt_new_extra_header)>)};
-    std::span<const std::byte> request_body{request_buffer.subspan(cur_extra_header_size)};
+
+    // Let's name `request_body` as `request_buffer.subspan(cur_extra_header_size)}`
 
     // If `regularize_extra_headers` gave us new header, then we must serialize `new_header` before `request_body`.
     //
@@ -298,7 +299,7 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     //
     // tl_storer will be: ... may be some bytes leaved here ... |our new header| |request-body|
 
-    // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it before `send_request(...)` call.
+    // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it in `f$rpc_clean(...)` call.
     size_t new_header_offset{detail::RESERVED_HEADER_SIZE + cur_extra_header_size - new_header.size()};
     request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
     std::ranges::copy(new_header, request_buffer.data());

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -82,9 +82,11 @@ class_instance<C$VK$TL$RpcResponse> fetch_function_typed(const class_instance<Rp
   const vk::final_action finalizer{[&cur_query] noexcept { cur_query.reset(); }};
   cur_query.set_current_tl_function(rpc_query);
   if (TlRpcError err{}; TRY_CALL(bool, class_instance<C$VK$TL$RpcResponse>, err.try_fetch())) {
+    kphp::log::warning("!!! fetch_function_typed -> error");
     return error_factory.make_error(std::move(err));
   }
 
+  kphp::log::warning("!!! fetch_function_typed -> response");
   // TODO: EOF handling
   return TRY_CALL(class_instance<C$VK$TL$RpcResponse>, class_instance<C$VK$TL$RpcResponse>, rpc_query.get()->result_fetcher->fetch_typed_response());
 }
@@ -226,6 +228,7 @@ kphp::coro::task<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) no
 
 kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(int64_t query_id, const RpcErrorFactory& error_factory) noexcept {
   if (query_id < kphp::rpc::VALID_QUERY_ID_RANGE_START) [[unlikely]] {
+    kphp::log::warning("--- A ---");
     co_return error_factory.make_error(TL_ERROR_WRONG_QUERY_ID, string{"wrong query_id"});
   }
 
@@ -247,6 +250,7 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
 
     if (it_response_fetcher == rpc_client_instance_st.response_fetcher_instances.end() || it_fork_task == rpc_client_instance_st.response_awaiter_tasks.end())
         [[unlikely]] {
+      kphp::log::warning("--- B ---");
       co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"unexpectedly could not find query in pending queries"});
     }
     rpc_query = std::move(it_response_fetcher->second);
@@ -254,18 +258,22 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
   }
 
   if (rpc_query.is_null()) [[unlikely]] {
+    kphp::log::warning("--- C ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"can't use rpc_tl_query_result for non-TL query"});
   }
   if (!rpc_query.get()->result_fetcher || rpc_query.get()->result_fetcher->empty()) [[unlikely]] {
+    kphp::log::warning("--- D ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"rpc query has empty result fetcher"});
   }
   if (!rpc_query.get()->result_fetcher->is_typed) [[unlikely]] {
+    kphp::log::warning("--- E ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"can't get typed result from untyped TL query. Use consistent API for that"});
   }
 
   kphp::log::assertion(opt_awaiter_task.has_value());
   auto response_expected{co_await kphp::forks::id_managed(*std::exchange(opt_awaiter_task, std::nullopt))};
   if (!response_expected) [[unlikely]] {
+    kphp::log::warning("--- F ---");
     co_return error_factory.make_error(response_expected.error(), string{"can't fetch rpc response"});
   }
 
@@ -276,8 +284,10 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
   auto res{fetch_function_typed(rpc_query, error_factory)}; // THROWING
   // handle exceptions that could arise during fetch_function_typed
   if (auto err{error_factory.transform_exception_into_error_if_possible()}; !err.is_null()) [[unlikely]] {
+    kphp::log::warning("--- G ---");
     co_return std::move(err);
   }
+  kphp::log::warning("+++ H +++");
   co_return std::move(res);
 }
 

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -353,7 +353,7 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     tl::i64 actor_id{};
     tl::mask flags{};
     tl::rpcInvokeReqExtra extra{};
-    tl::magic op;
+    // tl::magic op;
 
     tl::fetcher debug_fetcher{request_buffer};
 
@@ -365,9 +365,9 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     kphp::log::assertion(flags.fetch(debug_fetcher));
 
-    kphp::log::assertion(extra.fetch(debug_fetcher, flags));
+    // kphp::log::assertion(extra.fetch(debug_fetcher, flags));
 
-    kphp::log::assertion(op.fetch(debug_fetcher));
+    // kphp::log::assertion(op.fetch(debug_fetcher));
 
     // kphp::log::warning("REQUEST OP IS {:x}", op.value);
 

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -82,7 +82,7 @@ class_instance<C$VK$TL$RpcResponse> fetch_function_typed(const class_instance<Rp
   const vk::final_action finalizer{[&cur_query] noexcept { cur_query.reset(); }};
   cur_query.set_current_tl_function(rpc_query);
   if (TlRpcError err{}; TRY_CALL(bool, class_instance<C$VK$TL$RpcResponse>, err.try_fetch())) {
-    kphp::log::warning("!!! fetch_function_typed -> error");
+    kphp::log::warning("!!! fetch_function_typed -> error {}: {}", err.error_code, err.error_msg.c_str());
     return error_factory.make_error(std::move(err));
   }
 

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -335,6 +335,28 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
     std::ranges::copy(new_header, request_buffer.data());
+
+    tl::magic magic;
+    tl::i64 actor_id{};
+    tl::mask flags{};
+    tl::rpcInvokeReqExtra extra{};
+    tl::magic op;
+
+    tl::fetcher debug_fetcher{request_buffer};
+
+    kphp::log::assertion(magic.fetch(debug_fetcher));
+    kphp::log::assertion(magic.expect(TL_RPC_DEST_ACTOR_FLAGS));
+
+    kphp::log::assertion(actor_id.fetch(debug_fetcher));
+    kphp::log::assertion(actor_id.value == 0);
+
+    kphp::log::assertion(flags.fetch(debug_fetcher));
+
+    kphp::log::assertion(extra.fetch(debug_fetcher, flags));
+
+    kphp::log::assertion(op.fetch(debug_fetcher));
+
+    kphp::log::warning("REQUEST OP IS {:x}", op.value);
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -357,6 +357,27 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     kphp::log::assertion(op.fetch(debug_fetcher));
 
     kphp::log::warning("REQUEST OP IS {:x}", op.value);
+
+  } else {
+
+    tl::fetcher debug_fetcher{request_buffer};
+
+    tl::magic magic;
+
+    kphp::log::assertion(magic.fetch(debug_fetcher));
+
+    if (magic.expect(TL_RPC_DEST_ACTOR)) {
+      tl::i64 actor_id{};
+      kphp::log::assertion(actor_id.fetch(debug_fetcher));
+
+      kphp::log::assertion(magic.fetch(debug_fetcher));
+    }
+
+    kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR_FLAGS));
+    kphp::log::assertion(!magic.expect(TL_RPC_DEST_FLAGS));
+    kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR));
+
+    kphp::log::warning("request OP IS {:x}", magic.value);
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -41,8 +41,6 @@ namespace kphp::rpc {
 
 namespace detail {
 
-static constexpr size_t RESERVED_HEADER_SIZE{sizeof(kphp::rpc::dest_actor_flags_header)};
-
 mixed mixed_array_get_value(const mixed& arr, const string& str_key, int64_t num_key) noexcept {
   if (!arr.is_array()) [[unlikely]] {
     return {};
@@ -82,11 +80,11 @@ class_instance<C$VK$TL$RpcResponse> fetch_function_typed(const class_instance<Rp
   const vk::final_action finalizer{[&cur_query] noexcept { cur_query.reset(); }};
   cur_query.set_current_tl_function(rpc_query);
   if (TlRpcError err{}; TRY_CALL(bool, class_instance<C$VK$TL$RpcResponse>, err.try_fetch())) {
-    kphp::log::warning("!!! fetch_function_typed -> error {}: {}", err.error_code, err.error_msg.c_str());
+    // kphp::log::warning("!!! fetch_function_typed -> error {}: {}", err.error_code, err.error_msg.c_str());
     return error_factory.make_error(std::move(err));
   }
 
-  kphp::log::warning("!!! fetch_function_typed -> response");
+  // kphp::log::warning("!!! fetch_function_typed -> response");
   // TODO: EOF handling
   return TRY_CALL(class_instance<C$VK$TL$RpcResponse>, class_instance<C$VK$TL$RpcResponse>, rpc_query.get()->result_fetcher->fetch_typed_response());
 }
@@ -112,15 +110,6 @@ class_instance<RpcTlQuery> store_function(const mixed& tl_object) noexcept {
   return rpc_tl_query;
 }
 
-// store bytes for `kphp::rpc::dest_actor_flags_header` in RpcServerInstanceState::tl_storer.
-// we do this to avoid allocating new buffer for regularized rpc extra headers and copying whole request.
-void reserve_header() noexcept {
-  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  kphp::rpc::dest_actor_flags_header reserved_header{};
-  static_assert(sizeof(reserved_header) == RESERVED_HEADER_SIZE);
-  rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
-}
-
 kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed& tl_object, std::optional<double> opt_timeout, bool collect_resp_extra_info,
                                             bool ignore_answer) noexcept {
   if (!tl_object.is_array()) [[unlikely]] {
@@ -129,7 +118,6 @@ kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed&
   }
 
   f$rpc_clean();
-  reserve_header();
   auto rpc_tl_query{store_function(tl_object)}; // THROWING
   // handle exceptions that could arise during store_function
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || rpc_tl_query.is_null()) [[unlikely]] {
@@ -151,7 +139,6 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   }
 
   f$rpc_clean();
-  reserve_header();
   auto& rpc_server_instance_st{RpcServerInstanceState::get()};
   auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
   for (auto b : sp) {
@@ -165,8 +152,6 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
     return kphp::rpc::query_info{};
   }
   sp = rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE);
-  kphp::log::warning("NEW TL STORER TAKEN {}", sp.data() == rpc_server_instance_st.tl_storer.view().data());
-  kphp::log::warning("TL FUNCTION NAME: {}", rpc_request.tl_function_name().c_str());
   for (auto b : sp) {
     if (b != static_cast<std::byte>(0)) {
       kphp::log::error("BBB SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
@@ -302,7 +287,6 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
     kphp::log::warning("--- G ---");
     co_return std::move(err);
   }
-  kphp::log::warning("+++ H +++");
   co_return std::move(res);
 }
 
@@ -329,11 +313,10 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
   tl::magic magic;
   tl::fetcher debug_fetcherrr{request_buffer};
   kphp::log::assertion(magic.fetch(debug_fetcherrr));
-  kphp::log::warning("request_buffer start op: {:x}", magic.value);
   if (magic.value == TL_RPC_DEST_ACTOR) {
     debug_fetcherrr = tl::fetcher{request_buffer.subspan(sizeof(kphp::rpc::dest_actor_header))};
     kphp::log::assertion(magic.fetch(debug_fetcherrr));
-    kphp::log::warning("request_buffer start op AFTER DEST ACTOR: {:x}", magic.value);
+    // kphp::log::warning("request_buffer start op AFTER DEST ACTOR: {:x}", magic.value);
   }
 
   if (const auto& [opt_new_extra_header, cur_extra_header_size]{kphp::rpc::regularize_extra_headers(request_buffer, ignore_answer)}; opt_new_extra_header) {
@@ -354,14 +337,14 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it before `send_request(...)` call.
     size_t new_header_offset{detail::RESERVED_HEADER_SIZE + cur_extra_header_size - new_header.size()};
 
-    kphp::log::warning("OPTIMIZATION SUCKS: {} - {} - {} - {} - {} - {} - {}",
-      reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().data()),
-      reinterpret_cast<std::uintptr_t>(request_buffer.data()),
-      reinterpret_cast<std::uintptr_t>(request_body.data()),
-      detail::RESERVED_HEADER_SIZE,
-      cur_extra_header_size,
-      new_header.size(),
-      reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().subspan(new_header_offset).data()));
+    // kphp::log::warning("OPTIMIZATION SUCKS: {} - {} - {} - {} - {} - {} - {}",
+    //   reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().data()),
+    //   reinterpret_cast<std::uintptr_t>(request_buffer.data()),
+    //   reinterpret_cast<std::uintptr_t>(request_body.data()),
+    //   detail::RESERVED_HEADER_SIZE,
+    //   cur_extra_header_size,
+    //   new_header.size(),
+    //   reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().subspan(new_header_offset).data()));
 
     request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
     std::ranges::copy(new_header, request_buffer.data());
@@ -386,7 +369,7 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     kphp::log::assertion(op.fetch(debug_fetcher));
 
-    kphp::log::warning("REQUEST OP IS {:x}", op.value);
+    // kphp::log::warning("REQUEST OP IS {:x}", op.value);
 
   } else {
 
@@ -396,9 +379,9 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     kphp::log::assertion(magic.fetch(debug_fetcher));
 
-    bool was_dest_actor_header = false;
+    // bool was_dest_actor_header = false;
     if (magic.expect(TL_RPC_DEST_ACTOR)) {
-      was_dest_actor_header = true;
+      // was_dest_actor_header = true;
       tl::i64 actor_id{};
       kphp::log::assertion(actor_id.fetch(debug_fetcher));
 
@@ -409,7 +392,7 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     kphp::log::assertion(!magic.expect(TL_RPC_DEST_FLAGS));
     kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR));
 
-    kphp::log::warning("request OP IS {:x} was_dest_actor_header({})", magic.value, was_dest_actor_header);
+    // kphp::log::warning("request OP IS {:x} was_dest_actor_header({})", magic.value, was_dest_actor_header);
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -305,6 +305,15 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
   // We do this to have enough place for regularized header after `kphp::rpc::regularize_extra_headers(...)` call.
   // This optimization helps us avoid allocating and copying the whole request.
   std::span<std::byte> request_buffer{rpc_server_instance_st.tl_storer.view().subspan(detail::RESERVED_HEADER_SIZE)};
+  tl::magic magic;
+  tl::fetcher debug_fetcherrr{request_buffer};
+  kphp::log::assertion(magic.fetch(debug_fetcherrr));
+  kphp::log::warning("request_buffer start op: {:x}", magic.value);
+  if (magic.value == TL_RPC_DEST_ACTOR) {
+    debug_fetcherrr = tl::fetcher{request_buffer.subspan(sizeof(kphp::rpc::dest_actor_header))};
+    kphp::log::assertion(magic.fetch(debug_fetcherrr));
+    kphp::log::warning("request_buffer start op AFTER DEST ACTOR: {:x}", magic.value);
+  }
 
   if (const auto& [opt_new_extra_header, cur_extra_header_size]{kphp::rpc::regularize_extra_headers(request_buffer, ignore_answer)}; opt_new_extra_header) {
     std::span<const std::byte> new_header{reinterpret_cast<const std::byte*>(std::addressof(*opt_new_extra_header)),
@@ -366,7 +375,9 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     kphp::log::assertion(magic.fetch(debug_fetcher));
 
+    bool was_dest_actor_header = false;
     if (magic.expect(TL_RPC_DEST_ACTOR)) {
+      was_dest_actor_header = true;
       tl::i64 actor_id{};
       kphp::log::assertion(actor_id.fetch(debug_fetcher));
 
@@ -377,7 +388,7 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
     kphp::log::assertion(!magic.expect(TL_RPC_DEST_FLAGS));
     kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR));
 
-    kphp::log::warning("request OP IS {:x}", magic.value);
+    kphp::log::warning("request OP IS {:x} was_dest_actor_header({})", magic.value, was_dest_actor_header);
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -323,6 +323,16 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it before `send_request(...)` call.
     size_t new_header_offset{detail::RESERVED_HEADER_SIZE + cur_extra_header_size - new_header.size()};
+
+    kphp::log::warning("OPTIMIZATION SUCKS: {} - {} - {} - {} - {} - {} - {}",
+      reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().data()),
+      reinterpret_cast<std::uintptr_t>(request_buffer.data()),
+      reinterpret_cast<std::uintptr_t>(request_body.data()),
+      detail::RESERVED_HEADER_SIZE,
+      cur_extra_header_size,
+      new_header.size(),
+      reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().subspan(new_header_offset).data()));
+
     request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
     std::ranges::copy(new_header, request_buffer.data());
   }

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -164,6 +164,7 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || !static_cast<bool>(fetcher)) [[unlikely]] {
     return kphp::rpc::query_info{};
   }
+  sp = rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE);
   for (auto b : sp) {
     if (b != static_cast<std::byte>(0)) {
       kphp::log::error("B SERVER RESERVED HEADER BUFFER IS NOT ZEROED");

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -41,6 +41,24 @@ namespace kphp::rpc {
 
 namespace detail {
 
+// store bytes for `kphp::rpc::dest_actor_flags_header` in RpcServerInstanceState::tl_storer.
+// we do this to avoid allocating new buffer for regularized rpc extra headers and copying whole request.
+void reserve_header() noexcept {
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  kphp::rpc::dest_actor_flags_header reserved_header{};
+  static_assert(sizeof(reserved_header) == RESERVED_HEADER_SIZE);
+  rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
+}
+
+void clean_buffers() noexcept {
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  rpc_server_instance_st.tl_storer.clear();
+  kphp::rpc::detail::reserve_header();
+  // TODO we need this just because we have one buffer for f$store_* functions and f$fetch_* functions.
+  // if we make another buffer for `rpc_server_instance_st.tl_fetcher`, then we don't need this.
+  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)};
+}
+
 mixed mixed_array_get_value(const mixed& arr, const string& str_key, int64_t num_key) noexcept {
   if (!arr.is_array()) [[unlikely]] {
     return {};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -50,15 +50,6 @@ void reserve_header() noexcept {
   rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
 }
 
-void clean_buffers() noexcept {
-  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  rpc_server_instance_st.tl_storer.clear();
-  kphp::rpc::detail::reserve_header();
-  // TODO we need this just because we have one buffer for f$store_* functions and f$fetch_* functions.
-  // if we make another buffer for `rpc_server_instance_st.tl_fetcher`, then we don't need this.
-  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)};
-}
-
 mixed mixed_array_get_value(const mixed& arr, const string& str_key, int64_t num_key) noexcept {
   if (!arr.is_array()) [[unlikely]] {
     return {};
@@ -287,6 +278,15 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
 }
 
 } // namespace detail
+
+void clean_buffers() noexcept {
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  rpc_server_instance_st.tl_storer.clear();
+  kphp::rpc::detail::reserve_header();
+  // TODO we need this just because we have one buffer for f$store_* functions and f$fetch_* functions.
+  // if we make another buffer for `rpc_server_instance_st.tl_fetcher`, then we don't need this.
+  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)};
+}
 
 kphp::rpc::query_info send_request(std::string_view actor, std::optional<double> opt_timeout, bool ignore_answer, bool collect_responses_extra_info) noexcept {
   auto& rpc_client_instance_st{RpcClientInstanceState::get()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -41,6 +41,8 @@ namespace kphp::rpc {
 
 namespace detail {
 
+static constexpr size_t RESERVED_HEADER_SIZE{sizeof(kphp::rpc::dest_actor_flags_header)};
+
 mixed mixed_array_get_value(const mixed& arr, const string& str_key, int64_t num_key) noexcept {
   if (!arr.is_array()) [[unlikely]] {
     return {};
@@ -108,6 +110,15 @@ class_instance<RpcTlQuery> store_function(const mixed& tl_object) noexcept {
   return rpc_tl_query;
 }
 
+// store bytes for `kphp::rpc::dest_actor_flags_header` in RpcServerInstanceState::tl_storer.
+// we do this to avoid allocating new buffer for regularized rpc extra headers and copying whole request.
+void reserve_header() noexcept {
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  kphp::rpc::dest_actor_flags_header reserved_header{};
+  static_assert(sizeof(reserved_header) == RESERVED_HEADER_SIZE);
+  rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
+}
+
 kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed& tl_object, std::optional<double> opt_timeout, bool collect_resp_extra_info,
                                             bool ignore_answer) noexcept {
   if (!tl_object.is_array()) [[unlikely]] {
@@ -116,6 +127,7 @@ kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed&
   }
 
   f$rpc_clean();
+  reserve_header();
   auto rpc_tl_query{store_function(tl_object)}; // THROWING
   // handle exceptions that could arise during store_function
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || rpc_tl_query.is_null()) [[unlikely]] {
@@ -137,6 +149,7 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   }
 
   f$rpc_clean();
+  reserve_header();
   auto fetcher{rpc_request.store_request()}; // THROWING
   // handle exceptions that could arise during store_request
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || !static_cast<bool>(fetcher)) [[unlikely]] {
@@ -276,31 +289,32 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
   const auto timestamp{std::chrono::duration<double>{std::chrono::system_clock::now().time_since_epoch()}.count()};
 
-  // if we have to allocate memory for request buffer, it will be in this vector, and it will be freed at the end of the function
-  std::optional<kphp::stl::vector<std::byte, kphp::memory::script_allocator>> opt_request_vec{};
-  std::span<const std::byte> request_buffer{rpc_server_instance_st.tl_storer.view()};
+  // We have reserved place for one `kphp::rpc::dest_actor_flags_header` in `rpc_server_instance_st.tl_storer`
+  // before storing request and calling `send_request(...)`,
+  // so the real serialized request starts after `RESERVED_HEADER_SIZE` bytes in tl storer.
+  // We do this to have enough place for regularized header after `kphp::rpc::regularize_extra_headers(...)` call.
+  // This optimization helps us avoid allocating and copying the whole request.
+  std::span<std::byte> request_buffer{rpc_server_instance_st.tl_storer.view().subspan(detail::RESERVED_HEADER_SIZE)};
 
   if (const auto& [opt_new_extra_header, cur_extra_header_size]{kphp::rpc::regularize_extra_headers(request_buffer, ignore_answer)}; opt_new_extra_header) {
     std::span<const std::byte> new_header{reinterpret_cast<const std::byte*>(std::addressof(*opt_new_extra_header)),
                                           sizeof(std::remove_cvref_t<decltype(*opt_new_extra_header)>)};
-    std::span<const std::byte> request_body{rpc_server_instance_st.tl_storer.view().subspan(cur_extra_header_size)};
+    std::span<const std::byte> request_body{request_buffer.subspan(cur_extra_header_size)};
 
-    std::span<std::byte> new_request_buffer{};
-    size_t request_and_headers_size{new_header.size() + request_body.size()};
-    if (request_and_headers_size <= StringLibContext::STATIC_BUFFER_LENGTH) {
-      // we have enough space in static buffer to store request with regularized headers
-      auto& string_lib_ctx{StringLibContext::get()};
-      new_request_buffer = std::span<std::byte>{reinterpret_cast<std::byte*>(string_lib_ctx.static_buf.get()), request_and_headers_size};
-    } else {
-      // we have to allocate buffer for request with regularized headers
-      opt_request_vec.emplace(request_and_headers_size);
-      new_request_buffer = std::span<std::byte>{opt_request_vec->data(), request_and_headers_size};
-    }
+    // If `regularize_extra_headers` gave us new header, then we must serialize `new_header` before `request_body`.
+    //
+    //                               here serialized request (business logic) starts
+    //                                                   \/
+    // tl_storer was:  |reserved dest-actor-flags-header|  [optional old header] |request-body|
+    //
+    // We want to serialize |our new header| right before |request-body| :
+    //
+    // tl_storer will be: ... may be some bytes leaved here ... |our new header| |request-body|
 
-    std::ranges::copy(new_header, new_request_buffer.subspan(0, new_header.size()).begin());
-    std::ranges::copy(request_body, new_request_buffer.subspan(new_header.size()).begin());
-
-    request_buffer = new_request_buffer;
+    // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it before `send_request(...)` call.
+    size_t new_header_offset{detail::RESERVED_HEADER_SIZE + cur_extra_header_size - new_header.size()};
+    request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
+    std::ranges::copy(new_header, request_buffer.data());
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -156,7 +156,7 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
   for (auto b : sp) {
     if (b != static_cast<std::byte>(0)) {
-      kphp::log::error("A SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
+      kphp::log::error("AAA SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
     }
   }
   auto fetcher{rpc_request.store_request()}; // THROWING
@@ -165,9 +165,10 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
     return kphp::rpc::query_info{};
   }
   sp = rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE);
+  kphp::log::warning("NEW TL STORER TAKEN {}", sp.data() == rpc_server_instance_st.tl_storer.view().data());
   for (auto b : sp) {
     if (b != static_cast<std::byte>(0)) {
-      kphp::log::error("B SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
+      kphp::log::error("BBB SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
     }
   }
 

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -80,11 +80,9 @@ class_instance<C$VK$TL$RpcResponse> fetch_function_typed(const class_instance<Rp
   const vk::final_action finalizer{[&cur_query] noexcept { cur_query.reset(); }};
   cur_query.set_current_tl_function(rpc_query);
   if (TlRpcError err{}; TRY_CALL(bool, class_instance<C$VK$TL$RpcResponse>, err.try_fetch())) {
-    // kphp::log::warning("!!! fetch_function_typed -> error {}: {}", err.error_code, err.error_msg.c_str());
     return error_factory.make_error(std::move(err));
   }
 
-  // kphp::log::warning("!!! fetch_function_typed -> response");
   // TODO: EOF handling
   return TRY_CALL(class_instance<C$VK$TL$RpcResponse>, class_instance<C$VK$TL$RpcResponse>, rpc_query.get()->result_fetcher->fetch_typed_response());
 }
@@ -139,23 +137,10 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   }
 
   f$rpc_clean();
-  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
-  for (auto b : sp) {
-    if (b != static_cast<std::byte>(0)) {
-      kphp::log::error("AAA SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
-    }
-  }
   auto fetcher{rpc_request.store_request()}; // THROWING
   // handle exceptions that could arise during store_request
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || !static_cast<bool>(fetcher)) [[unlikely]] {
     return kphp::rpc::query_info{};
-  }
-  sp = rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE);
-  for (auto b : sp) {
-    if (b != static_cast<std::byte>(0)) {
-      kphp::log::error("BBB SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
-    }
   }
 
   const auto query_info{kphp::rpc::send_request(actor, opt_timeout, ignore_answer, collect_responses_extra_info)};
@@ -228,7 +213,6 @@ kphp::coro::task<array<mixed>> rpc_tl_query_result_one_impl(int64_t query_id) no
 
 kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(int64_t query_id, const RpcErrorFactory& error_factory) noexcept {
   if (query_id < kphp::rpc::VALID_QUERY_ID_RANGE_START) [[unlikely]] {
-    kphp::log::warning("--- A ---");
     co_return error_factory.make_error(TL_ERROR_WRONG_QUERY_ID, string{"wrong query_id"});
   }
 
@@ -250,7 +234,6 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
 
     if (it_response_fetcher == rpc_client_instance_st.response_fetcher_instances.end() || it_fork_task == rpc_client_instance_st.response_awaiter_tasks.end())
         [[unlikely]] {
-      kphp::log::warning("--- B ---");
       co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"unexpectedly could not find query in pending queries"});
     }
     rpc_query = std::move(it_response_fetcher->second);
@@ -258,22 +241,18 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
   }
 
   if (rpc_query.is_null()) [[unlikely]] {
-    kphp::log::warning("--- C ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"can't use rpc_tl_query_result for non-TL query"});
   }
   if (!rpc_query.get()->result_fetcher || rpc_query.get()->result_fetcher->empty()) [[unlikely]] {
-    kphp::log::warning("--- D ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"rpc query has empty result fetcher"});
   }
   if (!rpc_query.get()->result_fetcher->is_typed) [[unlikely]] {
-    kphp::log::warning("--- E ---");
     co_return error_factory.make_error(TL_ERROR_INTERNAL, string{"can't get typed result from untyped TL query. Use consistent API for that"});
   }
 
   kphp::log::assertion(opt_awaiter_task.has_value());
   auto response_expected{co_await kphp::forks::id_managed(*std::exchange(opt_awaiter_task, std::nullopt))};
   if (!response_expected) [[unlikely]] {
-    kphp::log::warning("--- F ---");
     co_return error_factory.make_error(response_expected.error(), string{"can't fetch rpc response"});
   }
 
@@ -284,7 +263,6 @@ kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_
   auto res{fetch_function_typed(rpc_query, error_factory)}; // THROWING
   // handle exceptions that could arise during fetch_function_typed
   if (auto err{error_factory.transform_exception_into_error_if_possible()}; !err.is_null()) [[unlikely]] {
-    kphp::log::warning("--- G ---");
     co_return std::move(err);
   }
   co_return std::move(res);
@@ -304,20 +282,6 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
   // We do this to have enough place for regularized header after `kphp::rpc::regularize_extra_headers(...)` call.
   // This optimization helps us avoid allocating and copying the whole request.
   std::span<std::byte> request_buffer{rpc_server_instance_st.tl_storer.view().subspan(detail::RESERVED_HEADER_SIZE)};
-  auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
-  for (auto b : sp) {
-    if (b != static_cast<std::byte>(0)) {
-      kphp::log::error("C SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
-    }
-  }
-  tl::magic magic;
-  tl::fetcher debug_fetcherrr{request_buffer};
-  kphp::log::assertion(magic.fetch(debug_fetcherrr));
-  if (magic.value == TL_RPC_DEST_ACTOR) {
-    debug_fetcherrr = tl::fetcher{request_buffer.subspan(sizeof(kphp::rpc::dest_actor_header))};
-    kphp::log::assertion(magic.fetch(debug_fetcherrr));
-    // kphp::log::warning("request_buffer start op AFTER DEST ACTOR: {:x}", magic.value);
-  }
 
   if (const auto& [opt_new_extra_header, cur_extra_header_size]{kphp::rpc::regularize_extra_headers(request_buffer, ignore_answer)}; opt_new_extra_header) {
     std::span<const std::byte> new_header{reinterpret_cast<const std::byte*>(std::addressof(*opt_new_extra_header)),
@@ -336,63 +300,8 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
 
     // we do always have enough bytes for `new_header` before `request_body`, because we have reserved it before `send_request(...)` call.
     size_t new_header_offset{detail::RESERVED_HEADER_SIZE + cur_extra_header_size - new_header.size()};
-
-    // kphp::log::warning("OPTIMIZATION SUCKS: {} - {} - {} - {} - {} - {} - {}",
-    //   reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().data()),
-    //   reinterpret_cast<std::uintptr_t>(request_buffer.data()),
-    //   reinterpret_cast<std::uintptr_t>(request_body.data()),
-    //   detail::RESERVED_HEADER_SIZE,
-    //   cur_extra_header_size,
-    //   new_header.size(),
-    //   reinterpret_cast<std::uintptr_t>(rpc_server_instance_st.tl_storer.view().subspan(new_header_offset).data()));
-
     request_buffer = rpc_server_instance_st.tl_storer.view().subspan(new_header_offset);
     std::ranges::copy(new_header, request_buffer.data());
-
-    tl::magic magic;
-    tl::i64 actor_id{};
-    tl::mask flags{};
-    tl::rpcInvokeReqExtra extra{};
-    // tl::magic op;
-
-    tl::fetcher debug_fetcher{request_buffer};
-
-    kphp::log::assertion(magic.fetch(debug_fetcher));
-    kphp::log::assertion(magic.expect(TL_RPC_DEST_ACTOR_FLAGS));
-
-    kphp::log::assertion(actor_id.fetch(debug_fetcher));
-    kphp::log::assertion(actor_id.value == 0);
-
-    kphp::log::assertion(flags.fetch(debug_fetcher));
-
-    // kphp::log::assertion(extra.fetch(debug_fetcher, flags));
-
-    // kphp::log::assertion(op.fetch(debug_fetcher));
-
-    // kphp::log::warning("REQUEST OP IS {:x}", op.value);
-
-  } else {
-
-    tl::fetcher debug_fetcher{request_buffer};
-
-    tl::magic magic;
-
-    kphp::log::assertion(magic.fetch(debug_fetcher));
-
-    // bool was_dest_actor_header = false;
-    if (magic.expect(TL_RPC_DEST_ACTOR)) {
-      // was_dest_actor_header = true;
-      tl::i64 actor_id{};
-      kphp::log::assertion(actor_id.fetch(debug_fetcher));
-
-      kphp::log::assertion(magic.fetch(debug_fetcher));
-    }
-
-    kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR_FLAGS));
-    kphp::log::assertion(!magic.expect(TL_RPC_DEST_FLAGS));
-    kphp::log::assertion(!magic.expect(TL_RPC_DEST_ACTOR));
-
-    // kphp::log::warning("request OP IS {:x} was_dest_actor_header({})", magic.value, was_dest_actor_header);
   }
 
   const size_t request_size{request_buffer.size_bytes()};

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -166,6 +166,7 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
   }
   sp = rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE);
   kphp::log::warning("NEW TL STORER TAKEN {}", sp.data() == rpc_server_instance_st.tl_storer.view().data());
+  kphp::log::warning("TL FUNCTION NAME: {}", rpc_request.tl_function_name().c_str());
   for (auto b : sp) {
     if (b != static_cast<std::byte>(0)) {
       kphp::log::error("BBB SERVER RESERVED HEADER BUFFER IS NOT ZEROED");

--- a/runtime-light/stdlib/rpc/rpc-api.cpp
+++ b/runtime-light/stdlib/rpc/rpc-api.cpp
@@ -152,10 +152,22 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
 
   f$rpc_clean();
   reserve_header();
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
+  for (auto b : sp) {
+    if (b != static_cast<std::byte>(0)) {
+      kphp::log::error("A SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
+    }
+  }
   auto fetcher{rpc_request.store_request()}; // THROWING
   // handle exceptions that could arise during store_request
   if (!TlRpcError::transform_exception_into_error_if_possible().empty() || !static_cast<bool>(fetcher)) [[unlikely]] {
     return kphp::rpc::query_info{};
+  }
+  for (auto b : sp) {
+    if (b != static_cast<std::byte>(0)) {
+      kphp::log::error("B SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
+    }
   }
 
   const auto query_info{kphp::rpc::send_request(actor, opt_timeout, ignore_answer, collect_responses_extra_info)};
@@ -305,6 +317,12 @@ kphp::rpc::query_info send_request(std::string_view actor, std::optional<double>
   // We do this to have enough place for regularized header after `kphp::rpc::regularize_extra_headers(...)` call.
   // This optimization helps us avoid allocating and copying the whole request.
   std::span<std::byte> request_buffer{rpc_server_instance_st.tl_storer.view().subspan(detail::RESERVED_HEADER_SIZE)};
+  auto sp{rpc_server_instance_st.tl_storer.view().subspan(0, detail::RESERVED_HEADER_SIZE)};
+  for (auto b : sp) {
+    if (b != static_cast<std::byte>(0)) {
+      kphp::log::error("C SERVER RESERVED HEADER BUFFER IS NOT ZEROED");
+    }
+  }
   tl::magic magic;
   tl::fetcher debug_fetcherrr{request_buffer};
   kphp::log::assertion(magic.fetch(debug_fetcherrr));

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -24,6 +24,7 @@
 #include "runtime-light/stdlib/rpc/rpc-client-state.h"
 #include "runtime-light/stdlib/rpc/rpc-constants.h"
 #include "runtime-light/stdlib/rpc/rpc-exceptions.h"
+#include "runtime-light/stdlib/rpc/rpc-extra-headers.h"
 #include "runtime-light/stdlib/rpc/rpc-extra-info.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-error.h"
 #include "runtime-light/stdlib/rpc/rpc-tl-function.h"
@@ -57,6 +58,17 @@ inline kphp::coro::task<std::expected<void, int32_t>> send_response(std::span<co
 }
 
 namespace detail {
+
+static constexpr size_t RESERVED_HEADER_SIZE{sizeof(kphp::rpc::dest_actor_flags_header)};
+
+// store bytes for `kphp::rpc::dest_actor_flags_header` in RpcServerInstanceState::tl_storer.
+// we do this to avoid allocating new buffer for regularized rpc extra headers and copying whole request.
+inline void reserve_header() noexcept {
+  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
+  kphp::rpc::dest_actor_flags_header reserved_header{};
+  static_assert(sizeof(reserved_header) == RESERVED_HEADER_SIZE);
+  rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
+}
 
 kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed& tl_object, std::optional<double> opt_timeout, bool collect_resp_extra_info,
                                             bool ignore_answer) noexcept;
@@ -199,7 +211,8 @@ inline void f$fetch_raw_vector_double(array<double>& vector, int64_t num_elems) 
 inline bool f$rpc_clean() noexcept {
   auto& rpc_server_instance_st{RpcServerInstanceState::get()};
   rpc_server_instance_st.tl_storer.clear();
-  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view()};
+  kphp::rpc::detail::reserve_header();
+  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)};
   return true;
 }
 
@@ -268,8 +281,9 @@ inline kphp::coro::task<> f$rpc_server_store_response(class_instance<C$VK$TL$Rpc
   // as we are in a coroutine, we must own the data to prevent it from being overwritten by another coroutine,
   // so create a TLBuffer owned by this coroutine
   auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  tl::K2RpcResponse rpc_response{.value =
-                                     tl::k2RpcResponseHeader{.flags = {}, .extra_flags = {}, .extra = {}, .result = rpc_server_instance_st.tl_storer.view()}};
+  tl::K2RpcResponse rpc_response{
+      .value = tl::k2RpcResponseHeader{
+          .flags = {}, .extra_flags = {}, .extra = {}, .result = rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)}};
   tl::storer tls{rpc_response.footprint()};
   rpc_response.store(tls);
 

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -61,14 +61,7 @@ namespace detail {
 
 static constexpr size_t RESERVED_HEADER_SIZE{sizeof(kphp::rpc::dest_actor_flags_header)};
 
-// store bytes for `kphp::rpc::dest_actor_flags_header` in RpcServerInstanceState::tl_storer.
-// we do this to avoid allocating new buffer for regularized rpc extra headers and copying whole request.
-inline void reserve_header() noexcept {
-  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  kphp::rpc::dest_actor_flags_header reserved_header{};
-  static_assert(sizeof(reserved_header) == RESERVED_HEADER_SIZE);
-  rpc_server_instance_st.tl_storer.store_bytes({reinterpret_cast<const std::byte*>(std::addressof(reserved_header)), sizeof(reserved_header)});
-}
+void clean_buffers() noexcept;
 
 kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed& tl_object, std::optional<double> opt_timeout, bool collect_resp_extra_info,
                                             bool ignore_answer) noexcept;
@@ -209,10 +202,7 @@ inline void f$fetch_raw_vector_double(array<double>& vector, int64_t num_elems) 
 }
 
 inline bool f$rpc_clean() noexcept {
-  auto& rpc_server_instance_st{RpcServerInstanceState::get()};
-  rpc_server_instance_st.tl_storer.clear();
-  kphp::rpc::detail::reserve_header();
-  rpc_server_instance_st.tl_fetcher = tl::fetcher{rpc_server_instance_st.tl_storer.view().subspan(kphp::rpc::detail::RESERVED_HEADER_SIZE)};
+  kphp::rpc::detail::clean_buffers();
   return true;
 }
 

--- a/runtime-light/stdlib/rpc/rpc-api.h
+++ b/runtime-light/stdlib/rpc/rpc-api.h
@@ -61,8 +61,6 @@ namespace detail {
 
 static constexpr size_t RESERVED_HEADER_SIZE{sizeof(kphp::rpc::dest_actor_flags_header)};
 
-void clean_buffers() noexcept;
-
 kphp::rpc::query_info rpc_tl_query_one_impl(std::string_view actor, const mixed& tl_object, std::optional<double> opt_timeout, bool collect_resp_extra_info,
                                             bool ignore_answer) noexcept;
 
@@ -74,6 +72,8 @@ kphp::rpc::query_info typed_rpc_tl_query_one_impl(std::string_view actor, const 
 kphp::coro::task<class_instance<C$VK$TL$RpcResponse>> typed_rpc_tl_query_result_one_impl(int64_t query_id, const RpcErrorFactory& error_factory) noexcept;
 
 } // namespace detail
+
+void clean_buffers() noexcept;
 
 } // namespace kphp::rpc
 
@@ -202,7 +202,7 @@ inline void f$fetch_raw_vector_double(array<double>& vector, int64_t num_elems) 
 }
 
 inline bool f$rpc_clean() noexcept {
-  kphp::rpc::detail::clean_buffers();
+  kphp::rpc::clean_buffers();
   return true;
 }
 

--- a/runtime-light/tl/tl-core.h
+++ b/runtime-light/tl/tl-core.h
@@ -54,6 +54,10 @@ public:
     return m_buffer;
   }
 
+  std::span<std::byte> view() noexcept {
+    return m_buffer;
+  }
+
   void clear() noexcept {
     m_buffer.clear();
   }


### PR DESCRIPTION
- changed `f$rpc_clean()` semantics: now it not only clears `tl_storer` and `tl_fetcher`, but also puts `kphp::rpc::detail::RESERVED_HEADER_SIZE` zero bytes in storer (`tl_fetcher` remains empty).
- RPC client (`kphp::rpc::send_request()` function) uses these reserved bytes to store new regularized rpc header directly before request body.
- RPC server (`f$rpc_server_store_response()` function) skips these bytes in copying response.
- `kphp::rpc::init_server()`: added `tl_storer` clear before `invoke_rpc.query` storing.