### PR TITLE
fix misaligned placement-new storages in runtime

### DIFF
--- a/runtime/files.cpp
+++ b/runtime/files.cpp
@@ -423,7 +423,7 @@ Optional<string> f$realpath(const string& path) {
 }
 
 static Optional<string> full_realpath(const string& path) { // realpath resolving only dirname to work with unexisted files
-  static char full_realpath_cache_storage[sizeof(array<string>)];
+  alignas(array<string>) static char full_realpath_cache_storage[sizeof(array<string>)];
   static array<string>* full_realpath_cache = reinterpret_cast<array<string>*>(full_realpath_cache_storage);
   static long long full_realpath_last_query_num = -1;
 
@@ -567,7 +567,7 @@ Optional<array<string>> f$scandir(const string& directory) {
   return file_list;
 }
 
-static char opened_files_storage[sizeof(array<FILE*>)];
+alignas(array<FILE*>) static char opened_files_storage[sizeof(array<FILE*>)];
 static array<FILE*>* opened_files = reinterpret_cast<array<FILE*>*>(opened_files_storage);
 static long long opened_files_last_query_num = -1;
 

--- a/runtime/interface.cpp
+++ b/runtime/interface.cpp
@@ -207,7 +207,7 @@ int64_t f$ob_get_level() {
 
 static int http_return_code;
 static string http_status_line;
-static char headers_storage[sizeof(array<string>)];
+alignas(array<string>) static char headers_storage[sizeof(array<string>)];
 static array<string>* headers = reinterpret_cast<array<string>*>(headers_storage);
 static long long header_last_query_num = -1;
 static bool headers_custom_handler_invoked = false;
@@ -1329,7 +1329,7 @@ static bool parse_multipart(const char* post, int post_len, const string& bounda
   return true;
 }
 
-static char arg_vars_storage[sizeof(array<string>)];
+alignas(array<string>) static char arg_vars_storage[sizeof(array<string>)];
 static array<string>* arg_vars = nullptr;
 
 Optional<int64_t>& get_dummy_rest_index() noexcept {
@@ -1897,7 +1897,7 @@ std::tuple<int64_t, int64_t, int64_t, int64_t> f$get_webserver_stats() {
   return {stats.running_workers, stats.waiting_workers, stats.ready_for_accept_workers, stats.total_workers};
 }
 
-static char ini_vars_storage[sizeof(array<string>)];
+alignas(array<string>) static char ini_vars_storage[sizeof(array<string>)];
 static array<string>* ini_vars = nullptr;
 
 void ini_set(vk::string_view key, vk::string_view value) {

--- a/runtime/openssl.cpp
+++ b/runtime/openssl.cpp
@@ -598,7 +598,7 @@ struct ssl_connection {
   SSL_CTX* ssl_ctx;
 };
 
-static char ssl_connections_storage[sizeof(array<ssl_connection>)];
+alignas(array<ssl_connection>) static char ssl_connections_storage[sizeof(array<ssl_connection>)];
 static array<ssl_connection>* ssl_connections = reinterpret_cast<array<ssl_connection>*>(ssl_connections_storage);
 static long long ssl_connections_last_query_num = -1;
 

--- a/runtime/regexp.cpp
+++ b/runtime/regexp.cpp
@@ -311,7 +311,7 @@ bool regexp::is_valid_RE2_regexp(const char* regexp_string, int64_t regexp_len, 
 }
 
 void regexp::init(const string& regexp_string, const char* function, const char* file) {
-  static char regexp_cache_storage[sizeof(array<regexp*>)];
+  alignas(array<regexp*>) static char regexp_cache_storage[sizeof(array<regexp*>)];
   static array<regexp*>* regexp_cache = (array<regexp*>*)regexp_cache_storage;
   static long long regexp_last_query_num = -1;
 

--- a/runtime/udp.cpp
+++ b/runtime/udp.cpp
@@ -19,7 +19,7 @@
 
 int DEFAULT_SOCKET_TIMEOUT = 60;
 
-static char opened_udp_sockets_storage[sizeof(array<int>)];
+alignas(array<int>) static char opened_udp_sockets_storage[sizeof(array<int>)];
 static array<int>* opened_udp_sockets = reinterpret_cast<array<int>*>(opened_udp_sockets_storage);
 static long long opened_udp_sockets_last_query_num = -1;
 


### PR DESCRIPTION
Static char storages used as backing memory for placement new of array<T> had alignment 1, which is UB when the linker places them at an address not aligned to alignof(array<T>). Add alignas() to all such storages.