### PR TITLE
fix code-gen-task.cpp build

### DIFF
--- a/compiler/code-gen/code-gen-task.cpp
+++ b/compiler/code-gen/code-gen-task.cpp
@@ -3,7 +3,6 @@
 // Distributed under the GPL v3 License, see LICENSE.notice.txt
 
 #include "compiler/code-gen/code-gen-task.h"
-#include "compiler/code-gen/code-gen-root-cmd.h"
 
 // this os exists to be passed to CodeGenerator constructor,
 // but it won't be used actually, as CodeGenerator is not created in "just calc hashes" mode

--- a/compiler/code-gen/code-gen-task.h
+++ b/compiler/code-gen/code-gen-task.h
@@ -4,14 +4,13 @@
 
 #pragma once
 
+#include "compiler/code-gen/code-gen-root-cmd.h"
 #include "compiler/code-gen/code-generator.h"
 #include "compiler/scheduler/task.h"
 #include "compiler/stage.h"
 #include "compiler/threading/profiler.h"
 
 ProfilerRaw& get_code_gen_profiler();
-
-struct CodeGenRootCmd;
 
 class CodeGenSchedulerTask : public Task {
   CodeGenerator W;


### PR DESCRIPTION
This PR fixes compiling of compiler.

code-gen-task.cpp changed order of includes, but CodeGenRootCmd should be defined before CodeGenSchedulerTask::~CodeGenSchedulerTask definition